### PR TITLE
Remove apparently unused `profile.dev` config

### DIFF
--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -45,9 +45,6 @@ uuid = "1.3.0"
 walkdir = "2"
 yaml-rust = "0.4.5"
 
-[profile.dev]
-rpath = true
-
 # The libR-sys package doesn't currently provide bindings for R on aarch64
 # Linux platforms, so on those systems we need to add the use-bingen feature,
 # which causes the package to build its own bindings from scratch.
@@ -56,4 +53,3 @@ rpath = true
 # installed on the build host.
 [target.'cfg(all(target_os="linux", target_arch="aarch64"))'.dependencies]
 libR-sys = { version = "0.5.0", features = ["use-bindgen"] }
-


### PR DESCRIPTION
`cargo build` always throws this warning, and today I figured out why

<img width="829" alt="Screen Shot 2023-06-23 at 5 00 41 PM" src="https://github.com/posit-dev/amalthea/assets/19150088/d06b2efa-81f5-4fd6-bfde-71cd5a082084">

There is a `profile.dev` config option that we set that is being completely ignored, because apparently they have to be set in the top level `Cargo.toml` file.

This `profile.dev` config bit was added here:
https://github.com/posit-dev/amalthea/commit/09522ad5d9603feb3a05f0979ca062dbcc9ab839

But I don't think it does anything now? It has been ignored for awhile, it seems.

@jmcphers is that correct?