### PR TITLE
Switch summary stats to supported

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -948,12 +948,9 @@ impl RDataExplorer {
                             profile_type: ColumnProfileType::NullCount,
                             support_status: SupportStatus::Supported,
                         },
-                        // Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
-                        // on 6/11/2024. This will be enabled again when the UI has been reworked to
-                        // more fully support column profiles.
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::SummaryStats,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Supported,
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::Histogram,


### PR DESCRIPTION
This PR switches `ColumnProfileType::SummaryStats` from `SupportStatus::Experimental` to `SupportStatus::Supported` so that users will see the column summary stats again.