### PR TITLE
Bump ark to 0.1.105

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.104"
+version = "0.1.105"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.104"
+version = "0.1.105"
 description = """
 The Amalthea R Kernel.
 """


### PR DESCRIPTION
Bump ark to 0.1.105

- https://github.com/posit-dev/amalthea/pull/392
- https://github.com/posit-dev/amalthea/pull/395
- https://github.com/posit-dev/amalthea/pull/397