### PR TITLE
Override `try()` to force `show.error.messages = TRUE` locally

### DIFF
--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -65,18 +65,15 @@
 # `show.error.messages` back to `TRUE`. This prevents the user from tweaking
 # this option, but we don't expect them to do that anyways.
 .ps.register_try_hook <- function() {
-    formals <- formals(base::try)
+    fn <- base::try
 
     # Can't use `local_options()` in the body, must be base code
-    body <- body(base::try)
+    body <- body(fn)
     body <- bquote({
         old <- options(show.error.messages = TRUE)
         on.exit(options(old), add = TRUE, after = FALSE)
         .(body)
     })
-
-    fn <- function() {}
-    formals(fn) <- formals
     body(fn) <- body
 
     .ps.register_base_hook("try", fn, namespace = TRUE)


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2694
Closes https://github.com/posit-dev/amalthea/pull/303 with an alternate approach.

- [ ] Merge https://github.com/posit-dev/amalthea/pull/383 first to use those utilities

This is essentially the same approach we take while in the debugger, which is also a place where we aren't given an opportunity to capture error conditions, but `show.error.messages = FALSE` is still allowed in.

I think we should eventually talk to Luke about this, and ask for a separate option specific to `try()` that could be used instead.

---

Regarding https://github.com/posit-dev/amalthea/pull/303 and `invokeRestart("abort")`, that does have the downside that the `traceback()` is no longer set up after the error occurs, so I decided not to use that approach in the end:

- An abort restart goes through here https://github.com/wch/r-source/blob/05bfe40425384c06ac179f64cd1060f04088064a/src/main/errors.c#L2095
- Which does a jump to top level with this `traceback` flag set to `false` (the first arg here) https://github.com/wch/r-source/blob/05bfe40425384c06ac179f64cd1060f04088064a/src/main/errors.c#L1084-L1090
- Which causes the `.Traceback` symbol to not get written https://github.com/wch/r-source/blob/05bfe40425384c06ac179f64cd1060f04088064a/src/main/errors.c#L1066-L1078