### PR TITLE
Delay initial heartbeat response until R has started up

### DIFF
--- a/crates/amalthea/tests/client.rs
+++ b/crates/amalthea/tests/client.rs
@@ -60,6 +60,8 @@ fn test_kernel() {
     )));
     let control = Arc::new(Mutex::new(control::Control {}));
 
+    let (kernel_heartbeat_tx, kernel_heartbeat_rx) = bounded::<()>(1);
+
     // Initialize logging
     env_logger::init();
     info!("Starting test kernel");
@@ -72,9 +74,13 @@ fn test_kernel() {
         StreamBehavior::None,
         stdin_request_rx,
         stdin_reply_tx,
+        kernel_heartbeat_rx,
     ) {
         panic!("Error connecting kernel: {err:?}");
     };
+
+    // Tell the kernel that R is "ready", so it can respond to an initial heartbeat
+    kernel_heartbeat_tx.send(()).unwrap();
 
     // Give the kernel a little time to start up
     info!("Waiting 500ms for kernel startup to complete");

--- a/crates/ark/src/kernel.rs
+++ b/crates/ark/src/kernel.rs
@@ -58,6 +58,13 @@ impl Kernel {
             log::error!("Error establishing working directory for frontend: {err:?}");
         }
 
+        // TODO: Even though we now expect R to be fully started up before
+        // this task runs (because R starts up before the UI comm opens), we
+        // should really do more to protect against deadlocks where if R isn't
+        // started yet, then our `busy()` hook won't be able to finish once it
+        // does start up because it requires a lock on the `kernel`, but it
+        // can't acquire one until this r-task finishes and unlocks the `kernel`
+        // in `listen()`, and this r-task can't finish until R starts up.
         // Get the current busy status
         let busy = r_task(|| {
             if RMain::initialized() {


### PR DESCRIPTION
Addresses a major stability issue we have been seeing where `CMD + Shift + 0` very regularly fails, typically giving you a big red 🟥  and eventually timing out the LSP connection.

I can now mash the ever living heck out of the restart command, and it seems to "just work" (barring some `textDocument/didOpen` toast failure notifications)

---

The problem here was actually on the ark side.

When ark is starting up, if the `EstablishUiCommChannel` request comes through _before_ R has actually started up, then we end up in a deadlock scenario.

Right here, we lock the kernel when we get a request to fulfill
https://github.com/posit-dev/amalthea/blob/3d6717d786090f92f44a657e958c12367f8933e5/crates/ark/src/shell.rs#L324

One of those requests is EstablishUiCommChannel, in which we send an r-task to get the initial busy state:
https://github.com/posit-dev/amalthea/blob/3d6717d786090f92f44a657e958c12367f8933e5/crates/ark/src/kernel.rs#L62

That puts an r-task on the queue, to be resolved at the next `read_console()` iteration, and _blocks_ until the task is resolved (i.e. remember the `kernel` is locked here!)

HOWEVER, if R hasn't started up yet, then the first thing R will do before calling `read_console()` is call the `busy()` hook. This _also_ tries to `lock()` the `kernel`, but it can't because its already locked by trying to fulfill the above request, and the above request can't resolve until the `busy()` hook resolves so R can call `read_console()`, thus, a terrible terrible deadlock.

---

I spoke with @jmcphers about this, and he thinks it would be nice if we could prevent the UI comm from opening _at all_ until the kernel is actually "ready".

The UI comm does wait to open until we switch into `RuntimeState.Ready`, but until this PR, that has never actually meant that R has fully started up:
https://github.com/posit-dev/positron/blob/17730ee5aa6e2f85be594ad162cb487680171e23/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts#L439-L458

We switch to `RuntimeState.Ready` after we receive the initial heartbeat response from ark:
https://github.com/posit-dev/positron/blob/17730ee5aa6e2f85be594ad162cb487680171e23/extensions/jupyter-adapter/src/JupyterKernel.ts#L443-L451

We currently send back that initial heartbeat response _immediately_ after our heartbeat socket has connect and we receive the initial heartbeat from the frontend.

**The goal of this PR is to delay this initial heartbeat response until _after_ R has fully started up, i.e. until after our first iteration of `read_console()`, which is a pretty good indicator of this. This is the same thing we are currently using to delay the LSP initialization until R starts up, and to pause the `handle_info_request()`.**

TODOs:
- [ ] It is possible that this approach of delaying that initial heartbeat response can supersede the need to wait in the LSP code and in `handle_info_request()`, but I need to look into that more.
- [ ] It is a little messy that we have `kernel_init_tx` and `kernel_heartbeat_tx`, but we currently have to do this because the `KernelInfo` of `kernel_init_tx` lives in ark, but we'd need it in amalthea for the heartbeat socket code. It seems a little messy that the LSP is getting a notification that includes `KernelInfo` but doesn't use it at all, so maybe we can somehow change this into a very simple `Bus` that just supplies the initialization notification, i.e. `Bus<()>`, and then `handle_info_request()` can get a separate special bounded _channel_ to ship the `KernelInfo` over. That seems a little more structured.
- [ ] Address the TODO in the code about making that `r_task()` more deadlock tolerant. It may be that we do nothing until we have "r-task with a timeout".