### PR TITLE
Bump ark to 0.1.117 and build on Ubuntu 20.04

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     build_linux:
         name: Build Linux
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         timeout-minutes: 60
 
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.116"
+version = "0.1.117"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
Part of https://github.com/posit-dev/positron/issues/3854