### PR TITLE
Update Rust before building release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,11 @@ jobs:
                       rust_target_prefix: x86_64
 
         steps:
+            - name: Install Rust toolchain
+              run: |
+                rustup update --no-self-update stable
+                rustup default stable
+
             # Checkout sources
             - name: Checkout sources
               uses: actions/checkout@v4


### PR DESCRIPTION
To fix this failure in release build:

> error: package `echo v0.1.0 (/Users/ec2-user/actions-runner/_work/ark/ark/crates/echo)` cannot be built because it requires rustc 1.80 or newer, while the currently active rustc version is 1.77.2
