### PR TITLE
Don't derive `Ord` and `PartialOrd` for `RSymbol`

### DIFF
--- a/crates/harp/src/symbol.rs
+++ b/crates/harp/src/symbol.rs
@@ -5,19 +5,21 @@
 //
 //
 
+use std::cmp::Ordering;
 use std::ffi::CStr;
 use std::ops::Deref;
 
 use libR_sys::*;
 
 use crate::error::Result;
+use crate::object::r_length;
 use crate::r_symbol;
 use crate::utils::r_assert_type;
 use crate::utils::r_str_to_owned_utf8_unchecked;
 use crate::utils::Sxpinfo;
 use crate::utils::HASHASH_MASK;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RSymbol {
     pub sexp: SEXP,
 }
@@ -34,6 +36,29 @@ impl RSymbol {
 
     pub fn has_hash(&self) -> bool {
         unsafe { (Sxpinfo::interpret(&PRINTNAME(self.sexp)).gp() & HASHASH_MASK) == 1 }
+    }
+}
+
+impl Ord for RSymbol {
+    fn cmp(&self, other: &Self) -> Ordering {
+        unsafe {
+            let self_char = PRINTNAME(self.sexp);
+            let other_char = PRINTNAME(other.sexp);
+
+            let self_nchar = r_length(self_char) as usize;
+            let other_nchar = r_length(other_char) as usize;
+
+            let self_slice = std::slice::from_raw_parts(R_CHAR(self_char), self_nchar);
+            let other_slice = std::slice::from_raw_parts(R_CHAR(other_char), other_nchar);
+
+            Ord::cmp(self_slice, other_slice)
+        }
+    }
+}
+
+impl PartialOrd for RSymbol {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -77,6 +102,21 @@ impl PartialEq<&str> for RSymbol {
             let utf8text = Rf_translateCharUTF8(PRINTNAME(self.sexp));
             vmaxset(vmax);
             CStr::from_ptr(utf8text).to_str().unwrap() == *other
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::r_test;
+    use crate::symbol::RSymbol;
+
+    #[test]
+    fn test_rsymbol_ord() {
+        r_test! {
+            let mut x = vec![RSymbol::from("z"), RSymbol::from("m"), RSymbol::from("a")];
+            x.sort();
+            assert_eq!(x, vec![RSymbol::from("a"), RSymbol::from("m"), RSymbol::from("z")]);
         }
     }
 }


### PR DESCRIPTION
Compare the string data instead of the addresses.

Somehow the `sort()` test I added causes a crash without the new implementations but I don't know why.

There is no behaviour change in the variables pane, so I'm not sure whether the `sort()` you pointed me to has any impact @DavisVaughan.