### PR TITLE
`R_Interactive` is not Unix specific after all

### DIFF
--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -588,6 +588,8 @@ constant_globals::generate! {
 }
 
 mutable_globals::generate! {
+    pub static mut R_Interactive: Rboolean;
+
     pub static mut R_interrupts_pending: std::ffi::c_int;
 
     pub static mut R_interrupts_suspended: Rboolean;
@@ -622,9 +624,6 @@ mutable_globals::generate! {
 
     #[cfg(target_family = "unix")]
     pub static mut R_running_as_main_program: std::ffi::c_int;
-
-    #[cfg(target_family = "unix")]
-    pub static mut R_Interactive: Rboolean;
 
     #[cfg(target_family = "unix")]
     pub static mut R_InputHandlers: *const std::ffi::c_void;


### PR DESCRIPTION
See https://github.com/posit-dev/amalthea/pull/238#issuecomment-1941596025

I'm still not 100% sure about flipping `R_Interactive` rapidly while in an active R session, but I guess we can try it out