### PR TITLE
Detect top-level usage of `WriteConsole()` and forward as `execute_result`

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -725,8 +725,15 @@ impl RMain {
             // streaming R output?
             let mut data = serde_json::Map::new();
 
-            if self.stdout.len() != 0 {
-                data.insert("text/plain".to_string(), json!(self.stdout));
+            // Remove the trailing newlines that R adds to outputs but that
+            // Jupyter frontends are not expecting. Is it worth taking a
+            // mutable self ref across calling methods to avoid the clone?
+            let mut stdout = self.stdout.clone();
+            if stdout.ends_with('\n') {
+                stdout.pop();
+            }
+            if stdout.len() != 0 {
+                data.insert("text/plain".to_string(), json!(stdout));
             }
 
             // Include HTML representation of data.frame


### PR DESCRIPTION
Addresses rstudio/positron#281.
Branched on top of posit-dev/amalthea#64 (for the browser detection).

R calls the `WriteConsole()` frontend method in two cases:

- When user code streams to `stdout`.
- When a top-level evaluation has finished with visibility enabled.

We now detect the latter case and accumulate this top-level output in the `RMain.stdout` buffer. It is then included as `text/plain` content of `execute_result`. This way user output appears before the output cell and top-level output appears in the output cell.

The detection of top-level output uses the same trick as the detection of top-level prompts in `ReadConsole()`. If the stack is empty, or if we are in a browser environment, then we consider that `WriteConsole()` is called by the REPL at top-level.

Another change is that we avoid sending empty output in the execution result message. This solves the issue of empty Jupyter output cells.