### PR TITLE
Temporarily disable supported feature get_column_profiles.supported

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -968,7 +968,10 @@ impl RDataExplorer {
             sort_keys: self.sort_keys.clone(),
             supported_features: SupportedFeatures {
                 get_column_profiles: GetColumnProfilesFeatures {
-                    supported: true,
+                    // Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
+                    // on 6/11/2024. This will be enabled again when the UI has been reworked to
+                    // more fully support column profiles.
+                    supported: false,
                     supported_types: vec![
                         ColumnProfileType::NullCount,
                         ColumnProfileType::SummaryStats,


### PR DESCRIPTION
This PR temporarily disables `SupportedFeatures.get_column_profiles.supported` to address https://github.com/posit-dev/positron/issues/3490.

This will be enabled again when the UI has been reworked to more fully support column profiles.