### PR TITLE
Fix `r_lock!` usage in `RDataViewer`

### DIFF
--- a/crates/ark/src/data_viewer/r_data_viewer.rs
+++ b/crates/ark/src/data_viewer/r_data_viewer.rs
@@ -70,7 +70,7 @@ pub struct DataSet {
 
 impl DataSet {
 
-    fn extract_columns(object: SEXP, name: Option<String>, row_count: usize, columns: &mut Vec<DataColumn>) -> Result<(), anyhow::Error> {
+    unsafe fn extract_columns(object: SEXP, name: Option<String>, row_count: usize, columns: &mut Vec<DataColumn>) -> Result<(), anyhow::Error> {
         if r_is_data_frame(object) {
             unsafe {
                 let names = Rf_getAttrib(object, R_NamesSymbol);
@@ -144,7 +144,7 @@ impl DataSet {
                 if r_is_simple_vector(object) {
                     harp::vector::format(object)
                 } else {
-                    let formatted = unsafe { RFunction::from("format").add(object).call()? };
+                    let formatted = RFunction::from("format").add(object).call()?;
                     r_assert_type(*formatted, &[STRSXP])?;
                     r_assert_length(*formatted, row_count)?;
                     harp::vector::format(*formatted)


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/589

- Used `r_lock!` as needed before calling the R API
- Tweaked `extract_columns()` to take `SEXP` rather than `RObject` to avoid some extra layers of `PROTECT()`. Plus i think it looks a little cleaner?