### PR TITLE
Refactor help to remove global `PORT` and clarify logic

### DIFF
--- a/crates/ark/src/browser.rs
+++ b/crates/ark/src/browser.rs
@@ -15,8 +15,6 @@ use crate::help::message::HelpEvent;
 use crate::help::message::ShowHelpUrlParams;
 use crate::interface::RMain;
 
-pub static mut PORT: u16 = 0;
-
 #[harp::register]
 pub unsafe extern "C" fn ps_browse_url(url: SEXP) -> anyhow::Result<SEXP> {
     ps_browse_url_impl(url).or_else(|err| {

--- a/crates/ark/src/modules/positron/help.R
+++ b/crates/ark/src/modules/positron/help.R
@@ -31,9 +31,12 @@ help <- function(topic, package = NULL) {
   }
 }
 
-# Start R's dynamic HTTP help server; returns the chosen port (invisibly)
+#' Start R's dynamic HTTP help server; returns the chosen port (invisibly)
+#'
+#' If the help server is already started, the port already in use is returned
+#' (due to using `start = NA`).
 #' @export
-.ps.help.startHelpServer <- function() {
+.ps.help.startOrReconnectToHelpServer <- function() {
     suppressMessages(tools::startDynamicHelp(start = NA))
 }
 

--- a/crates/ark/tests/help.rs
+++ b/crates/ark/tests/help.rs
@@ -14,6 +14,7 @@ use amalthea::comm::help_comm::ShowHelpTopicParams;
 use amalthea::socket::comm::CommInitiator;
 use amalthea::socket::comm::CommSocket;
 use ark::help::r_help::RHelp;
+use ark::help_proxy;
 use ark::r_task::r_task;
 use ark::test::r_test;
 use harp::exec::RFunction;
@@ -38,7 +39,9 @@ fn test_help_comm() {
         // Start the help comm. It's important to save the help event sender so
         // that the help comm doesn't exit before we're done with it; allowing the
         // sender to be dropped signals the help comm to exit.
-        let (_help_event_tx, _help_port) = RHelp::start(comm).unwrap();
+        let r_port = RHelp::r_start_or_reconnect_to_help_server().unwrap();
+        let proxy_port = help_proxy::start(r_port).unwrap();
+        let _help_event_tx = RHelp::start(comm, r_port, proxy_port).unwrap();
 
         // Utility function for testing `ShowHelpTopic` requests
         let test_topic = |topic: &str, id: &str| {


### PR DESCRIPTION
Branched from https://github.com/posit-dev/amalthea/pull/406

When I was getting more deeply acquainted with help, I was pretty confused by `pub static mut PORT: u16 = 0;`, a global variable that gets our proxy port number (not the R help server port number). I set out to see if I could remove the global, and I think it resulted in much clearer logic for how help works!

I don't think we really need `Arc<Mutex<u16>>` because the help port is always created in the `comm_open` event now, and is immediately forwarded to both the help handler and `RMain` from there, so it seems extremely unlikely for them to be out of sync.

I tried a `CMD+R` refresh, and that does _not_ seem to open a new help comm