### PR TITLE
Data Explorer: Add support for factors summary stats

### DIFF
--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -248,6 +248,20 @@ mod tests {
     }
 
     #[test]
+    fn test_string_summary_for_factors() {
+        r_test(|| {
+            let column = r_parse_eval0("factor(c('a', 'b', 'c', 'd', ''))", R_ENVS.global).unwrap();
+            let stats =
+                summary_stats_(column.sexp, ColumnDisplayType::String, &default_options()).unwrap();
+            let expected = SummaryStatsString {
+                num_empty: 1,
+                num_unique: 5,
+            };
+            assert_eq!(stats.string_stats, Some(expected));
+        })
+    }
+
+    #[test]
     fn test_boolean_summary() {
         r_test(|| {
             let column = r_parse_eval0("c(TRUE, FALSE, TRUE, TRUE, NA)", R_ENVS.global).unwrap();

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -63,6 +63,12 @@ summary_stats_number <- function(col) {
 }
 
 summary_stats_string <- function(col) {
+    if(is.factor(col)) {
+        # We could have an optimization here to get unique and empty values
+        # from levels, but probably not worth it.
+        col <- as.character(col)
+    }
+
     c(num_empty = sum(!nzchar(col)), num_unique = length(unique(col)))
 }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2161

Without this PR we fail to compute stats for factors. They are treated as strings by the front-ent, thus they get into the codepath of calling `summary_stats_string()` and `nzchar` requires a character vector.

