### PR TITLE
Always display NA as unquoted in the Variables pane

### DIFF
--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -18,6 +18,7 @@ use libr::STRSXP;
 
 use crate::object::RObject;
 use crate::utils::r_str_to_owned_utf8_unchecked;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -80,8 +81,15 @@ impl Vector for CharacterVector {
         r_str_to_owned_utf8_unchecked(*x)
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
-        x
+    fn format_one(
+        &self,
+        x: Self::Type,
+        options: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
+        match options {
+            Some(options) => self.format_with_string_options(x, options),
+            None => x,
+        }
     }
 }
 

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -18,7 +18,7 @@ use libr::STRSXP;
 
 use crate::object::RObject;
 use crate::utils::r_str_to_owned_utf8_unchecked;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -18,7 +18,7 @@ use libr::STRSXP;
 
 use crate::object::RObject;
 use crate::utils::r_str_to_owned_utf8_unchecked;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -81,13 +81,9 @@ impl Vector for CharacterVector {
         r_str_to_owned_utf8_unchecked(*x)
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        options: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, options: Option<&FormatOptions>) -> String {
         match options {
-            Some(options) => self.format_with_string_options(x, options),
+            Some(options) => self.format_with_options(x, options),
             None => x,
         }
     }

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -82,9 +82,14 @@ impl Vector for CharacterVector {
     }
 
     fn format_one(&self, x: Self::Type, options: Option<&FormatOptions>) -> String {
-        match options {
-            Some(options) => self.format_with_options(x, options),
-            None => x,
+        if let Some(&FormatOptions { quote, .. }) = options {
+            if quote {
+                format!(r#""{}""#, x.replace('"', r#"\""#))
+            } else {
+                x
+            }
+        } else {
+            x
         }
     }
 }

--- a/crates/harp/src/vector/complex_vector.rs
+++ b/crates/harp/src/vector/complex_vector.rs
@@ -15,6 +15,7 @@ use libr::DATAPTR;
 use libr::SEXP;
 
 use crate::object::RObject;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::Vector;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -81,7 +82,11 @@ impl Vector for ComplexVector {
         *x
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+        _option: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         format!("{}+{}i", x.r.to_string(), x.i.to_string())
     }
 }

--- a/crates/harp/src/vector/complex_vector.rs
+++ b/crates/harp/src/vector/complex_vector.rs
@@ -15,7 +15,7 @@ use libr::DATAPTR;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::Vector;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -82,11 +82,7 @@ impl Vector for ComplexVector {
         *x
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        _option: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         format!("{}+{}i", x.r.to_string(), x.i.to_string())
     }
 }

--- a/crates/harp/src/vector/complex_vector.rs
+++ b/crates/harp/src/vector/complex_vector.rs
@@ -15,7 +15,7 @@ use libr::DATAPTR;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/crates/harp/src/vector/factor.rs
+++ b/crates/harp/src/vector/factor.rs
@@ -16,6 +16,7 @@ use libr::SEXP;
 
 use crate::object::RObject;
 use crate::r_symbol;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
 
@@ -73,7 +74,11 @@ impl Vector for Factor {
         *x
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+        _option: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         self.levels.get_unchecked((x - 1) as isize).unwrap()
     }
 }

--- a/crates/harp/src/vector/factor.rs
+++ b/crates/harp/src/vector/factor.rs
@@ -16,7 +16,7 @@ use libr::SEXP;
 
 use crate::object::RObject;
 use crate::r_symbol;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
 
@@ -74,11 +74,7 @@ impl Vector for Factor {
         *x
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        _option: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         self.levels.get_unchecked((x - 1) as isize).unwrap()
     }
 }

--- a/crates/harp/src/vector/factor.rs
+++ b/crates/harp/src/vector/factor.rs
@@ -16,7 +16,7 @@ use libr::SEXP;
 
 use crate::object::RObject;
 use crate::r_symbol;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
 

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -47,7 +47,7 @@ pub enum FormattedVector {
     },
     Character {
         vector: CharacterVector,
-        options: FormattedVectorCharacterOptions,
+        options: FormatOptions,
     },
     Complex {
         vector: ComplexVector,
@@ -58,12 +58,12 @@ pub enum FormattedVector {
     },
     FormattedVector {
         vector: CharacterVector,
-        options: FormattedVectorCharacterOptions,
+        options: FormatOptions,
     },
 }
 
 // Formatting options for character vectors
-pub struct FormattedVectorCharacterOptions {
+pub struct FormatOptions {
     // Wether to quote the strings or not (defaults to `true`)
     // If `true`, elements will be quoted during format so, eg: c("a", "b") becomes ("\"a\"", "\"b\"") in Rust
     pub quote: bool,
@@ -73,10 +73,10 @@ pub struct FormattedVectorCharacterOptions {
 #[derive(Default)]
 pub struct FormattedVectorOptions {
     // Formatting options for character vectors
-    pub character: FormattedVectorCharacterOptions,
+    pub character: FormatOptions,
 }
 
-impl Default for FormattedVectorCharacterOptions {
+impl Default for FormatOptions {
     fn default() -> Self {
         Self { quote: true }
     }
@@ -235,8 +235,8 @@ mod tests {
     use crate::object::RObject;
     use crate::r_assert_type;
     use crate::test::r_test;
+    use crate::vector::formatted_vector::FormatOptions;
     use crate::vector::formatted_vector::FormattedVector;
-    use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
     use crate::vector::formatted_vector::FormattedVectorOptions;
 
     #[test]
@@ -273,7 +273,7 @@ mod tests {
             r_assert_type(x.sexp, &[STRSXP]).unwrap();
 
             let formatted = FormattedVector::new_with_options(x.sexp, FormattedVectorOptions {
-                character: FormattedVectorCharacterOptions { quote: false },
+                character: FormatOptions { quote: false },
             })
             .unwrap();
 
@@ -281,7 +281,7 @@ mod tests {
             assert_eq!(out, String::from("1 2"));
 
             let formatted = FormattedVector::new_with_options(x.sexp, FormattedVectorOptions {
-                character: FormattedVectorCharacterOptions { quote: true },
+                character: FormatOptions { quote: true },
             })
             .unwrap();
 

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -139,32 +139,18 @@ impl FormattedVector {
 
     pub fn get_unchecked(&self, index: isize) -> String {
         match self {
-            FormattedVector::Raw { vector } => vector.format_elt_unchecked(index),
-            FormattedVector::Logical { vector } => vector.format_elt_unchecked(index),
-            FormattedVector::Integer { vector } => vector.format_elt_unchecked(index),
-            FormattedVector::Numeric { vector } => vector.format_elt_unchecked(index),
+            FormattedVector::Raw { vector } => vector.format_elt_unchecked(index, None),
+            FormattedVector::Logical { vector } => vector.format_elt_unchecked(index, None),
+            FormattedVector::Integer { vector } => vector.format_elt_unchecked(index, None),
+            FormattedVector::Numeric { vector } => vector.format_elt_unchecked(index, None),
             FormattedVector::Character { vector, options } => {
-                let value = vector.format_elt_unchecked(index);
-                self.format_with_string_options(value, options)
+                vector.format_elt_unchecked(index, Some(options))
             },
-            FormattedVector::Complex { vector } => vector.format_elt_unchecked(index),
-            FormattedVector::Factor { vector } => vector.format_elt_unchecked(index),
+            FormattedVector::Complex { vector } => vector.format_elt_unchecked(index, None),
+            FormattedVector::Factor { vector } => vector.format_elt_unchecked(index, None),
             FormattedVector::FormattedVector { vector, options } => {
-                let value = vector.format_elt_unchecked(index);
-                self.format_with_string_options(value, options)
+                vector.format_elt_unchecked(index, Some(options))
             },
-        }
-    }
-
-    fn format_with_string_options(
-        &self,
-        value: String,
-        options: &FormattedVectorCharacterOptions,
-    ) -> String {
-        if options.quote {
-            format!("\"{}\"", value.replace("\"", "\\\""))
-        } else {
-            value
         }
     }
 

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -26,6 +26,7 @@ use crate::utils::r_typeof;
 use crate::vector::CharacterVector;
 use crate::vector::ComplexVector;
 use crate::vector::Factor;
+use crate::vector::FormatOptions;
 use crate::vector::IntegerVector;
 use crate::vector::LogicalVector;
 use crate::vector::NumericVector;
@@ -60,13 +61,6 @@ pub enum FormattedVector {
         vector: CharacterVector,
         options: FormatOptions,
     },
-}
-
-// Formatting options for character vectors
-pub struct FormatOptions {
-    // Wether to quote the strings or not (defaults to `true`)
-    // If `true`, elements will be quoted during format so, eg: c("a", "b") becomes ("\"a\"", "\"b\"") in Rust
-    pub quote: bool,
 }
 
 // Formatting options for vectors
@@ -237,9 +231,9 @@ mod tests {
     use crate::object::RObject;
     use crate::r_assert_type;
     use crate::test::r_test;
-    use crate::vector::formatted_vector::FormatOptions;
     use crate::vector::formatted_vector::FormattedVector;
     use crate::vector::formatted_vector::FormattedVectorOptions;
+    use crate::vector::FormatOptions;
 
     #[test]
     fn test_unconforming_format_method() {

--- a/crates/harp/src/vector/integer_vector.rs
+++ b/crates/harp/src/vector/integer_vector.rs
@@ -14,6 +14,7 @@ use libr::INTSXP;
 use libr::SEXP;
 
 use crate::object::RObject;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -68,7 +69,11 @@ impl Vector for IntegerVector {
         *x
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+        _option: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         x.to_string()
     }
 }

--- a/crates/harp/src/vector/integer_vector.rs
+++ b/crates/harp/src/vector/integer_vector.rs
@@ -14,7 +14,7 @@ use libr::INTSXP;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]

--- a/crates/harp/src/vector/integer_vector.rs
+++ b/crates/harp/src/vector/integer_vector.rs
@@ -14,7 +14,7 @@ use libr::INTSXP;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -69,11 +69,7 @@ impl Vector for IntegerVector {
         *x
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        _option: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         x.to_string()
     }
 }

--- a/crates/harp/src/vector/logical_vector.rs
+++ b/crates/harp/src/vector/logical_vector.rs
@@ -14,7 +14,7 @@ use libr::LOGICAL_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]

--- a/crates/harp/src/vector/logical_vector.rs
+++ b/crates/harp/src/vector/logical_vector.rs
@@ -14,6 +14,7 @@ use libr::LOGICAL_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -68,7 +69,11 @@ impl Vector for LogicalVector {
         *x == 1
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+        _option: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         if x {
             String::from("TRUE")
         } else {

--- a/crates/harp/src/vector/logical_vector.rs
+++ b/crates/harp/src/vector/logical_vector.rs
@@ -14,7 +14,7 @@ use libr::LOGICAL_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -69,11 +69,7 @@ impl Vector for LogicalVector {
         *x == 1
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        _option: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         if x {
             String::from("TRUE")
         } else {

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -115,12 +115,4 @@ pub trait Vector {
             None => String::from("NA"),
         }
     }
-
-    fn format_with_options(&self, value: String, options: &FormatOptions) -> String {
-        if options.quote {
-            format!("\"{}\"", value.replace("\"", "\\\""))
-        } else {
-            value
-        }
-    }
 }

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -12,7 +12,7 @@ use libr::SEXP;
 use crate::error::Result;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 
 pub mod character_vector;
 pub use character_vector::CharacterVector;
@@ -101,28 +101,16 @@ pub trait Vector {
         Rf_xlength(self.data()) as usize
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        options: Option<&FormattedVectorCharacterOptions>,
-    ) -> String;
+    fn format_one(&self, x: Self::Type, options: Option<&FormatOptions>) -> String;
 
-    fn format_elt_unchecked(
-        &self,
-        index: isize,
-        options: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_elt_unchecked(&self, index: isize, options: Option<&FormatOptions>) -> String {
         match self.get_unchecked(index) {
             Some(x) => self.format_one(x, options),
             None => String::from("NA"),
         }
     }
 
-    fn format_with_string_options(
-        &self,
-        value: String,
-        options: &FormattedVectorCharacterOptions,
-    ) -> String {
+    fn format_with_options(&self, value: String, options: &FormatOptions) -> String {
         if options.quote {
             format!("\"{}\"", value.replace("\"", "\\\""))
         } else {

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -12,7 +12,6 @@ use libr::SEXP;
 use crate::error::Result;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
-use crate::vector::formatted_vector::FormatOptions;
 
 pub mod character_vector;
 pub use character_vector::CharacterVector;
@@ -37,6 +36,13 @@ pub use raw_vector::RawVector;
 
 pub mod formatted_vector;
 pub mod names;
+
+// Formatting options for character vectors
+pub struct FormatOptions {
+    // Wether to quote the strings or not (defaults to `true`)
+    // If `true`, elements will be quoted during format so, eg: c("a", "b") becomes ("\"a\"", "\"b\"") in Rust
+    pub quote: bool,
+}
 
 pub trait Vector {
     type Type;

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -41,6 +41,7 @@ pub mod names;
 pub struct FormatOptions {
     // Wether to quote the strings or not (defaults to `true`)
     // If `true`, elements will be quoted during format so, eg: c("a", "b") becomes ("\"a\"", "\"b\"") in Rust
+    // Currently, this option is meaningful only for a character vector and is ignored on other types
     pub quote: bool,
 }
 

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -12,6 +12,7 @@ use libr::SEXP;
 use crate::error::Result;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 
 pub mod character_vector;
 pub use character_vector::CharacterVector;
@@ -100,12 +101,32 @@ pub trait Vector {
         Rf_xlength(self.data()) as usize
     }
 
-    fn format_one(&self, x: Self::Type) -> String;
+    fn format_one(
+        &self,
+        x: Self::Type,
+        options: Option<&FormattedVectorCharacterOptions>,
+    ) -> String;
 
-    fn format_elt_unchecked(&self, index: isize) -> String {
+    fn format_elt_unchecked(
+        &self,
+        index: isize,
+        options: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         match self.get_unchecked(index) {
-            Some(x) => self.format_one(x),
+            Some(x) => self.format_one(x, options),
             None => String::from("NA"),
+        }
+    }
+
+    fn format_with_string_options(
+        &self,
+        value: String,
+        options: &FormattedVectorCharacterOptions,
+    ) -> String {
+        if options.quote {
+            format!("\"{}\"", value.replace("\"", "\\\""))
+        } else {
+            value
         }
     }
 }

--- a/crates/harp/src/vector/numeric_vector.rs
+++ b/crates/harp/src/vector/numeric_vector.rs
@@ -14,7 +14,7 @@ use libr::REAL_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -69,11 +69,7 @@ impl Vector for NumericVector {
         *x
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        _option: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         x.to_string()
     }
 }

--- a/crates/harp/src/vector/numeric_vector.rs
+++ b/crates/harp/src/vector/numeric_vector.rs
@@ -14,6 +14,7 @@ use libr::REAL_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -68,7 +69,11 @@ impl Vector for NumericVector {
         *x
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+        _option: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         x.to_string()
     }
 }

--- a/crates/harp/src/vector/numeric_vector.rs
+++ b/crates/harp/src/vector/numeric_vector.rs
@@ -14,7 +14,7 @@ use libr::REAL_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]

--- a/crates/harp/src/vector/raw_vector.rs
+++ b/crates/harp/src/vector/raw_vector.rs
@@ -13,7 +13,7 @@ use libr::RAW_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormatOptions;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]

--- a/crates/harp/src/vector/raw_vector.rs
+++ b/crates/harp/src/vector/raw_vector.rs
@@ -13,6 +13,7 @@ use libr::RAW_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
+use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -67,7 +68,11 @@ impl Vector for RawVector {
         *x
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+        _option: Option<&FormattedVectorCharacterOptions>,
+    ) -> String {
         format!("{:02x}", x)
     }
 }

--- a/crates/harp/src/vector/raw_vector.rs
+++ b/crates/harp/src/vector/raw_vector.rs
@@ -13,7 +13,7 @@ use libr::RAW_ELT;
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::vector::formatted_vector::FormattedVectorCharacterOptions;
+use crate::vector::formatted_vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -68,11 +68,7 @@ impl Vector for RawVector {
         *x
     }
 
-    fn format_one(
-        &self,
-        x: Self::Type,
-        _option: Option<&FormattedVectorCharacterOptions>,
-    ) -> String {
+    fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         format!("{:02x}", x)
     }
 }


### PR DESCRIPTION
This pull request addresses https://github.com/posit-dev/positron/issues/3810

Since `format()` and `format_one()` belongs to `Vector`, I think `format_with_string_options()` should also belong to `Vector` and be called there. But, I'm not sure if it's a good idea to include `FormattedVectorCharacterOptions` in the signature of all types of `Vector`. Considering https://github.com/posit-dev/positron/issues/2860 will introduce a facility to handle this kind of distinction easier, I'm not sure if this is worth, but I share this code just in case this helps.