### PR TITLE
Downgrade problems in `harp_format()` to trace

### DIFF
--- a/crates/ark/src/data_explorer/format.rs
+++ b/crates/ark/src/data_explorer/format.rs
@@ -15,7 +15,7 @@ use harp::object::r_length;
 use harp::object::RObject;
 use harp::r_null;
 use harp::utils::r_classes;
-use harp::utils::r_format;
+use harp::utils::r_format_vec;
 use harp::utils::r_is_null;
 use harp::utils::r_typeof;
 use harp::vector::CharacterVector;
@@ -106,8 +106,8 @@ fn format_values(x: SEXP, format_options: &FormatOptions) -> anyhow::Result<Vec<
 }
 
 fn format_object(x: SEXP) -> Vec<FormattedValue> {
-    // We call r_format() to dispatch the format method
-    let formatted: Vec<Option<String>> = match r_format(x) {
+    // We call r_format_vec() to dispatch the format method
+    let formatted: Vec<Option<String>> = match r_format_vec(x) {
         Ok(fmt) => match RObject::from(fmt).try_into() {
             Ok(x) => x,
             Err(_) => return unknown_format(x),

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -301,7 +301,7 @@ impl WorkspaceVariableDisplayValue {
     }
 
     fn from_error(err: Error) -> Self {
-        log::warn!("Error while formatting variable: {err:?}");
+        log::trace!("Error while formatting variable: {err:?}");
         Self::new(String::from("??"), true)
     }
 }

--- a/crates/harp/src/modules/format.R
+++ b/crates/harp/src/modules/format.R
@@ -8,7 +8,7 @@
 # Works around possibly unconforming methods in `base::format()`. Tries
 # hard to recover from failed assumptions, including by unclassing and
 # reformatting with the default method.
-harp_format <- function(x, ...) {
+harp_format_vec <- function(x, ...) {
     if (is.object(x)) {
         format_oo(x, ...)
     } else {
@@ -20,7 +20,7 @@ format_oo <- function(x, ...) {
     out <- base::format(x, ...)
 
     if (!is.character(out)) {
-        log_warning(sprintf(
+        log_trace(sprintf(
             "`format()` method for <%s> should return a character vector.",
             class_collapsed(x)
         ))
@@ -28,7 +28,7 @@ format_oo <- function(x, ...) {
     }
 
     if (length(x) != length(out)) {
-        log_warning(sprintf(
+        log_trace(sprintf(
             "`format()` method for <%s> should return the same number of elements.",
             class_collapsed(x)
         ))
@@ -38,7 +38,7 @@ format_oo <- function(x, ...) {
     # Try to recover if dimensions don't agree (for example `format.Surv()`
     # doesn't preserve dimensions, see https://github.com/posit-dev/positron/issues/1862)
     if (!identical(dim(x), dim(out))) {
-        log_warning(sprintf(
+        log_trace(sprintf(
             "`format()` method for <%s> should return conforming dimensions.",
             class_collapsed(x)
         ))

--- a/crates/harp/src/modules/utils.R
+++ b/crates/harp/src/modules/utils.R
@@ -1,3 +1,8 @@
+log_trace <- function(msg) {
+    stopifnot(is_string(msg))
+    .Call("harp_log_trace", msg)
+}
+
 log_warning <- function(msg) {
     stopifnot(is_string(msg))
     .Call("harp_log_warning", msg)

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -107,6 +107,14 @@ impl Sxpinfo {
 }
 
 #[harp::register]
+pub extern "C" fn harp_log_trace(msg: SEXP) -> crate::error::Result<SEXP> {
+    let msg = String::try_from(RObject::view(msg))?;
+    log::trace!("{msg}");
+
+    unsafe { Ok(libr::R_NilValue) }
+}
+
+#[harp::register]
 pub extern "C" fn harp_log_warning(msg: SEXP) -> crate::error::Result<SEXP> {
     let msg = String::try_from(RObject::view(msg))?;
     log::warn!("{msg}");
@@ -748,9 +756,9 @@ pub fn r_printf(x: &str) {
     }
 }
 
-pub fn r_format(x: SEXP) -> Result<SEXP> {
+pub fn r_format_vec(x: SEXP) -> Result<SEXP> {
     unsafe {
-        let out = RFunction::new("", "harp_format")
+        let out = RFunction::new("", "harp_format_vec")
             .add(x)
             .call_in(HARP_ENV.unwrap())?;
         Ok(out.sexp)

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -18,7 +18,7 @@ use libr::STRSXP;
 
 use crate::error::Error;
 use crate::error::Result;
-use crate::r_format;
+use crate::r_format_vec;
 use crate::utils::r_assert_type;
 use crate::utils::r_inherits;
 use crate::utils::r_is_null;
@@ -119,7 +119,7 @@ impl FormattedVector {
                         vector: Factor::new_unchecked(vector),
                     })
                 } else {
-                    let formatted = r_format(vector)?;
+                    let formatted = r_format_vec(vector)?;
 
                     r_assert_type(formatted, &[STRSXP])?;
                     Ok(Self::FormattedVector {


### PR DESCRIPTION
Closes #479 

Addresses https://github.com/posit-dev/positron/issues/3115

Today we are again seeing examples of these errors/warnings showing up in logs as red herrings: https://github.com/posit-dev/positron/discussions/4437#discussioncomment-10433103 so I do think we at least want to fix up the logs.

This does _not_ actually fix how we are displaying formulas and other objects like quosures which have length > 1 but `base::format()` results of length 1, i.e. does _not_ address https://github.com/posit-dev/positron/issues/4119.

I also changed the name of the functions to more clearly specify they are about vectors.