### PR TITLE
Data explorer: Add support for histograms and frequency tables

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -417,8 +417,11 @@ pub struct SummaryStatsDatetime {
 /// Parameters for a column histogram profile request
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ColumnHistogramParams {
+	/// Method for determining number of bins
+	pub method: ColumnHistogramParamsMethod,
+
 	/// Number of bins in the computed histogram
-	pub num_bins: i64,
+	pub num_bins: Option<i64>,
 
 	/// Sample quantiles (numbers between 0 and 1) to compute along with the
 	/// histogram
@@ -812,6 +815,18 @@ pub enum ColumnProfileType {
 	#[serde(rename = "histogram")]
 	#[strum(to_string = "histogram")]
 	Histogram
+}
+
+/// Possible values for Method in ColumnHistogramParams
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+pub enum ColumnHistogramParamsMethod {
+	#[serde(rename = "sturges")]
+	#[strum(to_string = "sturges")]
+	Sturges,
+
+	#[serde(rename = "fixed")]
+	#[strum(to_string = "fixed")]
+	Fixed
 }
 
 /// Possible values for Kind in TableSelection

--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -304,11 +304,17 @@ pub struct ColumnProfileResult {
 	/// Results from summary_stats request
 	pub summary_stats: Option<ColumnSummaryStats>,
 
-	/// Results from histogram request
-	pub histogram: Option<ColumnHistogram>,
+	/// Results from small histogram request
+	pub small_histogram: Option<ColumnHistogram>,
 
-	/// Results from frequency_table request
-	pub frequency_table: Option<ColumnFrequencyTable>
+	/// Results from large histogram request
+	pub large_histogram: Option<ColumnHistogram>,
+
+	/// Results from small frequency_table request
+	pub small_frequency_table: Option<ColumnFrequencyTable>,
+
+	/// Results from large frequency_table request
+	pub large_frequency_table: Option<ColumnFrequencyTable>
 }
 
 /// Profile result containing summary stats for a column based on the data
@@ -420,8 +426,8 @@ pub struct ColumnHistogramParams {
 	/// Method for determining number of bins
 	pub method: ColumnHistogramParamsMethod,
 
-	/// Number of bins in the computed histogram
-	pub num_bins: Option<i64>,
+	/// Maximum number of bins in the computed histogram.
+	pub num_bins: i64,
 
 	/// Sample quantiles (numbers between 0 and 1) to compute along with the
 	/// histogram
@@ -808,13 +814,21 @@ pub enum ColumnProfileType {
 	#[strum(to_string = "summary_stats")]
 	SummaryStats,
 
-	#[serde(rename = "frequency_table")]
-	#[strum(to_string = "frequency_table")]
-	FrequencyTable,
+	#[serde(rename = "small_frequency_table")]
+	#[strum(to_string = "small_frequency_table")]
+	SmallFrequencyTable,
 
-	#[serde(rename = "histogram")]
-	#[strum(to_string = "histogram")]
-	Histogram
+	#[serde(rename = "large_frequency_table")]
+	#[strum(to_string = "large_frequency_table")]
+	LargeFrequencyTable,
+
+	#[serde(rename = "small_histogram")]
+	#[strum(to_string = "small_histogram")]
+	SmallHistogram,
+
+	#[serde(rename = "large_histogram")]
+	#[strum(to_string = "large_histogram")]
+	LargeHistogram
 }
 
 /// Possible values for Method in ColumnHistogramParams
@@ -935,9 +949,13 @@ pub enum ColumnFilterParams {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum ColumnProfileParams {
-	Histogram(ColumnHistogramParams),
+	SmallHistogram(ColumnHistogramParams),
 
-	FrequencyTable(ColumnFrequencyTableParams)
+	LargeHistogram(ColumnHistogramParams),
+
+	SmallFrequencyTable(ColumnFrequencyTableParams),
+
+	LargeFrequencyTable(ColumnFrequencyTableParams)
 }
 
 /// Union type Selection in Properties

--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -304,7 +304,7 @@ pub struct ColumnProfileResult {
 	/// Results from summary_stats request
 	pub summary_stats: Option<ColumnSummaryStats>,
 
-	/// Results from summary_stats request
+	/// Results from histogram request
 	pub histogram: Option<ColumnHistogram>,
 
 	/// Results from frequency_table request
@@ -823,6 +823,14 @@ pub enum ColumnHistogramParamsMethod {
 	#[serde(rename = "sturges")]
 	#[strum(to_string = "sturges")]
 	Sturges,
+
+	#[serde(rename = "freedman_diaconis")]
+	#[strum(to_string = "freedman_diaconis")]
+	FreedmanDiaconis,
+
+	#[serde(rename = "scott")]
+	#[strum(to_string = "scott")]
+	Scott,
 
 	#[serde(rename = "fixed")]
 	#[strum(to_string = "fixed")]

--- a/crates/ark/src/data_explorer/format.rs
+++ b/crates/ark/src/data_explorer/format.rs
@@ -736,6 +736,18 @@ mod tests {
                 FormattedValue::NA.into(),
                 ColumnValue::FormattedValue("2017-05-27".to_string())
             ]);
+
+            let data = r_parse_eval0(
+                r#"as.POSIXct(c("2012-01-01 00:01:00", NA, "2017-05-27 00:00:01"))"#,
+                R_ENVS.global,
+            )
+            .unwrap();
+            let formatted = format_column(data.sexp, &default_options());
+            assert_eq!(formatted, vec![
+                ColumnValue::FormattedValue("2012-01-01 00:01:00".to_string()),
+                FormattedValue::NA.into(),
+                ColumnValue::FormattedValue("2017-05-27 00:00:01".to_string())
+            ]);
         })
     }
 

--- a/crates/ark/src/data_explorer/histogram.rs
+++ b/crates/ark/src/data_explorer/histogram.rs
@@ -555,7 +555,7 @@ mod tests {
 
             // Works with dates
             test_frequency_table(
-                "rep(as.POSIXct(c('2010-01-01', '2017-05-17 11:00:00')), c(100, 200))",
+                "as.POSIXct(rep(c('2010-01-01', '2017-05-17 11:00:00'), c(100, 200)))",
                 5,
                 r_parse_eval0(
                     "as.POSIXct(c('2017-05-17 11:00:00','2010-01-01'))",

--- a/crates/ark/src/data_explorer/histogram.rs
+++ b/crates/ark/src/data_explorer/histogram.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+
+use amalthea::comm::data_explorer_comm::ColumnHistogram;
+use amalthea::comm::data_explorer_comm::ColumnHistogramParams;
+use amalthea::comm::data_explorer_comm::ColumnQuantileValue;
+use amalthea::comm::data_explorer_comm::FormatOptions;
+use anyhow::anyhow;
+use harp::exec::RFunction;
+use harp::exec::RFunctionExt;
+use harp::object::RObject;
+use harp::r_null;
+use harp::utils::r_classes;
+use harp::utils::r_inherits;
+use harp::utils::r_typeof;
+use libr::INTSXP;
+use libr::REALSXP;
+use libr::SEXP;
+use stdext::*;
+
+use crate::data_explorer::format::format_string;
+use crate::modules::ARK_ENVS;
+
+pub fn profile_histogram(
+    column: SEXP,
+    params: &ColumnHistogramParams,
+    format_options: &FormatOptions,
+) -> anyhow::Result<ColumnHistogram> {
+    let quantiles: RObject = match params.quantiles.clone() {
+        Some(v) => (&v).into(),
+        None => r_null().into(),
+    };
+
+    // Checks for supported objects:
+    // - Atomic integers and doubles
+    // - Dates and POSIXct objects
+    match r_classes(column) {
+        Some(v) => {
+            if !r_inherits(column, "Date") && !r_inherits(column, "POSIXct") {
+                return Err(anyhow!("Object with class '{:?}' unsupported.", v));
+            }
+        },
+        None => match r_typeof(column) {
+            INTSXP | REALSXP => {},
+            _ => return Err(anyhow!("Type not supported {:?}", r_typeof(column))),
+        },
+    }
+
+    let results: HashMap<String, RObject> = RFunction::from("profile_histogram")
+        .add(column)
+        .add(params.num_bins as i32)
+        .add(quantiles)
+        .call_in(ARK_ENVS.positron_ns)?
+        .try_into()?;
+
+    // Bin edges are expected to be objects that can be formatted, such as integers vectors,
+    // numeric vectors or even dates.
+    let bin_edges = unwrap!(results.get("bin_edges"), None => {
+        return Err(anyhow!("`bin_edges` were not computed."));
+    });
+    let bin_edges_formatted = format_string(bin_edges.sexp, &format_options);
+
+    // The quantile values should also be formattable
+    let quantile_values = unwrap!(results.get("quantiles"), None => {
+        return Err(anyhow!("`quantiles` were not computed"));
+    });
+    let quantile_values_formatted = format_string(quantile_values.sexp, &format_options);
+
+    // Counts the amount of elements for each bin.
+    let bin_counts: Vec<i32> = unwrap!(results.get("bin_counts"), None => {
+        return Err(anyhow!("`bin_counts` were not computed."))
+    })
+    .clone()
+    .try_into()?;
+
+    if bin_counts.len() != (bin_edges_formatted.len() - 1) {
+        return Err(anyhow!(
+            "`bin_counts` not compatible with `bin_edges`. `bin_counts.len()` ({}) and `bin_edges_formatted.len()` ({})",
+            bin_counts.len(),
+            bin_edges_formatted.len()
+        ));
+    }
+
+    // Computed quantile values are combined with the request probs to form
+    // ColumnQuantileValue's.
+    let quantiles = params
+        .quantiles
+        .clone()
+        .unwrap_or(vec![])
+        .into_iter()
+        .zip(quantile_values_formatted.into_iter())
+        .map(|(q, value)| ColumnQuantileValue {
+            q,
+            value,
+            exact: true,
+        })
+        .collect();
+
+    Ok(ColumnHistogram {
+        bin_edges: bin_edges_formatted,
+        bin_counts: bin_counts.into_iter().map(|v| v as i64).collect(),
+        quantiles,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use harp::environment::R_ENVS;
+    use harp::eval::r_parse_eval0;
+
+    use super::*;
+    use crate::test::r_test;
+
+    fn default_options() -> FormatOptions {
+        FormatOptions {
+            large_num_digits: 2,
+            small_num_digits: 4,
+            max_integral_digits: 7,
+            thousands_sep: Some(",".to_string()),
+            max_value_length: 100,
+        }
+    }
+
+    fn test_histogram(code: &str, num_bins: i64, bin_edges: Vec<&str>, bin_counts: Vec<i64>) {
+        let column = r_parse_eval0(code, R_ENVS.global).unwrap();
+
+        let hist = profile_histogram(
+            column.sexp,
+            &ColumnHistogramParams {
+                num_bins,
+                quantiles: None,
+            },
+            &default_options(),
+        )
+        .unwrap();
+
+        assert_eq!(hist, ColumnHistogram {
+            bin_edges: bin_edges.into_iter().map(|v| v.to_string()).collect(),
+            bin_counts,
+            quantiles: vec![]
+        })
+    }
+
+    #[test]
+    fn test_basic_histograms() {
+        r_test(|| {
+            test_histogram(
+                "0:10",
+                4,
+                vec!["0.00", "2.50", "5.00", "7.50", "10.00"],
+                vec![3, 3, 2, 3],
+            );
+        })
+    }
+
+    #[test]
+    fn test_date_histogram() {
+        r_test(|| {
+            test_histogram(
+                "seq(as.Date('2000-01-01'), by = 1, length.out = 11)",
+                4,
+                vec![
+                    "2000-01-01 00:00:00",
+                    "2000-01-03 12:00:00",
+                    "2000-01-06 00:00:00",
+                    "2000-01-08 12:00:00",
+                    "2000-01-11 00:00:00",
+                ],
+                vec![3, 2, 3, 3],
+            );
+
+            test_histogram(
+                "rep(seq(as.Date('2000-01-01'), by = 1, length.out = 2), 100)",
+                10,
+                vec![
+                    "2000-01-01 00:00:00",
+                    "2000-01-01 12:00:00",
+                    "2000-01-02 00:00:00",
+                ],
+                vec![100, 100],
+            );
+
+            test_histogram(
+                "rep(seq(as.Date('2000-01-01'), by = 2, length.out = 2), 100)",
+                10,
+                vec![
+                    "2000-01-01 00:00:00",
+                    "2000-01-01 16:00:00",
+                    "2000-01-02 08:00:00",
+                    "2000-01-03 00:00:00",
+                ],
+                vec![100, 0, 100],
+            );
+        })
+    }
+
+    #[test]
+    fn test_constant_column() {
+        r_test(|| {
+            test_histogram("c(1, 1, 1)", 4, vec!["1.00", "1.00"], vec![3]);
+        })
+    }
+
+    #[test]
+    fn test_integers() {
+        r_test(|| {
+            test_histogram(
+                "rep(c(1L, 2L), 100)",
+                5,
+                vec!["1.00", "1.20", "1.40", "1.60", "1.80", "2.00"],
+                vec![100, 0, 0, 0, 100],
+            );
+
+            test_histogram(
+                "rep(c(1L, 3L), 100)",
+                3,
+                vec!["1.00", "1.67", "2.33", "3.00"],
+                vec![100, 0, 100],
+            );
+
+            test_histogram(
+                "rep(c(1L, 3L), 100)",
+                2,
+                vec!["1.00", "2.00", "3.00"],
+                vec![100, 100],
+            );
+        })
+    }
+
+    #[test]
+    fn test_posixct() {
+        r_test(|| {
+            test_histogram(
+                // 1 sec, is the difference of 1 in the numeric data representation
+                // R doesn't distinguish changes in the decimal places as different dates
+                "rep(seq(as.POSIXct('2017-05-17 00:00:00'), by = '1 sec', length.out = 4), 10)",
+                10,
+                vec![
+                    "2017-05-17 00:00:00",
+                    "2017-05-17 00:00:00",
+                    "2017-05-17 00:00:01",
+                    "2017-05-17 00:00:02",
+                    "2017-05-17 00:00:03",
+                ],
+                vec![10, 10, 10, 10],
+            );
+        })
+    }
+}

--- a/crates/ark/src/data_explorer/histogram.rs
+++ b/crates/ark/src/data_explorer/histogram.rs
@@ -513,6 +513,15 @@ mod tests {
                 vec![200, 150],
                 Some(100),
             );
+
+            // Account for all factor levels, even if they don't appear in the data
+            test_frequency_table(
+                "factor(rep(c('a', 'b'), c(100, 200)), levels = c('a', 'b', 'c'))",
+                10,
+                r_parse_eval0("c('b', 'a', 'c')", R_ENVS.global).unwrap(),
+                vec![200, 100, 0],
+                None,
+            );
         })
     }
 

--- a/crates/ark/src/data_explorer/histogram.rs
+++ b/crates/ark/src/data_explorer/histogram.rs
@@ -48,10 +48,7 @@ pub fn profile_histogram(
         },
     }
 
-    let num_bins: RObject = match params.num_bins {
-        Some(v) => (v as i32).into(),
-        None => r_null().into(),
-    };
+    let num_bins: RObject = (params.num_bins as i32).into();
 
     let method: RObject = match params.method {
         ColumnHistogramParamsMethod::Fixed => "fixed".into(),
@@ -185,7 +182,7 @@ mod tests {
             column.sexp,
             &ColumnHistogramParams {
                 method: ColumnHistogramParamsMethod::Fixed,
-                num_bins: Some(num_bins),
+                num_bins,
                 quantiles: None,
             },
             &default_options(),
@@ -216,7 +213,7 @@ mod tests {
             column.sexp,
             &ColumnHistogramParams {
                 method,
-                num_bins: None,
+                num_bins: 100000,
                 quantiles: None,
             },
             &default_options(),
@@ -240,7 +237,7 @@ mod tests {
             column.sexp,
             &ColumnHistogramParams {
                 method: ColumnHistogramParamsMethod::Fixed,
-                num_bins: Some(100),
+                num_bins: 100,
                 quantiles: Some(quantiles),
             },
             &default_options(),

--- a/crates/ark/src/data_explorer/mod.rs
+++ b/crates/ark/src/data_explorer/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod export_selection;
 pub mod format;
+pub mod histogram;
 pub mod r_data_explorer;
 pub mod summary_stats;
 pub mod utils;

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -1020,11 +1020,11 @@ impl RDataExplorer {
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::Histogram,
-                            support_status: SupportStatus::Unsupported,
+                            support_status: SupportStatus::Experimental,
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::FrequencyTable,
-                            support_status: SupportStatus::Unsupported,
+                            support_status: SupportStatus::Experimental,
                         },
                     ],
                 },

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -36,12 +36,8 @@
     invisible(.ps.Call("ps_view_data_frame", x, title, var, env))
 }
 
-.ps.null_count <- function(column, filtered_indices) {
-    if (is.null(filtered_indices)) {
-        sum(is.na(column))
-    } else {
-        sum(is.na(column[filtered_indices]))
-    }
+.ps.null_count <- function(column) {
+    sum(is.na(column))
 }
 
 summary_stats_number <- function(col) {

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -435,23 +435,11 @@ profile_frequency_table <- function(x, limit) {
         ))
     }
 
-    # We don't use `table` directly because we don't want to loose the type
-    # of value types so they can be formatted with our formatting routines.
     if (!is.factor(x)) {
-        # This does more or less the same as `table` does with some small differences:
-        # - `table` calls `factor` without setting the levels, which triggers `factor` to
-        #   order the labels. Thhus we then loose the original values, as they are converted
-        #   to strings.
-        # - For dates, this is specially problematic as it's possible for two different
-        #   values to have the same string representation.
+        # We don't use `table` directly because we don't want to loose the type
+        # of value types so they can be formatted with our formatting routines.
         values <- unique(x)
-        if (inherits(x, "Date") || inherits(x, "POSIXt")) {
-            f <- factor(unclass(x), levels = unclass(values))
-        } else {
-            f <- factor(x, levels = values)
-        }
-
-        counts <- tabulate(f)
+        counts <- tabulate(match(x, values))
     } else {
         values <- levels(x)
         counts <- table(x)

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -459,7 +459,7 @@ histogram_num_bins <- function(x, method, fixed_num_bins) {
         width <- max_value - min_value
 
         if (as.integer(width) < num_bins) {
-        num_bins <- as.integer(width) + 1L
+            num_bins <- as.integer(width) + 1L
         }
     }
 

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -343,7 +343,7 @@ write_html <- function(x, include_header) {
     knitr::kable(x, format = "html", row.names = FALSE, col.names = col_names)
 }
 
-profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL, quantiles=NULL) {
+profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL, quantiles = NULL) {
   # We only use finite values for building this histogram.
   # This removes NA's, Inf, NaN and -Inf
   x <- x[is.finite(x)]
@@ -366,7 +366,7 @@ profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL
   if (!is.null(quantiles)) {
     quantiles <- stats::quantile(x, probs = quantiles)
   } else {
-    quantiles <- c() # we otherwise return an empty quantiles vector
+    quantiles <- NULL  # We otherwise return an empty quantiles vector
   }
 
   method <- match.arg(method)
@@ -375,7 +375,7 @@ profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL
   # We force something considering the integer representation.
   if (inherits(x, "POSIXct")) {
     if (method == "sturges") {
-        num_bins <- grDevices::nclass.Sturges(x)
+      num_bins <- grDevices::nclass.Sturges(x)
     }
 
     # The pretty bins algorithm doesn't really make sense for dates,
@@ -385,7 +385,7 @@ profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL
     range <- max_value - min_value
 
     if (inherits(x, "POSIXct") && as.integer(range) < num_bins) {
-     num_bins <- as.integer(range) + 1L
+      num_bins <- as.integer(range) + 1L
     }
 
     breaks <- seq(min_value, max_value, length.out = num_bins + 1)
@@ -397,7 +397,7 @@ profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL
     # > In the last three cases the number is a suggestion only; as the breakpoints will
     # > be set to `pretty` values.
     breaks <- num_bins
-    stopifnot(is.integer(breaks) && length(breaks) == 1)
+    stopifnot(is.integer(breaks), length(breaks) == 1)
   }
 
   # A warning is raised when computing the histogram for dates due to
@@ -425,8 +425,8 @@ profile_frequency_table <- function(x, limit) {
 
     if (length(x) == 0) {
         return(list(
-            values = c(),
-            counts = c(),
+            values = NULL,
+            counts = NULL,
             other_count = 0
         ))
     }

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -446,7 +446,6 @@ profile_frequency_table <- function(x, limit) {
     counts <- counts[index]
     other_count <- length(x) - sum(counts)
 
-    # Sorting and trimming to a `limit` is defered to the Rust side
     list(
         values = values,
         counts = counts,

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -423,3 +423,33 @@ profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL
       quantiles = quantiles
   )
 }
+
+profile_frequency_table <- function(x, limit) {
+    x <- x[!is.na(x)]
+
+    if (length(x) == 0) {
+        return(list(
+            values = c(),
+            counts = c(),
+            other_count = 0
+        ))
+    }
+
+    # We don't use `table` directly because we don't want to loose the type
+    # of value types so they can be formatted with our formatting routines.
+    values <- unique(x)
+    f <- factor(x, levels = values)
+    counts <- tabulate(f)
+
+    index <- utils::head(order(counts, decreasing = TRUE), limit)
+    values <- values[index]
+    counts <- counts[index]
+    other_count <- length(x) - sum(counts)
+
+    # Sorting and trimming to a `limit` is defered to the Rust side
+    list(
+        values = values,
+        counts = counts,
+        other_count = other_count
+    )
+}

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -415,14 +415,14 @@ profile_frequency_table <- function(x, limit) {
         ))
     }
 
-    if (!is.factor(x)) {
+    if (is.factor(x)) {
+        values <- levels(x)
+        counts <- table(x)
+    } else {
         # We don't use `table` directly because we don't want to loose the type
         # of value types so they can be formatted with our formatting routines.
         values <- unique(x)
         counts <- tabulate(match(x, values))
-    } else {
-        values <- levels(x)
-        counts <- table(x)
     }
 
     index <- utils::head(order(counts, decreasing = TRUE), limit)
@@ -439,28 +439,28 @@ profile_frequency_table <- function(x, limit) {
 
 histogram_num_bins <- function(x, method, fixed_num_bins) {
     num_bins <- if (method == "sturges") {
-      grDevices::nclass.Sturges(x)
+        grDevices::nclass.Sturges(x)
     } else if (method == "fd") {
-      # FD calls into signif, which is not implemented for Dates
-      grDevices::nclass.FD(unclass(x))
+        # FD calls into signif, which is not implemented for Dates
+        grDevices::nclass.FD(unclass(x))
     } else if (method == "scott") {
-      grDevices::nclass.scott(x)
+        grDevices::nclass.scott(x)
     } else if (method == "fixed") {
-      fixed_num_bins
+        fixed_num_bins
     } else {
-      stop("Unknow method :", method)
+        stop("Unknow method :", method)
     }
 
     if (is.integer(x) || inherits(x, "POSIXct")) {
-      # For integers, we don't want num_bins to be larger than the width of the range
-      # so we replace it if necessary.
-      min_value <- min(x)
-      max_value <- max(x)
-      width <- max_value - min_value
+        # For integers, we don't want num_bins to be larger than the width of the range
+        # so we replace it if necessary.
+        min_value <- min(x)
+        max_value <- max(x)
+        width <- max_value - min_value
 
-      if (as.integer(width) < num_bins) {
+        if (as.integer(width) < num_bins) {
         num_bins <- as.integer(width) + 1L
-      }
+        }
     }
 
     as.integer(num_bins)

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -347,7 +347,14 @@ write_html <- function(x, include_header) {
     knitr::kable(x, format = "html", row.names = FALSE, col.names = col_names)
 }
 
-profile_histogram <- function(x, num_bins, quantiles) {
+profile_histogram <- function(x, method = c("fixed", "sturges"), num_bins = NULL, quantiles=NULL) {
+  method <- match.arg(method)
+
+  if (method == "fixed") {
+    stopifnot(!is.null(num_bins))
+  } else if (method == "sturges") {
+    stop("Not implemented yet")
+  }
 
   # We only use finite values for building this histogram.
   # This removes NA's, Inf, NaN and -Inf

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -438,7 +438,7 @@ profile_frequency_table <- function(x, limit) {
     # We don't use `table` directly because we don't want to loose the type
     # of value types so they can be formatted with our formatting routines.
     values <- unique(x)
-    f <- factor(x, levels = values)
+    f <- factor(unclass(x), levels = unclass(values))
     counts <- tabulate(f)
 
     index <- utils::head(order(counts, decreasing = TRUE), limit)

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -348,28 +348,32 @@ write_html <- function(x, include_header) {
 }
 
 profile_histogram <- function(x, num_bins, quantiles) {
+
+  # We only use finite values for building this histogram.
+  # This removes NA's, Inf, NaN and -Inf
+  x <- x[is.finite(x)]
+
+  # No-non finite values, we early return as there's nothing we can compute.
+  if (length(x) == 0) {
+      return(list(
+          bin_edges = c(),
+          bin_counts = c(),
+          quantiles = rep(NA_real_, length(quantiles))
+      ))
+  }
+
   # If we have a Date variable, we convert it to POSIXct, in order to be able to have equal
   # width bins - that can be fractions of dates.
   if (inherits(x, "Date")) {
     x <- as.POSIXct(x)
   }
 
-  min_value <- min(x, na.rm = TRUE)
-  max_value <- max(x, na.rm = TRUE)
+  min_value <- min(x)
+  max_value <- max(x)
   range <- max_value - min_value
 
-  # If any of those are NA, it means that all values are NA's,
-  # so there are no bins to be computed and we return an empty vector.
-  if (is.na(min_value) || is.na(max_value)) {
-      return(list(
-          bin_edges = c(),
-          bin_counts = c(),
-          quantiles = c()
-      ))
-  }
-
   if (!is.null(quantiles)) {
-    quantiles <- quantile(x, probs = quantiles, na.rm = TRUE)
+    quantiles <- stats::quantile(x, probs = quantiles)
   } else {
     quantiles <- c() # we otherwise return an empty quantiles vector
   }

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -1686,8 +1686,8 @@ fn test_histogram() {
                 profiles: vec![ColumnProfileRequest {
                     column_index,
                     profiles: vec![ColumnProfileSpec {
-                        profile_type: ColumnProfileType::Histogram,
-                        params: Some(ColumnProfileParams::Histogram(ColumnHistogramParams {
+                        profile_type: ColumnProfileType::SmallHistogram,
+                        params: Some(ColumnProfileParams::SmallHistogram(ColumnHistogramParams {
                             method,
                             num_bins,
                             quantiles,
@@ -1698,10 +1698,10 @@ fn test_histogram() {
             })
         };
 
-        let req = make_histogram_req(0, ColumnHistogramParamsMethod::Fixed, Some(10), None);
+        let req = make_histogram_req(0, ColumnHistogramParamsMethod::Fixed, 10, None);
 
         assert_match!(socket_rpc(&socket, req), DataExplorerBackendReply::GetColumnProfilesReply(profiles) => {
-            let histogram = profiles[0].histogram.clone().unwrap();
+            let histogram = profiles[0].small_histogram.clone().unwrap();
             assert_eq!(histogram, ColumnHistogram {
                 bin_edges: format_string(r_parse_eval0("seq(1, 10, length.out=11)", R_ENVS.global).unwrap().sexp, &default_format_options()),
                 bin_counts: vec![10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // Pretty bind edges unite the first two intervals
@@ -1723,8 +1723,8 @@ fn test_frequency_table() {
                 profiles: vec![ColumnProfileRequest {
                     column_index,
                     profiles: vec![ColumnProfileSpec {
-                        profile_type: ColumnProfileType::FrequencyTable,
-                        params: Some(ColumnProfileParams::FrequencyTable(
+                        profile_type: ColumnProfileType::SmallFrequencyTable,
+                        params: Some(ColumnProfileParams::SmallFrequencyTable(
                             ColumnFrequencyTableParams { limit },
                         )),
                     }],
@@ -1736,7 +1736,7 @@ fn test_frequency_table() {
         let req = make_freq_table_req(0, 5);
 
         assert_match!(socket_rpc(&socket, req), DataExplorerBackendReply::GetColumnProfilesReply(profiles) => {
-            let freq_table = profiles[0].frequency_table.clone().unwrap();
+            let freq_table = profiles[0].small_frequency_table.clone().unwrap();
             assert_eq!(freq_table, ColumnFrequencyTable {
                 values: format_string(r_parse_eval0("letters[1:5]", R_ENVS.global).unwrap().sexp, &default_format_options()),
                 counts: vec![10, 9, 8, 7, 6],

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -1703,8 +1703,8 @@ fn test_histogram() {
         assert_match!(socket_rpc(&socket, req), DataExplorerBackendReply::GetColumnProfilesReply(profiles) => {
             let histogram = profiles[0].histogram.clone().unwrap();
             assert_eq!(histogram, ColumnHistogram {
-                bin_edges: format_string(r_parse_eval0("c(1:10)", R_ENVS.global).unwrap().sexp, &default_format_options()),
-                bin_counts: vec![19, 8, 7, 6, 5, 4, 3, 2, 1], // Pretty bind edges unite the first two intervals
+                bin_edges: format_string(r_parse_eval0("seq(1, 10, length.out=11)", R_ENVS.global).unwrap().sexp, &default_format_options()),
+                bin_counts: vec![10, 9, 8, 7, 6, 5, 4, 3, 2, 1], // Pretty bind edges unite the first two intervals
                 quantiles: vec![],
             });
         });

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -13,6 +13,7 @@ use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::sync::Once;
 
+use libc::c_double;
 use libr::*;
 
 use crate::error::Error;
@@ -597,6 +598,18 @@ impl From<&Vec<i64>> for RObject {
             let vector = RObject::from(Rf_allocVector(INTSXP, values.len() as isize));
             for idx in 0..values.len() {
                 SET_INTEGER_ELT(vector.sexp, idx as isize, values[idx] as c_int);
+            }
+            return vector;
+        }
+    }
+}
+
+impl From<&Vec<f64>> for RObject {
+    fn from(values: &Vec<f64>) -> Self {
+        unsafe {
+            let vector = RObject::from(Rf_allocVector(REALSXP, values.len() as isize));
+            for idx in 0..values.len() {
+                SET_REAL_ELT(vector.sexp, idx as isize, values[idx] as c_double);
             }
             return vector;
         }


### PR DESCRIPTION
This implements the OpenRPC protocol for support computing histograms and frequency tables. This is the backend for computing sparklines in the data explorer. 

Addresses https://github.com/posit-dev/positron/issues/4061

TODO:

- [x] Add support for frequency tables (consider factors, and character vectors)
- [x] Add tests for quantile computations.
- [x] Add implementation/tests for the Sturges algorithm
- [x] Plumb with the infra to produce results on the filtered data (if any filters are applied)