### PR TITLE
Remove winsafe related hacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "winsafe"
-version = "0.0.18"
+version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03caf2c481af7a0a06c80ffb9c18daa3b3d23bd7a41be1284d71d49c59046ba6"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "yaml-rust"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -52,7 +52,7 @@ uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"
 yaml-rust = "0.4.5"
-winsafe = { version = "0.0.18", features = ["kernel"] }
+winsafe = { version = "0.0.19", features = ["kernel"] }
 
 [build-dependencies]
 chrono = "0.4.23"

--- a/crates/ark/src/sys/windows/strings.rs
+++ b/crates/ark/src/sys/windows/strings.rs
@@ -27,31 +27,13 @@ pub fn code_page_to_utf8(x: &[u8], code_page: CP) -> anyhow::Result<String> {
 
     let x = MultiByteToWideChar(code_page, flags, x)?;
 
-    // TODO: Windows
-    // winsafe currently adds an extra byte for safety, but that makes the strings too long
-    // and in our experience it has never been necessary. Remove this if it gets fixed.
-    // https://github.com/rodrigocfd/winsafe/issues/111
-    let size = x.len() - 1;
-    let x = &x[..size];
-
-    // `WC::NoValue` doesn't exist, so we make it unsafely:
-    // https://github.com/rodrigocfd/winsafe/issues/110
-    let flags = unsafe { WC::from_raw(0) };
+    let flags = WC::NoValue;
     let default_char = None;
     let used_default_char = None;
 
-    let x = WideCharToMultiByte(CP::UTF8, flags, x, default_char, used_default_char)?;
+    let x = WideCharToMultiByte(CP::UTF8, flags, &x, default_char, used_default_char)?;
 
-    // TODO: Windows
-    // winsafe currently adds an extra byte for safety, but that makes the strings too long
-    // and in our experience it has never been necessary. Remove this if it gets fixed.
-    // https://github.com/rodrigocfd/winsafe/issues/111
-    let size = x.len() - 1;
-    let x = &x[..size];
-
-    let x = std::str::from_utf8(x)?;
-
-    let x = x.to_string();
+    let x = String::from_utf8(x)?;
 
     Ok(x)
 }


### PR DESCRIPTION
winsafe finally updated to 0.0.19 on crates.io, so I can now remove some of the hacks for the issues I reported to them