### PR TITLE
Data Explorer: Support for getting multiple profiles per column

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -943,11 +943,11 @@ impl RDataExplorer {
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::Histogram,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Unsupported,
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::FrequencyTable,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Unsupported,
                         },
                     ],
                 },

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -7,6 +7,7 @@
 
 use amalthea::comm::comm_channel::CommMsg;
 use amalthea::comm::data_explorer_comm::ColumnProfileRequest;
+use amalthea::comm::data_explorer_comm::ColumnProfileSpec;
 use amalthea::comm::data_explorer_comm::ColumnProfileType;
 use amalthea::comm::data_explorer_comm::ColumnSortKey;
 use amalthea::comm::data_explorer_comm::ColumnValue;
@@ -546,7 +547,10 @@ fn test_null_counts() {
         let req = DataExplorerBackendRequest::GetColumnProfiles(GetColumnProfilesParams {
             profiles: vec![ColumnProfileRequest {
                 column_index: 0,
-                profile_type: ColumnProfileType::NullCount,
+                profiles: vec![ColumnProfileSpec {
+                    profile_type: ColumnProfileType::NullCount,
+                    params: None,
+                }],
             }],
             format_options: default_format_options(),
         });
@@ -586,7 +590,10 @@ fn test_null_counts() {
         let req = DataExplorerBackendRequest::GetColumnProfiles(GetColumnProfilesParams {
             profiles: vec![ColumnProfileRequest {
                 column_index: 0,
-                profile_type: ColumnProfileType::NullCount,
+                profiles: vec![ColumnProfileSpec {
+                    profile_type: ColumnProfileType::NullCount,
+                    params: None,
+                }],
             }],
             format_options: default_format_options(),
         });
@@ -645,7 +652,10 @@ fn test_summary_stats() {
             profiles: (0..3)
                 .map(|i| ColumnProfileRequest {
                     column_index: i,
-                    profile_type: ColumnProfileType::SummaryStats,
+                    profiles: vec![ColumnProfileSpec {
+                        profile_type: ColumnProfileType::SummaryStats,
+                        params: None,
+                    }],
                 })
                 .collect(),
             format_options: default_format_options(),


### PR DESCRIPTION
Pairs with https://github.com/posit-dev/positron/pull/4189 - adapts to changes to the OpenRPC protocol.
It's the first step at addressing https://github.com/posit-dev/positron/issues/4061

