### PR TITLE
Make it possible to pass command line options to R

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -137,6 +137,7 @@ pub static mut R_MAIN: Option<RMain> = None;
 
 /// Starts the main R thread. Doesn't return.
 pub fn start_r(
+    r_args: Vec<String>,
     kernel_mutex: Arc<Mutex<Kernel>>,
     r_request_rx: Receiver<RRequest>,
     input_request_tx: Sender<ShellInputRequest>,
@@ -155,7 +156,14 @@ pub fn start_r(
     });
 
     unsafe {
-        let mut args = cargs!["ark", "--interactive"];
+        // Build the argument list from the command line arguments. The default
+        // list is `--interactive` unless altered with the `--` passthrough
+        // argument.
+        let mut args = cargs!["ark"];
+        for arg in r_args {
+            args.push(CString::new(arg).unwrap().into_raw());
+        }
+
         R_running_as_main_program = 1;
         R_SignalHandlers = 0;
         Rf_initialize_R(args.len() as i32, args.as_mut_ptr() as *mut *mut c_char);

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -71,6 +71,7 @@ pub enum REvent {
 impl Shell {
     /// Creates a new instance of the shell message handler.
     pub fn new(
+        r_args: Vec<String>,
         comm_manager_tx: Sender<CommEvent>,
         iopub_tx: Sender<IOPubMessage>,
         r_request_tx: Sender<RRequest>,
@@ -105,6 +106,7 @@ impl Shell {
 
             // Start the R REPL (does not return)
             crate::interface::start_r(
+                r_args,
                 kernel_clone,
                 r_request_rx,
                 input_request_tx,


### PR DESCRIPTION
This small change makes it possible to tell `ark` to pass arbitrary command line options to R when starting it. It uses the `--` convention; all of `ark`'s arguments are placed before the `--`, and any arguments that follow it are passed through, verbatim, to R when we call `Rf_initializeR`. 

The default behavior is to start R in `--interactive` mode as we did before. It's a bit of a judgement call whether we should also always pass `--interactive` when the user supplies their own R arguments. I chose not to since anyone using this probably knows what they're doing, but could see an argument for always including it.

Part of https://github.com/rstudio/positron/issues/930. 