### PR TITLE
Initial round of clippy warnings

### DIFF
--- a/crates/amalthea/src/socket/iopub.rs
+++ b/crates/amalthea/src/socket/iopub.rs
@@ -110,7 +110,7 @@ impl IOPub {
 
         // Flush the active stream (either stdout or stderr) at regular
         // intervals
-        let flush_interval = StreamBuffer::interval().clone();
+        let flush_interval = *StreamBuffer::interval();
         let flush_interval = tick(flush_interval);
 
         loop {
@@ -342,7 +342,7 @@ impl StreamBuffer {
         self.buffer.clear();
 
         StreamOutput {
-            name: self.name.clone(),
+            name: self.name,
             text,
         }
     }

--- a/crates/amalthea/src/wire/wire_message.rs
+++ b/crates/amalthea/src/wire/wire_message.rs
@@ -274,13 +274,13 @@ impl WireMessage {
                 if let Value::Object(map) = &self.content {
                     let comm_id = Self::comm_msg_id(map.get("comm_id"));
                     let comm_msg_type = Self::comm_msg_type(map.get("data"));
-                    return String::from(format!("comm_msg/{comm_id}/{comm_msg_type}"));
+                    return format!("comm_msg/{comm_id}/{comm_msg_type}");
                 }
             },
             "status" => {
                 if let Value::Object(map) = &self.content {
                     if let Some(Value::String(execution_state)) = map.get("execution_state") {
-                        return String::from(format!("status/{execution_state}"));
+                        return format!("status/{execution_state}");
                     }
                 }
             },

--- a/crates/ark/src/dap/dap_r_main.rs
+++ b/crates/ark/src/dap/dap_r_main.rs
@@ -170,7 +170,7 @@ impl RMainDap {
             DebugCallText::Finalized(call_text) => Some(call_text),
         };
 
-        let last_start_line = self.last_start_line.clone();
+        let last_start_line = self.last_start_line;
 
         let frames = self.r_stack_info(call_text, last_start_line)?;
 

--- a/crates/ark/src/dap/dap_r_main.rs
+++ b/crates/ark/src/dap/dap_r_main.rs
@@ -227,7 +227,7 @@ impl RMainDap {
                 .add(calls)
                 .call_in(ARK_ENVS.positron_ns)?;
 
-            let n: isize = Rf_xlength(info.sexp).try_into()?;
+            let n: isize = Rf_xlength(info.sexp);
 
             let mut out = Vec::with_capacity(n as usize);
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -436,10 +436,8 @@ impl<R: Read, W: Write> DapServer<R, W> {
             .copied()
             .unwrap_or(0);
 
-        let mut scopes = Vec::new();
-
         // Only 1 overarching scope for now
-        scopes.push(Scope {
+        let scopes = vec![Scope {
             name: String::from("Locals"),
             presentation_hint: Some(ScopePresentationhint::Locals),
             variables_reference,
@@ -451,7 +449,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
             column: None,
             end_line: None,
             end_column: None,
-        });
+        }];
 
         let rsp = req.success(ResponseBody::Scopes(ScopesResponse { scopes }));
 

--- a/crates/ark/src/dap/dap_variables.rs
+++ b/crates/ark/src/dap/dap_variables.rs
@@ -314,7 +314,7 @@ fn object_variable_bare_default(name: String, x_type: SEXPTYPE) -> RVariable {
 
     let mut value = "<".to_string();
     value.push_str(&class);
-    value.push_str(">");
+    value.push('>');
 
     let type_field = value.clone();
 
@@ -383,7 +383,7 @@ fn object_class(x: SEXP) -> Option<String> {
 
     let mut out = "<".to_string();
     out.push_str(&class);
-    out.push_str(">");
+    out.push('>');
 
     Some(out)
 }

--- a/crates/ark/src/data_explorer/format.rs
+++ b/crates/ark/src/data_explorer/format.rs
@@ -222,7 +222,7 @@ fn format_list_elt(x: SEXP) -> String {
 fn format_cpl(x: ComplexVector) -> Vec<FormattedValue> {
     x.iter()
         .map(|x| match x {
-            Some(v) => FormattedValue::Value(format!("{}+{}i", v.r.to_string(), v.i.to_string())),
+            Some(v) => FormattedValue::Value(format!("{}+{}i", v.r, v.i)),
             None => FormattedValue::NA,
         })
         .collect()

--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -81,7 +81,7 @@ fn summary_stats_number(
 
     let r_stats: HashMap<String, String> = names
         .iter()
-        .zip(values.into_iter())
+        .zip(values)
         .map(|(name, value)| match name {
             Some(name) => (name, value),
             None => ("unk".to_string(), value),

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -1055,7 +1055,7 @@ impl RMain {
         }
 
         // Push `\n`
-        input.push_str("\n");
+        input.push('\n');
 
         // Push `\0` (automatically, as it converts to a C string)
         let input = CString::new(input).unwrap();

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -766,7 +766,7 @@ impl RMain {
         // still inside a browser state. Should also handle cases like `debug(readline)`
         // followed by `n`.
         // https://github.com/posit-dev/positron/issues/2310
-        let frames = RObject::from(harp::session::r_sys_frames().unwrap());
+        let frames = harp::session::r_sys_frames().unwrap();
         let browser = r_pairlist_any(frames.sexp, |frame| {
             harp::session::r_env_is_browsed(frame).unwrap()
         });

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -69,7 +69,7 @@ pub(super) fn completion_item_from_file(entry: DirEntry) -> Result<CompletionIte
 
 pub(super) fn completion_item_from_directory(entry: DirEntry) -> Result<CompletionItem> {
     let mut name = entry.file_name().to_string_lossy().to_string();
-    name.push_str("/");
+    name.push('/');
 
     let mut item = completion_item(&name, CompletionData::Directory { path: entry.path() })?;
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -482,7 +482,7 @@ fn recurse_parameters(
 
         let location = name.range();
 
-        context.add_defined_variable(symbol.as_str(), location.into());
+        context.add_defined_variable(symbol.as_str(), location);
     }
 
     ().ok()
@@ -738,7 +738,7 @@ fn check_unmatched_closing_token(
     let range = node.range();
     let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
     let message = format!("unmatched closing {name} '{token}'");
-    let diagnostic = Diagnostic::new_simple(range, message.into());
+    let diagnostic = Diagnostic::new_simple(range, message);
     diagnostics.push(diagnostic);
 
     true.ok()
@@ -852,7 +852,7 @@ fn check_syntax_error(
     let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
     let text = context.contents.node_slice(&node)?.to_string();
     let message = format!("Syntax error: unexpected token '{}'", text);
-    let diagnostic = Diagnostic::new_simple(range, message.into());
+    let diagnostic = Diagnostic::new_simple(range, message);
     diagnostics.push(diagnostic);
 
     true.ok()
@@ -891,7 +891,7 @@ fn check_unclosed_arguments(
     let range = lhs.range();
     let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
     let message = format!("unmatched opening bracket '{}'", open);
-    let diagnostic = Diagnostic::new_simple(range, message.into());
+    let diagnostic = Diagnostic::new_simple(range, message);
     diagnostics.push(diagnostic);
 
     true.ok()
@@ -970,7 +970,7 @@ fn check_symbol_in_scope(
     let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
     let identifier = context.contents.node_slice(&node)?.to_string();
     let message = format!("no symbol named '{}' in scope", identifier);
-    let mut diagnostic = Diagnostic::new_simple(range, message.into());
+    let mut diagnostic = Diagnostic::new_simple(range, message);
     diagnostic.severity = Some(DiagnosticSeverity::WARNING);
     diagnostics.push(diagnostic);
 

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -490,7 +490,7 @@ pub(crate) fn log(level: lsp_types::MessageType, message: String) {
 
     // Check that channel is still alive in case the LSP was closed.
     // If closed, fallthrough.
-    if let Ok(_) = auxiliary_tx().send(AuxiliaryEvent::Log(level.clone(), message.clone())) {
+    if let Ok(_) = auxiliary_tx().send(AuxiliaryEvent::Log(level, message.clone())) {
         return;
     }
 

--- a/crates/ark/src/lsp/signature_help.rs
+++ b/crates/ark/src/lsp/signature_help.rs
@@ -216,7 +216,7 @@ pub(crate) unsafe fn r_signature_help(
     // parameters, so we can more easily record offsets.
     let mut label = String::new();
     label.push_str(code.as_str());
-    label.push_str("(");
+    label.push('(');
 
     // Get the available parameters.
     let mut parameters = vec![];
@@ -260,7 +260,7 @@ pub(crate) unsafe fn r_signature_help(
     }
 
     // Add a closing parenthesis.
-    label.push_str(")");
+    label.push(')');
 
     // Finally, if we don't have an offset, figure it out now.
     if offset.is_none() {

--- a/crates/ark/src/lsp/traits/node.rs
+++ b/crates/ark/src/lsp/traits/node.rs
@@ -20,11 +20,11 @@ fn _dump_impl(cursor: &mut TreeCursor, source: &str, indent: &str, output: &mut 
         output.push_str(
             format!(
                 "{} - {} - {} ({} -- {})\n",
-                indent.to_string(),
+                indent,
                 node.utf8_text(source.as_bytes()).unwrap(),
-                node.kind().to_string(),
-                node.start_position().to_string(),
-                node.end_position().to_string(),
+                node.kind(),
+                node.start_position(),
+                node.end_position(),
             )
             .as_str(),
         );

--- a/crates/ark/src/lsp/traits/node.rs
+++ b/crates/ark/src/lsp/traits/node.rs
@@ -136,7 +136,7 @@ impl<'tree> NodeExt for Node<'tree> {
         //    |           |
         //    x           x
         //
-        let mut node = self.clone();
+        let mut node = *self;
         while node.prev_sibling().is_none() {
             node = match node.parent() {
                 Some(parent) => parent,
@@ -170,7 +170,7 @@ impl<'tree> NodeExt for Node<'tree> {
         //    |           |
         //    x           x
         //
-        let mut node = self.clone();
+        let mut node = *self;
         while node.next_sibling().is_none() {
             node = match node.parent() {
                 Some(parent) => parent,
@@ -192,11 +192,11 @@ impl<'tree> NodeExt for Node<'tree> {
     }
 
     fn fwd_leaf_iter(&self) -> FwdLeafIterator<'_> {
-        FwdLeafIterator { node: self.clone() }
+        FwdLeafIterator { node: *self }
     }
 
     fn bwd_leaf_iter(&self) -> BwdLeafIterator<'_> {
-        BwdLeafIterator { node: self.clone() }
+        BwdLeafIterator { node: *self }
     }
 
     // From rowan. Note that until we switch to rowan, each `parent()` call
@@ -204,7 +204,7 @@ impl<'tree> NodeExt for Node<'tree> {
     // We could do better in the future:
     // https://github.com/tree-sitter/tree-sitter/pull/3214
     fn ancestors(&self) -> impl Iterator<Item = Node<'tree>> {
-        std::iter::successors(Some(self.clone()), |p| p.parent())
+        std::iter::successors(Some(*self), |p| p.parent())
     }
 }
 

--- a/crates/ark/src/test.rs
+++ b/crates/ark/src/test.rs
@@ -75,7 +75,7 @@ where
     println!("--> {:?}", json);
 
     // Convert the request to a CommMsg and send it.
-    let msg = CommMsg::Rpc(String::from(id), json);
+    let msg = CommMsg::Rpc(id, json);
     socket.incoming_tx.send(msg).unwrap();
     let msg = socket
         .outgoing_rx

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -140,7 +140,7 @@ impl WorkspaceVariableDisplayValue {
             }
         }
 
-        display_value.push_str("]");
+        display_value.push(']');
         Self::new(display_value, is_truncated)
     }
 
@@ -192,7 +192,7 @@ impl WorkspaceVariableDisplayValue {
             display_value.push_str(format!("{env_name}: ").as_str())
         }
 
-        display_value.push_str("{");
+        display_value.push('{');
 
         let mut is_truncated = false;
         for (i, name) in names
@@ -225,7 +225,7 @@ impl WorkspaceVariableDisplayValue {
             }
         }
 
-        display_value.push_str("}");
+        display_value.push('}');
 
         // Return the display value.
         Self::new(display_value, is_truncated)
@@ -245,7 +245,7 @@ impl WorkspaceVariableDisplayValue {
         unsafe {
             let dim = IntegerVector::new_unchecked(Rf_getAttrib(value, R_DimSymbol));
             let n_col = dim.get_unchecked(1).unwrap() as isize;
-            display_value.push_str("[");
+            display_value.push('[');
             for i in 0..n_col {
                 if first {
                     first = false;
@@ -253,7 +253,7 @@ impl WorkspaceVariableDisplayValue {
                     display_value.push_str(", ");
                 }
 
-                display_value.push_str("[");
+                display_value.push('[');
                 let display_column = formatted.column_iter(i).join(" ");
                 if display_column.len() > MAX_DISPLAY_VALUE_LENGTH {
                     is_truncated = true;
@@ -261,7 +261,7 @@ impl WorkspaceVariableDisplayValue {
                     //       of the first n (MAX_WIDTH?) characters in that case ?
                 }
                 display_value.push_str(display_column.as_str());
-                display_value.push_str("]");
+                display_value.push(']');
 
                 if display_value.len() > MAX_DISPLAY_VALUE_LENGTH {
                     is_truncated = true;
@@ -270,7 +270,7 @@ impl WorkspaceVariableDisplayValue {
                     break;
                 }
             }
-            display_value.push_str("]");
+            display_value.push(']');
         }
         Self::new(display_value, is_truncated)
     }
@@ -288,7 +288,7 @@ impl WorkspaceVariableDisplayValue {
             if first {
                 first = false;
             } else {
-                display_value.push_str(" ");
+                display_value.push(' ');
             }
             display_value.push_str(&x);
             if display_value.len() > MAX_DISPLAY_VALUE_LENGTH {

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1265,9 +1265,7 @@ pub fn is_binding_fancy(binding: &Binding) -> bool {
 pub fn plain_binding_force_with_rollback(binding: &Binding) -> anyhow::Result<RObject> {
     match &binding.value {
         BindingValue::Standard { object, .. } => Ok(object.clone()),
-        BindingValue::Promise { promise, .. } => {
-            Ok(r_promise_force_with_rollback(promise.sexp).map(|x| x.into())?)
-        },
+        BindingValue::Promise { promise, .. } => Ok(r_promise_force_with_rollback(promise.sexp)?),
         _ => Err(anyhow!("Unexpected binding type")),
     }
 }

--- a/crates/harp/harp-macros/src/lib.rs
+++ b/crates/harp/harp-macros/src/lib.rs
@@ -187,7 +187,7 @@ pub fn register(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Get the name (as a C string).
     let mut name = ident.to_string();
-    name.push_str("\0");
+    name.push('\0');
     let name = syn::LitByteStr::new(name.as_bytes(), ident.span());
 
     // Give a name to the registration function.

--- a/crates/harp/src/exec.rs
+++ b/crates/harp/src/exec.rs
@@ -363,7 +363,7 @@ where
             }
 
             Err(Error::TopLevelExecError {
-                message: String::from(format!("Unexpected longjump{err_buf}")),
+                message: format!("Unexpected longjump{err_buf}"),
                 backtrace: std::backtrace::Backtrace::force_capture(),
                 span_trace: tracing_error::SpanTrace::capture(),
             })

--- a/crates/harp/src/json.rs
+++ b/crates/harp/src/json.rs
@@ -245,9 +245,7 @@ impl TryFrom<RObject> for Value {
                                             // The value is not an array; create
                                             // one and append the new nad
                                             // existing values.
-                                            let mut arr = Vec::<Value>::new();
-                                            arr.push(existing.clone());
-                                            arr.push(val);
+                                            let arr = vec![existing.clone(), val];
                                             map.insert(key, Value::Array(arr));
                                         },
                                     },

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -315,7 +315,6 @@ pub fn r_altrep_class(object: SEXP) -> String {
 pub fn r_typeof(object: SEXP) -> u32 {
     // SAFETY: The type of an R object is typically considered constant,
     // and TYPEOF merely queries the R type directly from the SEXPREC struct.
-    let object = object.into();
     unsafe { TYPEOF(object) as u32 }
 }
 

--- a/crates/harp/src/vec_format.rs
+++ b/crates/harp/src/vec_format.rs
@@ -212,12 +212,12 @@ fn cpl_to_string(x: Rcomplex) -> String {
 
     // If `x.i < 0`, use `-` from converting the dbl to string
     if r_dbl_is_na(x.i) || r_dbl_is_nan(x.i) || x.i >= 0.0 {
-        out.push_str("+");
+        out.push('+');
     }
 
     let imaginary = dbl_to_string(x.i);
     out.push_str(&imaginary);
-    out.push_str("i");
+    out.push('i');
 
     out
 }
@@ -229,7 +229,7 @@ fn str_to_string(x: SEXP) -> String {
         let mut out = String::from("\"");
         let elt = r_str_to_owned_utf8(x).unwrap_or(String::from("???"));
         out.push_str(&elt);
-        out.push_str("\"");
+        out.push('"');
         out
     }
 }

--- a/crates/harp/src/vector/complex_vector.rs
+++ b/crates/harp/src/vector/complex_vector.rs
@@ -83,6 +83,6 @@ impl Vector for ComplexVector {
     }
 
     fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
-        format!("{}+{}i", x.r.to_string(), x.i.to_string())
+        format!("{}+{}i", x.r, x.i)
     }
 }


### PR DESCRIPTION
Closes https://github.com/posit-dev/ark/pull/436

@yutannihilation I've reproduced your workflow over here, just to get comfortable with it and to have it rebased on current main, but thanks a lot for getting it started. This PR fixes the same lints you started with, and I'll add more next week-ish.

As @yutannihilation said over in that other PR, the key to working these out one at a time is 

```
cargo clippy --fix -- -A clippy::all -W clippy::vec_init_then_push
```

- `--fix` to auto fix issues
- `-A clippy::all` to "allow all clippy issues", basically silencing everything else
- `-W clippy::vec_init_then_push` to then force 1 particular issue as a warning

If you just want to see the issues, remove the `--fix` and it won't auto fix them.

`--fix` doesn't auto fix every issue. For those it can't auto fix, it will show a warning in the terminal.

It is typically worth going through the changes manually, because you can occasionally (like 5% of the time) make another simplification in the code based on the fix.