### PR TITLE
Handle inspection of promises with `PRCODE()` == some object

### DIFF
--- a/crates/ark/src/environment/variable.rs
+++ b/crates/ark/src/environment/variable.rs
@@ -741,7 +741,11 @@ impl EnvironmentVariable {
                                         // if we are here, it means the promise is either
                                         // evaluated already, i.e. PRVALUE() is bound
                                         // or it is a promise to something that is
-                                        // not a call or a symbol
+                                        // not a call or a symbol because it would have been handled in
+                                        // Binding::new()
+
+                                        // Actual promises, i.e. unevaluated promises can't be expanded
+                                        // in the environment pane so we would not get here
 
                                         let value = PRVALUE(x);
                                         if r_is_unbound(value) {


### PR DESCRIPTION
Related to https://github.com/rstudio/positron/issues/626

Example: 

```r
rlang::env_bind_lazy(globalenv(), a = !!mtcars)
```

`a` is a promise to an already evaluated data frame because it has been inlined by `!!`, so as far as the env pane is concerned, this is the same as: 

```r
b <- mtcars
```

<img width="623" alt="image" src="https://github.com/posit-dev/amalthea/assets/2625526/598fa47b-8daf-45a0-93c1-137928dadbc3">
