### PR TITLE
Remove custom `IOPubMessage::Event`

### DIFF
--- a/crates/amalthea/src/socket/iopub.rs
+++ b/crates/amalthea/src/socket/iopub.rs
@@ -17,9 +17,7 @@ use log::trace;
 use log::warn;
 
 use crate::error::Error;
-use crate::events::PositronEvent;
 use crate::socket::socket::Socket;
-use crate::wire::client_event::ClientEvent;
 use crate::wire::comm_close::CommClose;
 use crate::wire::comm_msg::CommMsg;
 use crate::wire::comm_open::CommOpen;
@@ -73,7 +71,6 @@ pub enum IOPubMessage {
     ExecuteError(ExecuteError),
     ExecuteInput(ExecuteInput),
     Stream(StreamOutput),
-    Event(PositronEvent),
     CommOpen(CommOpen),
     CommMsgReply(JupyterHeader, CommMsg),
     CommMsgEvent(CommMsg),
@@ -210,7 +207,6 @@ impl IOPub {
                 self.flush_stream();
                 self.send_message_with_context(msg, IOPubContextChannel::Shell)
             },
-            IOPubMessage::Event(msg) => self.send_event(msg),
             IOPubMessage::Wait(msg) => self.process_wait_request(msg),
         }
     }
@@ -252,16 +248,6 @@ impl IOPub {
         content: T,
     ) -> Result<(), Error> {
         let msg = JupyterMessage::<T>::create(content, header, &self.socket.session);
-        msg.send(&self.socket)
-    }
-
-    /// Send an event
-    fn send_event(&self, event: PositronEvent) -> Result<(), Error> {
-        let msg = JupyterMessage::<ClientEvent>::create(
-            ClientEvent::from(event),
-            None,
-            &self.socket.session,
-        );
         msg.send(&self.socket)
     }
 

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -282,7 +282,7 @@ pub struct RMain {
 
     /// Shared reference to kernel. Currently used by the ark-execution
     /// thread, the R frontend callbacks, and LSP routines called from R
-    pub kernel: Arc<Mutex<Kernel>>,
+    kernel: Arc<Mutex<Kernel>>,
 
     /// Represents whether an error occurred during R code execution.
     pub error_occurred: bool,
@@ -1028,6 +1028,10 @@ impl RMain {
     pub fn get_comm_manager_tx(&self) -> &Sender<CommEvent> {
         // Read only access to `comm_manager_tx`
         &self.comm_manager_tx
+    }
+
+    pub fn get_kernel(&self) -> &Arc<Mutex<Kernel>> {
+        &self.kernel
     }
 }
 

--- a/crates/ark/src/kernel.rs
+++ b/crates/ark/src/kernel.rs
@@ -11,7 +11,6 @@ use std::result::Result::Err;
 use amalthea::events::BusyEvent;
 use amalthea::events::PositronEvent;
 use amalthea::events::WorkingDirectoryEvent;
-use amalthea::socket::iopub::IOPubMessage;
 use anyhow::Result;
 use crossbeam::channel::Sender;
 use log::*;
@@ -22,16 +21,14 @@ use crate::request::KernelRequest;
 
 /// Represents the Rust state of the R kernel
 pub struct Kernel {
-    iopub_tx: Sender<IOPubMessage>,
     event_tx: Option<Sender<PositronEvent>>,
     working_directory: PathBuf,
 }
 
 impl Kernel {
     /// Create a new R kernel instance
-    pub fn new(iopub_tx: Sender<IOPubMessage>) -> Self {
+    pub fn new() -> Self {
         Self {
-            iopub_tx,
             event_tx: None,
             working_directory: PathBuf::new(),
         }
@@ -43,14 +40,6 @@ impl Kernel {
             KernelRequest::EstablishEventChannel(sender) => {
                 self.establish_event_handler(sender.clone())
             },
-            KernelRequest::DeliverEvent(event) => self.handle_event(event),
-        }
-    }
-
-    /// Handle an event from the back end to the front end
-    pub fn handle_event(&mut self, event: &PositronEvent) {
-        if let Err(err) = self.iopub_tx.send(IOPubMessage::Event(event.clone())) {
-            warn!("Error attempting to deliver client event: {}", err);
         }
     }
 

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -48,7 +48,6 @@ use crate::lsp::signature_help::signature_help;
 use crate::lsp::statement_range;
 use crate::lsp::symbols;
 use crate::r_task;
-use crate::request::KernelRequest;
 
 #[macro_export]
 macro_rules! backend_trace {
@@ -78,8 +77,6 @@ pub struct Backend {
     pub client: Client,
     pub documents: Arc<DashMap<Url, Document>>,
     pub workspace: Arc<Mutex<Workspace>>,
-    #[allow(dead_code)]
-    pub kernel_request_tx: Sender<KernelRequest>,
 }
 
 impl Backend {
@@ -604,11 +601,7 @@ impl Backend {
 }
 
 #[tokio::main]
-pub async fn start_lsp(
-    address: String,
-    kernel_request_tx: Sender<KernelRequest>,
-    conn_init_tx: Sender<bool>,
-) {
+pub async fn start_lsp(address: String, conn_init_tx: Sender<bool>) {
     #[cfg(feature = "runtime-agnostic")]
     use tokio_util::compat::TokioAsyncReadCompatExt;
     #[cfg(feature = "runtime-agnostic")]
@@ -631,14 +624,13 @@ pub async fn start_lsp(
 
     let init = |client: Client| {
         // initialize shared globals (needed for R callbacks)
-        globals::initialize(client.clone(), kernel_request_tx.clone());
+        globals::initialize(client.clone());
 
         // create backend
         let backend = Backend {
             client,
             documents: DOCUMENT_INDEX.clone(),
             workspace: Arc::new(Mutex::new(Workspace::default())),
-            kernel_request_tx: kernel_request_tx.clone(),
         };
 
         backend

--- a/crates/ark/src/lsp/globals.rs
+++ b/crates/ark/src/lsp/globals.rs
@@ -5,10 +5,7 @@
 //
 //
 
-use crossbeam::channel::Sender;
 use tower_lsp::Client;
-
-use crate::request::KernelRequest;
 
 // The global state used by R callbacks.
 //
@@ -19,20 +16,16 @@ pub(super) static mut R_CALLBACK_GLOBALS: Option<RCallbackGlobals> = None;
 
 pub(super) struct RCallbackGlobals {
     pub(super) lsp_client: Client,
-    pub(super) kernel_request_tx: Sender<KernelRequest>,
 }
 
 impl RCallbackGlobals {
-    fn new(lsp_client: Client, kernel_request_tx: Sender<KernelRequest>) -> Self {
-        Self {
-            lsp_client,
-            kernel_request_tx,
-        }
+    fn new(lsp_client: Client) -> Self {
+        Self { lsp_client }
     }
 }
 
-pub fn initialize(lsp_client: Client, kernel_request_tx: Sender<KernelRequest>) {
+pub fn initialize(lsp_client: Client) {
     unsafe {
-        R_CALLBACK_GLOBALS = Some(RCallbackGlobals::new(lsp_client, kernel_request_tx));
+        R_CALLBACK_GLOBALS = Some(RCallbackGlobals::new(lsp_client));
     }
 }

--- a/crates/ark/src/lsp/handler.rs
+++ b/crates/ark/src/lsp/handler.rs
@@ -13,21 +13,15 @@ use stdext::spawn;
 
 use super::backend;
 use crate::interface::KernelInfo;
-use crate::request::KernelRequest;
 
 pub struct Lsp {
-    kernel_request_tx: Sender<KernelRequest>,
     kernel_init_rx: BusReader<KernelInfo>,
     kernel_initialized: bool,
 }
 
 impl Lsp {
-    pub fn new(
-        kernel_request_tx: Sender<KernelRequest>,
-        kernel_init_rx: BusReader<KernelInfo>,
-    ) -> Self {
+    pub fn new(kernel_init_rx: BusReader<KernelInfo>) -> Self {
         Self {
-            kernel_request_tx,
             kernel_init_rx,
             kernel_initialized: false,
         }
@@ -53,10 +47,8 @@ impl ServerHandler for Lsp {
             self.kernel_initialized = true;
         }
 
-        let kernel_request_tx = self.kernel_request_tx.clone();
-
         spawn!("ark-lsp", move || {
-            backend::start_lsp(tcp_address, kernel_request_tx, conn_init_tx)
+            backend::start_lsp(tcp_address, conn_init_tx)
         });
         return Ok(());
     }

--- a/crates/ark/src/lsp/show_message.rs
+++ b/crates/ark/src/lsp/show_message.rs
@@ -9,37 +9,28 @@ use amalthea::events::PositronEvent;
 use amalthea::events::ShowMessageEvent;
 use harp::object::RObject;
 use libR_sys::*;
-use stdext::local;
 use stdext::unwrap;
 
-use crate::lsp::globals::R_CALLBACK_GLOBALS;
-use crate::request::KernelRequest;
+use crate::interface::RMain;
 
 /// Shows a message in the Positron frontend
+///
+/// Test helper for `R_ShowMessage()` support
 #[harp::register]
 pub unsafe extern "C" fn ps_show_message(message: SEXP) -> SEXP {
-    let result: anyhow::Result<()> = local! {
-        // Convert message to a string
-        let message = RObject::view(message).to::<String>()?;
-
-        // Get the global instance of the channel used to deliver requests to the
-        // front end, and send a request to show the message
-        let event = PositronEvent::ShowMessage(ShowMessageEvent { message });
-        let event = KernelRequest::DeliverEvent(event);
-
-        let globals = R_CALLBACK_GLOBALS.as_ref().unwrap();
-
-        let status = unwrap!(globals.kernel_request_tx.send(event), Err(error) => {
-            anyhow::bail!("Error sending request: {}", error);
-        });
-
-        Ok(status)
-    };
-
-    let _result = unwrap!(result, Err(error) => {
-        log::error!("{}", error);
-        return Rf_ScalarLogical(0);
+    // Convert message to a string
+    let message = unwrap!(RObject::view(message).to::<String>(), Err(error) => {
+        log::error!("Failed to convert `message` to a string: {error:?}.");
+        return R_NilValue;
     });
 
-    Rf_ScalarLogical(1)
+    let main = RMain::get();
+
+    // Send a request to show the message
+    let event = PositronEvent::ShowMessage(ShowMessageEvent { message });
+
+    let kernel = main.get_kernel().lock().unwrap();
+    kernel.send_event(event);
+
+    R_NilValue
 }

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -63,10 +63,7 @@ fn start_kernel(
     // Create the LSP and DAP clients.
     // Not all Amalthea kernels provide these, but ark does.
     // They must be able to deliver messages to the shell channel directly.
-    let lsp = Arc::new(Mutex::new(lsp::handler::Lsp::new(
-        kernel_request_tx.clone(),
-        kernel_init_tx.add_rx(),
-    )));
+    let lsp = Arc::new(Mutex::new(lsp::handler::Lsp::new(kernel_init_tx.add_rx())));
 
     // DAP needs the `RRequest` channel to communicate with
     // `read_console()` and send commands to the debug interpreter

--- a/crates/ark/src/request.rs
+++ b/crates/ark/src/request.rs
@@ -49,7 +49,4 @@ pub fn debug_request_command(req: DebugRequest) -> String {
 pub enum KernelRequest {
     /// Establish a channel to the front end to send events
     EstablishEventChannel(Sender<PositronEvent>),
-
-    /// Deliver an event to the front end
-    DeliverEvent(PositronEvent),
 }

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -84,7 +84,7 @@ impl Shell {
         kernel_request_rx: Receiver<KernelRequest>,
     ) -> Self {
         // Start building the kernel object. It is shared by the shell, LSP, and main threads.
-        let kernel = Arc::new(Mutex::new(Kernel::new(iopub_tx.clone())));
+        let kernel = Arc::new(Mutex::new(Kernel::new()));
 
         let kernel_clone = kernel.clone();
         spawn!("ark-shell-thread", move || {


### PR DESCRIPTION
I noticed that our `PositronEvent` handling code was oddly complicated because we had both `send_event()` (which forwards over `ark-comm-frontend`) and `handle_event()` (which sends a custom IOPub message).

We have moved away from the custom IOPub message for everything except `ps_show_message()`, a test hook used to test `R_ShowMessage()` capabilities. This actually isn't even hooked up on the frontend AFAICT (search for `ShowMessageEvent` in Positron itself). I switched this over to use `send_event()`, which is how it should eventually be handled once we support this in the frontend, and it also aligns with how our `r_show_message()` hook in RMain already works. I also removed the usage of globals here in favor of `RMain` (woo!).

This in turn let me remove our custom `IOPubMessage::Event`, so now we are almost 100% in spec for IOPub messages (we have 1 custom `Wait` message that I recently added, but otherwise we are aligned with the spec)

All of this allowed me to remove quite a bit of dead code, which is pretty nice!


---

We have one remaining usage of `R_CALLBACK_GLOBALS` in `ps_editor()` where we need the LSP client object. This isn't part of RMain, so itll be a little more tricky to remove, but it sure would be nice if we could remove that!