### PR TITLE
Remove global `DOCUMENT_INDEX`

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -34,7 +34,6 @@ use crate::lsp::definitions::goto_definition;
 use crate::lsp::diagnostics;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::documents::Document;
-use crate::lsp::documents::DOCUMENT_INDEX;
 use crate::lsp::encoding::convert_position_to_point;
 use crate::lsp::encoding::get_position_encoding_kind;
 use crate::lsp::help_topic;
@@ -540,10 +539,12 @@ pub fn start_lsp(runtime: Arc<Runtime>, address: String, conn_init_tx: Sender<bo
                 }
             });
 
-            // create backend
+            // Create backend.
+            // Note that DashMap uses synchronization primitives internally, so we
+            // don't guard access to the map via a mutex.
             let backend = Backend {
                 client,
-                documents: DOCUMENT_INDEX.clone(),
+                documents: Arc::new(DashMap::new()),
                 workspace: Arc::new(Mutex::new(Workspace::default())),
             };
 

--- a/crates/ark/src/lsp/documents.rs
+++ b/crates/ark/src/lsp/documents.rs
@@ -5,15 +5,10 @@
 //
 //
 
-use std::sync::Arc;
-
 use anyhow::*;
-use dashmap::DashMap;
-use lazy_static::lazy_static;
 use ropey::Rope;
 use tower_lsp::lsp_types::DidChangeTextDocumentParams;
 use tower_lsp::lsp_types::TextDocumentContentChangeEvent;
-use tower_lsp::lsp_types::Url;
 use tree_sitter::InputEdit;
 use tree_sitter::Parser;
 use tree_sitter::Point;
@@ -21,18 +16,6 @@ use tree_sitter::Tree;
 
 use crate::lsp::encoding::convert_position_to_point;
 use crate::lsp::traits::rope::RopeExt;
-
-lazy_static! {
-
-    // The document index. Stored as a global since various components need to
-    // access the document index, and we want to do so without needing to share
-    // too many pieces everywhere.
-    //
-    // Note that DashMap uses synchronization primitives internally, so we
-    // don't guard access to the map via a mutex.
-    pub static ref DOCUMENT_INDEX: Arc<DashMap<Url, Document>> = Default::default();
-
-}
 
 fn compute_point(point: Point, text: &str) -> Point {
     // figure out where the newlines in this edit are

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -20,13 +20,11 @@ use ropey::Rope;
 use stdext::unwrap;
 use stdext::unwrap::IntoResult;
 use tower_lsp::lsp_types::Range;
-use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 use walkdir::DirEntry;
 use walkdir::WalkDir;
 
 use crate::lsp::documents::Document;
-use crate::lsp::documents::DOCUMENT_INDEX;
 use crate::lsp::encoding::convert_point_to_position;
 use crate::lsp::traits::rope::RopeExt;
 
@@ -172,13 +170,6 @@ fn index_file(path: &Path) -> Result<bool> {
     let document = Document::new(contents.as_str());
 
     index_document(&document, path)?;
-
-    if let Ok(url) = Url::from_file_path(path) {
-        let index = DOCUMENT_INDEX.clone();
-        if !index.contains_key(&url) {
-            index.insert(url, document);
-        }
-    }
 
     Ok(true)
 }


### PR DESCRIPTION
Should unblock https://github.com/posit-dev/amalthea/pull/218

Our workspace "indexer" was adding every file in the workspace into the `documents` DashMap used by the LSP. This was in addition to the LSP backend trying to track `did_open()` and `did_close()` events using the same `document` map. The indexer didn't actually use the `documents` map for anything, so all this was doing was making it difficult for the LSP to track "open" documents.