### PR TITLE
Send LSP server init notification to frontend

### DIFF
--- a/crates/amalthea/src/comm/lsp_comm.rs
+++ b/crates/amalthea/src/comm/lsp_comm.rs
@@ -11,7 +11,6 @@ use std::sync::Mutex;
 use crossbeam::channel::Sender;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::json;
 
 use crate::comm::comm_channel::CommChannelMsg;
 use crate::error::Error;
@@ -25,7 +24,7 @@ pub struct StartLsp {
 
 pub struct LspComm {
     handler: Arc<Mutex<dyn LspHandler>>,
-    msg_tx: Sender<CommChannelMsg>,
+    _msg_tx: Sender<CommChannelMsg>,
 }
 
 /**
@@ -37,17 +36,16 @@ pub struct LspComm {
  */
 impl LspComm {
     pub fn new(handler: Arc<Mutex<dyn LspHandler>>, msg_tx: Sender<CommChannelMsg>) -> LspComm {
-        LspComm { handler, msg_tx }
+        LspComm {
+            handler,
+            _msg_tx: msg_tx,
+        }
     }
 
-    pub fn start(&self, data: &StartLsp) -> Result<(), Error> {
+    pub fn start(&self, data: &StartLsp, conn_init_tx: Sender<bool>) -> Result<(), Error> {
         let mut handler = self.handler.lock().unwrap();
-        handler.start(data.client_address.clone()).unwrap();
-        self.msg_tx
-            .send(CommChannelMsg::Data(json!({
-                "msg_type": "lsp_started",
-                "content": {}
-            })))
+        handler
+            .start(data.client_address.clone(), conn_init_tx)
             .unwrap();
         Ok(())
     }

--- a/crates/amalthea/src/language/lsp_handler.rs
+++ b/crates/amalthea/src/language/lsp_handler.rs
@@ -6,6 +6,7 @@
  */
 
 use async_trait::async_trait;
+use crossbeam::channel::Sender;
 
 use crate::error::Error;
 
@@ -15,5 +16,5 @@ use crate::error::Error;
 #[async_trait]
 pub trait LspHandler: Send {
     /// Starts the LSP server and binds it to the given TCP address.
-    fn start(&mut self, tcp_address: String) -> Result<(), Error>;
+    fn start(&mut self, tcp_address: String, conn_init_tx: Sender<bool>) -> Result<(), Error>;
 }

--- a/crates/ark/src/lsp/handler.rs
+++ b/crates/ark/src/lsp/handler.rs
@@ -34,7 +34,11 @@ impl Lsp {
 }
 
 impl LspHandler for Lsp {
-    fn start(&mut self, tcp_address: String) -> Result<(), amalthea::error::Error> {
+    fn start(
+        &mut self,
+        tcp_address: String,
+        conn_init_tx: Sender<bool>,
+    ) -> Result<(), amalthea::error::Error> {
         // If the kernel hasn't been initialized yet, wait for it to finish.
         // This prevents the LSP from attempting to start up before the kernel
         // is ready; on subsequent starts (reconnects), the kernel will already
@@ -48,8 +52,9 @@ impl LspHandler for Lsp {
         }
 
         let kernel_request_tx = self.kernel_request_tx.clone();
+
         spawn!("ark-lsp", move || {
-            backend::start_lsp(tcp_address, kernel_request_tx)
+            backend::start_lsp(tcp_address, kernel_request_tx, conn_init_tx)
         });
         return Ok(());
     }


### PR DESCRIPTION
- Move responsibility of sending LSP start notification from `LspComm` to `Shell::open_comm()`.

- The start notification message is now of type `server_started` instead of `lsp_started`. This more general message type will be shared for all comms wrapping a server (e.g. DAP).

- The server notifies `open_comm()` that it is ready to accept connections via a channel. The notification is then forwarded to the frontend through the comm. Before this change we were potentially sending the notification message too soon.