### PR TITLE
Draft hacky implementation of diagnostic refresh on code execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
 dependencies = [
  "bitflags",
  "serde",
@@ -2397,9 +2397,9 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-lsp"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b38fb0e6ce037835174256518aace3ca621c4f96383c56bb846cfc11b341910"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2420,13 +2420,13 @@ dependencies = [
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34723c06344244474fdde365b76aebef8050bf6be61a935b91ee9ff7c4e91157"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.154", features = ["derive"] }
 serde_json = "1.0.94"
 stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
-tower-lsp = "0.19.0"
+tower-lsp = "0.20.0"
 tree-sitter = "0.20.9"
 tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", branch = "next" }
 uuid = "1.3.0"

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -122,7 +122,7 @@ pub async fn enqueue_diagnostics(backend: Backend, uri: Url, version: i32) {
     });
 }
 
-fn generate_diagnostics(doc: &Document) -> Vec<Diagnostic> {
+pub fn generate_diagnostics(doc: &Document) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     {

--- a/crates/ark/src/lsp/globals.rs
+++ b/crates/ark/src/lsp/globals.rs
@@ -15,10 +15,10 @@ use crate::request::KernelRequest;
 // Doesn't need a mutex because it's only accessed by the R thread. Should
 // not be used elsewhere than from an R frontend callback or an R function
 // invoked by the REPL.
-pub(super) static mut R_CALLBACK_GLOBALS: Option<RCallbackGlobals> = None;
+pub static mut R_CALLBACK_GLOBALS: Option<RCallbackGlobals> = None;
 
-pub(super) struct RCallbackGlobals {
-    pub(super) lsp_client: Client,
+pub struct RCallbackGlobals {
+    pub lsp_client: Client,
     pub(super) kernel_request_tx: Sender<KernelRequest>,
 }
 


### PR DESCRIPTION
This is not done but there are some outstanding issues to solve before we can proceed further.

To use this, you also have to update `positron-r`'s `package.json` to use `vscode-languageclient` `^8.1.0` so that it brings in a version of the language server that is new enough to support `workspace/diagnostic/refresh`. But that currently has a major issue as well, see below.

The general idea of this is that we are using a relatively new LSP feature called a "pull request" diagnostic. This allows the server to send a `workspace/diagnostic/refresh` request to the client, which is intercepted by the middleware, and the middleware will iterate over the open R documents and send a `textDocument/diagnostic` request back to the client for each open document to _pull_ diagnostics for it. I've implemented that request on the ark side by overriding the `diagnostic()` tower-lsp method.

---

Major issues:

- [ ] Updating to 8.1.0 for vscode-languageclient also brings in vscode-languageserver 3.17.4 (which is what we actually need). The problem is that 3.17.4 includes these new encoding related changes that _require_ the server to use UTF-16 for `Position` encodings (encapsulated by these two commits https://github.com/microsoft/vscode-languageserver-node/commit/79c2eb195fd90cf10f99e3f74dda0858f11074ff, https://github.com/microsoft/vscode-languageserver-node/commit/1ab1a69884667a71a2d2e04bf42c04622d460044). Problem is, Kevin had added in Emoji support a little while back by using a UTF-8 encoding (https://github.com/posit-dev/positron/commit/9486c985a405536e316e69437fea0a38c1936f30), which now causes an error when Positron boots up the ark LSP. I imagine we will have to solve this eventually to keep our deps up to date. This languageserver restriction is a hotly debated topic, you can read about it here https://github.com/microsoft/vscode-languageserver-node/issues/1224.
    
    The only way I can actually test this PR out with 3.17.4 installed is to manually go into the installed `node_modules` and tweak this line https://github.com/microsoft/vscode-languageserver-node/blob/fb0a3d48b9aa1c52d527f623164b0b4f11115d5a/client/src/common/client.ts#L1253 from `UTF16` to `UTF8`, then it magically works again. I suppose you could probably also change `UTF8` to `UTF16` on the ark server side, which is probably easier, but then you lose multibyte character support.

- [ ] I need to figure out a clean way to plumb the LSP `client` through to either `handle_execute_request()` or something slightly upstream of it. Right now I use an ugly global variable hack we had in place for something else, but this is unsafe!

Minor TODOs:

- [ ] Figure out how to reconcile the fact that we now need to `await` the `workspace_diagnostic_refresh()` request with the fact that the `kernel` is not `Send` safe (see commented out code)

- [ ] Formalize `register_capability()` related JSON structures
