### PR TITLE
Defer completion from string to handle subsetting cases

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -31,6 +31,11 @@ use tower_lsp::lsp_types::CompletionItemKind;
 use tree_sitter::Node;
 use workspace::completions_from_workspace;
 
+// TODO: string can be either a unique case (e.g. file path) or a composite case
+// (e.g. a variable name in `[` operator). To handle the both case, use this in
+// the code for composite cases because otherwise it returns early and never
+// visits the latter case.
+use super::unique::string::completions_from_string;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 use crate::treesitter::NodeType;
@@ -58,6 +63,11 @@ pub fn completions_from_composite_sources(
 
     // Try subset completions (`[` or `[[`)
     if let Some(mut additional_completions) = completions_from_subset(context)? {
+        completions.append(&mut additional_completions);
+    }
+
+    // Try string (like file path) completions
+    if let Some(mut additional_completions) = completions_from_string(context)? {
         completions.append(&mut additional_completions);
     }
 

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -160,9 +160,11 @@ fn is_identifier_like(x: Node) -> bool {
 mod tests {
     use tree_sitter::Point;
 
+    use crate::lsp::completions::sources::completions_from_composite_sources;
     use crate::lsp::completions::sources::composite::is_identifier_like;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
+    use crate::lsp::state::WorldState;
     use crate::test::r_test;
     use crate::treesitter::NodeType;
     use crate::treesitter::NodeTypeExt;
@@ -183,6 +185,23 @@ mod tests {
                     NodeType::Anonymous(keyword.to_string())
                 );
             }
+        })
+    }
+
+    #[test]
+    fn test_unique_completion_from_string_in_composite() {
+        r_test(|| {
+            // Before or after the `''`, i.e. `|''` or `''|`.
+            // Still considered part of the string node.
+            let point = Point { row: 0, column: 2 };
+
+            // Assume home directory is not empty
+            let document = Document::new("'~/'", None);
+
+            // `None` trigger -> Return file completions
+            let context = DocumentContext::new(&document, point, None);
+            let res = completions_from_composite_sources(&context, &WorldState::default()).unwrap();
+            assert!(!res.is_empty());
         })
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -149,10 +149,28 @@ mod tests {
             assert_eq!(completions.len(), 2);
 
             let completion = completions.get(0).unwrap();
-            assert_eq!(completion.label, "b".to_string());
+            assert_eq!(&completion.label, "b");
+            assert_eq!(completion.insert_text.as_ref().unwrap(), r#""b""#);
 
             let completion = completions.get(1).unwrap();
             assert_eq!(completion.label, "a".to_string());
+            assert_eq!(completion.insert_text.as_ref().unwrap(), r#""a""#);
+
+            // Right after the `[` and inside ""
+            let point = Point { row: 0, column: 5 };
+            let document = Document::new(r#"foo[""]"#, None);
+            let context = DocumentContext::new(&document, point, None);
+
+            let completions = completions_from_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+
+            let completion = completions.get(0).unwrap();
+            assert_eq!(completion.label, "b".to_string());
+            assert!(completion.insert_text.is_none()); // returns the unquoted result
+
+            let completion = completions.get(1).unwrap();
+            assert_eq!(completion.label, "a".to_string());
+            assert!(completion.insert_text.is_none());
 
             // Right before the `[`
             let point = Point { row: 0, column: 3 };

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -26,10 +26,11 @@ pub(super) fn completions_from_subset(
 ) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_subset()");
 
-    const ENQUOTE: bool = true;
-
     let mut node = context.node;
     let mut subset_type = None;
+
+    // Wrap the variable quote only when the user doesn't yet do it by themselves.
+    let enquote = !node.is_string();
 
     loop {
         let node_type = node.node_type();
@@ -70,7 +71,7 @@ pub(super) fn completions_from_subset(
 
     let text = context.document.contents.node_slice(&child)?.to_string();
 
-    completions_from_evaluated_object_names(&text, ENQUOTE)
+    completions_from_evaluated_object_names(&text, enquote)
 }
 
 fn is_within_subset_delimiters(x: &Point, subset_node: &Node, subset_type: &NodeType) -> bool {

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -139,10 +139,10 @@ mod tests {
 
             // Set up a list with names
             r_parse_eval("foo <- list(b = 1, a = 2)", options.clone()).unwrap();
+            let document = Document::new("foo[]", None);
 
             // Right after the `[`
             let point = Point { row: 0, column: 4 };
-            let document = Document::new("foo[]", None);
             let context = DocumentContext::new(&document, point, None);
 
             let completions = completions_from_subset(&context).unwrap().unwrap();
@@ -153,8 +153,20 @@ mod tests {
             assert_eq!(completion.insert_text.as_ref().unwrap(), r#""b""#);
 
             let completion = completions.get(1).unwrap();
-            assert_eq!(completion.label, "a".to_string());
+            assert_eq!(&completion.label, "a");
             assert_eq!(completion.insert_text.as_ref().unwrap(), r#""a""#);
+
+            // Right before the `[`
+            let point = Point { row: 0, column: 3 };
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_subset(&context).unwrap();
+            assert!(completions.is_none());
+
+            // Right after the `]`
+            let point = Point { row: 0, column: 5 };
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_subset(&context).unwrap();
+            assert!(completions.is_none());
 
             // Right after the `[` and inside ""
             let point = Point { row: 0, column: 5 };
@@ -165,26 +177,12 @@ mod tests {
             assert_eq!(completions.len(), 2);
 
             let completion = completions.get(0).unwrap();
-            assert_eq!(completion.label, "b".to_string());
+            assert_eq!(&completion.label, "b");
             assert!(completion.insert_text.is_none()); // returns the unquoted result
 
             let completion = completions.get(1).unwrap();
-            assert_eq!(completion.label, "a".to_string());
+            assert_eq!(&completion.label, "a");
             assert!(completion.insert_text.is_none());
-
-            // Right before the `[`
-            let point = Point { row: 0, column: 3 };
-            let document = Document::new("foo[]", None);
-            let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_subset(&context).unwrap();
-            assert!(completions.is_none());
-
-            // Right after the `]`
-            let point = Point { row: 0, column: 5 };
-            let document = Document::new("foo[]", None);
-            let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_subset(&context).unwrap();
-            assert!(completions.is_none());
 
             // Clean up
             r_parse_eval("remove(foo)", options.clone()).unwrap();

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -11,7 +11,12 @@ mod custom;
 mod extractor;
 mod file_path;
 mod namespace;
-mod string;
+
+// TODO: string can be either a unique case (e.g. file path) or a composite case
+// (e.g. a variable name in `[` operator). To handle the both case, use this in
+// the code for composite cases because otherwise it returns early and never
+// visits the latter case.
+pub(crate) mod string;
 
 use anyhow::Result;
 use colon::completions_from_single_colon;
@@ -20,7 +25,6 @@ use custom::completions_from_custom_source;
 use extractor::completions_from_at;
 use extractor::completions_from_dollar;
 use namespace::completions_from_namespace;
-use string::completions_from_string;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::document_context::DocumentContext;
@@ -38,11 +42,6 @@ pub fn completions_from_unique_sources(
 
     // Try comment / roxygen2 completions
     if let Some(completions) = completions_from_comment(context)? {
-        return Ok(Some(completions));
-    }
-
-    // Try string (like file path) completions
-    if let Some(completions) = completions_from_string(context)? {
         return Ok(Some(completions));
     }
 

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -49,7 +49,6 @@ mod tests {
     use harp::assert_match;
     use tree_sitter::Point;
 
-    use crate::lsp::completions::sources::completions_from_unique_sources;
     use crate::lsp::completions::sources::unique::string::completions_from_string;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
@@ -104,10 +103,6 @@ mod tests {
             // `Some` trigger -> Should return empty completion set
             let context = DocumentContext::new(&document, point, Some(String::from("$")));
             let res = completions_from_string(&context).unwrap();
-            assert_match!(res, Some(items) => { assert!(items.len() == 0) });
-
-            // Check one level up too
-            let res = completions_from_unique_sources(&context).unwrap();
             assert_match!(res, Some(items) => { assert!(items.len() == 0) });
         })
     }


### PR DESCRIPTION
This PR should address https://github.com/posit-dev/positron/issues/3931

Currently, `completions_from_string()` is invoked in unique cases and return early, but what https://github.com/posit-dev/positron/issues/3931 revealed is that it can be a composite case. So, this pull request moves `completions_from_string()` into `completions_from_composite_sources()` so that it can provide completion items for both cases.

(A string can be treated more specially to handle more cases, but what I could come up with is only the subsetting case.)