### PR TITLE
Avoid warning with invalid regex filter in Data Explorer

### DIFF
--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -283,7 +283,10 @@ col_filter_indices <- function(col, idx = NULL) {
     # Search for the term anywhere in the column's values, as a regular
     # expression
     else if (identical(params$search_type, "regex_match")) {
-        grepl(pattern = params$term, col, ignore.case = !params$case_sensitive)
+        # We suppress warnings because invalid regex will raise both an error and a warning.
+        # We already catch the error when calling this functions, but the warning leaks to
+        # the user console.
+        suppressWarnings(grepl(pattern = params$term, col, ignore.case = !params$case_sensitive))
     }
 
     # Unsupported search type


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/4392
The error was caused because `grepl` in R will show a warning and an error when an invalid regex appears.
We already catch the error, but the warning was leaking to the console.

QA: Following the issue description should not show any console warning any longer.