### PR TITLE
Remove usage of `debug!` in favor of `info!` or `trace!`

### DIFF
--- a/crates/ark/src/control.rs
+++ b/crates/ark/src/control.rs
@@ -13,7 +13,6 @@ use amalthea::wire::shutdown_reply::ShutdownReply;
 use amalthea::wire::shutdown_request::ShutdownRequest;
 use async_trait::async_trait;
 use crossbeam::channel::Sender;
-use log::*;
 
 use crate::request::RRequest;
 
@@ -35,7 +34,7 @@ impl ControlHandler for Control {
         &self,
         msg: &ShutdownRequest,
     ) -> Result<ShutdownReply, Exception> {
-        debug!("Received shutdown request: {:?}", msg);
+        log::info!("Received shutdown request: {msg:?}");
 
         // According to the Jupyter protocol we should block here until the
         // shutdown is complete. However AFAICS ipykernel doesn't wait
@@ -56,7 +55,7 @@ impl ControlHandler for Control {
     }
 
     async fn handle_interrupt_request(&self) -> Result<InterruptReply, Exception> {
-        debug!("Received interrupt request");
+        log::info!("Received interrupt request");
         crate::sys::control::handle_interrupt_request();
         Ok(InterruptReply { status: Status::Ok })
     }

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -86,7 +86,6 @@ use libr::Rf_error;
 use libr::Rf_findVarInFrame;
 use libr::Rf_onintr;
 use libr::SEXP;
-use log::*;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde_json::json;
@@ -534,11 +533,11 @@ impl RMain {
                 continuation_prompt: Some(continuation_prompt),
             };
 
-            debug!("Sending kernel info: {}", version);
+            log::info!("Sending kernel info: {version}");
             self.kernel_init_tx.broadcast(kernel_info);
             self.initializing = false;
         } else {
-            warn!("Initialization already complete!");
+            log::warn!("Initialization already complete!");
         }
     }
 
@@ -563,9 +562,10 @@ impl RMain {
                 code: req.code.clone(),
                 execution_count: self.execution_count,
             })) {
-                warn!(
+                log::warn!(
                     "Could not broadcast execution input {} to all frontends: {}",
-                    self.execution_count, err
+                    self.execution_count,
+                    err
                 );
             }
         }
@@ -592,7 +592,7 @@ impl RMain {
         _hist: c_int,
     ) -> ConsoleResult {
         let info = Self::prompt_info(prompt);
-        debug!("R prompt: {}", info.input_prompt);
+        log::trace!("R prompt: {}", info.input_prompt);
 
         // Upon entering read-console, finalize any debug call text that we were capturing.
         // At this point, the user can either advance the debugger, causing us to capture
@@ -666,7 +666,7 @@ impl RMain {
                 Ok(stack) => {
                     self.dap.start_debug(stack);
                 },
-                Err(err) => error!("ReadConsole: Can't get stack info: {err}"),
+                Err(err) => log::error!("ReadConsole: Can't get stack info: {err}"),
             };
         } else {
             if self.dap.is_debugging() {
@@ -751,7 +751,7 @@ impl RMain {
     // bad state (e.g. causing freezes)
     fn prompt_info(prompt_c: *const c_char) -> PromptInfo {
         let n_frame = harp::session::r_n_frame().unwrap();
-        trace!("prompt_info(): n_frame = '{}'", n_frame);
+        log::trace!("prompt_info(): n_frame = '{n_frame}'");
 
         let prompt_slice = unsafe { CStr::from_ptr(prompt_c) };
         let prompt = prompt_slice.to_string_lossy().into_owned();
@@ -780,9 +780,9 @@ impl RMain {
         let incomplete = !user_request && prompt == continuation_prompt;
 
         if incomplete {
-            trace!("Got R prompt '{}', marking request incomplete", prompt);
+            log::trace!("Got R prompt '{prompt}', marking request incomplete");
         } else if user_request {
-            trace!("Got R prompt '{}', asking user for input", prompt);
+            log::trace!("Got R prompt '{prompt}', asking user for input");
         }
 
         return PromptInfo {

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -30,7 +30,6 @@ use ark::version::detect_r;
 use bus::Bus;
 use crossbeam::channel::bounded;
 use crossbeam::channel::unbounded;
-use log::*;
 use notify::Watcher;
 use stdext::unwrap;
 
@@ -48,8 +47,8 @@ fn start_kernel(
     // Create a new kernel from the connection file
     let mut kernel = match Kernel::new("ark", connection_file) {
         Ok(k) => k,
-        Err(e) => {
-            error!("Failed to create kernel: {}", e);
+        Err(err) => {
+            log::error!("Failed to create kernel: {err}");
             return;
         },
     };
@@ -211,11 +210,8 @@ fn parse_file(
 ) {
     match ConnectionFile::from_file(connection_file) {
         Ok(connection) => {
-            info!(
-                "Loaded connection information from frontend in {}",
-                connection_file
-            );
-            debug!("Connection data: {:?}", connection);
+            log::info!("Loaded connection information from frontend in {connection_file}");
+            log::info!("Connection data: {:?}", connection);
             start_kernel(
                 connection,
                 r_args,
@@ -225,10 +221,7 @@ fn parse_file(
             );
         },
         Err(error) => {
-            error!(
-                "Couldn't read connection file {}: {:?}",
-                connection_file, error
-            );
+            log::error!("Couldn't read connection file {connection_file}: {error:?}");
         },
     }
 }

--- a/crates/echo/src/main.rs
+++ b/crates/echo/src/main.rs
@@ -20,9 +20,6 @@ use amalthea::kernel_spec::KernelSpec;
 use amalthea::socket::stdin::StdInRequest;
 use crossbeam::channel::bounded;
 use crossbeam::channel::unbounded;
-use log::debug;
-use log::error;
-use log::info;
 
 use crate::control::Control;
 use crate::shell::Shell;
@@ -98,18 +95,12 @@ fn install_kernel_spec() {
 fn parse_file(connection_file: &String) {
     match ConnectionFile::from_file(connection_file) {
         Ok(connection) => {
-            info!(
-                "Loaded connection information from front-end in {}",
-                connection_file
-            );
-            debug!("Connection data: {:?}", connection);
+            log::info!("Loaded connection information from front-end in {connection_file}");
+            log::info!("Connection data: {connection:?}");
             start_kernel(connection);
         },
         Err(error) => {
-            error!(
-                "Couldn't read connection file {}: {:?}",
-                connection_file, error
-            );
+            log::error!("Couldn't read connection file {connection_file}: {error:?}");
         },
     }
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4023

Most of the uses of `debug!` have been moved to `info!` because I think they provide valuable information that will be useful when users report issues. A few have been moved to `trace!` instead, if they really felt to be very low level

Along the way, modernized to use `log::error!()` instead of imported `error!()` in the files I touched