### PR TITLE
Pin tree-sitter-r while `next` is in flux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-r"
 version = "0.20.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?branch=next#aad3f67a483dfc5717edb85cbda26c6b4f16fb1f"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=af5fef876ac2577e3d0b6e5c88faeae8cb04d815#af5fef876ac2577e3d0b6e5c88faeae8cb04d815"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.21.0"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", branch = "next" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "af5fef876ac2577e3d0b6e5c88faeae8cb04d815" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"


### PR DESCRIPTION
I'm getting ready to merge https://github.com/r-lib/tree-sitter-r/pull/83 and have a few follow up tree-sitter-r PRs to do on top of it, then I will be able to sync everything back up here with new `next`. For now, I'm pinning to the current `next` of tree-sitter-r