### PR TITLE
Tell the front-end the connection has been closed on the R side

### DIFF
--- a/crates/ark/src/modules/positron/connection.R
+++ b/crates/ark/src/modules/positron/connection.R
@@ -135,13 +135,16 @@ connection_flatten_object_types <- function(object_tree) {
 
 #' @export
 .ps.connection_close <- function(id, ...) {
-    con <- get(id, getOption("connectionObserver")$.connections)
+    con <- getOption("connectionObserver")$.connections[[id]]
     if (is.null(con)) {
-        return(NULL)
+         # this value is used to determine if we should send a close msg to the frontend
+         # ie. closing the connection was an action from the R console, not from the frontend
+        return(FALSE)
     }
     # disconnect is resposible for calling connectionClosed that
     # will remove the connection from the list of connections
     con$disconnect(...)
+    return(TRUE)
 }
 
 #' @export


### PR DESCRIPTION
Adresses https://github.com/posit-dev/positron/issues/2898

If the connection is no longer tracked on the R side, we send a close message to the front-end before interrupting the message loop.