### PR TITLE
Comment out protection logs

### DIFF
--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -72,7 +72,8 @@ unsafe fn protect(object: SEXP) -> SEXP {
     // Clean up the protect stack and return.
     Rf_unprotect(2);
 
-    trace!("Protecting cell:   {:?}", cell);
+    // Uncomment if debugging protection issues
+    // trace!("Protecting cell:   {:?}", cell);
     return cell;
 }
 
@@ -81,7 +82,8 @@ unsafe fn unprotect(cell: SEXP) {
         return;
     }
 
-    trace!("Unprotecting cell: {:?}", cell);
+    // Uncomment if debugging protection issues
+    // trace!("Unprotecting cell: {:?}", cell);
 
     // We need to remove the cell from the precious list.
     // The CAR of the cell points to the previous cell in the precious list.


### PR DESCRIPTION
Now that we know it works fairly well. We can uncomment on an ad hoc basis if we are debugging something related to protection.

These have been pretty noisy in the logs lately