### PR TITLE
Rebuild LSP service, socket, and client on reconnect

### DIFF
--- a/crates/ark/src/lsp/editor.rs
+++ b/crates/ark/src/lsp/editor.rs
@@ -18,7 +18,11 @@ use crate::interface::RMain;
 unsafe extern "C" fn ps_editor(file: SEXP, _title: SEXP) -> anyhow::Result<SEXP> {
     let main = RMain::get();
     let runtime = main.get_lsp_runtime();
-    let client = main.get_lsp_client();
+
+    let client = unwrap!(main.get_lsp_client(), None => {
+        log::error!("Failed to open file. LSP client has not been initialized.");
+        return Ok(R_NilValue);
+    });
 
     let files = CharacterVector::new_unchecked(file);
 

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -65,15 +65,12 @@ fn start_kernel(
     // Used in the main LSP thread and from R callbacks.
     // Not wrapped in a `Mutex` since none of the methods require a mutable reference.
     let lsp_runtime = Arc::new(tokio::runtime::Runtime::new().unwrap());
-    let (lsp_service, lsp_socket, lsp_client) = lsp::backend::build_lsp_service();
 
     // Create the LSP and DAP clients.
     // Not all Amalthea kernels provide these, but ark does.
     // They must be able to deliver messages to the shell channel directly.
     let lsp = Arc::new(Mutex::new(lsp::handler::Lsp::new(
         Arc::clone(&lsp_runtime),
-        lsp_service,
-        lsp_socket,
         kernel_init_tx.add_rx(),
     )));
 
@@ -142,7 +139,6 @@ fn start_kernel(
         iopub_tx,
         kernel_init_tx,
         lsp_runtime,
-        lsp_client,
         dap,
     )
 }

--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -250,12 +250,14 @@ fn get_tasks_tx() -> Sender<RTaskMain> {
         // and set `R_MAIN_TASKS_TX`
         drop(guard);
 
+        log::info!("`tasks_tx` not yet initialized, going to sleep for 100ms.");
+
         std::thread::sleep(Duration::from_millis(100));
 
         let elapsed = now.elapsed().unwrap().as_secs();
 
         if elapsed > 50 {
-            panic!("Can't acquire `tasks_tx`.");
+            panic!("Can't acquire `tasks_tx` after 50 seconds.");
         }
     }
 }


### PR DESCRIPTION
Follow up to #193 

I accidentally introduced a bug related to UI refreshes with `CMD + R`. If you run that with an active R session, then you should get a panic related to the LSP (something about unwrapping a `None`).

---

It turns out that we can't move the LSP service, socket, and client to `start_kernel()`. That code will get run exactly 1 time per ark session lifetime, but the `lsp_start()` method will get called every time the UI is refreshed (i.e. `CMD + R`) (which prompts a new `comm_open` request). This means we really do need "fresh" instances of these objects after each refresh.

Most of the code from #193 related to these objects is now reverted, moving their creation back into `start_lsp()`.

However, we now also use an `r_task()` to ship the `Client` over to `RMain` after each refresh.

`R_MAIN` actually _should_ be started up by the time we get here to call this `r_task()`, because the `Lsp::start()` method that calls `start_lsp()` will wait for the `kernel_init_tx` notification that is sent out by the first `r_read_console()` iteration, and `R_MAIN` exists at that point. I'm convinced that even if it didn't exist yet, then `r_task()` would correctly block until the channel for communicating with the main R thread was set up, due to `get_tasks_tx()`.

I did some testing and things like `usethis::edit_r_profile()` (which use the `Client` stored in `R_MAIN`) work as expected before and after a `CMD + R` refresh, which makes me somewhat confident that the client is getting refreshed properly.