### PR TITLE
Prototype of `refresh_all_diagnostics()`

### DIFF
--- a/crates/ark/src/lsp/editor.rs
+++ b/crates/ark/src/lsp/editor.rs
@@ -20,8 +20,8 @@ unsafe extern "C" fn ps_editor(file: SEXP, _title: SEXP) -> anyhow::Result<SEXP>
     let main = RMain::get();
     let runtime = main.get_lsp_runtime();
 
-    let client = unwrap!(main.get_lsp_client(), None => {
-        log::error!("Failed to open file. LSP client has not been initialized.");
+    let backend = unwrap!(main.get_lsp_backend(), None => {
+        log::error!("Failed to open file. LSP backend has not been initialized.");
         return Ok(R_NilValue);
     });
 
@@ -61,7 +61,8 @@ unsafe extern "C" fn ps_editor(file: SEXP, _title: SEXP) -> anyhow::Result<SEXP>
     // https://github.com/posit-dev/positron/issues/1885
     for uri in uris.into_iter() {
         runtime.spawn(async move {
-            let result = client
+            let result = backend
+                .client
                 .show_document(ShowDocumentParams {
                     uri: uri.clone(),
                     external: Some(false),

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -51,6 +51,7 @@ use crate::help::r_help::RHelp;
 use crate::interface::KernelInfo;
 use crate::interface::RMain;
 use crate::kernel::Kernel;
+use crate::lsp::diagnostics;
 use crate::plots::graphics_device;
 use crate::r_task;
 use crate::request::KernelRequest;
@@ -236,6 +237,8 @@ impl ShellHandler for Shell {
                 kernel.ui_connected(),
             )
         };
+
+        diagnostics::refresh_all_diagnostics();
 
         // Check for changes to the working directory
         if let Err(err) = kernel.poll_working_directory() {


### PR DESCRIPTION
Doesn't currently work exactly right (too aggressive) because we don't have an accurate view of "all open documents" based on `did_open()` and `did_close()` events alone. It is currently intertwined with the "indexer", which adds all documents in the workspace to the DashMap too (so, wayyyy too many to run diagnostics on). We need to untangle this first in a separate PR.