### PR TITLE
Declare that we are in debug mode if any frame is marked with `RDEBUG`

### DIFF
--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -256,6 +256,16 @@ pub fn r_alloc_list(size: R_xlen_t) -> SEXP {
     unsafe { Rf_allocVector(VECSXP, size) }
 }
 
+pub fn r_node_car(x: SEXP) -> SEXP {
+    unsafe { CAR(x) }
+}
+pub fn r_node_tag(x: SEXP) -> SEXP {
+    unsafe { TAG(x) }
+}
+pub fn r_node_cdr(x: SEXP) -> SEXP {
+    unsafe { CDR(x) }
+}
+
 impl RObject {
     pub unsafe fn new(data: SEXP) -> Self {
         RObject {

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -30,6 +30,8 @@ use crate::object::r_chr_get;
 use crate::object::r_chr_poke;
 use crate::object::r_dim;
 use crate::object::r_length;
+use crate::object::r_node_car;
+use crate::object::r_node_cdr;
 use crate::object::r_str_blank;
 use crate::object::r_str_na;
 use crate::object::RObject;
@@ -658,6 +660,26 @@ pub unsafe fn r_ns_env_name(env: SEXP) -> SEXP {
     }
 
     STRING_ELT(spec, 0)
+}
+
+/// Returns `true` if `f` returns `true` for any node of the pairlist
+pub fn r_pairlist_any<F>(x: SEXP, f: F) -> bool
+where
+    F: Fn(SEXP) -> bool,
+{
+    let mut node = x;
+
+    while node != r_null() {
+        let elt = r_node_car(node);
+
+        if f(elt) {
+            return true;
+        }
+
+        node = r_node_cdr(node);
+    }
+
+    return false;
 }
 
 pub unsafe fn r_try_eval_silent(x: SEXP, env: SEXP) -> Result<SEXP> {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2310 enough for public beta, I think

The biggest win here is that we no longer leave "debug mode" when a frame gets added to the stack that isn't marked with `RDEBUG`, which was horribly confusing because R is still in the browser but you can't click "next" using the UI, you have to go down and type it in the console to continue.

This approach technically gives an "accurate" view of the frame you are in, but it isn't particularly useful with these cases (lazy eval of args and extra try-catch frames) as you will see in the videos. I also tried the idea of _dropping_ the non-debug frames, but that ends up being just as confusing, so I think that this simpler approach of showing everything that R tells you is on the stack (even if some are not debug frames) is probably good enough for now - this way also preserves the ability to look at the stack in the bottom left and click your way up the stack of tryCatch internals if you want to.

https://github.com/posit-dev/amalthea/assets/19150088/c45937a0-ab35-444b-b848-3aa13f14cec1

https://github.com/posit-dev/amalthea/assets/19150088/fe776ae0-cb77-4a6a-92a8-566124a00b4c

https://github.com/posit-dev/amalthea/assets/19150088/0fd0f9d7-e017-412f-998f-011d2e46e367

