### PR TITLE
Add rpc handlers for help/vignette link display

### DIFF
--- a/crates/ark/src/modules/public/help.R
+++ b/crates/ark/src/modules/public/help.R
@@ -57,7 +57,7 @@ options(help_type = "html")
     results <- suppressWarnings(vignette(topic, package = package))
 
     # If we found a vignette, show it.
-    if (is(results, "vignette")) {
+    if ("vignette" %in% class(results)) {
         print(results)
         TRUE
     } else {


### PR DESCRIPTION
Adds a couple of quick RPC handlers so we can handle help and vignette links in Positron,.