### PR TITLE
Use busy/idle guards for input replies

### DIFF
--- a/crates/amalthea/src/socket/iopub.rs
+++ b/crates/amalthea/src/socket/iopub.rs
@@ -68,11 +68,9 @@ impl IOPub {
     ///   subscribed clients.
     /// * `receiver` - The receiver channel that will receive IOPub
     ///   messages from other threads.
-    pub fn new(
-        socket: Socket,
-        receiver: Receiver<IOPubMessage>,
-        msg_context: Arc<Mutex<Option<JupyterHeader>>>,
-    ) -> Self {
+    pub fn new(socket: Socket, receiver: Receiver<IOPubMessage>) -> Self {
+        let msg_context = Arc::new(Mutex::new(None));
+
         Self {
             socket,
             receiver,

--- a/crates/amalthea/src/socket/stdin.rs
+++ b/crates/amalthea/src/socket/stdin.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use crossbeam::channel::Receiver;
+use crossbeam::channel::SendError;
 use crossbeam::channel::Sender;
 use crossbeam::select;
 use futures::executor::block_on;
@@ -18,12 +19,16 @@ use log::warn;
 
 use crate::language::shell_handler::ShellHandler;
 use crate::session::Session;
-use crate::wire::header::JupyterHeader;
+use crate::socket::iopub::IOPubMessage;
+use crate::wire::input_reply::InputReply;
 use crate::wire::input_request::ShellInputRequest;
 use crate::wire::jupyter_message::JupyterMessage;
 use crate::wire::jupyter_message::Message;
 use crate::wire::jupyter_message::OutboundMessage;
+use crate::wire::jupyter_message::ProtocolMessage;
 use crate::wire::originator::Originator;
+use crate::wire::status::ExecutionState;
+use crate::wire::status::KernelStatus;
 
 pub struct Stdin {
     /// Receiver connected to the StdIn's ZeroMQ socket
@@ -33,11 +38,12 @@ pub struct Stdin {
     outbound_tx: Sender<OutboundMessage>,
 
     /// Language-provided shell handler object
-    handler: Arc<Mutex<dyn ShellHandler>>,
+    shell_handler: Arc<Mutex<dyn ShellHandler>>,
 
-    // IOPub message context. Updated from StdIn on input replies so that new
-    // output gets attached to the correct input element in the console.
-    msg_context: Arc<Mutex<Option<JupyterHeader>>>,
+    // Sends messages to the IOPub socket. In particular for busy/idle updates
+    // related to input replies so that new output gets attached to the correct
+    // input element in the console.
+    iopub_tx: Sender<IOPubMessage>,
 
     // 0MQ session, needed to create `JupyterMessage` objects
     session: Session,
@@ -47,20 +53,20 @@ impl Stdin {
     /// Create a new Stdin socket
     ///
     /// * `socket` - The underlying ZeroMQ socket
-    /// * `handler` - The language's shell handler
-    /// * `msg_context` - The IOPub message context
+    /// * `shell_handler` - The language's shell handler
+    /// * `iopub_tx` - The IOPub message sender
     pub fn new(
         inbound_rx: Receiver<Message>,
         outbound_tx: Sender<OutboundMessage>,
-        handler: Arc<Mutex<dyn ShellHandler>>,
-        msg_context: Arc<Mutex<Option<JupyterHeader>>>,
+        shell_handler: Arc<Mutex<dyn ShellHandler>>,
+        iopub_tx: Sender<IOPubMessage>,
         session: Session,
     ) -> Self {
         Self {
             inbound_rx,
             outbound_tx,
-            handler,
-            msg_context,
+            shell_handler,
+            iopub_tx,
             session,
         }
     }
@@ -149,18 +155,44 @@ impl Stdin {
             };
             trace!("Received input reply from front-end: {:?}", reply);
 
-            // Update IOPub message context
-            {
-                let mut ctxt = self.msg_context.lock().unwrap();
-                *ctxt = Some(reply.header.clone());
-            }
+            self.handle_input_reply(reply)
+        }
+    }
 
-            // Send the reply to the shell handler
-            let handler = self.handler.lock().unwrap();
-            let orig = Originator::from(&reply);
-            if let Err(err) = block_on(handler.handle_input_reply(&reply.content, orig)) {
-                warn!("Error handling input reply: {:?}", err);
-            }
+    fn send_state<T: ProtocolMessage>(
+        &self,
+        parent: JupyterMessage<T>,
+        state: ExecutionState,
+    ) -> Result<(), SendError<IOPubMessage>> {
+        // TODO: Simplify with common `send_state()` extension
+        let reply = KernelStatus {
+            execution_state: state,
+        };
+        self.iopub_tx
+            .send(IOPubMessage::Status(parent.header, reply))
+    }
+
+    // Mimics the structure of handling other messages in `Shell`. In
+    // particular, toggling busy/idle states.
+    fn handle_input_reply(&self, reply: JupyterMessage<InputReply>) {
+        // Enter the kernel-busy state in preparation for handling the message.
+        if let Err(err) = self.send_state(reply.clone(), ExecutionState::Busy) {
+            warn!("Failed to change kernel status to busy: {err}");
+        }
+
+        // Send the reply to the shell handler
+        let shell_handler = self.shell_handler.lock().unwrap();
+
+        let orig = Originator::from(&reply);
+        if let Err(err) = block_on(shell_handler.handle_input_reply(&reply.content, orig)) {
+            warn!("Error handling input reply: {:?}", err);
+        }
+
+        // Return to idle -- we always do this, even if the message generated an
+        // error, since many front ends won't submit additional messages until
+        // the kernel is marked idle.
+        if let Err(err) = self.send_state(reply, ExecutionState::Idle) {
+            warn!("Failed to restore kernel status to idle: {err}");
         }
     }
 }


### PR DESCRIPTION
PR 1 of 3

I noticed that we plumb the IOPub `msg_context` through the Kernel as of
https://github.com/posit-dev/amalthea/pull/9/commits/8d42aa9bb7430f22d3246de99ef480995045483f

We do this so that when we handle an `input_reply`, we update the `msg_context` so that stdout that comes after it gets associated with the right UI input in the Console.

IIUC, this should be treated like any other kernel related message, i.e. we _must_ emit busy and idle states here as well.

This actually makes things simpler, as emitting the Busy message with `iopub_tx` and a parent of `reply` will update the `msg_context` for us, allowing us to locally scope the `msg_context` object back to being owned by `IOPub`, where I think it really belongs.

---

References:

> "Busy and idle messages should be sent before/after handling every request, not just execution."

https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-status
https://jupyter-client.readthedocs.io/en/stable/messaging.html#messages-on-the-stdin-router-dealer-channel