### PR TITLE
Correctly handle primitives when looking up package name

### DIFF
--- a/crates/ark/src/modules/positron/s3.R
+++ b/crates/ark/src/modules/positron/s3.R
@@ -10,11 +10,12 @@
 
 #' @export
 .ps.s3.genericNameFromFunction <- function(callable) {
-
     # Check whether we can safely cache the result.
-    isCacheable <- !is.null(utils::packageName(environment(callable)))
-    if (!isCacheable)
+    package <- fn_package_name(callable)
+    if (is.null(package)) {
+        # Can't cache
         return(.ps.s3.genericNameFromFunctionImpl(callable))
+    }
 
     id <- .ps.objectId(callable)
     .ps.s3.genericNameCache[[id]] <-

--- a/crates/ark/src/modules/positron/tools.R
+++ b/crates/ark/src/modules/positron/tools.R
@@ -157,3 +157,26 @@ positron_tempdir <- function(...) {
 
     out
 }
+
+fn_package_name <- function(fn) {
+    env <- fn_env(fn)
+
+    if (is.null(env)) {
+        # We hope not, since `fn_env()` handles the builtin/special case, but just in case
+        return(NULL)
+    }
+
+    # Returns `NULL` on local functions
+    utils::packageName(env)
+}
+
+fn_env <- function(fn) {
+    # Primitives like `c()` have `NULL` `environment()` results.
+    switch(
+        typeof(fn),
+        builtin = asNamespace("base"),
+        special = asNamespace("base"),
+        closure = environment(fn),
+        stop(sprintf("`fn` must be a function, not a '%s'.", typeof(fn)))
+    )
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3117

We were calling `utils::packageName()` on what ended up being a `NULL` environment, and that throws an error. Our R traceback capturing machinery was capturing the _inlined_ objects in the upstream call to `.ps.completions.formalNames()` where the entire tibble with its nested list-columns were being inlined as the `object` there, which exceeded the 512mb limit allowed for a string that can be created on the Node side.

This fixes the underlying issue of calling `packageName(NULL)`, but we should probably also not inline objects into calls (i.e. add machinery to evaluate in a child env instead). (We have an issue for this, see https://github.com/posit-dev/ark/issues/695)

The video just shows that it no longer hangs

https://github.com/posit-dev/amalthea/assets/19150088/58134d27-977c-4b96-85da-a35e413d720d

