### PR TITLE
Add new `.ps.ui.evaluateWhenClause` OpenRPC method

### DIFF
--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -201,6 +201,13 @@ pub struct ExecuteCommandParams {
 	pub command: String,
 }
 
+/// Parameters for the EvaluateWhenClause method.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct EvaluateWhenClauseParams {
+	/// The values for context keys, as a `when` clause
+	pub when_clause: String,
+}
+
 /// Parameters for the ExecuteCode method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ExecuteCodeParams {
@@ -309,6 +316,12 @@ pub enum UiFrontendRequest {
 	#[serde(rename = "debug_sleep")]
 	DebugSleep(DebugSleepParams),
 
+	/// Get a logical for a `when` clause (a set of context keys)
+	///
+	/// Use this to evaluate a `when` clause of context keys in the frontend
+	#[serde(rename = "evaluate_when_clause")]
+	EvaluateWhenClause(EvaluateWhenClauseParams),
+
 	/// Execute code in a Positron runtime
 	///
 	/// Use this to execute code in a Positron runtime
@@ -354,6 +367,9 @@ pub enum UiFrontendReply {
 
 	/// Reply for the debug_sleep method (no result)
 	DebugSleepReply(),
+
+	/// Whether the `when` clause evaluates as true or false
+	EvaluateWhenClauseReply(bool),
 
 	/// Reply for the execute_code method (no result)
 	ExecuteCodeReply(),
@@ -436,6 +452,7 @@ pub fn ui_frontend_reply_from_value(
 		UiFrontendRequest::ShowQuestion(_) => Ok(UiFrontendReply::ShowQuestionReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ShowDialog(_) => Ok(UiFrontendReply::ShowDialogReply()),
 		UiFrontendRequest::DebugSleep(_) => Ok(UiFrontendReply::DebugSleepReply()),
+		UiFrontendRequest::EvaluateWhenClause(_) => Ok(UiFrontendReply::EvaluateWhenClauseReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ExecuteCode(_) => Ok(UiFrontendReply::ExecuteCodeReply()),
 		UiFrontendRequest::WorkspaceFolder => Ok(UiFrontendReply::WorkspaceFolderReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ModifyEditorSelections(_) => Ok(UiFrontendReply::ModifyEditorSelectionsReply()),

--- a/crates/ark/src/modules/positron/frontend-methods.R
+++ b/crates/ark/src/modules/positron/frontend-methods.R
@@ -74,6 +74,11 @@
 }
 
 #' @export
+.ps.ui.evaluateWhenClause <- function(whenClause) {
+    .ps.Call("ps_ui_evaluate_when_clause", whenClause)
+}
+
+#' @export
 .ps.ui.debugSleep <- function(ms) {
     # stopifnot(is.numeric(ms) && length(ms) == 1 && !is.na(ms))
     .ps.Call("ps_ui_debug_sleep", ms)

--- a/crates/ark/src/modules/rstudio/commands.R
+++ b/crates/ark/src/modules/rstudio/commands.R
@@ -8,7 +8,7 @@
         "saveAllSourceDocs" = "workbench.action.files.saveAll",
         # This command is a silent no-op in RStudio when there is no git repo:
         "vcsRefresh" = {
-            if (.ps.ui.evaluateWhenClause("gitOpenRepositoryCount >= 1")) {
+            if (.ps.ui.evaluateWhenClause("gitOpenRepositoryCount > 0")) {
                 "git.refresh"
             } else {
                 return()

--- a/crates/ark/src/modules/rstudio/commands.R
+++ b/crates/ark/src/modules/rstudio/commands.R
@@ -9,7 +9,7 @@
         # https://github.com/posit-dev/positron/issues/2697
         # This command is a silent no-op in RStudio when there is no git repo:
         "vcsRefresh" = {
-            if (.ps.ui.evaluateWhenClause("gitOpenRepositoryCount > 0")) {
+            if (.ps.ui.evaluateWhenClause("config.git.enabled && gitOpenRepositoryCount > 0")) {
                 "git.refresh"
             } else {
                 return()

--- a/crates/ark/src/modules/rstudio/commands.R
+++ b/crates/ark/src/modules/rstudio/commands.R
@@ -6,7 +6,14 @@
         "activateTerminal" = "workbench.action.terminal.focus",
         # This command includes untitled files in RStudio:
         "saveAllSourceDocs" = "workbench.action.files.saveAll",
-        "vcsRefresh" = "git.refresh",
+        # This command is a silent no-op in RStudio when there is no git repo:
+        "vcsRefresh" = {
+            if (.ps.ui.evaluateWhenClause("gitOpenRepositoryCount >= 1")) {
+                "git.refresh"
+            } else {
+                return()
+            }
+        },
         "refreshFiles" = "workbench.files.action.refreshFilesExplorer",
         {
             if (!quiet) {

--- a/crates/ark/src/modules/rstudio/commands.R
+++ b/crates/ark/src/modules/rstudio/commands.R
@@ -6,6 +6,7 @@
         "activateTerminal" = "workbench.action.terminal.focus",
         # This command includes untitled files in RStudio:
         "saveAllSourceDocs" = "workbench.action.files.saveAll",
+        # https://github.com/posit-dev/positron/issues/2697
         # This command is a silent no-op in RStudio when there is no git repo:
         "vcsRefresh" = {
             if (.ps.ui.evaluateWhenClause("gitOpenRepositoryCount > 0")) {

--- a/crates/ark/src/ui/methods.rs
+++ b/crates/ark/src/ui/methods.rs
@@ -11,6 +11,7 @@ use amalthea::comm::ui_comm::ModifyEditorSelectionsParams;
 use amalthea::comm::ui_comm::NewDocumentParams;
 use amalthea::comm::ui_comm::ShowDialogParams;
 use amalthea::comm::ui_comm::ShowQuestionParams;
+use amalthea::comm::ui_comm::EvaluateWhenClauseParams;
 use amalthea::comm::ui_comm::UiFrontendRequest;
 use harp::object::RObject;
 use harp::utils::r_is_null;
@@ -117,6 +118,17 @@ pub unsafe extern "C" fn ps_ui_execute_code(code: SEXP, focus: SEXP) -> anyhow::
 
     let main = RMain::get();
     let out = main.call_frontend_method(UiFrontendRequest::ExecuteCode(params))?;
+    Ok(out.sexp)
+}
+
+#[harp::register]
+pub unsafe extern "C" fn ps_ui_evaluate_when_clause(when_clause: SEXP) -> anyhow::Result<SEXP> {
+    let params = EvaluateWhenClauseParams {
+        when_clause: RObject::view(when_clause).try_into()?
+    };
+
+    let main = RMain::get();
+    let out = main.call_frontend_method(UiFrontendRequest::EvaluateWhenClause(params))?;
     Ok(out.sexp)
 }
 


### PR DESCRIPTION
I was thinking about how to address https://github.com/posit-dev/positron/issues/2697 and have a proposed approach in this PR plus one I will open next in Positron. I looked at how various extensions (like the git extension, etc) check for whether we are in a git repo in the workspace and all that checking is typically based on context keys. In an extension specifically, you can check those keys with a [when clause](https://code.visualstudio.com/api/references/when-clause-contexts) and I realized that approach (i.e. a string) could work well as an OpenRPC method and would be flexible for other context keys we need to check from runtimes.

This PR does not yet actually check for git repos for #2697 but I wanted to get input on the approach before going much further. To see the behavior, you can check out code such as:

```r
.ps.ui.evaluateWhenClause("isLinux || isWindows")
.ps.ui.evaluateWhenClause("isMac")
.ps.ui.evaluateWhenClause("gitOpenRepositoryCount >= 1")
```