### PR TITLE
Further refine / test `call_node_position_type()`

### DIFF
--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -115,6 +115,9 @@ pub fn completions_from_custom_source_impl(
     // provide certain completions in the 'name' position.
     let position = match call_node_position_type(&node, point) {
         CallNodePositionType::Name => "name",
+        // Currently mapping ambiguous `fn(arg<tab>)` to `"name"`, but we could
+        // return `"ambiguous"` and allow our handlers to handle this individually
+        CallNodePositionType::Ambiguous => "name",
         CallNodePositionType::Value => "value",
         CallNodePositionType::Outside => {
             // Call detected, but on the RHS of a `)` node or the LHS


### PR DESCRIPTION
@lionel- this further refines your PR and merges into it. I was aware of this issue and planned to come back to it with a few additional ideas. It also affects call completions, i.e.

```r
vctrs::vec_sort(dire<tab>)
```

this currently doesn't provide `direction =` as a completion option due to the same problem (fixed with this PR).

---

It is also the root cause of https://github.com/posit-dev/positron/issues/127#issuecomment-1824045147

---

For the purpose of `call_node_position_type()`, I don't _think_ we need an `Ambiguous` variant. I think `fn(x<tab>)` can always be considered a `name` position for what this is used for. I think we can consider coming back to this in the future and adding that in if we need to do something special there.

I've gone through and removed the recursion from `call_node_position_type()`. I don't think we need it, as I don't think we actually need to look beyond the "previous leaf" to determine the position type. I think this makes it a little easier to think about all of the possible states, and works well for all of the new test cases I added (based on all the minor issues we've discovered).