### PR TITLE
Turn on preferred final new line settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,7 @@
         "--target-dir", "${workspaceFolder}/target/check"
     ],
     "cmake.configureOnOpen": false,
-    "rust-analyzer.showUnlinkedFileNotification": false
+    "rust-analyzer.showUnlinkedFileNotification": false,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true
 }


### PR DESCRIPTION
Manually turning on `"files.insertFinalNewline": true` like we do in Positron itself, we just don't inherit this setting due to having our own settings file, I think. Can be removed if we do https://github.com/rstudio/positron/issues/726

I also prefer `"files.trimFinalNewlines": true`, which may cause a little noise in the short term if there are existing files with too many new lines at the end, but I am ok with that?