### PR TITLE
remove the `dummy.do_something` command

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -174,7 +174,7 @@ impl LanguageServer for Backend {
                 document_symbol_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
                 execute_command_provider: Some(ExecuteCommandOptions {
-                    commands: vec!["dummy.do_something".to_string()],
+                    commands: vec![],
                     work_done_progress_options: Default::default(),
                 }),
                 workspace: Some(WorkspaceServerCapabilities {


### PR DESCRIPTION
Following https://github.com/posit-dev/positron/pull/1476, we will start a new ARK language client for each notebook. This currently tries to re-register a global command with ID `dummy.do_something` which fails once more than one language client have initialized.