### PR TITLE
Switch to `on_err()`

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -18,7 +18,7 @@ use log::*;
 use parking_lot::Mutex;
 use regex::Regex;
 use serde_json::Value;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use stdext::*;
 use tokio::net::TcpListener;
 use tower_lsp::jsonrpc::Result;
@@ -591,7 +591,7 @@ pub async fn start_lsp(
     // Notify frontend that we are ready to accept connections
     conn_init_tx
         .send(true)
-        .or_log_warning("Couldn't send LSP server init notification");
+        .on_err(|e| log::warn!("Couldn't send LSP server init notification due to: {e}."));
 
     let (stream, _) = listener.accept().await.unwrap();
     debug!("Connected to LSP at '{}'", address);

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -46,7 +46,7 @@ use harp::r_lock;
 use libR_sys::*;
 use once_cell::sync::Lazy;
 use serde_json::json;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use stdext::unwrap;
 use uuid::Uuid;
 
@@ -196,7 +196,7 @@ impl DeviceContext {
                     socket
                         .outgoing_tx
                         .send(CommChannelMsg::Rpc(rpc_id.to_string(), json))
-                        .or_log_error("Failed to send plot due to");
+                        .on_err(|e| log::error!("Failed to send plot due to: {e}."));
                 },
             }
         }
@@ -278,7 +278,7 @@ impl DeviceContext {
                 metadata,
                 transient,
             }))
-            .or_log_warning(&format!("Could not publish display data on IOPub."));
+            .on_err(|e| log::warn!("Could not publish display data on IOPub due to: {e}."));
     }
 
     fn process_update_plot(
@@ -310,7 +310,7 @@ impl DeviceContext {
         socket
             .outgoing_tx
             .send(CommChannelMsg::Data(value))
-            .or_log_error("Failed to send update message for id {id}.");
+            .on_err(|e| log::error!("Failed to send update message for id {id} due to {e}."));
     }
 
     fn process_update_plot_jupyter_protocol(&mut self, id: &str, iopub_tx: Sender<IOPubMessage>) {
@@ -334,7 +334,7 @@ impl DeviceContext {
                 metadata,
                 transient,
             }))
-            .or_log_warning(&format!("Could not publish update display data on IOPub."));
+            .on_err(|e| log::warn!("Could not publish update display data on IOPub due to: {e}."));
     }
 
     fn create_display_data_plot(&mut self, id: &str) -> Result<serde_json::Value, anyhow::Error> {

--- a/crates/stdext/src/result.rs
+++ b/crates/stdext/src/result.rs
@@ -5,43 +5,18 @@
 //
 //
 
-use std::fmt::Display;
-
-pub trait ResultOrLog<E> {
-    /// If `self` is an error, log an error, else do nothing and consume self.
-    fn or_log_error(self, prefix: &str);
-
-    /// If `self` is an error, log a warning, else do nothing and consume self.
-    fn or_log_warning(self, prefix: &str);
-
-    /// If `self` is an error, log info, else do nothing and consume self.
-    fn or_log_info(self, prefix: &str);
+pub trait ResultExt<T, E> {
+    /// Calls the provided closure with the contained error (if [`Err`]).
+    ///
+    /// Consumes the Result, unlike `inspect_err()` which propagates it and
+    /// still requires you to handle the Result in some way.
+    fn on_err<F: FnOnce(E)>(self, f: F);
 }
 
-// Implemented for "empty" results that never contain values,
-// but may contain errors
-impl<E> ResultOrLog<E> for Result<(), E>
-where
-    E: Display,
-{
-    fn or_log_error(self, prefix: &str) {
-        match self {
-            Ok(_) => return,
-            Err(err) => log::error!("{}: {}", prefix, err),
-        }
-    }
-
-    fn or_log_warning(self, prefix: &str) {
-        match self {
-            Ok(_) => return,
-            Err(err) => log::warn!("{}: {}", prefix, err),
-        }
-    }
-
-    fn or_log_info(self, prefix: &str) {
-        match self {
-            Ok(_) => return,
-            Err(err) => log::info!("{}: {}", prefix, err),
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn on_err<F: FnOnce(E)>(self, f: F) {
+        if let Err(e) = self {
+            f(e);
         }
     }
 }


### PR DESCRIPTION
To consume a Result and perform an action if `Err`

---

I think this is cleaner and more general than the `.or_log_*()` as it lets you perform any generic action on error. I can see us having lots of uses for this besides just logging.

I looked into the nightly `inspect_err()`, which is where this API was inspired from. But that doesn't _consume_ the result, it propagates it, so you still have to "handle" the Result in some way at the call site, and often with `Result<(), Error>` we don't care to actually handle it once we get to the top level.

I called it `.on_err()` but would be open to other names that try to convey the "consume" nature of it. I thought about `.consume_err()` but that doesn't really convey the fact that you would apply `f` on error.

---

Or maybe `consume_err()` _is_ right, if you also add `consume()`!

```
fn consume<F: FnOnce(T)>(self, f: F);
fn consume_err<F: FnOnce(E)>(self, f: F);
```

That would actually align with `inspect()` and `inspect_err()` perfectly
https://github.com/rust-lang/rfcs/issues/3190

---

Or, one last alternative, `handle_err()` - which conveys the idea that you are fully taking ownership of the object and doing something on error? I do wonder if something like `consume()` would be considered an antipattern in rust because it would add an "easy" way to throw away potential errors rather than properly handling them.