### PR TITLE
Bump anyhow to 1.0.80 and drop backtrace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,15 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,12 +266,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-dependencies = [
- "backtrace",
-]
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
@@ -290,7 +278,6 @@ dependencies = [
  "amalthea",
  "anyhow",
  "async-trait",
- "backtrace",
  "base64",
  "bus",
  "cfg-if",
@@ -363,21 +350,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide 0.6.2",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -919,7 +891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1109,12 +1081,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "h2"
@@ -1641,15 +1607,6 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -1758,15 +1715,6 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2295,12 +2243,6 @@ dependencies = [
  "sha2",
  "walkdir",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"

--- a/crates/amalthea/Cargo.toml
+++ b/crates/amalthea/Cargo.toml
@@ -25,7 +25,7 @@ zmq = "0.10.0"
 strum = "0.24"
 strum_macros = "0.24"
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
-anyhow = "1.0.71"
+anyhow = "1.0.80"
 serde_with = "3.0.0"
 serde_repr = "0.1.17"
 

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -11,9 +11,8 @@ authors = ["Posit, PBC"]
 [dependencies]
 actix-web = "4.4.0"
 amalthea = { path = "../amalthea" }
-anyhow = { version = "^1.0", features = ["backtrace"] }
+anyhow = "1.0.80"
 async-trait = "0.1.66"
-backtrace = "0.3.67"
 base64 = "0.21.0"
 bus = "2.3.0"
 cfg-if = "1.0.0"

--- a/crates/ark/src/traps.rs
+++ b/crates/ark/src/traps.rs
@@ -37,6 +37,6 @@ pub extern "C" fn backtrace_handler(signum: libc::c_int) {
     // Unlike asynchronous signals, SIGSEGV and SIGBUS are synchronous and
     // always delivered to the thread that caused it, so we can just
     // capture the current thread's backtrace
-    let bt = backtrace::Backtrace::new();
+    let bt = std::backtrace::Backtrace::capture();
     log::info!("{}\n{:?}", header, bt);
 }

--- a/crates/harp/Cargo.toml
+++ b/crates/harp/Cargo.toml
@@ -8,7 +8,7 @@ Tools for integrating R and Rust.
 """
 
 [dependencies]
-anyhow = "1.0.71"
+anyhow = "1.0.80"
 c2rust-bitfields = "0.17.0"
 cfg-if = "1.0.0"
 ctor = "0.1.26"


### PR DESCRIPTION
On the Windows VM, the `indexer::start()` command we use in LSP initialization takes over 40 seconds to complete when run in the `vctrs/` project. On a Mac, this typically takes a few milliseconds.

This is a bigger difference than just computer horsepower.

The way the indexer code is written is a little strange, `index_function()` and `index_comment()` end up propagating an _anyhow error_ upwards in the extremely common cases where no match is found, even though this error is immediately discarded in `index_node()`. These anyhow errors _always_ capture backtraces from what I can tell, so they actually have non zero cost to create, in particular on Windows apparently! The `index_function/comment()` functions are called hundreds of time, so this adds up.

With anyhow 1.0.71, the backtrace crate was used for backtrace capture, but in >=1.0.77 with Rust >=1.65, it started using the standard library's new backtrace support.
https://github.com/dtolnay/anyhow/pull/293
https://github.com/rust-lang/rust/pull/64154

They also encourage you to stop enabling the backtrace feature, as it is always on in Rust >=1.65 now:

> enabling the backtrace crate feature does nothing essentially (except downloading the dependency, so don't do that).

Switching to anyhow 1.0.80 (current release) somehow ends up fixing the performance issue. My guess is that std backtraces are either lazier or just way faster to capture on windows.

I consider this a "quick fix" and intend to rewrite the indexer code in a follow up PR to have an API that works more off `Option` than `Result`, avoiding this entirely (hopefully making it faster on all platforms).

---

Side note, I originally thought this was related to this anyhow performance regression:
https://github.com/dtolnay/anyhow/issues/347

But that seems to actually be unrelated and is a different scenario (there upgrading to 1.0.80 actually hurt performance, i think they previously were not capturing backtraces at all and all of a sudden they started to do so)