### PR TITLE
Bump ark to 0.1.65

### DIFF
--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.64"
+version = "0.1.65"
 edition = "2021"
 rust-version = "1.75.0"
 description = """


### PR DESCRIPTION
I am wondering if the problems I am reporting in https://github.com/posit-dev/positron/issues/2463 are because ark didn't get bumped correctly. Let's try to see if we bump here, bump in Positron, and that fixed it.