### PR TITLE
Only emit dynamic plots for console sessions

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -124,6 +124,7 @@ use crate::startup;
 use crate::sys::console::console_to_utf8;
 
 /// An enum representing the different modes in which the R session can run.
+#[derive(PartialEq, Clone)]
 pub enum SessionMode {
     /// A session with an interactive console (REPL), such as in Positron.
     Console,

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -94,6 +94,7 @@ fn start_kernel(
         kernel_init_rx,
         kernel_request_tx,
         kernel_request_rx,
+        session_mode.clone(),
     );
 
     // Create the control handler; this is used to handle shutdown/interrupt and

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -1,7 +1,7 @@
 //
 // graphics_device.rs
 //
-// Copyright (C) 2022 by Posit Software, PBC
+// Copyright (C) 2022-2024 by Posit Software, PBC
 //
 
 ///
@@ -133,13 +133,13 @@ impl DeviceContext {
         &mut self,
         comm_manager_tx: Sender<CommManagerEvent>,
         iopub_tx: Sender<IOPubMessage>,
-        positron_connected: bool,
+        dynamic_plots: bool,
     ) {
         // After R code has completed execution, we use this to check if any graphics
         // need to be created
         if self._changes {
             self._changes = false;
-            self.process_changes(comm_manager_tx, iopub_tx, positron_connected);
+            self.process_changes(comm_manager_tx, iopub_tx, dynamic_plots);
         }
     }
 
@@ -450,9 +450,9 @@ pub unsafe fn on_process_events() {
 pub unsafe fn on_did_execute_request(
     comm_manager_tx: Sender<CommManagerEvent>,
     iopub_tx: Sender<IOPubMessage>,
-    positron_connected: bool,
+    dynamic_plots: bool,
 ) {
-    DEVICE_CONTEXT.on_did_execute_request(comm_manager_tx, iopub_tx, positron_connected);
+    DEVICE_CONTEXT.on_did_execute_request(comm_manager_tx, iopub_tx, dynamic_plots);
 }
 
 // NOTE: May be called when rendering a plot to file, since this is done by

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -221,7 +221,7 @@ impl DeviceContext {
         &mut self,
         comm_manager_tx: Sender<CommManagerEvent>,
         iopub_tx: Sender<IOPubMessage>,
-        positron_connected: bool,
+        dynamic_plots: bool,
     ) {
         let id = unwrap!(self._id.clone(), None => {
             log::error!("Unexpected uninitialized `id`.");
@@ -230,9 +230,9 @@ impl DeviceContext {
 
         if self._new_page {
             self._new_page = false;
-            self.process_new_plot(id.as_str(), comm_manager_tx, iopub_tx, positron_connected);
+            self.process_new_plot(id.as_str(), comm_manager_tx, iopub_tx, dynamic_plots);
         } else {
-            self.process_update_plot(id.as_str(), iopub_tx, positron_connected);
+            self.process_update_plot(id.as_str(), iopub_tx, dynamic_plots);
         }
     }
 
@@ -241,9 +241,9 @@ impl DeviceContext {
         id: &str,
         comm_manager_tx: Sender<CommManagerEvent>,
         iopub_tx: Sender<IOPubMessage>,
-        positron_connected: bool,
+        dynamic_plots: bool,
     ) {
-        if positron_connected {
+        if dynamic_plots {
             self.process_new_plot_positron(id, comm_manager_tx);
         } else {
             self.process_new_plot_jupyter_protocol(id, iopub_tx);
@@ -354,8 +354,8 @@ impl DeviceContext {
 
     fn create_display_data_plot(&mut self, id: &str) -> Result<serde_json::Value, anyhow::Error> {
         // TODO: Take these from R global options? Like `ark.plot.width`?
-        let width = 400;
-        let height = 650;
+        let width = 800;
+        let height = 600;
         let pixel_ratio = 1.0;
         let format = RenderFormat::Png;
 

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -1,7 +1,7 @@
 //
 // shell.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -52,6 +52,7 @@ use crate::help::r_help::RHelp;
 use crate::help_proxy;
 use crate::interface::KernelInfo;
 use crate::interface::RMain;
+use crate::interface::SessionMode;
 use crate::kernel::Kernel;
 use crate::plots::graphics_device;
 use crate::r_task;
@@ -69,6 +70,7 @@ pub struct Shell {
     kernel_request_tx: Sender<KernelRequest>,
     kernel_init_rx: BusReader<KernelInfo>,
     kernel_info: Option<KernelInfo>,
+    session_mode: SessionMode,
 }
 
 #[derive(Debug)]
@@ -86,6 +88,7 @@ impl Shell {
         kernel_init_rx: BusReader<KernelInfo>,
         kernel_request_tx: Sender<KernelRequest>,
         kernel_request_rx: Receiver<KernelRequest>,
+        session_mode: SessionMode,
     ) -> Self {
         // Start building the kernel object. It is shared by the shell, LSP, and main threads.
         let kernel = Kernel::new();
@@ -104,6 +107,7 @@ impl Shell {
             kernel_request_tx,
             kernel_init_rx,
             kernel_info: None,
+            session_mode,
         }
     }
 
@@ -235,7 +239,7 @@ impl ShellHandler for Shell {
             graphics_device::on_did_execute_request(
                 self.comm_manager_tx.clone(),
                 self.iopub_tx.clone(),
-                kernel.ui_connected(),
+                kernel.ui_connected() && self.session_mode == SessionMode::Console,
             )
         };
 


### PR DESCRIPTION
This change fixes a frequently reported bug in which Jupyter R notebooks in Positron don't show plots in the right location.

The problem is that dynamic plots (which always go to the Plots pane) are always emitted if Positron is connected to Ark. 

The fix is pretty simple; we just _also_ need to be sure we're in console mode before emitting a dynamic plot. 

Addresses https://github.com/posit-dev/positron/issues/3846