### PR TITLE
Set amalthea workspace log level to `"trace"`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
-    "diffEditor.ignoreTrimWhitespace": false
+    "diffEditor.ignoreTrimWhitespace": false,
+    "positron.r.kernel.logLevel": "trace"
 }


### PR DESCRIPTION
As follow up to https://github.com/rstudio/positron/pull/752

Most people don't need trace logs, so https://github.com/rstudio/positron/pull/752 defaults to `"warn"` for the R logs. But if you are working on amalthea directly, you probably do want `"trace"` logs, so this updates the Workspace settings so you get that by default, and can override on an ad hoc basis as needed