### PR TITLE
Filter out help pages unrelated to a function usage

### DIFF
--- a/crates/ark/src/modules/positron/help.R
+++ b/crates/ark/src/modules/positron/help.R
@@ -139,6 +139,11 @@ getHtmlHelpContentsInstalled <- function(helpFiles, package) {
 
   rd <- utils:::.getHelpFile(helpFile)
 
+  # Reject helps unrelated to a function usage
+  if (length(tools:::.Rd_get_section(rd, "usage")) == 0) {
+    return(NULL)
+  }
+
   # Set 'package' now if it was unknown.
   if (is.null(package)) {
     pattern <- "/library/([^/]+)/"


### PR DESCRIPTION
Fix this error https://github.com/posit-dev/positron/issues/3467#issuecomment-2213963654 of `completionItem/resolve` by filtering out help pages about the other topics than a function usage. I'm not sure if this is the best option, but this should work to some extent.

``` r
bar <- function(...) {}

bar()
#   ^
#   get errors when moving a cursor to here
```

I found this function when I looked around the source code of base R.

https://github.com/r-devel/r-svn/blob/1f537a2469956b505ad10135eeee282fe33a8475/src/library/tools/R/Rd.R#L689-L690