### PR TITLE
Bump ark to 0.1.102

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.101"
+version = "0.1.102"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.101"
+version = "0.1.102"
 edition = "2021"
 rust-version = "1.75.0"
 description = """


### PR DESCRIPTION
For https://github.com/posit-dev/amalthea/commit/441ba7bc4dc0b45300e9547949ee7379a4ba3de9