### PR TITLE
Add `try_eval_with_x()` POC

### DIFF
--- a/crates/ark/src/dap/dap_variables.rs
+++ b/crates/ark/src/dap/dap_variables.rs
@@ -444,7 +444,7 @@ mod tests {
     use harp::exec::RFunctionExt;
     use harp::object::*;
     use harp::r_char;
-    use harp::utils::r_envir_set;
+    use harp::utils::r_env_poke;
     use libr::*;
 
     use crate::dap::dap_variables::env_binding_variable;
@@ -459,7 +459,7 @@ mod tests {
                 .unwrap();
 
             let a = RObject::from(Rf_ScalarInteger(1));
-            r_envir_set("a", a.sexp, env.sexp);
+            r_env_poke(env.sexp, "a", a.sexp);
             let variable = env_binding_variable(String::from("a"), env.sexp).unwrap();
             assert_eq!(variable.name, String::from("a"));
             assert_eq!(variable.value, String::from("1L"));
@@ -479,7 +479,7 @@ mod tests {
                 .unwrap();
 
             let a = RObject::from(Rf_ScalarInteger(1));
-            r_envir_set("a", a.sexp, env.sexp);
+            r_env_poke(env.sexp, "a", a.sexp);
 
             let class = RObject::from(r_char!("foo"));
             let class = RObject::from(Rf_ScalarString(class.sexp));

--- a/crates/ark/tests/environment.rs
+++ b/crates/ark/tests/environment.rs
@@ -24,8 +24,8 @@ use harp::exec::RFunctionExt;
 use harp::object::RObject;
 use harp::r_symbol;
 use harp::test::start_r;
+use harp::utils::r_env_poke;
 use harp::utils::r_envir_remove;
-use harp::utils::r_envir_set;
 use libr::R_EmptyEnv;
 use libr::R_lsInternal;
 use libr::Rboolean_TRUE;
@@ -141,7 +141,7 @@ fn test_environment_list() {
     // Create another variable
     r_task(|| unsafe {
         let test_env = test_env.get().clone();
-        r_envir_set("nothing", Rf_ScalarInteger(43), *test_env);
+        r_env_poke(*test_env, "nothing", Rf_ScalarInteger(43));
         r_envir_remove("everything", *test_env);
     });
 

--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -308,6 +308,9 @@ functions::generate! {
 
     pub fn Rf_installChar(x: SEXP) -> SEXP;
 
+    /// R >= 4.1.0
+    pub fn R_NewEnv(enclos: SEXP, hash: std::ffi::c_int, size: std::ffi::c_int) -> SEXP;
+
     /// R >= 4.2.0
     pub fn R_existsVarInFrame(rho: SEXP, symbol: SEXP) -> Rboolean;
 


### PR DESCRIPTION
POC, not done, needs discussion with @lionel- about what this should look like. Part of a larger plan to stop inlining the heck out of everything when we do an R function call - see https://github.com/posit-dev/ark/issues/695

This technically addresses https://github.com/posit-dev/positron/issues/4008 and is motivated by it

The problem in that issue is that when `r_format(x)` calls the R level `harp_format(x)`, it _inlines_ `x` into the call. This means that when `harp_format()` errors and the R traceback is captured, the inlined version of `x` is captured in the R traceback, which we then print in the Output pane.

In this case `x` was an absolutely massive brmsfit object with elements in it that we don't know how to format, causing an error to get thrown from `harp_format()`, causing it to get inlined.

There are really two things to address here:

- First off, we actually expect `harp_format()` to error sometimes, so when we propagate its `Result` upward, do we really want the full traceback report to be provided whenever that `Error` is eventually logged? It feels to me like this is an "expected" error in some cases, and seeing the full traceback is noisy and misleading. I really just want to see the `message`, I think.

- Secondly, I think we need to invest in some infrastructure that allows us to replicate rlang's `eval_with_x()` idea. i.e. create a child env, define variables in it, and evaluate in that child env. This avoids the inline problem and results in cleaner tracebacks. I'd really like for this to be hooked into `RCall` and `RFunction` somehow, but I think we need to talk about the idea some more.

This PR starts by adding `try_eval_with_x()`, but it feels like the wrong level of abstraction

---

Reprex:

Run

```r
library(marginaleffects)
library(brms)

mod_miss <- insight::download_model("brms_miss_1")
```

Then go to the Variables pane and try and expand `mod_miss`.

Before:

Note that the `R backtrace` contains the entire inlined object.

<img width="882" alt="Screenshot 2024-07-17 at 4 39 35 PM" src="https://github.com/user-attachments/assets/dd035bd8-b9f2-42af-9740-b8a167e09d53">

After (note that we still noisily show the R thread traceback here, but at least we can tell what is going on):

<img width="883" alt="Screenshot 2024-07-17 at 4 36 17 PM" src="https://github.com/user-attachments/assets/873934cb-9c52-48e3-981d-d6074416f0cb">
