### PR TITLE
Bump ark to 0.1.81

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.80"
+version = "0.1.81"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.80"
+version = "0.1.81"
 edition = "2021"
 rust-version = "1.75.0"
 description = """


### PR DESCRIPTION
To include changes for support other plot save formats.