### PR TITLE
showing only first class

### DIFF
--- a/crates/ark/src/environment/variable.rs
+++ b/crates/ark/src/environment/variable.rs
@@ -169,18 +169,21 @@ impl WorkspaceVariableDisplayValue {
         if rtype == VECSXP && !r_inherits(value, "POSIXlt") {
             if r_inherits(value, "data.frame") {
                 let dim = dim_data_frame(value);
-                let classes = r_classes(value)
-                    .unwrap()
-                    .iter()
-                    .map(|s| s.unwrap())
-                    .join(" / ");
+                let class = match r_classes(value) {
+                    None => String::from(""),
+                    Some(classes) => match classes.get_unchecked(0) {
+                        Some(class) => format!(" <{}>", class),
+                        None => String::from(""),
+                    },
+                };
+
                 let value = format!(
-                    "[{} {} x {} {}] <{}>",
+                    "[{} {} x {} {}]{}",
                     dim.nrow,
                     plural("row", dim.nrow),
                     dim.ncol,
                     plural("column", dim.ncol),
-                    classes
+                    class
                 );
                 return Self::new(value, false);
             }


### PR DESCRIPTION
Followup to https://github.com/rstudio/positron/issues/638#issuecomment-1572521749

```r
x <- dplyr::group_by(mtcars, cyl)
```

![image](https://github.com/posit-dev/amalthea/assets/2625526/44e0cc07-e863-4c01-85f8-174b34615154)

Is that redundant to see `grouped_df`  twice though ?