### PR TITLE
Implement a deadlock watcher thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,10 +1314,13 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
+ "backtrace",
  "cfg-if",
  "libc",
+ "petgraph",
  "redox_syscall",
  "smallvec",
+ "thread-id",
  "windows-sys 0.45.0",
 ]
 
@@ -1326,6 +1335,16 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -2053,6 +2072,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -399,6 +399,9 @@ pub fn start_r(
         *KERNEL.borrow_mut() = Some(Arc::new(Mutex::new(kernel)));
     });
 
+    // Start thread to watch for `r_lock!` deadlocks
+    harp::deadlock::watch();
+
     // Start thread to listen to execution requests
     spawn!("ark-execution", move || {
         listen(shell_request_rx, rprompt_rx)

--- a/crates/harp/Cargo.toml
+++ b/crates/harp/Cargo.toml
@@ -17,7 +17,7 @@ libR-sys = "0.5.0"
 libc = "0.2.140"
 log = "0.4.17"
 once_cell = "1.17.1"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 regex = "1.7.3"
 stdext = { path = "../stdext" }
 

--- a/crates/harp/src/deadlock.rs
+++ b/crates/harp/src/deadlock.rs
@@ -1,0 +1,46 @@
+//
+// deadlock.rs
+//
+// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::thread;
+use std::time::Duration;
+
+use parking_lot::deadlock;
+use stdext::spawn;
+
+/// Watch for `parking_lot::Mutex` deadlocks, particularly for the
+/// `R_RUNTIME_LOCK` used by `r_lock!`. This allows us to determine
+/// if and where we have called `r_lock!` from within another `r_lock!`.
+pub fn watch() {
+    spawn!("ark-deadlock-watcher", || { deadlock_thread() });
+}
+
+fn deadlock_thread() {
+    loop {
+        // Check for deadlocks every 20 seconds
+        thread::sleep(Duration::from_secs(20));
+
+        let deadlocks = deadlock::check_deadlock();
+        if deadlocks.is_empty() {
+            log::info!("No new deadlocks detected.");
+            continue;
+        }
+
+        log::error!("{} deadlock(s) detected.", deadlocks.len());
+
+        for (i, threads) in deadlocks.iter().enumerate() {
+            log::error!("Deadlock #{}", i + 1);
+
+            for thread in threads {
+                log::error!(
+                    "Thread Id: {:#?}\nBacktrace:\n{:#?}",
+                    thread.thread_id(),
+                    thread.backtrace()
+                );
+            }
+        }
+    }
+}

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -5,6 +5,7 @@
 //
 //
 
+pub mod deadlock;
 pub mod environment;
 pub mod error;
 pub mod eval;


### PR DESCRIPTION
This turns on a _very_ cool `parking_lot` feature called "deadlock detection". The TLDR is that it allows us to determine if and _where_ we may have called `r_lock!` from inside another `r_lock!`. Essentially, if your session hangs all of a sudden, you should go check the R logs and hang out for a little bit to see if a deadlock backtrace pops up! The clickable links in the backtrace make it incredibly simple to step up the stack to find the deadlock.

Two questions:

- I've set the sleep timer to 20 seconds. I originally thought this would be a debug only feature, but 20 seconds seems like it would be long enough that we could turn this on for both debug and release builds with minimal performance impact. Any thoughts there?

- I'm not exactly sure where to start the thread from. Currently I start it from `start_r()`, but I'll be honest in that I don't know if that is the best place to start it from or not.

Additionally in my research I found lockbud, which has static analysis tools for deadlock detection, among other neat things we may want to use in the future https://github.com/BurtonQin/lockbud/tree/all/Code

https://github.com/posit-dev/amalthea/assets/19150088/ae511cfd-f68a-4c33-bed6-1b0ef39499d7

