### PR TITLE
Build only on production for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
     # Build ARK for macOS. Both arm64 (Apple Silicon) and x64 (Intel) hosts.
     build_macos:
         name: Build macOS
-        runs-on: [self-hosted, macos, arm64]
+        runs-on: [self-hosted-production, macos, arm64]
         needs: [do_release, revive_agent, get_version]
         timeout-minutes: 40
 


### PR DESCRIPTION
This change ensures that Amalthea only attempts to build on MacInCloud until the EC2 runner is able to absorb work.