### PR TITLE
Emit `IOPubMessage::ExecuteError` in execution error case

### DIFF
--- a/crates/stdext/src/lib.rs
+++ b/crates/stdext/src/lib.rs
@@ -13,6 +13,7 @@ pub mod join;
 pub mod local;
 pub mod ok;
 pub mod push;
+pub mod result;
 pub mod spawn;
 pub mod traps;
 pub mod unwrap;

--- a/crates/stdext/src/result.rs
+++ b/crates/stdext/src/result.rs
@@ -1,0 +1,47 @@
+//
+// result.rs
+//
+// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::fmt::Display;
+
+pub trait ResultOrLog<E> {
+    /// If `self` is an error, log an error, else do nothing and consume self.
+    fn or_log_error(self, prefix: &str);
+
+    /// If `self` is an error, log a warning, else do nothing and consume self.
+    fn or_log_warning(self, prefix: &str);
+
+    /// If `self` is an error, log info, else do nothing and consume self.
+    fn or_log_info(self, prefix: &str);
+}
+
+// Implemented for "empty" results that never contain values,
+// but may contain errors
+impl<E> ResultOrLog<E> for Result<(), E>
+where
+    E: Display,
+{
+    fn or_log_error(self, prefix: &str) {
+        match self {
+            Ok(_) => return,
+            Err(err) => log::error!("{}: {}", prefix, err),
+        }
+    }
+
+    fn or_log_warning(self, prefix: &str) {
+        match self {
+            Ok(_) => return,
+            Err(err) => log::warn!("{}: {}", prefix, err),
+        }
+    }
+
+    fn or_log_info(self, prefix: &str) {
+        match self {
+            Ok(_) => return,
+            Err(err) => log::info!("{}: {}", prefix, err),
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/rstudio/positron/issues/786

First commit reapplies part of https://github.com/posit-dev/amalthea/pull/53, which we accidentally lost in #57 (specifically about only emitting `IOPubMessage::ExecuteResponse` in the success case)

Second commit is specifically about:

> In a follow up PR I'll add an IOPubMessage::ExecuteError to the error path, since Jupyter front ends seem to expect those

mentioned at https://github.com/posit-dev/amalthea/pull/53#issue-1771853594

---

Ignore the logging, but now we at least see the red error blocks in jupyter-lab. There is extensive discussion in https://github.com/rstudio/positron/issues/786 about more improvements that are required here, but having them show up at all is the first step.

<img width="1337" alt="Screenshot 2023-07-06 at 1 53 57 PM" src="https://github.com/posit-dev/amalthea/assets/19150088/3ca2c9f5-e584-4ca1-9843-f557c7ff77b0">


