### PR TITLE
Assign parent ID to input requests from kernel

### DIFF
--- a/crates/amalthea/src/language/shell_handler.rs
+++ b/crates/amalthea/src/language/shell_handler.rs
@@ -21,6 +21,7 @@ use crate::wire::is_complete_reply::IsCompleteReply;
 use crate::wire::is_complete_request::IsCompleteRequest;
 use crate::wire::kernel_info_reply::KernelInfoReply;
 use crate::wire::kernel_info_request::KernelInfoRequest;
+use crate::wire::originator::Originator;
 
 use async_trait::async_trait;
 use crossbeam::channel::Sender;
@@ -52,7 +53,7 @@ pub trait ShellHandler: Send {
     /// Docs: https://jupyter-client.readthedocs.io/en/stable/messaging.html#execute
     async fn handle_execute_request(
         &mut self,
-        originator: &Vec<u8>,
+        originator: Option<Originator>,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException>;
 

--- a/crates/amalthea/src/socket/shell.rs
+++ b/crates/amalthea/src/socket/shell.rs
@@ -37,6 +37,7 @@ use crate::wire::jupyter_message::ProtocolMessage;
 use crate::wire::jupyter_message::Status;
 use crate::wire::kernel_info_reply::KernelInfoReply;
 use crate::wire::kernel_info_request::KernelInfoRequest;
+use crate::wire::originator::Originator;
 use crate::wire::status::ExecutionState;
 use crate::wire::status::KernelStatus;
 use crossbeam::channel::Receiver;
@@ -220,8 +221,8 @@ impl Shell {
         req: JupyterMessage<ExecuteRequest>,
     ) -> Result<(), Error> {
         debug!("Received execution request {:?}", req);
-        let originator = req.zmq_identities[0].clone();
-        match block_on(handler.handle_execute_request(&originator, &req.content)) {
+        let originator = Originator::from(&req);
+        match block_on(handler.handle_execute_request(Some(originator), &req.content)) {
             Ok(reply) => {
                 trace!("Got execution reply, delivering to front end: {:?}", reply);
                 let r = req.send_reply(reply, &self.socket);

--- a/crates/amalthea/src/wire/input_request.rs
+++ b/crates/amalthea/src/wire/input_request.rs
@@ -7,6 +7,7 @@
 
 use crate::wire::jupyter_message::MessageType;
 use serde::{Deserialize, Serialize};
+use crate::wire::originator::Originator;
 
 /// Represents a request from the kernel to the front end to prompt the user for
 /// input
@@ -23,7 +24,7 @@ pub struct InputRequest {
 /// An input request originating from a Shell handler
 pub struct ShellInputRequest {
     /// The identity of the Shell that sent the request
-    pub originator: Vec<u8>,
+    pub originator: Option<Originator>,
 
     /// The input request itself
     pub request: InputRequest,

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -34,6 +34,7 @@ use crate::wire::is_complete_reply::IsCompleteReply;
 use crate::wire::is_complete_request::IsCompleteRequest;
 use crate::wire::kernel_info_reply::KernelInfoReply;
 use crate::wire::kernel_info_request::KernelInfoRequest;
+use crate::wire::originator::Originator;
 use crate::wire::shutdown_request::ShutdownRequest;
 use crate::wire::status::KernelStatus;
 use crate::wire::wire_message::WireMessage;
@@ -251,18 +252,23 @@ where
 
     /// Create a new Jupyter message with a specific ZeroMQ identity.
     pub fn create_with_identity(
-        identity: Vec<u8>,
+        orig: Option<Originator>,
         content: T,
         session: &Session,
     ) -> JupyterMessage<T> {
+        let (id, parent_header) = match orig {
+            Some(orig) => (orig.zmq_id, Some(orig.header)),
+            None => (Vec::new(), None)
+        };
+
         JupyterMessage::<T> {
-            zmq_identities: vec![identity],
+            zmq_identities: vec![id],
             header: JupyterHeader::create(
                 T::message_type(),
                 session.session_id.clone(),
                 session.username.clone(),
             ),
-            parent_header: None,
+            parent_header,
             content: content,
         }
     }

--- a/crates/amalthea/src/wire/mod.rs
+++ b/crates/amalthea/src/wire/mod.rs
@@ -36,6 +36,7 @@ pub mod jupyter_message;
 pub mod kernel_info_reply;
 pub mod kernel_info_request;
 pub mod language_info;
+pub mod originator;
 pub mod shutdown_reply;
 pub mod shutdown_request;
 pub mod status;

--- a/crates/amalthea/src/wire/originator.rs
+++ b/crates/amalthea/src/wire/originator.rs
@@ -1,0 +1,24 @@
+/*
+ * originator.rs
+ *
+ * Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+use crate::wire::header::JupyterHeader;
+use crate::wire::jupyter_message::JupyterMessage;
+
+#[derive(Debug, Clone)]
+pub struct Originator {
+    pub zmq_id: Vec<u8>,
+    pub header: JupyterHeader,
+}
+
+impl<T> From<&JupyterMessage<T>> for Originator {
+    fn from(msg: &JupyterMessage<T>) -> Originator {
+        Originator {
+            zmq_id: msg.zmq_identities[0].clone(),
+            header: msg.header.clone(),
+        }
+    }
+}

--- a/crates/amalthea/tests/shell/mod.rs
+++ b/crates/amalthea/tests/shell/mod.rs
@@ -33,6 +33,7 @@ use amalthea::wire::jupyter_message::Status;
 use amalthea::wire::kernel_info_reply::KernelInfoReply;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::language_info::LanguageInfo;
+use amalthea::wire::originator::Originator;
 use async_trait::async_trait;
 use crossbeam::channel::Sender;
 use log::warn;
@@ -55,7 +56,7 @@ impl Shell {
     }
 
     // Simluates an input request
-    fn prompt_for_input(&self, originator: &Vec<u8>) {
+    fn prompt_for_input(&self, originator: Option<Originator>) {
         if let Some(sender) = &self.input_tx {
             if let Err(err) = sender.send(ShellInputRequest {
                 originator: originator.clone(),
@@ -126,7 +127,7 @@ impl ShellHandler for Shell {
     /// Handles an ExecuteRequest; "executes" the code by echoing it.
     async fn handle_execute_request(
         &mut self,
-        originator: &Vec<u8>,
+        originator: Option<Originator>,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException> {
         // Increment counter if we are storing this execution in history
@@ -182,7 +183,7 @@ impl ShellHandler for Shell {
         //
         // Create an artificial prompt for input
         if req.code == "prompt" {
-            self.prompt_for_input(&originator);
+            self.prompt_for_input(originator);
         }
 
         // For this toy echo language, generate a result that's just the input

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -492,11 +492,10 @@ fn complete_execute_request(
     if prompt != default_prompt {
         trace!("Got R prompt '{}', asking user for input", prompt);
         if let Request::ExecuteCode(_, originator, _) = req {
-            kernel.request_input(originator, &prompt);
+            kernel.request_input(originator.clone(), &prompt);
         } else {
             warn!("No originator for input request, omitting");
-            let originator: Vec<u8> = Vec::new();
-            kernel.request_input(&originator, &prompt);
+            kernel.request_input(None, &prompt);
         }
 
         trace!("Input requested, waiting for reply...");

--- a/crates/ark/src/kernel.rs
+++ b/crates/ark/src/kernel.rs
@@ -21,6 +21,7 @@ use amalthea::wire::execute_result::ExecuteResult;
 use amalthea::wire::input_request::InputRequest;
 use amalthea::wire::input_request::ShellInputRequest;
 use amalthea::wire::jupyter_message::Status;
+use amalthea::wire::originator::Originator;
 use amalthea::wire::stream::Stream;
 use amalthea::wire::stream::StreamOutput;
 use anyhow::*;
@@ -264,12 +265,12 @@ impl Kernel {
     }
 
     /// Requests input from the front end
-    pub fn request_input(&self, originator: &Vec<u8>, prompt: &str) {
+    pub fn request_input(&self, originator: Option<Originator>, prompt: &str) {
         if let Some(requestor) = &self.input_request_tx {
             trace!("Requesting input from front-end for prompt: {}", prompt);
             requestor
                 .send(ShellInputRequest {
-                    originator: originator.clone(),
+                    originator,
                     request: InputRequest {
                         prompt: prompt.to_string(),
                         password: false,

--- a/crates/ark/src/request.rs
+++ b/crates/ark/src/request.rs
@@ -9,13 +9,18 @@ use amalthea::{wire::execute_request::ExecuteRequest, events::PositronEvent};
 use amalthea::wire::execute_response::ExecuteResponse;
 use amalthea::wire::input_request::ShellInputRequest;
 use crossbeam::channel::Sender;
+use amalthea::wire::originator::Originator;
 
 /// Represents requests to the primary R execution thread.
 #[derive(Debug, Clone)]
 pub enum Request {
     /// Fulfill an execution request from the front end, producing either a
     /// Reply or an Exception
-    ExecuteCode(ExecuteRequest, Vec<u8>, Sender<ExecuteResponse>),
+    ExecuteCode(
+        ExecuteRequest,
+        Option<Originator>,
+        Sender<ExecuteResponse>,
+    ),
 
     /// Establish a channel to the front end to send input requests
     EstablishInputChannel(Sender<ShellInputRequest>),

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -27,6 +27,7 @@ use amalthea::wire::jupyter_message::Status;
 use amalthea::wire::kernel_info_reply::KernelInfoReply;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::language_info::LanguageInfo;
+use amalthea::wire::originator::Originator;
 use async_trait::async_trait;
 use bus::Bus;
 use bus::BusReader;
@@ -186,13 +187,13 @@ impl ShellHandler for Shell {
     /// for processing.
     async fn handle_execute_request(
         &mut self,
-        originator: &Vec<u8>,
+        originator: Option<Originator>,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException> {
         let (sender, receiver) = unbounded::<ExecuteResponse>();
         if let Err(err) = self.shell_request_tx.send(Request::ExecuteCode(
             req.clone(),
-            originator.clone(),
+            originator,
             sender,
         )) {
             warn!(
@@ -264,11 +265,10 @@ impl ShellHandler for Shell {
             allow_stdin: false,
             stop_on_error: false,
         };
-        let originator = Vec::new();
         let (sender, receiver) = unbounded::<ExecuteResponse>();
         if let Err(err) = self.shell_request_tx.send(Request::ExecuteCode(
             req.clone(),
-            originator.clone(),
+            None,
             sender,
         )) {
             warn!("Could not deliver input reply to execution thread: {}", err)

--- a/crates/echo/src/shell.rs
+++ b/crates/echo/src/shell.rs
@@ -29,6 +29,7 @@ use amalthea::wire::jupyter_message::Status;
 use amalthea::wire::kernel_info_reply::KernelInfoReply;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::language_info::LanguageInfo;
+use amalthea::wire::originator::Originator;
 use async_trait::async_trait;
 use crossbeam::channel::Sender;
 use log::warn;
@@ -104,7 +105,7 @@ impl ShellHandler for Shell {
     /// Handles an ExecuteRequest; "executes" the code by echoing it.
     async fn handle_execute_request(
         &mut self,
-        _originator: &Vec<u8>,
+        _originator: Option<Originator>,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException> {
         // Increment counter if we are storing this execution in history


### PR DESCRIPTION
Addresses rstudio/positron#534.

Currently the activity prompt items created on input requests from the kernel (e.g. `readline()`) do not have the correct parent. This causes the out-of-order rendering issues described in rstudio/positron#534. This PR fixes this by keeping track of the id of execution requests from inputs (e.g. a `readline()` call supplied by the user) and setting these as parents of the input requests from the kernel.

Since `JupyterKernel::emitMessage()` already sets parent IDs if a `JupyterHeader` is stored in the parent field of a message, we just need to pass the header to `JupyterMessage::create_with_identity()` and store it as parent.

As before we also need to pass along the 0MQ ID for routing. Instead of passing a whole `JupyterMessage`, a new `Originator` struct is constructed that contains only the elements that we need. This avoids a generic parameter for the message content and abstracts away the JupyterMessage details. The struct is passed by value (clone) to avoid having to include reference lifetimes in all the enums, structs, and functions that directly or indirectly reference the struct (e.g. via the `Request::ExecuteCode` enum variant).
