### PR TITLE
POC for `r_lock!` enforcement on the R API

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -436,12 +436,10 @@ impl LanguageServer for Backend {
             return Ok(item);
         });
 
-        unsafe {
-            unwrap!(resolve_completion_item(&mut item, &data), Err(error) => {
-                error!("{:?}", error);
-                return Ok(item);
-            });
-        }
+        unwrap!(r_lock! { resolve_completion_item(&mut item, &data) }, Err(error) => {
+            error!("{:?}", error);
+            return Ok(item);
+        });
 
         Ok(item)
     }
@@ -464,7 +462,9 @@ impl LanguageServer for Backend {
         });
 
         // request hover information
-        let result = unsafe { hover(&document, &context) };
+        let result = r_lock! {
+            hover(&document, &context)
+        };
 
         // unwrap errors
         let result = unwrap!(result, Err(error) => {
@@ -494,7 +494,7 @@ impl LanguageServer for Backend {
 
         // request signature help
         let position = params.text_document_position_params.position;
-        let result = unsafe { signature_help(document.value(), &position) };
+        let result = r_lock! { signature_help(document.value(), &position) };
 
         // unwrap errors
         let result = unwrap!(result, Err(error) => {

--- a/crates/ark/tests/environment.rs
+++ b/crates/ark/tests/environment.rs
@@ -59,10 +59,12 @@ fn test_environment_list() {
 
     // Create a new environment handler and give it a view of the test
     // environment we created.
-    let test_env_view = RObject::view(test_env.sexp);
     let incoming_tx = comm.incoming_tx.clone();
     let outgoing_rx = comm.outgoing_rx.clone();
-    REnvironment::start(test_env_view, comm);
+    r_lock! {
+        let test_env_view = RObject::view(test_env.sexp);
+        REnvironment::start(test_env_view, comm.clone())
+    }
 
     // Ensure we get a list of variables after initialization
     let msg = outgoing_rx.recv().unwrap();

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -13,6 +13,7 @@ pub mod interrupts;
 pub mod lock;
 pub mod object;
 pub mod protect;
+pub mod r_api;
 pub mod routines;
 pub mod string;
 pub mod symbol;

--- a/crates/harp/src/protect.rs
+++ b/crates/harp/src/protect.rs
@@ -5,7 +5,9 @@
 //
 //
 
-use libR_sys::*;
+use crate::r_api::Rf_protect;
+use crate::r_api::Rf_unprotect;
+use crate::r_api::SEXP;
 
 // NOTE: The RProtect struct uses R's stack-based object protection, and so is
 // only appropriate for R objects with 'automatic' lifetime. In general, this
@@ -16,21 +18,20 @@ pub struct RProtect {
 }
 
 impl RProtect {
-    /// SAFETY: Assumes that the R lock is held.
-    pub unsafe fn new() -> Self {
+    pub fn new() -> Self {
         Self { count: 0 }
     }
 
-    /// SAFETY: Assumes that the R lock is held.
-    pub unsafe fn add(&mut self, object: SEXP) -> SEXP {
+    /// SAFETY: Requires that the R lock is held.
+    pub fn add(&mut self, object: SEXP) -> SEXP {
         self.count += 1;
         return Rf_protect(object);
     }
 }
 
 impl Drop for RProtect {
-    /// SAFETY: Assumes that the R lock is held.
+    /// SAFETY: Requires that the R lock is held.
     fn drop(&mut self) {
-        unsafe { Rf_unprotect(self.count) }
+        Rf_unprotect(self.count)
     }
 }

--- a/crates/harp/src/r_api.rs
+++ b/crates/harp/src/r_api.rs
@@ -1,0 +1,30 @@
+//
+// r_api.rs
+//
+// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+//
+//
+
+#![allow(non_snake_case)]
+
+pub use libR_sys::SEXP;
+
+#[harp_macros::lock]
+pub fn Rf_xlength(x: SEXP) -> isize {
+    unsafe { libR_sys::Rf_xlength(x) }
+}
+
+#[harp_macros::lock]
+pub fn TYPEOF(x: SEXP) -> std::os::raw::c_int {
+    unsafe { libR_sys::TYPEOF(x) }
+}
+
+#[harp_macros::lock]
+pub fn Rf_protect(x: SEXP) -> SEXP {
+    unsafe { libR_sys::Rf_protect(x) }
+}
+
+#[harp_macros::lock]
+pub fn Rf_unprotect(count: i32) {
+    unsafe { libR_sys::Rf_unprotect(count) }
+}

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -10,6 +10,7 @@ use libR_sys::*;
 use crate::error::Result;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
+use crate::utils::r_length;
 
 pub mod character_vector;
 pub use character_vector::CharacterVector;
@@ -87,7 +88,7 @@ pub trait Vector {
         <T as IntoIterator>::Item: AsRef<Self::Item>;
 
     unsafe fn len(&self) -> usize {
-        Rf_xlength(self.data()) as usize
+        r_length(self.data()) as usize
     }
 
     fn format_one(&self, x: Self::Type) -> String;


### PR DESCRIPTION
"Fixed" just enough of the missing `r_lock!`s to get tests passing, but interactive usage could reveal more