### PR TITLE
Bump Rust requirement to 1.75.0

### DIFF
--- a/crates/amalthea/Cargo.toml
+++ b/crates/amalthea/Cargo.toml
@@ -2,7 +2,7 @@
 name = "amalthea"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 
 [dependencies]
 amalthea-macros = { path = "./amalthea-macros" }

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ark"
 version = "0.1.47"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 description = """
 The Amalthea R Kernel.
 """

--- a/crates/echo/Cargo.toml
+++ b/crates/echo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "echo"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 
 [dependencies]
 amalthea = { path = "../amalthea" }

--- a/crates/harp/Cargo.toml
+++ b/crates/harp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "harp"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 description = """
 Tools for integrating R and Rust.
 """

--- a/crates/libr/Cargo.toml
+++ b/crates/libr/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libr"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 description = """
 Bindings to R's C API, resolved dynamically at runtime.
 """

--- a/crates/stdext/Cargo.toml
+++ b/crates/stdext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stdext"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 description = """
 Useful extensions to the Rust standard library.
 """


### PR DESCRIPTION
Now that we've resolved the warnings that come with it

```
rustup update stable
```

should update, and you should see:

```
rustc --version
rustc 1.75.0 (82e1608df 2023-12-21)

rustup default
stable-aarch64-apple-darwin (default)
```

Note that we still run rustfmt with nightly builds due to needing unstable options there https://github.com/posit-dev/amalthea/pull/11