### PR TITLE
Use global lock to synchronise LSP handlers

### DIFF
--- a/crates/ark/src/lsp/help_topic.rs
+++ b/crates/ark/src/lsp/help_topic.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use tower_lsp::lsp_types::Position;
 use tower_lsp::lsp_types::VersionedTextDocumentIdentifier;
 
+use crate::backend_read_method;
 use crate::backend_trace;
 use crate::lsp::backend::Backend;
 use crate::lsp::encoding::convert_position_to_point;
@@ -40,7 +41,7 @@ impl Backend {
         &self,
         params: HelpTopicParams,
     ) -> tower_lsp::jsonrpc::Result<Option<HelpTopicResponse>> {
-        backend_trace!(self, "help_topic({:?})", params);
+        backend_read_method!(self, "help_topic({:?})", params);
 
         let uri = &params.text_document.uri;
         let Some(document) = self.documents.get(uri) else {

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -19,6 +19,7 @@ use tower_lsp::lsp_types::VersionedTextDocumentIdentifier;
 use tree_sitter::Node;
 use tree_sitter::Point;
 
+use crate::backend_read_method;
 use crate::backend_trace;
 use crate::lsp::backend::Backend;
 use crate::lsp::encoding::convert_point_to_position;
@@ -58,7 +59,7 @@ impl Backend {
         &self,
         params: StatementRangeParams,
     ) -> tower_lsp::jsonrpc::Result<Option<StatementRangeResponse>> {
-        backend_trace!(self, "statement_range({:?})", params);
+        backend_read_method!(self, "statement_range({:?})", params);
 
         let uri = &params.text_document.uri;
         let Some(document) = self.documents.get(uri) else {


### PR DESCRIPTION
Addresses (hopefully!) https://github.com/posit-dev/positron/issues/2692.
Addresses part of https://github.com/posit-dev/positron/issues/2999.

LSP handlers are run in message order but they run concurrently.  This means that a single `.await`, for instance to log a message, may cause out of order handling. This is problematic for state-changing methods should only run after all other methods have finished or were cancelled (the latter would be preferred, see `ContentModified` error and this thread: https://github.com/microsoft/language-server-protocol/issues/584).

To fix this, we now request an `RwLock` at entry in each handler. World-changing handlers require an exclusive lock whereas world-observing handlers require a non-exclusive shared lock. This should prevent handlers from operating on outdated documents with stale positions or ranges. The tokio lock uses a fifo acquisition strategy so we should be good regarding ordering. 

Note that this doesn't address the issue discussed in https://github.com/ebkalderon/tower-lsp/issues/284, which is that response ordering might be messed up by the concurrent execution of handlers. To fix this, we could run handlers strictly sequentially by acquiring exclusive locks in all handlers, or we could set up a smarter synchronisation strategy on exit to still run handlers in parallel but guarantee response order via some kind of queue.

As mentioned above, we should also find a way to cancel pending requests with a `ContentModified` error when a state-changing request comes in. This way we don't spend time on possibly invalidated requests and we give priority to locking state updates.