### PR TITLE
Write an R error to the buffer when user input is too large

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -816,9 +816,8 @@ impl RMain {
         let buflen = buflen - 2;
 
         if input.len() > buflen {
-            let dropped = &input[buflen..input.len()];
-            log::error!("Console input too large for buffer. Input has been trimmed, dropping: '{dropped}'.");
-            input = input[..buflen].to_string();
+            log::error!("Console input too large for buffer, writing R error.");
+            input = Self::buffer_overflow_call();
         }
 
         // Push `\n`
@@ -830,6 +829,22 @@ impl RMain {
         unsafe {
             libc::strcpy(buf as *mut c_char, input.as_ptr());
         }
+    }
+
+    // Temporary patch for https://github.com/posit-dev/positron/issues/2675.
+    // We write an informative `stop()` call rather than the user's actual input.
+    fn buffer_overflow_call() -> String {
+        let message = r#"
+Can't pass console input on to R, it exceeds R's internal console buffer size.
+This is a Positron limitation we plan to fix. In the meantime, you can:
+- Break the command you sent to the console into smaller chunks, if possible.
+- Otherwise, send the whole script to the console using `source()`.
+        "#;
+
+        let message = message.trim();
+        let message = format!("stop(\"{message}\")");
+
+        message
     }
 
     // Reply to the previously active request. The current prompt type and


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron/issues/2675, I would not say it addresses that issue, but it does prevent R from crashing and returns an informative and actionable error message now, which is our target behavior to fix for beta

It seemed like writing a `stop()` call to the buffer instead is the most reasonable way to prevent a weird state. Is there anything huge I'm missing here?

<img width="705" alt="Screenshot 2024-06-03 at 2 03 12 PM" src="https://github.com/posit-dev/amalthea/assets/19150088/f2b22252-df1c-41c6-8538-63cf9c979458">
