### PR TITLE
Followup to #1585 index out of range -- log an error if not already handled

### DIFF
--- a/crates/ark/src/data_viewer/r_data_viewer.rs
+++ b/crates/ark/src/data_viewer/r_data_viewer.rs
@@ -235,14 +235,14 @@ impl DataSet {
             return Ok(self.columns.clone());
         }
 
-        let end = start + size; // exclusive, 1 more than the final row index of the slice
+        let mut end = start + size; // exclusive, 1 more than the final row index of the slice
 
         if end > self.row_count {
             // Censor end to avoid a panic, but log an error as we expect the frontend
             // to handle this case already
             let row_count = self.row_count;
             log::error!("Requested rows [{start}, {end}), but only {row_count} rows exist.");
-            end = row_count;
+            end = self.row_count;
         }
 
         let mut sliced_columns: Vec<DataColumn> = Vec::with_capacity(self.columns.len());


### PR DESCRIPTION
https://github.com/posit-dev/positron/pull/1614 handles this issue on the frontend, such that R should never receive a `size` that will create an out of range situation. But just in case, we add this bit of error handling