### PR TITLE
Reorganize data explorer tests

### DIFF
--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -1058,9 +1058,9 @@ DataExplorerBackendReply::SetSortColumnsReply() => {});
         assert_match!(socket_rpc(&socket, req),
             DataExplorerBackendReply::GetDataValuesReply(data) => {
                 assert_eq!(data.columns.len(), 1);
-                assert_eq!(data.columns[0][0], ColumnValue::FormattedValue("0".to_string()));
-                assert_eq!(data.columns[0][1], ColumnValue::FormattedValue("1".to_string()));
-                assert_eq!(data.columns[0][2], ColumnValue::FormattedValue("2".to_string()));
+                assert_eq!(data.columns[0][0], ColumnValue::FormattedValue("0.00".to_string()));
+                assert_eq!(data.columns[0][1], ColumnValue::FormattedValue("1.00".to_string()));
+                assert_eq!(data.columns[0][2], ColumnValue::FormattedValue("2.00".to_string()));
             }
         );
 
@@ -1091,9 +1091,9 @@ DataExplorerBackendReply::SetSortColumnsReply() => {});
         assert_match!(socket_rpc(&socket, req),
             DataExplorerBackendReply::GetDataValuesReply(data) => {
                 assert_eq!(data.columns.len(), 1);
-                assert_eq!(data.columns[0][0], ColumnValue::FormattedValue("1".to_string()));
-                assert_eq!(data.columns[0][1], ColumnValue::FormattedValue("2".to_string()));
-                assert_eq!(data.columns[0][2], ColumnValue::FormattedValue("3".to_string()));
+                assert_eq!(data.columns[0][0], ColumnValue::FormattedValue("1.00".to_string()));
+                assert_eq!(data.columns[0][1], ColumnValue::FormattedValue("2.00".to_string()));
+                assert_eq!(data.columns[0][2], ColumnValue::FormattedValue("3.00".to_string()));
             }
         );
 


### PR DESCRIPTION
Based off #368, so wait for it to be merged.

I wrongly assumed that all tests had to go on the same function, but we can actually split them into their own contexts so its easier to maintain and understand.
