### PR TITLE
Regenerate comms with strum support

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -567,195 +567,246 @@ pub struct DataSelectionIndices {
 }
 
 /// Possible values for ColumnDisplayType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnDisplayType {
 	#[serde(rename = "number")]
+	#[strum(to_string = "number")]
 	Number,
 
 	#[serde(rename = "boolean")]
+	#[strum(to_string = "boolean")]
 	Boolean,
 
 	#[serde(rename = "string")]
+	#[strum(to_string = "string")]
 	String,
 
 	#[serde(rename = "date")]
+	#[strum(to_string = "date")]
 	Date,
 
 	#[serde(rename = "datetime")]
+	#[strum(to_string = "datetime")]
 	Datetime,
 
 	#[serde(rename = "time")]
+	#[strum(to_string = "time")]
 	Time,
 
 	#[serde(rename = "object")]
+	#[strum(to_string = "object")]
 	Object,
 
 	#[serde(rename = "array")]
+	#[strum(to_string = "array")]
 	Array,
 
 	#[serde(rename = "struct")]
+	#[strum(to_string = "struct")]
 	Struct,
 
 	#[serde(rename = "unknown")]
+	#[strum(to_string = "unknown")]
 	Unknown
 }
 
 /// Possible values for Condition in RowFilter
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum RowFilterCondition {
 	#[serde(rename = "and")]
+	#[strum(to_string = "and")]
 	And,
 
 	#[serde(rename = "or")]
+	#[strum(to_string = "or")]
 	Or
 }
 
 /// Possible values for RowFilterType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum RowFilterType {
 	#[serde(rename = "between")]
+	#[strum(to_string = "between")]
 	Between,
 
 	#[serde(rename = "compare")]
+	#[strum(to_string = "compare")]
 	Compare,
 
 	#[serde(rename = "is_empty")]
+	#[strum(to_string = "is_empty")]
 	IsEmpty,
 
 	#[serde(rename = "is_false")]
+	#[strum(to_string = "is_false")]
 	IsFalse,
 
 	#[serde(rename = "is_null")]
+	#[strum(to_string = "is_null")]
 	IsNull,
 
 	#[serde(rename = "is_true")]
+	#[strum(to_string = "is_true")]
 	IsTrue,
 
 	#[serde(rename = "not_between")]
+	#[strum(to_string = "not_between")]
 	NotBetween,
 
 	#[serde(rename = "not_empty")]
+	#[strum(to_string = "not_empty")]
 	NotEmpty,
 
 	#[serde(rename = "not_null")]
+	#[strum(to_string = "not_null")]
 	NotNull,
 
 	#[serde(rename = "search")]
+	#[strum(to_string = "search")]
 	Search,
 
 	#[serde(rename = "set_membership")]
+	#[strum(to_string = "set_membership")]
 	SetMembership
 }
 
 /// Possible values for Op in FilterComparison
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum FilterComparisonOp {
 	#[serde(rename = "=")]
+	#[strum(to_string = "=")]
 	Eq,
 
 	#[serde(rename = "!=")]
+	#[strum(to_string = "!=")]
 	NotEq,
 
 	#[serde(rename = "<")]
+	#[strum(to_string = "<")]
 	Lt,
 
 	#[serde(rename = "<=")]
+	#[strum(to_string = "<=")]
 	LtEq,
 
 	#[serde(rename = ">")]
+	#[strum(to_string = ">")]
 	Gt,
 
 	#[serde(rename = ">=")]
+	#[strum(to_string = ">=")]
 	GtEq
 }
 
 /// Possible values for TextSearchType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum TextSearchType {
 	#[serde(rename = "contains")]
+	#[strum(to_string = "contains")]
 	Contains,
 
 	#[serde(rename = "starts_with")]
+	#[strum(to_string = "starts_with")]
 	StartsWith,
 
 	#[serde(rename = "ends_with")]
+	#[strum(to_string = "ends_with")]
 	EndsWith,
 
 	#[serde(rename = "regex_match")]
+	#[strum(to_string = "regex_match")]
 	RegexMatch
 }
 
 /// Possible values for ColumnFilterType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnFilterType {
 	#[serde(rename = "text_search")]
+	#[strum(to_string = "text_search")]
 	TextSearch,
 
 	#[serde(rename = "match_data_types")]
+	#[strum(to_string = "match_data_types")]
 	MatchDataTypes
 }
 
 /// Possible values for ColumnProfileType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnProfileType {
 	#[serde(rename = "null_count")]
+	#[strum(to_string = "null_count")]
 	NullCount,
 
 	#[serde(rename = "summary_stats")]
+	#[strum(to_string = "summary_stats")]
 	SummaryStats,
 
 	#[serde(rename = "frequency_table")]
+	#[strum(to_string = "frequency_table")]
 	FrequencyTable,
 
 	#[serde(rename = "histogram")]
+	#[strum(to_string = "histogram")]
 	Histogram
 }
 
 /// Possible values for Kind in DataSelection
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum DataSelectionKind {
 	#[serde(rename = "single_cell")]
+	#[strum(to_string = "single_cell")]
 	SingleCell,
 
 	#[serde(rename = "cell_range")]
+	#[strum(to_string = "cell_range")]
 	CellRange,
 
 	#[serde(rename = "column_range")]
+	#[strum(to_string = "column_range")]
 	ColumnRange,
 
 	#[serde(rename = "row_range")]
+	#[strum(to_string = "row_range")]
 	RowRange,
 
 	#[serde(rename = "column_indices")]
+	#[strum(to_string = "column_indices")]
 	ColumnIndices,
 
 	#[serde(rename = "row_indices")]
+	#[strum(to_string = "row_indices")]
 	RowIndices
 }
 
 /// Possible values for ExportFormat
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ExportFormat {
 	#[serde(rename = "csv")]
+	#[strum(to_string = "csv")]
 	Csv,
 
 	#[serde(rename = "tsv")]
+	#[strum(to_string = "tsv")]
 	Tsv,
 
 	#[serde(rename = "html")]
+	#[strum(to_string = "html")]
 	Html
 }
 
 /// Possible values for SupportStatus
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum SupportStatus {
 	#[serde(rename = "unsupported")]
+	#[strum(to_string = "unsupported")]
 	Unsupported,
 
 	#[serde(rename = "supported")]
+	#[strum(to_string = "supported")]
 	Supported,
 
 	#[serde(rename = "experimental")]
+	#[strum(to_string = "experimental")]
 	Experimental
 }
 

--- a/crates/amalthea/src/comm/help_comm.rs
+++ b/crates/amalthea/src/comm/help_comm.rs
@@ -12,15 +12,18 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// Possible values for Kind in ShowHelp
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ShowHelpKind {
 	#[serde(rename = "html")]
+	#[strum(to_string = "html")]
 	Html,
 
 	#[serde(rename = "markdown")]
+	#[strum(to_string = "markdown")]
 	Markdown,
 
 	#[serde(rename = "url")]
+	#[strum(to_string = "url")]
 	Url
 }
 

--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -25,15 +25,19 @@ pub struct PlotResult {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum RenderFormat {
 	#[serde(rename = "png")]
+	#[strum(to_string = "png")]
 	Png,
 
 	#[serde(rename = "jpeg")]
+	#[strum(to_string = "jpeg")]
 	Jpeg,
 
 	#[serde(rename = "svg")]
+	#[strum(to_string = "svg")]
 	Svg,
 
 	#[serde(rename = "pdf")]
+	#[strum(to_string = "pdf")]
 	Pdf
 }
 
@@ -108,3 +112,4 @@ pub enum PlotFrontendEvent {
 	Show,
 
 }
+

--- a/crates/amalthea/src/comm/variables_comm.rs
+++ b/crates/amalthea/src/comm/variables_comm.rs
@@ -91,55 +91,70 @@ pub struct Variable {
 }
 
 /// Possible values for Format in ClipboardFormat
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ClipboardFormatFormat {
 	#[serde(rename = "text/html")]
+	#[strum(to_string = "text/html")]
 	TextHtml,
 
 	#[serde(rename = "text/plain")]
+	#[strum(to_string = "text/plain")]
 	TextPlain
 }
 
 /// Possible values for Kind in Variable
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum VariableKind {
 	#[serde(rename = "boolean")]
+	#[strum(to_string = "boolean")]
 	Boolean,
 
 	#[serde(rename = "bytes")]
+	#[strum(to_string = "bytes")]
 	Bytes,
 
 	#[serde(rename = "class")]
+	#[strum(to_string = "class")]
 	Class,
 
 	#[serde(rename = "collection")]
+	#[strum(to_string = "collection")]
 	Collection,
 
 	#[serde(rename = "empty")]
+	#[strum(to_string = "empty")]
 	Empty,
 
 	#[serde(rename = "function")]
+	#[strum(to_string = "function")]
 	Function,
 
 	#[serde(rename = "map")]
+	#[strum(to_string = "map")]
 	Map,
 
 	#[serde(rename = "number")]
+	#[strum(to_string = "number")]
 	Number,
 
 	#[serde(rename = "other")]
+	#[strum(to_string = "other")]
 	Other,
 
 	#[serde(rename = "string")]
+	#[strum(to_string = "string")]
 	String,
 
 	#[serde(rename = "table")]
+	#[strum(to_string = "table")]
 	Table,
 
 	#[serde(rename = "lazy")]
+	#[strum(to_string = "lazy")]
 	Lazy,
 
 	#[serde(rename = "connection")]
+	#[strum(to_string = "connection")]
 	Connection
 }
 

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -387,7 +387,7 @@ impl DeviceContext {
                 .param("width", RObject::try_from(width)?)
                 .param("height", RObject::try_from(height)?)
                 .param("dpr", pixel_ratio)
-                .param("format", format.to_string().to_lowercase())
+                .param("format", format.to_string())
                 .call()?
                 .to::<String>()
         });


### PR DESCRIPTION
Address https://github.com/posit-dev/positron/issues/3852

Enums implement a `to_string` that returns the value instead of variant name

Updates the plot saving to use the implemented `to_string`.