### PR TITLE
Fix issue causing plot duplication in Positron plot history

### DIFF
--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -7,11 +7,11 @@
 
 # Set up plot hooks.
 setHook("before.plot.new", action = "replace", function(...) {
-    .ps.call("ps_graphics_event", "before.plot.new")
+    .ps.Call("ps_graphics_event", "before.plot.new")
 })
 
 setHook("before.grid.newpage", action = "replace", function(...) {
-    .ps.call("ps_graphics_event", "before.grid.newpage")
+    .ps.Call("ps_graphics_event", "before.grid.newpage")
 })
 
 default_device_type <- function() {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2453.

The problem here turned out to be pretty simple: We write snapshots of plots in order to replay them when they are redrawn.  These snapshots were never getting written because our graphics hooks weren't set up correctly -- they used `.ps.call()` which doesn't exist.

The fix is to use the correct casing so that the hooks are invoked. 