### PR TITLE
Improve snippets provided from ark

### DIFF
--- a/crates/ark/src/lsp/completions.rs
+++ b/crates/ark/src/lsp/completions.rs
@@ -1233,7 +1233,7 @@ unsafe fn append_roxygen_completions(
             item.insert_text = Some(format!("@{}", label.as_str()));
         }
 
-        item.detail = Some(format!("@{}{}", name, template.unwrap_or("")));
+        item.detail = Some(format!("roxygen @{} (R)", name));
         if let Some(description) = entry["description"].as_str() {
             let markup = MarkupContent {
                 kind: MarkupKind::Markdown,


### PR DESCRIPTION
This PR makes two changes:

- Addresses posit-dev/positron#1607 by fixing the not-quite-right roxygen snippets. As I outlined in that issue, the YAML file in the roxygen2 package changed about 10 months ago and this code was never updated to reflect those changes.
- Remove duplicate snippets that were also added in posit-dev/positron#1474. It will be easier to maintain those snippets as part of the R extension, not written here in Rust.