### PR TITLE
Add `List` and `ListIter` types

### DIFF
--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -224,7 +224,7 @@ macro_rules! anyhow {
     }}
 }
 
-pub fn as_error<T, E>(res: std::result::Result<T, E>) -> crate::Result<T>
+pub fn as_result<T, E>(res: std::result::Result<T, E>) -> crate::Result<T>
 where
     E: std::fmt::Debug,
 {

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -39,9 +39,11 @@ pub mod vector;
 
 // Reexport API
 pub use eval::*;
+pub use object::*;
 pub use parse::*;
 pub use source::*;
 pub use table::*;
+pub use vector::list::*;
 
 // Necessary for the `harp::` references in macros, e.g. `harp::register`, to
 // resolve to the correct symbols

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -112,6 +112,12 @@ pub struct RObject {
     pub cell: SEXP,
 }
 
+impl AsRef<SEXP> for RObject {
+    fn as_ref(&self) -> &SEXP {
+        &self.sexp
+    }
+}
+
 pub trait RObjectExt<T> {
     unsafe fn elt(&self, index: T) -> crate::error::Result<RObject>;
 }

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -112,6 +112,8 @@ pub struct RObject {
     pub cell: SEXP,
 }
 
+// Needed to implement the Vector trait for List.
+// Can we do better to avoid this coercion?
 impl AsRef<SEXP> for RObject {
     fn as_ref(&self) -> &SEXP {
         &self.sexp

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -278,7 +278,7 @@ pub fn alloc_list(size: usize) -> crate::Result<SEXP> {
 }
 
 pub fn as_r_ssize(size: usize) -> crate::Result<R_xlen_t> {
-    if size > unsafe { harp::as_error(libr::R_XLEN_T_MAX.try_into())? } {
+    if size > unsafe { harp::as_result(libr::R_XLEN_T_MAX.try_into())? } {
         return Err(crate::anyhow!("`size` is larger than `R_XLEN_T_MAX`"));
     }
 

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -266,8 +266,12 @@ pub fn r_alloc_character(size: R_xlen_t) -> SEXP {
 }
 
 pub fn alloc_list(size: usize) -> crate::Result<SEXP> {
+    alloc_vector(VECSXP, size)
+}
+
+fn alloc_vector(kind: libr::SEXPTYPE, size: usize) -> crate::Result<SEXP> {
     let size = as_r_ssize(size)?;
-    let res = crate::try_catch(|| unsafe { Rf_allocVector(VECSXP, size) });
+    let res = crate::try_catch(|| unsafe { Rf_allocVector(kind, size) });
 
     match res {
         Ok(_) => res,

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -25,6 +25,10 @@ pub struct ListIter {
 }
 
 impl List {
+    pub fn new(xs: impl Into<RObject>) -> Self {
+        Self { inner: xs.into() }
+    }
+
     pub fn create<T>(data: T) -> crate::Result<Self>
     where
         T: IntoIterator,

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -1,0 +1,117 @@
+//
+// list.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use libr::SEXP;
+
+use crate::object::list_cbegin;
+use crate::object::r_length;
+use crate::object::r_list_poke;
+use crate::object::RObject;
+use crate::r_typeof;
+
+pub struct List {
+    inner: RObject,
+}
+
+pub struct ListIter {
+    index: usize,
+    size: usize,
+    ptr: *const SEXP,
+    _shelter: RObject,
+}
+
+impl List {
+    pub fn create<T>(data: T) -> crate::Result<Self>
+    where
+        T: IntoIterator,
+        <T as IntoIterator>::IntoIter: ExactSizeIterator,
+        <T as IntoIterator>::Item: Into<SEXP>,
+    {
+        let mut data = data.into_iter();
+
+        let size = data.len();
+        let inner = crate::alloc_list(size)?;
+        let inner: RObject = inner.into();
+
+        for i in 0..size {
+            unsafe {
+                let value = data.next().unwrap_unchecked();
+                r_list_poke(inner.sexp, i as libr::R_xlen_t, value.into())
+            }
+        }
+
+        Ok(Self { inner })
+    }
+
+    pub fn iter(&self) -> ListIter {
+        unsafe { ListIter::new_unchecked(self.inner.sexp) }
+    }
+}
+
+impl ListIter {
+    pub fn new(x: SEXP) -> crate::Result<Self> {
+        match r_typeof(x) {
+            libr::VECSXP | libr::EXPRSXP => {},
+            _ => {
+                let exp = vec![libr::VECSXP, libr::EXPRSXP];
+                return Err(crate::Error::UnexpectedType(r_typeof(x), exp));
+            },
+        };
+
+        Ok(unsafe { Self::new_unchecked(x) })
+    }
+
+    /// SAFETY: Assumes `x` is VECSXP or EXPRSXP
+    pub unsafe fn new_unchecked(x: SEXP) -> Self {
+        let ptr = list_cbegin(x);
+
+        Self {
+            index: 0,
+            size: r_length(x) as usize,
+            ptr,
+            _shelter: x.into(),
+        }
+    }
+}
+
+impl std::iter::Iterator for ListIter {
+    type Item = SEXP;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.size {
+            return None;
+        }
+
+        let item = unsafe { *self.ptr.wrapping_add(self.index) };
+        self.index = self.index + 1;
+        Some(item)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use libr::SEXP;
+
+    use crate::r_test;
+    use crate::vector::list::List;
+    use crate::RObject;
+
+    #[test]
+    fn test_list() {
+        r_test! {
+            let xs = List::create::<[SEXP;0]>([]).unwrap();
+            assert!(xs.iter().next().is_none());
+
+            let xs = List::create([RObject::from(1), RObject::from("foo")]).unwrap();
+            let mut it = xs.iter();
+
+            assert!(crate::is_identical(it.next().unwrap(), RObject::from(1).sexp));
+            assert!(crate::is_identical(it.next().unwrap(), RObject::from("foo").sexp));
+            assert!(it.next().is_none());
+        }
+    }
+}

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -13,6 +13,8 @@ use crate::error::Result;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
 
+pub mod list;
+
 pub mod character_vector;
 pub use character_vector::CharacterVector;
 

--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -212,6 +212,8 @@ functions::generate! {
 
     pub fn DATAPTR(x: SEXP) -> *mut std::ffi::c_void;
 
+    pub fn DATAPTR_RO(x: SEXP) -> *const std::ffi::c_void;
+
     pub fn ENCLOS(x: SEXP) -> SEXP;
 
     pub fn EXTPTR_PROT(x: SEXP) -> SEXP;
@@ -315,6 +317,8 @@ functions::generate! {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 
     pub fn Rf_installChar(x: SEXP) -> SEXP;
+
+    pub fn R_compute_identical(x: SEXP, y: SEXP, flags: i32) -> Rboolean;
 
     /// R >= 4.2.0
     pub fn R_existsVarInFrame(rho: SEXP, symbol: SEXP) -> Rboolean;
@@ -632,6 +636,9 @@ constant_globals::generate! {
     #[doc = "\"\" as a STRSXP"]
     #[default = std::ptr::null_mut()]
     pub static R_BlankScalarString: SEXP;
+
+    #[default = 4503599627370496]
+    pub static R_XLEN_T_MAX: u64;
 }
 
 mutable_globals::generate! {


### PR DESCRIPTION
Branched from #480.

~These are bare bones for now. Implemented outside of the `Vector` trait as I was struggling to make the types work, it seemed simpler to implement the interface manually for lists.~

Edit: Now implemented with the `Vector` trait.

- Create lists with `List::create([...])`. Currently no support for named elements.
- Retrieve iterator over `SEXP` elements with `iter()`. Or create one from an unwrapped list with `ListIter::new()`.

New supporting infra:

- `harp::Error::OutOfMemory` error, progress towards posit-dev/positron#2600.
- `harp::alloc_list()`. Checks for OOM errors.
- `harp::as_error()`, handy to convert any error to `harp::error::AnyhowError`, e.g. with `?`
- `harp::as_r_ssize()` to safely convert from `usize` to `r_xlen_t`.
- `harp::list_cbegin()`
- `harp::is_identical()`