### PR TITLE
Temporarily restrict get_column_profiles to only return ColumnProfile…

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -971,7 +971,10 @@ impl RDataExplorer {
                     supported: true,
                     supported_types: vec![
                         ColumnProfileType::NullCount,
-                        ColumnProfileType::SummaryStats,
+                        // Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
+                        // on 6/11/2024. This will be enabled again when the UI has been reworked to
+                        // more fully support column profiles.
+                        // ColumnProfileType::SummaryStats,
                     ],
                 },
                 search_schema: SearchSchemaFeatures { supported: false },


### PR DESCRIPTION
In order to address https://github.com/posit-dev/positron/issues/3490, this PR temporarily restricts `get_column_profiles` to only return `ColumnProfileType::NullCount`.

`ColumnProfileType::SummaryStats` will be enabled again when the UI has been reworked to more fully support column profiles.
