### PR TITLE
Only use `get_mut()` when we absolutely have to

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -331,7 +331,7 @@ impl LanguageServer for Backend {
 
         // Get reference to document.
         let uri = &params.text_document_position.text_document.uri;
-        let document = unwrap!(self.documents.get_mut(uri), None => {
+        let document = unwrap!(self.documents.get(uri), None => {
             backend_trace!(self, "completion(): No document associated with URI {}", uri);
             return Ok(None);
         });
@@ -378,7 +378,7 @@ impl LanguageServer for Backend {
 
         // get document reference
         let uri = &params.text_document_position_params.text_document.uri;
-        let document = unwrap!(self.documents.get_mut(uri), None => {
+        let document = unwrap!(self.documents.get(uri), None => {
             backend_trace!(self, "hover(): No document associated with URI {}", uri);
             return Ok(None);
         });
@@ -413,7 +413,7 @@ impl LanguageServer for Backend {
     async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
         // get document reference
         let uri = &params.text_document_position_params.text_document.uri;
-        let document = unwrap!(self.documents.get_mut(uri), None => {
+        let document = unwrap!(self.documents.get(uri), None => {
             backend_trace!(self, "signature_help(): No document associated with URI {}", uri);
             return Ok(None);
         });

--- a/crates/ark/src/lsp/help_topic.rs
+++ b/crates/ark/src/lsp/help_topic.rs
@@ -43,7 +43,7 @@ impl Backend {
         backend_trace!(self, "help_topic({:?})", params);
 
         let uri = &params.text_document.uri;
-        let Some(document) = self.documents.get_mut(uri) else {
+        let Some(document) = self.documents.get(uri) else {
             backend_trace!(self, "help_topic(): No document associated with URI {uri}");
             return Ok(None);
         };

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -61,7 +61,7 @@ impl Backend {
         backend_trace!(self, "statement_range({:?})", params);
 
         let uri = &params.text_document.uri;
-        let Some(document) = self.documents.get_mut(uri) else {
+        let Some(document) = self.documents.get(uri) else {
             backend_trace!(
                 self,
                 "statement_range(): No document associated with URI {uri}"


### PR DESCRIPTION
In theory this frees up the LSP so it can run some of these requests more concurrently (as long as they don't require R, which will also block).

The `DashMap` allows:
- Many `get()` calls, as long as there have not been any `get_mut()` calls
- Exactly 1 `get_mut()` call

i.e. like an RW lock https://doc.rust-lang.org/std/sync/struct.RwLock.html