### PR TITLE
Bump ark to v0.1.125

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.124"
+version = "0.1.125"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.124"
+version = "0.1.125"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
For: 

- https://github.com/posit-dev/ark/pull/474
- https://github.com/posit-dev/ark/pull/471
- https://github.com/posit-dev/ark/pull/468