### PR TITLE
Stub for rstudio version needs to be a function

### DIFF
--- a/crates/ark/src/modules/rstudioapi/rstudioapi.R
+++ b/crates/ark/src/modules/rstudioapi/rstudioapi.R
@@ -1,7 +1,20 @@
 #' @export
-.rs.api.versionInfo <- list(
-    citation = NULL,
-    mode = "desktop",
-    version = package_version("2023.3"),
-    long_version = "2023.03.0"
-)
+.rs.api.versionInfo <- function() {
+    # comments are what rstudioapi actually does
+    # https://github.com/rstudio/rstudio/blob/bb729e14867f6f95e26600d8b38e4551402cf7de/src/cpp/r/R/Api.R#L135-L145
+    # info <- list()
+    list(
+        # info$citation <- .Call("rs_rstudioCitation", PACKAGE = "(embedding)")
+        citation = NULL,
+        # info$mode <- .Call("rs_rstudioProgramMode", PACKAGE = "(embedding)")
+        mode = "desktop",
+        # info$edition <- .Call("rs_rstudioEdition", PACKAGE = "(embedding)")
+        # info$version <- .Call("rs_rstudioVersion", PACKAGE = "(embedding)")
+        # info$version <- package_version(info$version)
+        version = package_version("2023.3"),
+        # info$long_version <- .Call("rs_rstudioLongVersion", PACKAGE = "(embedding)")
+        long_version = "2023.03.0"
+        # info$release_name <- .Call("rs_rstudioReleaseName", PACKAGE = "(embedding)")
+    )
+    #     info
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2106

`.rs.api.versionInfo()` needs to be a function because it will (or at least can) be `do.call()`'ed by rstudioapi:

https://github.com/rstudio/rstudioapi/blob/7bcdf15d81997c4e901d0eb2f7a67f20ebb6bb93/R/code.R#L68-L112