### PR TITLE
Highlight potential need to set R_HOME when building ARK (libr-sys, really) on Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,14 +3,16 @@
     "tasks": [
         {
             "type": "shell",
-            "command": "cargo build && scripts/post-install.sh",
+            "osx": {
+                "command": "cargo build && scripts/post-install.sh"
+            },
             "windows": {
-                "command": "cargo build",
-                "options": {
-                    "env": {
-                        "R_HOME": "C:\\Program Files\\R\\R-4.3.2"
-                    }
-                }
+                // Note that the environment variable, R_HOME, must be set prior to `cargo build`
+                // in order to build the ark dependency libR-sys. Once libR-sys is built,
+                // R_HOME is not required for subsequent runs of `cargo build`.
+                // Execute something like the following in a terminal prior to running `cargo build`:
+                // set R_HOME=C:\Program Files\R\R-4.3.2
+                "command": "cargo build"
             },
             "problemMatcher": [
                 "$rustc"


### PR DESCRIPTION
This is a small quality of life improvement that:

* Makes Cmd/Ctrl + Shift + B work on Windows, i.e. the default build task
* Sets the `R_HOME` env var prior to build