### PR TITLE
Showing names display_value for lists

### DIFF
--- a/crates/ark/src/environment/variable.rs
+++ b/crates/ark/src/environment/variable.rs
@@ -192,11 +192,17 @@ impl WorkspaceVariableDisplayValue {
                 let n = Rf_xlength(value);
                 let mut display_value = String::from("");
                 let mut is_truncated = false;
+                let names = Names::new(value, |_i| String::from(""));
                 for i in 0..n {
                     if i > 0 {
                         display_value.push_str(", ");
                     }
                     let display_i = Self::from(VECTOR_ELT(value, i));
+                    let name = names.get_unchecked(i);
+                    if !name.is_empty() {
+                        display_value.push_str(&name);
+                        display_value.push_str(" = ");
+                    }
                     display_value.push_str("[");
                     display_value.push_str(&display_i.display_value);
                     display_value.push_str("]");


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/749

```r
x <- list(a = 1:10, b = list(c = 1:2, d = 1:2))
```

<img width="531" alt="image" src="https://github.com/posit-dev/amalthea/assets/2625526/e436b382-760b-4f0e-9690-3fab29bc65d3">
