### PR TITLE
New `lock_api` for `parking_lot` has released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "libr",
+ "lock_api",
  "log",
  "nix",
  "notify",
@@ -450,7 +451,7 @@ checksum = "34701d821c19736317bc716b8eb6153a78b431b06fbd3950716cedc705a6c811"
 dependencies = [
  "crossbeam-channel",
  "num_cpus",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -753,9 +754,9 @@ checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
  "hashbrown 0.12.3",
- "lock_api 0.4.9",
+ "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1158,6 +1159,7 @@ dependencies = [
  "libc",
  "libloading",
  "libr",
+ "lock_api",
  "log",
  "once_cell",
  "parking_lot",
@@ -1572,18 +1574,9 @@ checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "git+https://github.com/Amanieu/parking_lot?branch=master#d36110fde9b50adedbe4fcff8d3d42dbda92348a"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1847,10 +1840,11 @@ dependencies = [
 [[package]]
 name = "parking_lot"
 version = "0.12.1"
-source = "git+https://github.com/Amanieu/parking_lot?branch=master#d36110fde9b50adedbe4fcff8d3d42dbda92348a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.10",
- "parking_lot_core 0.9.8",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1864,18 +1858,6 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "git+https://github.com/Amanieu/parking_lot?branch=master#d36110fde9b50adedbe4fcff8d3d42dbda92348a"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.3.5",
- "smallvec",
- "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2197,15 +2179,6 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,3 @@ members = [
     "crates/libr",
     "crates/stdext"
 ]
-
-# For https://github.com/Amanieu/parking_lot/pull/390
-[patch.crates-io]
-parking_lot = { git = 'https://github.com/Amanieu/parking_lot', branch = 'master' }

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -31,6 +31,7 @@ itertools = "0.10.5"
 lazy_static = "1.4.0"
 libc = "0.2"
 libr = { path = "../libr" }
+lock_api = "0.4.11"
 log = "0.4.17"
 nix = { version = "0.26.2", features = ["signal"] }
 notify = "6.0.0"

--- a/crates/harp/Cargo.toml
+++ b/crates/harp/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1.4.0"
 libc = "0.2.140"
 libloading = "0.8.1"
 libr = { path = "../libr" }
+lock_api = "0.4.11"
 log = "0.4.17"
 once_cell = "1.17.1"
 parking_lot = "0.12.1"


### PR DESCRIPTION
We don't actually use the `ReentrantMutex` that this fix was intended for anymore:
https://github.com/Amanieu/parking_lot/pull/390

But I figure it is better to be safe and just bump it anyways.

At the very least it means we don't need the github dep anymore

(the fix happened in the sort-of-internal `lock_api` that `parking_lot` uses, so that's what we have to bump)