### PR TITLE
Improve diagnostics of `<<-`, `->`, and `->>`

### DIFF
--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1439,4 +1439,23 @@ mod tests {
             assert!(diagnostics.is_empty());
         })
     }
+
+    #[test]
+    fn test_symbol_not_in_scope_diagnostic_is_ordering_dependent() {
+        r_test(|| {
+            let text = "
+                x + 1
+                x <- 1
+                x + 1
+            ";
+            let document = Document::new(text, None);
+
+            let diagnostics = generate_diagnostics(&document);
+            assert_eq!(diagnostics.len(), 1);
+
+            // Only marks the `x` before the `x <- 1`
+            let diagnostic = diagnostics.get(0).unwrap();
+            assert_eq!(diagnostic.range.start.line, 1)
+        })
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2704

Since apparently some people out there use right assignment 😆 

- Left super assignment wasn't adding the symbol to `document_symbols`, so future usage of the symbol would still be marked even though immediate usage in the `x <<- 1` call itself wasn't marked.
- Right assignment wasn't supported at all, but is now
- Right super assignment wasn't supported at all, but is now

Added some tests for these cases too, yay tests!

<img width="218" alt="Screenshot 2024-04-11 at 12 56 54 PM" src="https://github.com/posit-dev/amalthea/assets/19150088/f51e5ddd-ff1e-4413-9b6c-362b9994269f">
