### PR TITLE
Add a workaround for an argument matching error

### DIFF
--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -18,6 +18,7 @@ use stdext::unwrap;
 use stdext::IntoResult;
 use tower_lsp::lsp_types::CompletionItem;
 
+use crate::lsp;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::completion_item::completion_item_from_dataset;
 use crate::lsp::completions::completion_item::completion_item_from_package;
@@ -89,6 +90,7 @@ pub fn completions_from_custom_source_impl(
     //
     // cf. https://github.com/posit-dev/positron/issues/3467
     if index >= parameters.len() {
+        lsp::log_error!("Index {index} is out of bounds of the arguments of `{name}`");
         return Ok(None);
     }
     let parameter = parameters.get(index).into_result()?;

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -82,8 +82,16 @@ pub fn completions_from_custom_source_impl(
     let signature = signatures.signatures.get(0).into_result()?;
     let mut name = signature.label.clone();
     let parameters = signature.parameters.as_ref().into_result()?;
-    let index = signature.active_parameter.into_result()?;
-    let parameter = parameters.get(index as usize).into_result()?;
+    let index = signature.active_parameter.into_result()? as usize;
+    // TODO: Currently, argument matching is not very accurate. This is just a
+    // workaround to supresses the error rather than showing a cryptic error
+    // message to users, but there should be some better option.
+    //
+    // cf. https://github.com/posit-dev/positron/issues/3467
+    if index >= parameters.len() {
+        return Ok(None);
+    }
+    let parameter = parameters.get(index).into_result()?;
 
     // Extract the argument text.
     let argument = match parameter.label.clone() {


### PR DESCRIPTION
A workaround for https://github.com/posit-dev/positron/issues/3467.

I read https://github.com/posit-dev/positron/issues/3467#issuecomment-2158872927, and I don't think this is the proper fix to the problem, but it might be good as a temporary workaround if it will take some time to overhaul the signature-help method.