### PR TITLE
Don't tie the diagnostics version to the document version

### DIFF
--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::os::raw::c_void;
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicI64;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -35,7 +35,7 @@ use crate::lsp::backend::Backend;
 use crate::lsp::indexer;
 use crate::Range;
 
-static VERSION: AtomicI32 = AtomicI32::new(0);
+static DIAGNOSTICS_VERSION: AtomicI64 = AtomicI64::new(0);
 
 #[derive(Clone)]
 pub struct DiagnosticContext<'a> {
@@ -83,29 +83,29 @@ impl<'a> DiagnosticContext<'a> {
     }
 }
 
-pub async fn enqueue_diagnostics(backend: Backend, uri: Url, version: i32) {
-    // Make sure we're trying to enqueue diagnostics for a newer version of the document.
-    let current_version = VERSION.load(std::sync::atomic::Ordering::Acquire);
-    if version < current_version {
-        return;
-    }
+pub async fn enqueue_diagnostics(backend: Backend, uri: Url) {
+    // Bump to the version associated with this diagnostics call.
+    let version = DIAGNOSTICS_VERSION.load(std::sync::atomic::Ordering::Acquire) + 1;
+    // log::trace!("[diagnostics({version})] Spawning task to enqueue diagnostics.");
 
     // Store the version we're planning to apply diagnostics for.
-    VERSION.store(version, std::sync::atomic::Ordering::Release);
+    DIAGNOSTICS_VERSION.store(version, std::sync::atomic::Ordering::Release);
 
     // Spawn a task to enqueue diagnostics.
     tokio::spawn(async move {
         // Wait some amount of time. Note that the document version is updated on
         // every document change, so if the document changes while this task is waiting,
-        // we'll see that the global VERSION is now out-of-sync with the version associated
-        // with this task, and toss it away.
+        // we'll see that the global DIAGNOSTICS_VERSION is now out-of-sync with the version
+        // associated with this task, and toss it away.
         tokio::time::sleep(Duration::from_millis(1000)).await;
-        let current_version = VERSION.load(std::sync::atomic::Ordering::Acquire);
+        let current_version = DIAGNOSTICS_VERSION.load(std::sync::atomic::Ordering::Acquire);
         if version != current_version {
+            // log::trace!("[diagnostics({version})] Aborting diagnostics in favor of version {current_version}.");
             return;
         }
 
         // Okay, it's our chance to provide diagnostics.
+        // log::trace!("[diagnostics({version})] Generating diagnostics.");
         enqueue_diagnostics_impl(backend, uri).await;
     });
 }


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/999
Addresses https://github.com/rstudio/positron/issues/997

I think our global `VERSION` was too closely tied to the document version.

If the console was at "document" version 200, but `foo.R` was at document version 50, then we will _never_ run diagnostics for `foo.R` since we essentially always end up setting the global `VERSION` to the maximum document version we see, and we always bail from running the diagnostics on any document version that is lower than `VERSION`

Instead I've given the global `DIAGNOSTICS_VERSION` its own separate counter. It increments anytime anyone requests diagnostics and now serves the sole purpose of aborting diagnostic generation if we see that the global version has been incremented elsewhere by the user continually typing.

The previous `VERSION` implementation had some checks to make sure that we don't try and generate diagnostics for a change that is "old", and I think I've kept the spirit of that by moving a similar check back up into `did_change()` that only tries to run diagnostics if `on_did_change()` was able to successfully bring the document all the way up to the "change" version.

Some proof that document diagnostics are regenerated now:

https://github.com/posit-dev/amalthea/assets/19150088/19c9cdb3-9bb1-4110-a799-66b706f1e3e4


