### PR TITLE
Use enums generated from plot comm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "stdext",
- "strum",
+ "strum 0.24.1",
  "strum_macros",
  "uuid",
  "zmq",
@@ -311,6 +311,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stdext",
+ "strum 0.26.2",
  "tokio",
  "tower-lsp",
  "tree-sitter",
@@ -2616,6 +2617,12 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"

--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -21,6 +21,22 @@ pub struct PlotResult {
 	pub mime_type: String
 }
 
+/// Possible values for Format in Render
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+pub enum RenderFormat {
+	#[serde(rename = "png")]
+	Png,
+
+	#[serde(rename = "jpeg")]
+	Jpeg,
+
+	#[serde(rename = "svg")]
+	Svg,
+
+	#[serde(rename = "pdf")]
+	Pdf
+}
+
 /// Parameters for the Render method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RenderParams {
@@ -34,7 +50,7 @@ pub struct RenderParams {
 	pub pixel_ratio: f64,
 
 	/// The requested plot format
-	pub format: String,
+	pub format: RenderFormat,
 }
 
 /**
@@ -88,5 +104,7 @@ pub enum PlotFrontendEvent {
 	#[serde(rename = "update")]
 	Update,
 
-}
+	#[serde(rename = "show")]
+	Show,
 
+}

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -54,6 +54,7 @@ url = "2.4.1"
 walkdir = "2"
 yaml-rust = "0.4.5"
 winsafe = { version = "0.0.19", features = ["kernel"] }
+strum = "0.26.2"
 
 [build-dependencies]
 chrono = "0.4.23"

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -33,6 +33,7 @@ use amalthea::comm::plot_comm::PlotBackendReply;
 use amalthea::comm::plot_comm::PlotBackendRequest;
 use amalthea::comm::plot_comm::PlotFrontendEvent;
 use amalthea::comm::plot_comm::PlotResult;
+use amalthea::comm::plot_comm::RenderFormat;
 use amalthea::socket::comm::CommInitiator;
 use amalthea::socket::comm::CommSocket;
 use amalthea::socket::iopub::IOPubMessage;
@@ -207,16 +208,12 @@ impl DeviceContext {
         }
     }
 
-    fn get_mime_type(format: &str) -> String {
+    fn get_mime_type(format: &RenderFormat) -> String {
         match format {
-            "png" => "image/png".to_string(),
-            "svg" => "image/svg+xml".to_string(),
-            "pdf" => "application/pdf".to_string(),
-            "jpeg" => "image/jpeg".to_string(),
-            _ => {
-                log::error!("Unknown plot type '{format}'. Falling back to 'image/png'.");
-                "image/png".to_string()
-            },
+            RenderFormat::Png => "image/png".to_string(),
+            RenderFormat::Svg => "image/svg+xml".to_string(),
+            RenderFormat::Pdf => "application/pdf".to_string(),
+            RenderFormat::Jpeg => "image/jpeg".to_string(),
         }
     }
 
@@ -360,7 +357,7 @@ impl DeviceContext {
         let width = 400;
         let height = 650;
         let pixel_ratio = 1.0;
-        let format = "png";
+        let format = RenderFormat::Png;
 
         let data = unwrap!(self.render_plot(id, width, height, pixel_ratio, &format), Err(error) => {
             bail!("Failed to render plot with id {id} due to: {error}.");
@@ -378,7 +375,7 @@ impl DeviceContext {
         width: i64,
         height: i64,
         pixel_ratio: f64,
-        format: &str,
+        format: &RenderFormat,
     ) -> anyhow::Result<String> {
         // Render the plot to file.
         // TODO: Is it possible to do this without writing to file; e.g. could
@@ -390,7 +387,7 @@ impl DeviceContext {
                 .param("width", RObject::try_from(width)?)
                 .param("height", RObject::try_from(height)?)
                 .param("dpr", pixel_ratio)
-                .param("format", format)
+                .param("format", format.to_string().to_lowercase())
                 .call()?
                 .to::<String>()
         });


### PR DESCRIPTION
Refactor plot format enum so it is defined in the comm spec. See [Issue](https://github.com/posit-dev/positron/issues/2657) and [PR](https://github.com/posit-dev/positron/pull/2814)

Adds `strum` to convert the enum into a string.