### PR TITLE
Use rust-analyzer's build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,17 +1,15 @@
 {
-    "tasks": [
-        {
-            "type": "cargo",
-            "command": "build",
-            "problemMatcher": [
-                "$rustc"
-            ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "label": "rust: cargo build"
-        }
-    ]
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"problemMatcher": [
+				"$rustc",
+				"$rust-panic"
+			],
+			"group": "build",
+			"label": "rust: cargo build"
+		}
+	]
 }
-


### PR DESCRIPTION
If you install the openvsx version of rust-analyzer (which I think we all should!) then CMD+SHIFT+B doesn't work right in amalthea anymore.

It gives me:

```
Error: The cargo task detection didn't contribute a task for the following configuration:
{
    "type": "cargo",
    "subcommand": "build",
    "problemMatcher": [
        "$rustc"
    ],
    "group": {
        "kind": "build",
        "isDefault": true
    },
    "label": "Rust: cargo build - amalthea"
}
The task will be ignored.
```

I think the problem is that rust-analyzer provides its own variant of a "build" task, and somehow they conflict. I somewhat confirmed this by looking at https://github.com/rust-lang/rust-analyzer/issues/3983

If I just delete the task and then hit CMD+SHIFT+B then I see

<img width="629" alt="Screen Shot 2023-05-19 at 11 10 53 AM" src="https://github.com/posit-dev/amalthea/assets/19150088/8e5a9d0a-2b44-4c62-beaf-2fca6cad3d44">

where `rust: cargo build` seems to be supplied by rust-analyzer. Running that task does run `cargo build` correctly.

If I hit the settings "wheel" on the right hand side of `rust: cargo build` then it generates the `task.json` that is now in this PR, and CMD+SHIFT+B "just works" again, so I think we should just use that?