### PR TITLE
rm dead struct `RObjectI32Iterator`

### DIFF
--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -451,34 +451,6 @@ impl TryFrom<RObject> for Vec<String> {
     }
 }
 
-pub struct RObjectI32Iterator {
-    object: RObject,
-    current: isize,
-    size: isize,
-}
-
-impl Iterator for RObjectI32Iterator {
-    type Item = Option<i32>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
-            self.current += 1;
-
-            if self.current >= self.size {
-                None
-            } else {
-                // TODO: consider GET_REGION() instead of calling INTEGER_ELT() each time
-                let value = INTEGER_ELT(self.object.sexp, self.current);
-                if value == R_NaInt {
-                    Some(None)
-                } else {
-                    Some(Some(value))
-                }
-            }
-        }
-    }
-}
-
 impl TryFrom<RObject> for Vec<Option<String>> {
     type Error = crate::error::Error;
     fn try_from(value: RObject) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Follow up after https://github.com/rstudio/positron/pull/302#event-8822099813 just removing a struct that is no longer in use