### PR TITLE
Intrinsic plot sizing (placeholder implementation)

### DIFF
--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -11,6 +11,22 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+/// The intrinsic size of a plot, if known
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct IntrinsicSize {
+	/// The width of the plot
+	pub width: f64,
+
+	/// The height of the plot
+	pub height: f64,
+
+	/// The unit of measurement of the plot's dimensions
+	pub unit: PlotUnit,
+
+	/// The source of the intrinsic size e.g. 'Matplotlib'
+	pub source: String
+}
+
 /// A rendered plot
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PlotResult {
@@ -19,6 +35,16 @@ pub struct PlotResult {
 
 	/// The MIME type of the plot data
 	pub mime_type: String
+}
+
+/// The size of a plot
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PlotSize {
+	/// The plot's height, in pixels
+	pub height: i64,
+
+	/// The plot's width, in pixels
+	pub width: i64
 }
 
 /// Possible values for Format in Render
@@ -41,14 +67,24 @@ pub enum RenderFormat {
 	Pdf
 }
 
+/// Possible values for PlotUnit
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+pub enum PlotUnit {
+	#[serde(rename = "pixels")]
+	#[strum(to_string = "pixels")]
+	Pixels,
+
+	#[serde(rename = "inches")]
+	#[strum(to_string = "inches")]
+	Inches
+}
+
 /// Parameters for the Render method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RenderParams {
-	/// The requested plot height, in pixels
-	pub height: i64,
-
-	/// The requested plot width, in pixels
-	pub width: i64,
+	/// The requested size of the plot. If not provided, the plot will be
+	/// rendered at its intrinsic size.
+	pub size: Option<PlotSize>,
 
 	/// The pixel ratio of the display device
 	pub pixel_ratio: f64,
@@ -63,10 +99,17 @@ pub struct RenderParams {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "params")]
 pub enum PlotBackendRequest {
+	/// Get the intrinsic size of a plot, if known.
+	///
+	/// The intrinsic size of a plot is the size at which a plot would be if
+	/// no size constraints were applied by Positron.
+	#[serde(rename = "get_intrinsic_size")]
+	GetIntrinsicSize,
+
 	/// Render a plot
 	///
-	/// Requests a plot to be rendered at a given height and width. The plot
-	/// data is returned in a base64-encoded string.
+	/// Requests a plot to be rendered. The plot data is returned in a
+	/// base64-encoded string.
 	#[serde(rename = "render")]
 	Render(RenderParams),
 
@@ -78,6 +121,9 @@ pub enum PlotBackendRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "result")]
 pub enum PlotBackendReply {
+	/// The intrinsic size of a plot, if known
+	GetIntrinsicSizeReply(Option<IntrinsicSize>),
+
 	/// A rendered plot
 	RenderReply(PlotResult),
 

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -190,11 +190,17 @@ impl DeviceContext {
         plot_id: &String,
     ) -> anyhow::Result<PlotBackendReply> {
         match message {
+            PlotBackendRequest::GetIntrinsicSize => {
+                Ok(PlotBackendReply::GetIntrinsicSizeReply(None))
+            },
             PlotBackendRequest::Render(plot_meta) => {
+                let size = unwrap!(plot_meta.size, None => {
+                    bail!("Intrinsically sized plots are not yet supported.");
+                });
                 let data = self.render_plot(
                     &plot_id,
-                    plot_meta.width,
-                    plot_meta.height,
+                    size.width,
+                    size.height,
                     plot_meta.pixel_ratio,
                     &plot_meta.format,
                 )?;


### PR DESCRIPTION
This PR provides a minimum required change to support a corresponding Positron PR: https://github.com/posit-dev/positron/pull/4323 i.e.

1. It always responds with an empty result to `get_intrinsic_result` on the plot comm, which disables the feature for the plot in Positron.
2. It `bail`s on `render` with an unspecified `size`. Those shouldn't happen given the Positron-side changes mentioned in point 1.