### PR TITLE
Use `completion_item()` for keyword completions

### DIFF
--- a/crates/ark/src/lsp/completions/resolve.rs
+++ b/crates/ark/src/lsp/completions/resolve.rs
@@ -37,6 +37,7 @@ pub unsafe fn resolve_completion(item: &mut CompletionItem) -> Result<bool> {
             resolve_parameter_completion_item(item, name.as_str(), function.as_str())
         },
         CompletionData::Object { name: _ } => Ok(false),
+        CompletionData::Keyword { name: _ } => Ok(false),
         CompletionData::RoxygenTag { tag: _ } => Ok(false),
         CompletionData::ScopeVariable { name: _ } => Ok(false),
         CompletionData::ScopeParameter { name: _ } => Ok(false),

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -5,8 +5,12 @@
 //
 //
 
+use stdext::unwrap;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionItemKind;
+
+use crate::lsp::completions::completion_item::completion_item;
+use crate::lsp::completions::types::CompletionData;
 
 pub(super) fn completions_from_keywords() -> Vec<CompletionItem> {
     log::info!("completions_from_keywords()");
@@ -35,8 +39,18 @@ pub(super) fn completions_from_keywords() -> Vec<CompletionItem> {
     ];
 
     for keyword in keywords {
-        let mut item = CompletionItem::new_simple(keyword.to_string(), "[keyword]".to_string());
+        let item = completion_item(keyword.to_string(), CompletionData::Keyword {
+            name: keyword.to_string(),
+        });
+
+        let mut item = unwrap!(item, Err(err) => {
+            log::error!("Failed to construct completion item for keyword '{keyword}' due to {err:?}.");
+            continue;
+        });
+
+        item.detail = Some("[keyword]".to_string());
         item.kind = Some(CompletionItemKind::KEYWORD);
+
         completions.push(item);
     }
 

--- a/crates/ark/src/lsp/completions/types.rs
+++ b/crates/ark/src/lsp/completions/types.rs
@@ -29,6 +29,9 @@ pub(super) enum CompletionData {
     Object {
         name: String,
     },
+    Keyword {
+        name: String,
+    },
     Package {
         name: String,
     },


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2405

Thought this was addressed by https://github.com/posit-dev/amalthea/pull/290 but on a closer look it was a different issue.

Making a "simple" completion item with `CompletionItem::new_simple()` doesn't include the `data` field, which we require on the `completion_resolve()` side, otherwise we log an error and bail out. We should be using `completion_item()` as the base for all completion items, so that's what I've switched us to.

We didn't have a `CompletionData` variant for keywords, and nothing else really fit, so I went ahead and made one that is basically a no-op on the resolution side. This is fine, plenty of other variants are also no-ops.