### PR TITLE
Convert `\r\n` to `\n` before calling `parse(text =)`

### DIFF
--- a/crates/harp/src/exec.rs
+++ b/crates/harp/src/exec.rs
@@ -522,6 +522,9 @@ pub fn r_parse_exprs(code: &str) -> Result<RObject> {
 pub fn r_parse_exprs_with_srcrefs(code: &str) -> Result<RObject> {
     unsafe {
         let mut protect = RProtect::new();
+
+        // Because `parse(text =)` doesn't allow `\r\n` even on Windows
+        let code = convert_line_endings(code, LineEnding::Posix);
         let code = r_string!(code, protect);
 
         RFunction::new("base", "parse")


### PR DESCRIPTION
Fixes a buglet with the new module loading procedure on Windows. Same issue as `R_ParseVector()` where the text can't have `\r\n` in it, even on Windows. Luckily we have the tooling for that.