### PR TITLE
Fix `library()` completions when user has typed prefix

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -65,9 +65,18 @@ pub(super) fn completions_from_call(
     // fn(name = value)
     //    ~~~~
     //
-    if call_node_position_type(&context.node, context.point) != CallNodePositionType::Name {
-        return Ok(None);
-    }
+    match call_node_position_type(&context.node, context.point) {
+        // We should provide argument completions. Ambiguous states like
+        // `fn(arg<tab>)` or `fn(x, arg<tab>)` should still get argument
+        // completions.
+        CallNodePositionType::Name => (),
+        CallNodePositionType::Ambiguous => (),
+        // We shouldn't provide argument completions, let another source
+        // contribute completions
+        CallNodePositionType::Value |
+        CallNodePositionType::Outside |
+        CallNodePositionType::Unknown => return Ok(None),
+    };
 
     // Get the caller text.
     let Some(callee) = node.child(0) else {
@@ -206,4 +215,42 @@ fn completions_from_arguments(
     set_sort_text_by_first_appearance(&mut completions);
 
     Ok(completions)
+}
+
+#[cfg(test)]
+mod tests {
+    use tree_sitter::Point;
+
+    use crate::lsp::completions::sources::composite::call::completions_from_call;
+    use crate::lsp::document_context::DocumentContext;
+    use crate::lsp::documents::Document;
+    use crate::test::r_test;
+
+    #[test]
+    fn test_completions_after_user_types_part_of_an_argument_name() {
+        r_test(|| {
+            // Right after `tab`
+            let point = Point { row: 0, column: 9 };
+            let document = Document::new("match(tab)");
+            let context = DocumentContext::new(&document, point);
+            let completions = completions_from_call(&context, None).unwrap().unwrap();
+
+            // We detect this as a `name` position and return all possible completions
+            assert_eq!(completions.len(), 4);
+            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.get(1).unwrap().label, "table = ");
+
+            // Right after `tab`
+            let point = Point { row: 0, column: 12 };
+            let document = Document::new("match(1, tab)");
+            let context = DocumentContext::new(&document, point);
+            let completions = completions_from_call(&context, None).unwrap().unwrap();
+
+            // We detect this as a `name` position and return all possible completions
+            // (TODO: Should not return `x` as a possible completion)
+            assert_eq!(completions.len(), 4);
+            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.get(1).unwrap().label, "table = ");
+        })
+    }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -115,11 +115,17 @@ pub fn completions_from_custom_source_impl(
     // provide certain completions in the 'name' position.
     let position = match call_node_position_type(&node, point) {
         CallNodePositionType::Name => "name",
+        // Currently mapping ambiguous `fn(arg<tab>)` to `"name"`, but we could
+        // return `"ambiguous"` and allow our handlers to handle this individually
+        CallNodePositionType::Ambiguous => "name",
         CallNodePositionType::Value => "value",
-        CallNodePositionType::Other => "value",
         CallNodePositionType::Outside => {
-            // Call detected, but possibly on the RHS of a `)` node or the LHS
+            // Call detected, but on the RHS of a `)` node or the LHS
             // of a `(` node, i.e. outside the parenthesis.
+            return Ok(None);
+        },
+        CallNodePositionType::Unknown => {
+            // Call detected, but inside some very odd edge case
             return Ok(None);
         },
     };

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -87,12 +87,13 @@ pub(super) fn filter_out_dot_prefixes(
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub(super) enum CallNodePositionType {
     Name,
     Value,
+    Ambiguous,
     Outside,
-    Other,
+    Unknown,
 }
 
 pub(super) fn call_node_position_type(node: &Node, point: Point) -> CallNodePositionType {
@@ -113,26 +114,52 @@ pub(super) fn call_node_position_type(node: &Node, point: Point) -> CallNodePosi
             } else {
                 // Let previous leaf determine type (i.e. did the `)`
                 // follow a `=` or a `,`?)
-                match node.prev_leaf() {
-                    Some(node) => return call_node_position_type(&node, point),
-                    None => return CallNodePositionType::Other,
-                }
+                return call_prev_leaf_position_type(&node, false);
             }
         },
         "comma" => return CallNodePositionType::Name,
         "=" => return CallNodePositionType::Value,
+        // Like `fn(arg<tab>)` or `fn(x = 1, arg<tab>)` (which are ambiguous)
+        // or `fn(x = arg<tab>)` (which is clearly a `Value`)
+        "identifier" => return call_prev_leaf_position_type(&node, true),
         _ => {
+            // Probably a complex node inside `()`. Typically a `Value`
+            // unless we are at the very beginning of the node.
+
+            // For things like `vctrs::vec_sort(x = 1, |2)` where you typed
+            // the argument value but want to go back and fill in the name.
             if point == node.start_position() {
-                // For things like `vctrs::vec_sort(x = 1, |2)` where you typed
-                // the argument value but want to go back and fill in the name.
-                match node.prev_leaf() {
-                    Some(node) => return call_node_position_type(&node, point),
-                    None => return CallNodePositionType::Other,
-                }
+                return call_prev_leaf_position_type(&node, false);
+            }
+
+            return CallNodePositionType::Value;
+        },
+    }
+}
+
+fn call_prev_leaf_position_type(node: &Node, allow_ambiguous: bool) -> CallNodePositionType {
+    let Some(previous) = node.prev_leaf() else {
+        // We expect a previous leaf to exist anywhere we use this, so if it
+        // doesn't exist then we return this marker type that tells us we should
+        // probably investigate our heuristics.
+        log::warn!(
+            "Expected `node` to have a previous leaf. Is `call_node_position_type()` written correctly?"
+        );
+        return CallNodePositionType::Unknown;
+    };
+
+    match previous.kind() {
+        "(" | "comma" => {
+            if allow_ambiguous {
+                // i.e. `fn(arg<tab>)` or `fn(x, arg<tab>)` where it can be
+                // ambiguous whether we are on a `Name` or a `Value`.
+                return CallNodePositionType::Ambiguous;
             } else {
-                return CallNodePositionType::Other;
+                return CallNodePositionType::Name;
             }
         },
+        "=" => return CallNodePositionType::Value,
+        _ => return CallNodePositionType::Value,
     }
 }
 
@@ -195,4 +222,147 @@ pub(super) fn completions_from_object_names(
     }
 
     Ok(completions)
+}
+
+#[cfg(test)]
+mod tests {
+    use tree_sitter::Point;
+
+    use crate::lsp::completions::sources::utils::call_node_position_type;
+    use crate::lsp::completions::sources::utils::CallNodePositionType;
+    use crate::lsp::document_context::DocumentContext;
+    use crate::lsp::documents::Document;
+
+    #[test]
+    fn test_call_node_position_type() {
+        // Before `(`, but on it
+        let point = Point { row: 0, column: 3 };
+        let document = Document::new("fn ()");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "(");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Outside
+        );
+
+        // After `)`, but on it
+        let point = Point { row: 0, column: 4 };
+        let document = Document::new("fn()");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), ")");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Outside
+        );
+
+        // After `(`, but on it
+        let point = Point { row: 0, column: 3 };
+        let document = Document::new("fn()");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "(");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Name
+        );
+
+        // After `x`
+        let point = Point { row: 0, column: 4 };
+        let document = Document::new("fn(x)");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Ambiguous
+        );
+
+        // After `x`
+        let point = Point { row: 0, column: 7 };
+        let document = Document::new("fn(1, x)");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Ambiguous
+        );
+
+        // Directly after `,`
+        let point = Point { row: 0, column: 5 };
+        let document = Document::new("fn(x, )");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "comma");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Name
+        );
+
+        // After `,`, but on `)`
+        let point = Point { row: 0, column: 6 };
+        let document = Document::new("fn(x, )");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), ")");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Name
+        );
+
+        // After `=`
+        let point = Point { row: 0, column: 6 };
+        let document = Document::new("fn(x =)");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "=");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Value
+        );
+
+        // In an expression
+        let point = Point { row: 0, column: 4 };
+        let document = Document::new("fn(1 + 1)");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "float");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Value
+        );
+
+        let point = Point { row: 0, column: 8 };
+        let document = Document::new("fn(1 + 1)");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "float");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Value
+        );
+
+        // Right before an expression
+        // (special case where we still provide argument completions)
+        let point = Point { row: 0, column: 6 };
+        let document = Document::new("fn(1, 1 + 1)");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "float");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Name
+        );
+
+        // After an identifier, before the `)`, with whitespace between them,
+        // but on the `)`
+        let point = Point { row: 0, column: 5 };
+        let document = Document::new("fn(x )");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), ")");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Value
+        );
+
+        // After an identifier, before the `)`, with whitespace between them,
+        // but on the identifier
+        let point = Point { row: 0, column: 4 };
+        let document = Document::new("fn(x )");
+        let context = DocumentContext::new(&document, point);
+        assert_eq!(context.node.kind(), "identifier");
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Ambiguous
+        );
+    }
 }


### PR DESCRIPTION
Addresses posit-dev/positron#1887.
Addresses https://github.com/posit-dev/positron/issues/127#issuecomment-1824045147

After the recent update to completions this is no longer handled by the `library()` handler:

```r
library(dpl<>)
```

That's because of the way arguments categorised as "Other" by `call_node_position_type()` are treated. The previous implementation used "value" as default position type and passed that to the `library()` completion handler. This is no longer the case which causes the handler to be ignored when the user has typed some characters.

The new implementation has improved detection of positions outside of delimiters but these are subsumed in the "Other" category. To fix this I added an enum value "Outside" to untangle outside positions and ambiguous positions. And we now treat the latter as "value", as before.

Maybe the category for ambiguous positions should be renamed from "Other" to "Ambiguous"? At least that's how I interpret this category. We treat `foo(<>)` as name, `foo(bar = <>)` as value, and `foo(bar<>)` could be either?