### PR TITLE
Change warnings/errors in `harp_format()` to trace

### DIFF
--- a/crates/harp/src/modules/format.R
+++ b/crates/harp/src/modules/format.R
@@ -25,7 +25,7 @@ format_oo <- function(x, ...) {
     }
 
     if (!is.character(out)) {
-        log_warning(sprintf(
+        log_trace(sprintf(
             "`format()` method for <%s> should return a character vector.",
             class_collapsed(x)
         ))
@@ -33,7 +33,7 @@ format_oo <- function(x, ...) {
     }
 
     if (length(x) != length(out)) {
-        log_warning(sprintf(
+        log_trace(sprintf(
             "`format()` method for <%s> should return the same number of elements.",
             class_collapsed(x)
         ))
@@ -43,7 +43,7 @@ format_oo <- function(x, ...) {
     # Try to recover if dimensions don't agree (for example `format.Surv()`
     # doesn't preserve dimensions, see https://github.com/posit-dev/positron/issues/1862)
     if (!identical(dim(x), dim(out))) {
-        log_warning(sprintf(
+        log_trace(sprintf(
             "`format()` method for <%s> should return conforming dimensions.",
             class_collapsed(x)
         ))
@@ -60,13 +60,13 @@ format_fallback <- function(x, ...) {
 
     # Shouldn't happen but just in case
     if (!is.character(out)) {
-        stop("Unexpected type from `base::format()`.")
+        log_trace("Unexpected type from `base::format()`.")
     }
     if (length(x) != length(out)) {
-        stop("Unexpected length from `base::format()`.")
+        log_trace("Unexpected length from `base::format()`.")
     }
     if (!identical(dim(x), dim(out))) {
-        stop("Unexpected dimensions from `base::format()`.")
+        log_trace("Unexpected dimensions from `base::format()`.")
     }
 
     out

--- a/crates/harp/src/modules/format.R
+++ b/crates/harp/src/modules/format.R
@@ -19,11 +19,6 @@ harp_format <- function(x, ...) {
 format_oo <- function(x, ...) {
     out <- base::format(x, ...)
 
-    if (inherits(x, "formula")) {
-        # Need special handling for this scalar type
-        return(out)
-    }
-
     if (!is.character(out)) {
         log_trace(sprintf(
             "`format()` method for <%s> should return a character vector.",

--- a/crates/harp/src/modules/format.R
+++ b/crates/harp/src/modules/format.R
@@ -9,7 +9,7 @@
 # hard to recover from failed assumptions, including by unclassing and
 # reformatting with the default method.
 harp_format <- function(x, ...) {
-    if (is.object(x) && !inherits(x, "formula")) {
+    if (is.object(x)) {
         format_oo(x, ...)
     } else {
         base::format(x, ...)
@@ -18,6 +18,11 @@ harp_format <- function(x, ...) {
 
 format_oo <- function(x, ...) {
     out <- base::format(x, ...)
+
+    if (inherits(x, "formula")) {
+        # Need special handling for this scalar type
+        return(out)
+    }
 
     if (!is.character(out)) {
         log_warning(sprintf(

--- a/crates/harp/src/modules/format.R
+++ b/crates/harp/src/modules/format.R
@@ -9,7 +9,7 @@
 # hard to recover from failed assumptions, including by unclassing and
 # reformatting with the default method.
 harp_format <- function(x, ...) {
-    if (is.object(x)) {
+    if (is.object(x) && !inherits(x, "formula")) {
         format_oo(x, ...)
     } else {
         base::format(x, ...)

--- a/crates/harp/src/modules/utils.R
+++ b/crates/harp/src/modules/utils.R
@@ -1,3 +1,8 @@
+log_trace <- function(msg) {
+    stopifnot(is_string(msg))
+    .Call("harp_log_trace", msg)
+}
+
 log_warning <- function(msg) {
     stopifnot(is_string(msg))
     .Call("harp_log_warning", msg)

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -107,6 +107,14 @@ impl Sxpinfo {
 }
 
 #[harp::register]
+pub extern "C" fn harp_log_trace(msg: SEXP) -> crate::error::Result<SEXP> {
+    let msg = String::try_from(RObject::view(msg))?;
+    log::trace!("{msg}");
+
+    unsafe { Ok(libr::R_NilValue) }
+}
+
+#[harp::register]
 pub extern "C" fn harp_log_warning(msg: SEXP) -> crate::error::Result<SEXP> {
     let msg = String::try_from(RObject::view(msg))?;
     log::warn!("{msg}");


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3115, mainly because it shows up as a red herring in our console output a fair amount such as in https://github.com/posit-dev/positron/issues/3915. I think we'll want this type of handling for everything that inherits from a formula:

``` r
length(as.formula(y ~ a + b + c))
#> [1] 3
```

<sup>Created on 2024-08-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

After this change, a formula/quosure looks like this in the Variables pane:

![Screenshot 2024-08-20 at 4 01 33 PM](https://github.com/user-attachments/assets/3addffc2-cc8b-47b1-af58-cb526e854a1c)

As opposed to the ❓❓❓ we see now, and there are no longer errors in the console output 