### PR TITLE
Fix `.ps.Call()` calls in plot hooks

### DIFF
--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -7,11 +7,11 @@
 
 # Set up plot hooks.
 setHook("before.plot.new", action = "replace", function(...) {
-    .ps.call("ps_graphics_event", "before.plot.new")
+    .ps.Call("ps_graphics_event", "before.plot.new")
 })
 
 setHook("before.grid.newpage", action = "replace", function(...) {
-    .ps.call("ps_graphics_event", "before.grid.newpage")
+    .ps.Call("ps_graphics_event", "before.grid.newpage")
 })
 
 default_device_type <- function() {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2686

This was a bit confusing because the error message only happens within debug sessions even though the error is actually emitted every time a plot is started, including outside debugging sessions. Because the hook is run within a `try()` (see https://github.com/r-devel/r-svn/blob/895a8d7b58b3ec7f36411c5daae12cad7c086071/src/library/grid/R/grid.R#L341) and because `try()` consults `show.error.messages`, which we set to `FALSE`, to determine verbosity (see https://github.com/posit-dev/positron/issues/2694), the message was not displayed.

The reason it started to show up within the debugger is because we reenable `show.error.messages` while `browser()` is active to fix an issue that prevents our global handling from working within the browser REPL (see https://bugs.r-project.org/show_bug.cgi?id=18590).