### PR TITLE
Data Explorer: Add support for truncating outputs at specified length

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -122,6 +122,10 @@ pub struct FormatOptions {
 	/// scientific notation
 	pub max_integral_digits: i64,
 
+	/// Maximum size of formatted value, for truncating large strings or other
+	/// large formatted values
+	pub max_value_length: i64,
+
 	/// Thousands separator string
 	pub thousands_sep: Option<String>
 }

--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -195,6 +195,7 @@ mod tests {
             small_num_digits: 4,
             max_integral_digits: 7,
             thousands_sep: Some(",".to_string()),
+            max_value_length: 100,
         }
     }
 

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -136,6 +136,7 @@ fn default_format_options() -> FormatOptions {
         small_num_digits: 4,
         max_integral_digits: 7,
         thousands_sep: Some(",".to_string()),
+        max_value_length: 100,
     }
 }
 


### PR DESCRIPTION
Makes the data explorer safer by avoiding transfering a lot of data over RPC if single cells contain a lot of data.
Address: https://github.com/posit-dev/positron/issues/3823

