### PR TITLE
Data Explorer: Avoid warnings when summarizing columns

### DIFF
--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -202,6 +202,23 @@ mod tests {
     #[test]
     fn test_numeric_summary() {
         r_test(|| {
+            let column = r_parse_eval0("c(NA_real_, NA_real_, NA_real_)", R_ENVS.global).unwrap();
+            let stats =
+                summary_stats_(column.sexp, ColumnDisplayType::Number, &default_options()).unwrap();
+            let expected = SummaryStatsNumber {
+                min_value: None,
+                max_value: None,
+                mean: None,
+                median: None,
+                stdev: None,
+            };
+            assert_eq!(stats.number_stats, Some(expected));
+        })
+    }
+
+    #[test]
+    fn test_numeric_all_nas() {
+        r_test(|| {
             let column = r_parse_eval0("c(1,2,3,4,5, NA)", R_ENVS.global).unwrap();
             let stats =
                 summary_stats_(column.sexp, ColumnDisplayType::Number, &default_options()).unwrap();

--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -202,23 +202,6 @@ mod tests {
     #[test]
     fn test_numeric_summary() {
         r_test(|| {
-            let column = r_parse_eval0("c(NA_real_, NA_real_, NA_real_)", R_ENVS.global).unwrap();
-            let stats =
-                summary_stats_(column.sexp, ColumnDisplayType::Number, &default_options()).unwrap();
-            let expected = SummaryStatsNumber {
-                min_value: None,
-                max_value: None,
-                mean: None,
-                median: None,
-                stdev: None,
-            };
-            assert_eq!(stats.number_stats, Some(expected));
-        })
-    }
-
-    #[test]
-    fn test_numeric_all_nas() {
-        r_test(|| {
             let column = r_parse_eval0("c(1,2,3,4,5, NA)", R_ENVS.global).unwrap();
             let stats =
                 summary_stats_(column.sexp, ColumnDisplayType::Number, &default_options()).unwrap();
@@ -228,6 +211,23 @@ mod tests {
                 mean: Some("3.00".to_string()),
                 median: Some("3.00".to_string()),
                 stdev: Some("1.58".to_string()),
+            };
+            assert_eq!(stats.number_stats, Some(expected));
+        })
+    }
+
+    #[test]
+    fn test_numeric_all_nas() {
+        r_test(|| {
+            let column = r_parse_eval0("c(NA_real_, NA_real_, NA_real_)", R_ENVS.global).unwrap();
+            let stats =
+                summary_stats_(column.sexp, ColumnDisplayType::Number, &default_options()).unwrap();
+            let expected = SummaryStatsNumber {
+                min_value: None,
+                max_value: None,
+                mean: None,
+                median: None,
+                stdev: None,
             };
             assert_eq!(stats.number_stats, Some(expected));
         })

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -45,6 +45,14 @@
 }
 
 summary_stats_number <- function(col) {
+
+    col <- col[!is.na(col)]
+
+    # Don't compute stats if the column is all NA's or empty.
+    if (length(col) == 0) {
+        return(numeric(0))
+    }
+
     c(
         min_value = min(col, na.rm = TRUE),
         max_value = max(col, na.rm = TRUE),
@@ -63,13 +71,19 @@ summary_stats_boolean <- function(col) {
 }
 
 summary_stats_date <- function(col) {
-    list(
-        min_date = as.character(min(col, na.rm = TRUE)),
-        mean_date = as.character(mean(col, na.rm = TRUE)),
-        median_date = as.character(stats::median(col, na.rm = TRUE)),
-        max_date = as.character(max(col, na.rm = TRUE)),
-        num_unique = length(unique(col))
-    )
+    # We have to suppress warnings here because malformed datetimes, eg:
+    # x <- as.POSIXct(c("2010-01-01 00:00:00"), tz = "+01:00")
+    # When calling `min` on `x` woudl raise a warnings.
+    # Turns out, some Parquet files might generate malformed timezones too.
+    suppressWarnings({
+        list(
+            min_date = as.character(min(col, na.rm = TRUE)),
+            mean_date = as.character(mean(col, na.rm = TRUE)),
+            median_date = as.character(stats::median(col, na.rm = TRUE)),
+            max_date = as.character(max(col, na.rm = TRUE)),
+            num_unique = length(unique(col))
+        )
+    })
 }
 
 summary_stats_get_timezone <- function(x) {

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -73,7 +73,7 @@ summary_stats_boolean <- function(col) {
 summary_stats_date <- function(col) {
     # We have to suppress warnings here because malformed datetimes, eg:
     # x <- as.POSIXct(c("2010-01-01 00:00:00"), tz = "+01:00")
-    # When calling `min` on `x` woudl raise a warnings.
+    # When calling `min` on `x` would raise a warning.
     # Turns out, some Parquet files might generate malformed timezones too.
     suppressWarnings({
         list(


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/4353

It fixes two separate issues:

- We actually want to return `None` when there are no statistics to be computed for numeric values. (Related to https://github.com/posit-dev/positron/issues/4352). This also avoids the warnings that appear in https://github.com/posit-dev/positron/issues/4353

- For datetimes containing invalid timezones such as `x <- as.POSIXct(c("2010-01-01 00:00:00"), tz = "+01:00")`, computing `min` or `max` will raise a warning, so we suppress those.

