### PR TITLE
Use `bump()` to yield the lock in a fair manner

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -363,12 +363,10 @@ pub unsafe extern "C" fn r_polled_events() {
     );
     let now = SystemTime::now();
 
-    // Release the lock. This drops the lock, and gives other threads
-    // waiting for the lock a chance to acquire it.
-    R_RUNTIME_LOCK_GUARD = None;
-
-    // Take the lock back.
-    R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.lock());
+    // `bump()` does a fair unlock, giving other threads
+    // waiting for the lock a chance to acquire it, and then
+    // relocks it.
+    MutexGuard::bump(R_RUNTIME_LOCK_GUARD.as_mut().unwrap());
 
     info!(
         "The main thread re-acquired the R runtime lock after {} milliseconds.",


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/750

Rather than switching to a `RawMutexFair` mutex (which requires tweaking some "more advanced" bits of parking_lot), it looks like we can just use this `bump()` method instead to do a fair unlock / relock in this one spot.
https://docs.rs/lock_api/0.4.10/lock_api/struct.MutexGuard.html#method.bump

The crux of this is a pair of low level calls to `unlock_fair()` and `lock()`, but it happens on the "raw" mutex so is supposedly more efficient than calling these methods yourself.

I don't have any proof that this fixes what @lionel- saw here https://github.com/rstudio/positron/issues/750#issue-1758895929, but if you believe the docs of parking_lot, it should fix it since the default is not a fair unlock.

---

Note that `MutexGuard` has a fairly weird (but sensible) restriction because it is a _smart pointer_ (i.e. it implements `Deref`). There is no `bump()` _method_, i.e. you can't do `R_RUNTIME_LOCK_GUARD.bump()` like you may expect. You can only use the `bump()` _associated function_ that goes along with the `MutexGuard` struct, which takes a mutable reference to a guard and is callable as `MutexGuard::bump(guard)` instead. The fact that a `MutexGuard` is a smart pointer means that "auto dereferencing" can kick in, which allows you to do `R_RUNTIME_LOCK_GUARD.method_from_T()` where `method_from_T()` is any method from the `T` type in `MutexGuard<T>` (so it acts as a kind of passthrough). This means that `MutexGuard` itself isn't supposed to add any additional methods, to avoid any chance of conflicting with the methods from `T`. See also: 
- A parking_lot issue about this https://github.com/Amanieu/parking_lot/issues/85
- The official rust API guideline about smart pointers https://rust-lang.github.io/api-guidelines/predictability.html?highlight=deref#smart-pointers-do-not-add-inherent-methods-c-smart-ptr