### PR TITLE
Update statement range tests for new tree-sitter-r

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-r"
 version = "0.20.1"
-source = "git+https://github.com/DavisVaughan/tree-sitter-r?branch=fix/newlines#3a20e06e6a62ee5382d9c69e1f88c11ecafc9766"
+source = "git+https://github.com/r-lib/tree-sitter-r?branch=next#fe7fd6fdc34e90e7cbdc60078a84c5cac77f47b9"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -49,7 +49,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter" }
-tree-sitter-r = { git = "https://github.com/DavisVaughan/tree-sitter-r", branch = "fix/newlines" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", branch = "next" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1464

We finally figured out how to fix this issue upstream in tree-sitter-r through
https://github.com/r-lib/tree-sitter-r/pull/72

Here is a recording of the reprex from https://github.com/posit-dev/positron/issues/1464#issuecomment-1787666141, working much better now. It still isn't quite right when we have two expressions on the same line, i.e. `}; lapply(1:5, print)`, but that is a separate bug related to us not taking the `column` into account, I think. I put that in https://github.com/posit-dev/ark/issues/714

https://github.com/posit-dev/amalthea/assets/19150088/07d58dbb-62e1-4007-951b-3ae1d8a92f40

