### PR TITLE
Emit busy/idle status from Control requests

### DIFF
--- a/crates/amalthea/src/kernel.rs
+++ b/crates/amalthea/src/kernel.rs
@@ -292,7 +292,12 @@ impl Kernel {
 
         // TODO: thread/join thread? Exiting this thread will cause the whole
         // kernel to exit.
-        Self::control_thread(control_socket, control_handler, stdin_interrupt_tx);
+        Self::control_thread(
+            control_socket,
+            self.create_iopub_tx(),
+            control_handler,
+            stdin_interrupt_tx,
+        );
         info!("Control thread exited, exiting kernel");
         Ok(())
     }
@@ -310,10 +315,11 @@ impl Kernel {
     /// Starts the control thread
     fn control_thread(
         socket: Socket,
+        iopub_tx: Sender<IOPubMessage>,
         handler: Arc<Mutex<dyn ControlHandler>>,
         stdin_interrupt_tx: Sender<bool>,
     ) {
-        let control = Control::new(socket, handler, stdin_interrupt_tx);
+        let control = Control::new(socket, iopub_tx, handler, stdin_interrupt_tx);
         control.listen();
     }
 

--- a/crates/amalthea/src/socket/control.rs
+++ b/crates/amalthea/src/socket/control.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crossbeam::channel::SendError;
 use crossbeam::channel::Sender;
 use futures::executor::block_on;
 use log::error;
@@ -17,11 +18,20 @@ use log::warn;
 
 use crate::error::Error;
 use crate::language::control_handler::ControlHandler;
+use crate::socket::iopub::IOPubContextChannel;
+use crate::socket::iopub::IOPubMessage;
 use crate::socket::socket::Socket;
+use crate::wire::interrupt_request::InterruptRequest;
+use crate::wire::jupyter_message::JupyterMessage;
 use crate::wire::jupyter_message::Message;
+use crate::wire::jupyter_message::ProtocolMessage;
+use crate::wire::shutdown_request::ShutdownRequest;
+use crate::wire::status::ExecutionState;
+use crate::wire::status::KernelStatus;
 
 pub struct Control {
     socket: Socket,
+    iopub_tx: Sender<IOPubMessage>,
     handler: Arc<Mutex<dyn ControlHandler>>,
     stdin_interrupt_tx: Sender<bool>,
 }
@@ -29,11 +39,13 @@ pub struct Control {
 impl Control {
     pub fn new(
         socket: Socket,
+        iopub_tx: Sender<IOPubMessage>,
         handler: Arc<Mutex<dyn ControlHandler>>,
         stdin_interrupt_tx: Sender<bool>,
     ) -> Self {
         Self {
             socket,
+            iopub_tx,
             handler,
             stdin_interrupt_tx,
         }
@@ -52,43 +64,95 @@ impl Control {
                 },
             };
 
-            match message {
-                Message::ShutdownRequest(req) => {
-                    info!("Received shutdown request, shutting down kernel: {:?}", req);
-
-                    // Lock the shell handler object on this thread
-                    let shell_handler = self.handler.lock().unwrap();
-                    if let Err(err) = block_on(shell_handler.handle_shutdown_request(&req.content))
-                    {
-                        warn!("Failed to handle shutdown request: {:?}", err);
-                        // TODO: if this fails, maybe we need to force a process shutdown?
-                    }
-                    break;
-                },
-                Message::InterruptRequest(req) => {
-                    info!(
-                        "Received interrupt request, asking kernel to stop: {:?}",
-                        req
-                    );
-
-                    // Notify StdIn socket first in case it's waiting for
-                    // input which is never going to come because of the
-                    // interrupt
-                    if let Err(err) = self.stdin_interrupt_tx.send(true) {
-                        error!("Failed to send interrupt request: {:?}", err);
-                    }
-
-                    let control_handler = self.handler.lock().unwrap();
-                    if let Err(err) = block_on(control_handler.handle_interrupt_request()) {
-                        error!("Failed to handle interrupt request: {:?}", err);
-                    }
-                    // TODO: What happens if the interrupt isn't handled?
-                },
-                _ => warn!(
-                    "{}",
-                    Error::UnsupportedMessage(message, String::from("Control"))
-                ),
+            if let Err(err) = self.process_message(message) {
+                warn!("Could not handle control message: {err}");
             }
         }
+    }
+
+    fn process_message(&self, message: Message) -> Result<(), Error> {
+        match message {
+            Message::ShutdownRequest(req) => {
+                self.handle_request(req, |r| self.handle_shutdown_request(r))
+            },
+            Message::InterruptRequest(req) => {
+                self.handle_request(req, |r| self.handle_interrupt_request(r))
+            },
+            _ => Err(Error::UnsupportedMessage(message, String::from("control"))),
+        }
+    }
+
+    /// Sets the kernel state by sending a message on the IOPub channel.
+    fn send_state<T: ProtocolMessage>(
+        &self,
+        parent: JupyterMessage<T>,
+        state: ExecutionState,
+    ) -> Result<(), SendError<IOPubMessage>> {
+        let reply = KernelStatus {
+            execution_state: state,
+        };
+        let message = IOPubMessage::Status(parent.header, IOPubContextChannel::Control, reply);
+        self.iopub_tx.send(message)
+    }
+
+    fn handle_request<T, H>(&self, req: JupyterMessage<T>, handler: H) -> Result<(), Error>
+    where
+        T: ProtocolMessage,
+        H: FnOnce(JupyterMessage<T>) -> Result<(), Error>,
+    {
+        // Enter the kernel-busy state in preparation for handling the message.
+        if let Err(err) = self.send_state(req.clone(), ExecutionState::Busy) {
+            warn!("Failed to change kernel status to busy: {err}");
+        }
+
+        // Call amalthea side of the handler.
+        let result = handler(req.clone());
+
+        // Return to idle -- we always do this, even if the message generated an
+        // error, since many front ends won't submit additional messages until
+        // the kernel is marked idle.
+        if let Err(err) = self.send_state(req, ExecutionState::Idle) {
+            warn!("Failed to restore kernel status to idle: {err}");
+        }
+
+        return result;
+    }
+
+    fn handle_shutdown_request(&self, req: JupyterMessage<ShutdownRequest>) -> Result<(), Error> {
+        info!("Received shutdown request, shutting down kernel: {:?}", req);
+
+        // Lock the control handler object on this thread
+        let control_handler = self.handler.lock().unwrap();
+
+        if let Err(err) = block_on(control_handler.handle_shutdown_request(&req.content)) {
+            warn!("Failed to handle shutdown request: {:?}", err);
+            // TODO: if this fails, maybe we need to force a process shutdown?
+        }
+
+        Ok(())
+    }
+
+    fn handle_interrupt_request(&self, req: JupyterMessage<InterruptRequest>) -> Result<(), Error> {
+        info!(
+            "Received interrupt request, asking kernel to stop: {:?}",
+            req
+        );
+
+        // Notify StdIn socket first in case it's waiting for
+        // input which is never going to come because of the
+        // interrupt
+        if let Err(err) = self.stdin_interrupt_tx.send(true) {
+            error!("Failed to send interrupt request: {:?}", err);
+        }
+
+        // Lock the control handler object on this thread
+        let control_handler = self.handler.lock().unwrap();
+
+        if let Err(err) = block_on(control_handler.handle_interrupt_request()) {
+            error!("Failed to handle interrupt request: {:?}", err);
+            // TODO: What happens if the interrupt isn't handled?
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
PR 2 of 2
Replaces https://github.com/posit-dev/amalthea/pull/89. Same implementation, just no longer on top of https://github.com/posit-dev/amalthea/pull/87.
Requires https://github.com/posit-dev/amalthea/pull/91
Requires https://github.com/posit-dev/positron/pull/1265
Addresses https://github.com/posit-dev/positron/issues/1234

Already approved here https://github.com/posit-dev/amalthea/pull/89#pullrequestreview-1616913250, description from there is repeated below for cohesion

---

The problem in https://github.com/posit-dev/positron/issues/1234 was that our Control requests (for shutdown and interrupt) were not emitting IOPub busy/idle statuses, even though they definitely should be, per the Jupyter documentation ("Busy and idle messages should be sent before/after handling every request, not just execution.", https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-status). This meant that the Console never receives any notification that it should switch out of the `interrupting` state, so it just sits there in that state indefinitely.

The solution presented in this PR is rather simple, we just change up the Control implementation to look more like the Shell implementation, which guards each request with busy/idle state messages. That fixes the `CTRL+C` bug:

https://github.com/posit-dev/amalthea/assets/19150088/e5ff21fd-0d5a-48fa-ac48-c31b79ec746a

The complicating factor is that now if you run something like `Sys.sleep(100)` and then press `CTRL+C`, then the interrupt occurs BUT then the Console is stuck in an infinite busy state. The issue has to do with the `msg_context` that we use as a parent in IOPub messages. Previously we only ever sent IOPub messages from the Shell, and the Shell requests are processed synchronously, so there was no way we could ever use an invalid parent `msg_context` there. However, we now emit IOPub Status messages from Control, and that occurs asynchronously, so we end up with the following when the user sends `Sys.sleep(100)` followed by `CTRL+C`: 

- A Shell `execute_request` sets the IOPub status to `busy` which sets the `msg_context` to the Shell `execute_request`
- The user triggers an interrupt. This sets the IOPub status to `busy` again and sets the `msg_context` to the Control `interrupt_request`
- The interrupt is processed (i.e. it has been acknowledged that the interrupt was at least sent) and the IOPub status is set back to `idle` via the Control thread (note the `msg_context` is still the Control `interrupt_request`)
- The code execution wraps up, due to the interrupt, and an IOPub `execute_result` message is sent back - **but with a faulty parent of the Control `interrupt_request`!!**
- The code execution is done, so we send back an `idle` state - **but with a faulty parent of the Control `interrupt_request`!!**

Since the original `execute_request`'s `busy` status never receives a corresponding `idle`, we end up in a weird place.

I noticed that ipykernel does a similar thing to our `msg_context`, but they use a _per channel_ context, one for Shell and one for Control
https://github.com/ipython/ipykernel/blob/c24b252dc4fc81e6cf6354f8d64ea06ed1ce3496/ipykernel/kernelbase.py#L608

So that is what PR 1 implements, and it does seem to work