### PR TITLE
Update minimal Rust version to 1.70.0

### DIFF
--- a/crates/amalthea/Cargo.toml
+++ b/crates/amalthea/Cargo.toml
@@ -2,7 +2,7 @@
 name = "amalthea"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [dependencies]
 amalthea-macros = { path = "./amalthea-macros" }

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ark"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 description = """
 The Amalthea R Kernel.
 """

--- a/crates/echo/Cargo.toml
+++ b/crates/echo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "echo"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [dependencies]
 amalthea = { path = "../amalthea" }

--- a/crates/harp/Cargo.toml
+++ b/crates/harp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "harp"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 description = """
 Tools for integrating R and Rust.
 """

--- a/crates/stdext/Cargo.toml
+++ b/crates/stdext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stdext"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 description = """
 Useful extensions to the Rust standard library.
 """


### PR DESCRIPTION
For `Option` method `is_some_and()`, which was made stable in that release

I updated them across the board even though technically I think only ark needs it