### PR TITLE
Add new version of "execute a command" that also waits

### DIFF
--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -201,6 +201,13 @@ pub struct ExecuteCommandParams {
 	pub command: String,
 }
 
+/// Parameters for the ExecuteCommandAwait method.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExecuteCommandAwaitParams {
+	/// The command to execute
+	pub command: String,
+}
+
 /// Parameters for the EvaluateWhenClause method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EvaluateWhenClauseParams {
@@ -335,6 +342,13 @@ pub enum UiFrontendRequest {
 	#[serde(rename = "debug_sleep")]
 	DebugSleep(DebugSleepParams),
 
+	/// Execute a Positron command and wait for it to return
+	///
+	/// Use this to execute a Positron command from the backend (like from a
+	/// runtime) and wait for it to return
+	#[serde(rename = "execute_command_await")]
+	ExecuteCommandAwait(ExecuteCommandAwaitParams),
+
 	/// Get a logical for a `when` clause (a set of context keys)
 	///
 	/// Use this to evaluate a `when` clause of context keys in the frontend
@@ -386,6 +400,9 @@ pub enum UiFrontendReply {
 
 	/// Reply for the debug_sleep method (no result)
 	DebugSleepReply(),
+
+	/// Evaluates to true when the command has been executed
+	ExecuteCommandAwaitReply(bool),
 
 	/// Whether the `when` clause evaluates as true or false
 	EvaluateWhenClauseReply(bool),
@@ -475,6 +492,7 @@ pub fn ui_frontend_reply_from_value(
 		UiFrontendRequest::ShowQuestion(_) => Ok(UiFrontendReply::ShowQuestionReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ShowDialog(_) => Ok(UiFrontendReply::ShowDialogReply()),
 		UiFrontendRequest::DebugSleep(_) => Ok(UiFrontendReply::DebugSleepReply()),
+		UiFrontendRequest::ExecuteCommandAwait(_) => Ok(UiFrontendReply::ExecuteCommandAwaitReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::EvaluateWhenClause(_) => Ok(UiFrontendReply::EvaluateWhenClauseReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ExecuteCode(_) => Ok(UiFrontendReply::ExecuteCodeReply()),
 		UiFrontendRequest::WorkspaceFolder => Ok(UiFrontendReply::WorkspaceFolderReply(serde_json::from_value(reply)?)),

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -201,13 +201,6 @@ pub struct ExecuteCommandParams {
 	pub command: String,
 }
 
-/// Parameters for the ExecuteCommandAwait method.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct ExecuteCommandAwaitParams {
-	/// The command to execute
-	pub command: String,
-}
-
 /// Parameters for the EvaluateWhenClause method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EvaluateWhenClauseParams {
@@ -342,12 +335,12 @@ pub enum UiFrontendRequest {
 	#[serde(rename = "debug_sleep")]
 	DebugSleep(DebugSleepParams),
 
-	/// Execute a Positron command and wait for it to return
+	/// Execute a Positron command
 	///
 	/// Use this to execute a Positron command from the backend (like from a
-	/// runtime) and wait for it to return
-	#[serde(rename = "execute_command_await")]
-	ExecuteCommandAwait(ExecuteCommandAwaitParams),
+	/// runtime)
+	#[serde(rename = "execute_command")]
+	ExecuteCommand(ExecuteCommandParams),
 
 	/// Get a logical for a `when` clause (a set of context keys)
 	///
@@ -401,8 +394,8 @@ pub enum UiFrontendReply {
 	/// Reply for the debug_sleep method (no result)
 	DebugSleepReply(),
 
-	/// Evaluates to true when the command has been executed
-	ExecuteCommandAwaitReply(bool),
+	/// Reply for the execute_command method (no result)
+	ExecuteCommandReply(),
 
 	/// Whether the `when` clause evaluates as true or false
 	EvaluateWhenClauseReply(bool),
@@ -456,11 +449,6 @@ pub enum UiFrontendEvent {
 	#[serde(rename = "working_directory")]
 	WorkingDirectory(WorkingDirectoryParams),
 
-	/// Use this to execute a Positron command from the backend (like from a
-	/// runtime)
-	#[serde(rename = "execute_command")]
-	ExecuteCommand(ExecuteCommandParams),
-
 	/// Use this to open a workspace in Positron
 	#[serde(rename = "open_workspace")]
 	OpenWorkspace(OpenWorkspaceParams),
@@ -492,7 +480,7 @@ pub fn ui_frontend_reply_from_value(
 		UiFrontendRequest::ShowQuestion(_) => Ok(UiFrontendReply::ShowQuestionReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ShowDialog(_) => Ok(UiFrontendReply::ShowDialogReply()),
 		UiFrontendRequest::DebugSleep(_) => Ok(UiFrontendReply::DebugSleepReply()),
-		UiFrontendRequest::ExecuteCommandAwait(_) => Ok(UiFrontendReply::ExecuteCommandAwaitReply(serde_json::from_value(reply)?)),
+		UiFrontendRequest::ExecuteCommand(_) => Ok(UiFrontendReply::ExecuteCommandReply()),
 		UiFrontendRequest::EvaluateWhenClause(_) => Ok(UiFrontendReply::EvaluateWhenClauseReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ExecuteCode(_) => Ok(UiFrontendReply::ExecuteCodeReply()),
 		UiFrontendRequest::WorkspaceFolder => Ok(UiFrontendReply::WorkspaceFolderReply(serde_json::from_value(reply)?)),

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -338,7 +338,7 @@ pub enum UiFrontendRequest {
 	/// Execute a Positron command
 	///
 	/// Use this to execute a Positron command from the backend (like from a
-	/// runtime)
+	/// runtime), and wait for the command to finish
 	#[serde(rename = "execute_command")]
 	ExecuteCommand(ExecuteCommandParams),
 

--- a/crates/ark/src/modules/positron/frontend-methods.R
+++ b/crates/ark/src/modules/positron/frontend-methods.R
@@ -49,11 +49,6 @@
 }
 
 #' @export
-.ps.ui.executeCommandAwait <- function(command) {
-    .ps.Call("ps_ui_execute_command_await", command)
-}
-
-#' @export
 .ps.ui.executeCode <- function(code, focus) {
     .ps.Call("ps_ui_execute_code", code, focus)
 }

--- a/crates/ark/src/modules/positron/frontend-methods.R
+++ b/crates/ark/src/modules/positron/frontend-methods.R
@@ -49,6 +49,11 @@
 }
 
 #' @export
+.ps.ui.executeCommandAwait <- function(command) {
+    .ps.Call("ps_ui_execute_command_await", command)
+}
+
+#' @export
 .ps.ui.executeCode <- function(code, focus) {
     .ps.Call("ps_ui_execute_code", code, focus)
 }

--- a/crates/ark/src/modules/rstudio/commands.R
+++ b/crates/ark/src/modules/rstudio/commands.R
@@ -12,7 +12,7 @@
             if (.ps.ui.evaluateWhenClause("config.git.enabled && gitOpenRepositoryCount > 0")) {
                 "git.refresh"
             } else {
-                return()
+                return(NULL)
             }
         },
         "refreshFiles" = "workbench.files.action.refreshFilesExplorer",

--- a/crates/ark/src/modules/rstudio/document-api.R
+++ b/crates/ark/src/modules/rstudio/document-api.R
@@ -177,7 +177,7 @@ asRangeList <- function(location) {
 #' @export
 .rs.api.documentSaveAll <- function() {
     # This function excludes untitled files in RStudio:
-    invisible(.ps.ui.executeCommand("workbench.action.files.saveAllTitled"))
+    .ps.ui.executeCommandAwait("workbench.action.files.saveAllTitled")
 }
 
 #' @export
@@ -185,5 +185,5 @@ asRangeList <- function(location) {
     # TODO: Support document IDs
     stopifnot(is.null(id))
 
-    invisible(.ps.ui.executeCommand("workbench.action.files.save"))
+    .ps.ui.executeCommandAwait("workbench.action.files.save")
 }

--- a/crates/ark/src/modules/rstudio/document-api.R
+++ b/crates/ark/src/modules/rstudio/document-api.R
@@ -177,7 +177,8 @@ asRangeList <- function(location) {
 #' @export
 .rs.api.documentSaveAll <- function() {
     # This function excludes untitled files in RStudio:
-    .ps.ui.executeCommandAwait("workbench.action.files.saveAllTitled")
+    .ps.ui.executeCommand("workbench.action.files.saveAllTitled")
+    return(TRUE)
 }
 
 #' @export
@@ -185,5 +186,6 @@ asRangeList <- function(location) {
     # TODO: Support document IDs
     stopifnot(is.null(id))
 
-    .ps.ui.executeCommandAwait("workbench.action.files.save")
+    .ps.ui.executeCommand("workbench.action.files.save")
+    return(TRUE)
 }

--- a/crates/ark/src/ui/events.rs
+++ b/crates/ark/src/ui/events.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use amalthea::comm::ui_comm::ExecuteCommandParams;
 use amalthea::comm::ui_comm::OpenEditorParams;
 use amalthea::comm::ui_comm::OpenWorkspaceParams;
 use amalthea::comm::ui_comm::Position;
@@ -28,18 +27,6 @@ pub unsafe extern "C" fn ps_ui_show_message(message: SEXP) -> anyhow::Result<SEX
 
     let main = RMain::get();
     let event = UiFrontendEvent::ShowMessage(params);
-    main.send_frontend_event(event);
-    Ok(R_NilValue)
-}
-
-#[harp::register]
-pub unsafe extern "C" fn ps_ui_execute_command(command: SEXP) -> anyhow::Result<SEXP> {
-    let params = ExecuteCommandParams {
-        command: RObject::view(command).try_into()?,
-    };
-
-    let main = RMain::get();
-    let event = UiFrontendEvent::ExecuteCommand(params);
     main.send_frontend_event(event);
     Ok(R_NilValue)
 }

--- a/crates/ark/src/ui/methods.rs
+++ b/crates/ark/src/ui/methods.rs
@@ -7,7 +7,7 @@
 
 use amalthea::comm::ui_comm::DebugSleepParams;
 use amalthea::comm::ui_comm::ExecuteCodeParams;
-use amalthea::comm::ui_comm::ExecuteCommandAwaitParams;
+use amalthea::comm::ui_comm::ExecuteCommandParams;
 use amalthea::comm::ui_comm::ModifyEditorSelectionsParams;
 use amalthea::comm::ui_comm::NewDocumentParams;
 use amalthea::comm::ui_comm::ShowDialogParams;
@@ -109,13 +109,13 @@ pub unsafe extern "C" fn ps_ui_new_document(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_execute_command_await(command: SEXP) -> anyhow::Result<SEXP> {
-    let params = ExecuteCommandAwaitParams {
+pub unsafe extern "C" fn ps_ui_execute_command(command: SEXP) -> anyhow::Result<SEXP> {
+    let params = ExecuteCommandParams {
         command: RObject::view(command).try_into()?,
     };
 
     let main = RMain::get();
-    let out = main.call_frontend_method(UiFrontendRequest::ExecuteCommandAwait(params))?;
+    let out = main.call_frontend_method(UiFrontendRequest::ExecuteCommand(params))?;
     Ok(out.sexp)
 }
 

--- a/crates/ark/src/ui/methods.rs
+++ b/crates/ark/src/ui/methods.rs
@@ -7,6 +7,7 @@
 
 use amalthea::comm::ui_comm::DebugSleepParams;
 use amalthea::comm::ui_comm::ExecuteCodeParams;
+use amalthea::comm::ui_comm::ExecuteCommandAwaitParams;
 use amalthea::comm::ui_comm::ModifyEditorSelectionsParams;
 use amalthea::comm::ui_comm::NewDocumentParams;
 use amalthea::comm::ui_comm::ShowDialogParams;
@@ -104,6 +105,17 @@ pub unsafe extern "C" fn ps_ui_new_document(
 
     let main = RMain::get();
     let out = main.call_frontend_method(UiFrontendRequest::NewDocument(params))?;
+    Ok(out.sexp)
+}
+
+#[harp::register]
+pub unsafe extern "C" fn ps_ui_execute_command_await(command: SEXP) -> anyhow::Result<SEXP> {
+    let params = ExecuteCommandAwaitParams {
+        command: RObject::view(command).try_into()?,
+    };
+
+    let main = RMain::get();
+    let out = main.call_frontend_method(UiFrontendRequest::ExecuteCommandAwait(params))?;
     Ok(out.sexp)
 }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3256

You _can_ wait for commands in some situations to do something vs. only kick them off. An example is `'workbench.action.files.saveFiles'` which has an async accessor that waits through `editorService.saveAll()` and then returns success. This PR adds support for treating a command as a frontend request rather than an event. It basically adds back functionality that I took out in https://github.com/posit-dev/ark/pull/267.

I currently tend to like this idea of having both an event version (doesn't wait) and a method version (does wait) but I guess I could be convinced that they all should be methods, like I had them originally, but that wait?