### PR TITLE
Unwrap Rust errors for all registered `.Call` callbacks

### DIFF
--- a/crates/ark/src/browser.rs
+++ b/crates/ark/src/browser.rs
@@ -18,7 +18,7 @@ use crate::interface::RMain;
 pub static mut PORT: u16 = 0;
 
 #[harp::register]
-pub unsafe extern "C" fn ps_browse_url(url: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_browse_url(url: SEXP) -> Result<SEXP> {
     ps_browse_url_impl(url).or_else(|err| {
         log::error!("{err:?}");
         Ok(Rf_ScalarLogical(0))

--- a/crates/ark/src/data_viewer/r_data_viewer.rs
+++ b/crates/ark/src/data_viewer/r_data_viewer.rs
@@ -433,7 +433,7 @@ impl RDataViewer {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_view_data_frame(x: SEXP, title: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_view_data_frame(x: SEXP, title: SEXP) -> anyhow::Result<SEXP> {
     let x = RObject::new(x);
 
     let title = RObject::new(title);

--- a/crates/ark/src/errors.rs
+++ b/crates/ark/src/errors.rs
@@ -15,7 +15,7 @@ use stdext::unwrap;
 use crate::interface::RMain;
 
 #[harp::register]
-unsafe extern "C" fn ps_record_error(evalue: SEXP, traceback: SEXP) -> SEXP {
+unsafe extern "C" fn ps_record_error(evalue: SEXP, traceback: SEXP) -> anyhow::Result<SEXP> {
     let main = RMain::get_mut();
 
     // Convert to `RObject` for access to `try_from()` / `try_into()` methods.
@@ -52,7 +52,7 @@ pub unsafe fn initialize() {
 }
 
 #[harp::register]
-unsafe extern "C" fn ps_rust_backtrace() -> SEXP {
+unsafe extern "C" fn ps_rust_backtrace() -> anyhow::Result<SEXP> {
     let trace = std::backtrace::Backtrace::capture();
     let trace = format!("{trace}");
     Ok(*RObject::from(trace))

--- a/crates/ark/src/html_widget.rs
+++ b/crates/ark/src/html_widget.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use crate::interface::RMain;
 
 #[harp::register]
-pub unsafe extern "C" fn ps_html_widget(kind: SEXP, tags: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_html_widget(kind: SEXP, tags: SEXP) -> Result<SEXP, anyhow::Error> {
     // For friendly display: the class/kind of the widget
     let widget_class = String::try_from(RObject::view(kind))?;
 

--- a/crates/ark/src/json.rs
+++ b/crates/ark/src/json.rs
@@ -10,7 +10,7 @@ use libR_sys::SEXP;
 
 /// Convenience method to convert a JSON object to a string
 #[harp::register]
-pub unsafe extern "C" fn ps_to_json(obj: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_to_json(obj: SEXP) -> anyhow::Result<SEXP> {
     let obj = RObject::view(obj);
 
     // Convert the object to a JSON value; this is the core serialization step

--- a/crates/ark/src/lsp/editor.rs
+++ b/crates/ark/src/lsp/editor.rs
@@ -16,7 +16,7 @@ use tower_lsp::lsp_types::Url;
 use crate::lsp::globals::R_CALLBACK_GLOBALS;
 
 #[harp::register]
-unsafe extern "C" fn ps_editor(file: SEXP, _title: SEXP) -> SEXP {
+unsafe extern "C" fn ps_editor(file: SEXP, _title: SEXP) -> anyhow::Result<SEXP> {
     let rt = Runtime::new().unwrap();
     let globals = R_CALLBACK_GLOBALS.as_ref().unwrap();
     let files = CharacterVector::new_unchecked(file);

--- a/crates/ark/src/lsp/show_message.rs
+++ b/crates/ark/src/lsp/show_message.rs
@@ -17,7 +17,7 @@ use crate::interface::RMain;
 ///
 /// Test helper for `R_ShowMessage()` support
 #[harp::register]
-pub unsafe extern "C" fn ps_show_message(message: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_show_message(message: SEXP) -> anyhow::Result<SEXP> {
     // Convert message to a string
     let message = unwrap!(RObject::view(message).to::<String>(), Err(error) => {
         log::error!("Failed to convert `message` to a string: {error:?}.");

--- a/crates/ark/src/lsp/treesitter.rs
+++ b/crates/ark/src/lsp/treesitter.rs
@@ -11,7 +11,10 @@ use libR_sys::SEXP;
 use tree_sitter::Node;
 
 #[harp::register]
-pub unsafe extern "C" fn ps_treesitter_node_text(node_ptr: SEXP, source_ptr: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_treesitter_node_text(
+    node_ptr: SEXP,
+    source_ptr: SEXP,
+) -> anyhow::Result<SEXP> {
     let node = ExternalPointer::<Node>::reference(node_ptr);
     let source = ExternalPointer::<&str>::reference(source_ptr);
 
@@ -20,7 +23,7 @@ pub unsafe extern "C" fn ps_treesitter_node_text(node_ptr: SEXP, source_ptr: SEX
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_treesitter_node_kind(node_ptr: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_treesitter_node_kind(node_ptr: SEXP) -> anyhow::Result<SEXP> {
     let node = ExternalPointer::<Node>::reference(node_ptr);
 
     Ok(*RObject::from(node.kind()))

--- a/crates/ark/src/lsp/util.rs
+++ b/crates/ark/src/lsp/util.rs
@@ -12,7 +12,7 @@ use libR_sys::*;
 
 /// Shows a message in the Positron frontend
 #[harp::register]
-pub unsafe extern "C" fn ps_log_error(message: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_log_error(message: SEXP) -> anyhow::Result<SEXP> {
     let message = RObject::view(message).to::<String>();
     if let Ok(message) = message {
         log::error!("{}", message);
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn ps_log_error(message: SEXP) -> SEXP {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_object_id(object: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_object_id(object: SEXP) -> anyhow::Result<SEXP> {
     let value = format!("{:p}", object);
     return Ok(Rf_mkString(value.as_ptr() as *const c_char));
 }

--- a/crates/ark/src/modules.rs
+++ b/crates/ark/src/modules.rs
@@ -245,7 +245,7 @@ pub unsafe fn import(file: &Path) -> anyhow::Result<()> {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_deep_sleep(secs: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_deep_sleep(secs: SEXP) -> anyhow::Result<SEXP> {
     let secs = Rf_asInteger(secs);
     let secs = std::time::Duration::from_secs(secs as u64);
     std::thread::sleep(secs);

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -540,7 +540,7 @@ unsafe fn ps_graphics_device_impl() -> anyhow::Result<SEXP> {
 }
 
 #[harp::register]
-unsafe extern "C" fn ps_graphics_device() -> SEXP {
+unsafe extern "C" fn ps_graphics_device() -> anyhow::Result<SEXP> {
     ps_graphics_device_impl().or_else(|err| {
         log::error!("{}", err);
         Ok(R_NilValue)
@@ -548,7 +548,7 @@ unsafe extern "C" fn ps_graphics_device() -> SEXP {
 }
 
 #[harp::register]
-unsafe extern "C" fn ps_graphics_event(_name: SEXP) -> SEXP {
+unsafe extern "C" fn ps_graphics_event(_name: SEXP) -> anyhow::Result<SEXP> {
     let id = unwrap!(DEVICE_CONTEXT._id.clone(), None => {
         return Ok(Rf_ScalarLogical(0));
     });

--- a/crates/ark/src/version.rs
+++ b/crates/ark/src/version.rs
@@ -70,7 +70,7 @@ pub fn detect_r() -> anyhow::Result<RVersion> {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ark_version() -> SEXP {
+pub unsafe extern "C" fn ps_ark_version() -> anyhow::Result<SEXP> {
     let mut info = HashMap::<String, String>::new();
     // Set the version info in the map
     info.insert(

--- a/crates/ark/src/viewer.rs
+++ b/crates/ark/src/viewer.rs
@@ -41,7 +41,7 @@ fn emit_html_output(iopub_tx: Sender<IOPubMessage>, path: String) -> Result<()> 
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_html_viewer(url: SEXP) -> SEXP {
+pub unsafe extern "C" fn ps_html_viewer(url: SEXP) -> anyhow::Result<SEXP> {
     // Convert url to a string; note that we are only passed URLs that
     // correspond to files in the temporary directory.
     let path = RObject::view(url).to::<String>();


### PR DESCRIPTION
Implements @jmcphers's idea in https://github.com/posit-dev/amalthea/pull/146#discussion_r1397681610. All functions registered for `.Call()` now must return a `Result`. Rust Errors are automatically converted into R errors at the Rust/R boundary.

In addition, we now sandbox the wrappers to:

- Disable interrupts and condition catching over our Rust stacks.
- Detect unexpected R errors and convert to panics.

I'm a bit concerned that this is disabling interrupts without a timeout mechanism so I left a TODO note about this.