### PR TITLE
Log at info level for (mostly) expected try catch errors

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -104,13 +104,19 @@ fn eval_pipe_root(name: &str) -> Option<RObject> {
 
     // If we get an `UnsafeEvaluationError` here from setting
     // `forbid_function_calls`, we don't want that to prevent
-    // other sources from contributing completions
+    // other sources from contributing completions.
+    // If we get a `TryCatchError`, that is typically an 'object not found' error resulting
+    // from the user typing pseudocode. Log those at info level without a full backtrace.
     let value = match value {
         Ok(value) => value,
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return None,
+            Error::TryCatchError { message, .. } => {
+                log::info!("Can't evaluate pipe root: {message}");
+                return None;
+            },
             _ => {
-                log::error!("{err:?}");
+                log::error!("Can't evaluate pipe root: {err:?}");
                 return None;
             },
         },


### PR DESCRIPTION
There are a number of places where we try `r_parse_eval()` with the expectation that the user _may_ be writing pseudocode, and it's totally fine for the evaluation to fail with "object not found" errors.

Those cases were generating full backtraces and sometimes logging at error level, resulting in a lot of misleading noise when looking at the logs. Like this:

<img width="1048" alt="Screenshot 2024-07-13 at 6 05 54 PM" src="https://github.com/user-attachments/assets/13048767-d01a-4eb4-b0ba-2fe4bbc253ec">

It's not a bad idea to log something here, but I think we can just log the `message` and do it at info level, resulting in:

<img width="956" alt="Screenshot 2024-07-13 at 6 01 41 PM" src="https://github.com/user-attachments/assets/eea4f378-6196-40c8-bf0d-83f51700f2ee">
