### PR TITLE
Compile portably for x86_64 Linux

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -25,7 +25,7 @@ jobs:
         strategy:
             matrix:
                 arch: [x64]
-                flavor: [release]
+                flavor: [debug, release]
 
         steps:
             - name: Checkout sources
@@ -41,24 +41,9 @@ jobs:
                   sudo apt install python3-pip
                   pip3 install ziglang
 
-                  # Install static OpenSSL
-                  sudo apt-get install -y libssl-dev
-
-                  # The openssl-sys crate expects to see all headers in one place but
-                  # Ubuntu puts configured headers in an arch-specific folder. We
-                  # merge these folders as a workaround.
-                  sudo cp /usr/include/x86_64-linux-gnu/openssl/* /usr/include/openssl
-
             - name: Compile ARK (${{ matrix.flavor }})
               run: |
                   cargo clean
-
-                  # Instruct the openssl-sys crate to link to libssl statically.
-                  # This is important for portability because distributions have
-                  # various requirements for their dynamic libssl libraries.
-                  export OPENSSL_STATIC=yes
-                  export OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
-                  export OPENSSL_INCLUDE_DIR=/usr/include
 
                   # Use the zig linker. This allows linking to a specific version of glibc.
                   # We use a sufficiently old version that is available on all platforms we target.

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -19,11 +19,13 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             DEBUG_FLAG: ${{ matrix.flavor == 'debug' && '-debug' || '' }}
+            TARGET_FLAG: ${{ matrix.flavor == 'release' && '--release' || '' }}
+            GLIBC_MAX_VERSION: '2.26'  # Sufficiently old for all our target platforms
 
         strategy:
             matrix:
                 arch: [x64]
-                flavor: [debug, release]
+                flavor: [release]
 
         steps:
             - name: Checkout sources
@@ -34,16 +36,40 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y cargo
 
+                  # We're linking with zig to select the libc version
+                  cargo install --locked cargo-zigbuild
+                  sudo apt install python3-pip
+                  pip3 install ziglang
+
+                  # Install static OpenSSL
+                  sudo apt-get install -y libssl-dev
+
+                  # The openssl-sys crate expects to see all headers in one place but
+                  # Ubuntu puts configured headers in an arch-specific folder. We
+                  # merge these folders as a workaround.
+                  sudo cp /usr/include/x86_64-linux-gnu/openssl/* /usr/include/openssl
+
             - name: Compile ARK (${{ matrix.flavor }})
               run: |
                   cargo clean
-                  cargo build ${{ matrix.flavor == 'release' && '--release' || '' }}
+
+                  # Instruct the openssl-sys crate to link to libssl statically.
+                  # This is important for portability because distributions have
+                  # various requirements for their dynamic libssl libraries.
+                  export OPENSSL_STATIC=yes
+                  export OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+                  export OPENSSL_INCLUDE_DIR=/usr/include
+
+                  # Use the zig linker. This allows linking to a specific version of glibc.
+                  # We use a sufficiently old version that is available on all platforms we target.
+                  # See https://github.com/ziglang/glibc-abi-tool
+                  cargo zigbuild --target x86_64-unknown-linux-gnu.$GLIBC_MAX_VERSION $TARGET_FLAG
 
             # Compress kernel to a zip file
             - name: Create archive
               run: |
                   # Enter the build directory
-                  pushd target/${{ matrix.flavor }}
+                  pushd target/x86_64-unknown-linux-gnu/${{ matrix.flavor }}
 
                   # Compress the kernel to an archive
                   ARCHIVE="$GITHUB_WORKSPACE/ark-${{ inputs.version }}-${{ matrix.flavor }}-linux-x64.zip"

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -20,11 +20,12 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             DEBUG_FLAG: ${{ matrix.flavor == 'debug' && '-debug' || '' }}
             TARGET_FLAG: ${{ matrix.flavor == 'release' && '--release' || '' }}
+            ARCH_FLAG: ${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}
             GLIBC_MAX_VERSION: '2.26'  # Sufficiently old for all our target platforms
 
         strategy:
             matrix:
-                arch: [x64]
+                arch: [x64, arm64]
                 flavor: [debug, release]
 
         steps:
@@ -41,6 +42,11 @@ jobs:
                   sudo apt install python3-pip
                   pip3 install ziglang
 
+            - name: Setup Build Environment for arm64
+              if: matrix.arch == 'arm64'
+              run: |
+                  rustup target add aarch64-unknown-linux-gnu
+
             - name: Compile ARK (${{ matrix.flavor }})
               run: |
                   cargo clean
@@ -48,16 +54,16 @@ jobs:
                   # Use the zig linker. This allows linking to a specific version of glibc.
                   # We use a sufficiently old version that is available on all platforms we target.
                   # See https://github.com/ziglang/glibc-abi-tool
-                  cargo zigbuild --target x86_64-unknown-linux-gnu.$GLIBC_MAX_VERSION $TARGET_FLAG
+                  cargo zigbuild --target ${ARCH_FLAG}-unknown-linux-gnu.$GLIBC_MAX_VERSION $TARGET_FLAG
 
             # Compress kernel to a zip file
             - name: Create archive
               run: |
                   # Enter the build directory
-                  pushd target/x86_64-unknown-linux-gnu/${{ matrix.flavor }}
+                  pushd target/${ARCH_FLAG}-unknown-linux-gnu/${{ matrix.flavor }}
 
                   # Compress the kernel to an archive
-                  ARCHIVE="$GITHUB_WORKSPACE/ark-${{ inputs.version }}-${{ matrix.flavor }}-linux-x64.zip"
+                  ARCHIVE="$GITHUB_WORKSPACE/ark-${{ inputs.version }}-${{ matrix.flavor }}-linux-${{ matrix.arch }}.zip"
                   [ -e LICENSE ] || cp "$GITHUB_WORKSPACE/LICENSE" LICENSE
                   [ -e NOTICE ] || cp "$GITHUB_WORKSPACE/crates/ark/NOTICE" NOTICE
                   zip -Xry $ARCHIVE ark LICENSE NOTICE
@@ -67,5 +73,5 @@ jobs:
             - name: Upload archive
               uses: actions/upload-artifact@v4
               with:
-                  name: ark-${{ matrix.flavor }}-linux-x64-archive
-                  path: ark-${{ inputs.version }}-${{ matrix.flavor }}-linux-x64.zip
+                  name: ark-${{ matrix.flavor }}-linux-${{ matrix.arch }}-archive
+                  path: ark-${{ inputs.version }}-${{ matrix.flavor }}-linux-${{ matrix.arch }}.zip


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4506
Addresses the ark side of https://github.com/posit-dev/positron/issues/3854

Solves linking issues for:

- Open SSL by statically linking to libssl. See https://github.com/posit-dev/positron/issues/3854#issuecomment-2226860016 for an example of linking issue. Static linking is supported by the `openssl-sys` crate, though it's slightly tricky as it expects us to provide the location of the static lib and headers in a single folder. The system installation of libssl on Ubuntu puts headers in two folders, so we merge them as a workaround.

  Another approach supported by `openssl-sys` is to compile Open SSL as part of the build ("vendored" crate feature), but I had trouble getting it to work. Might be worth looking into further for arm64 support though.

- GNU libc by using the zig linker with https://github.com/rust-cross/cargo-zigbuild. This linker supports linking to specific versions of glibc: https://github.com/ziglang/glibc-abi-tool. We use this to target glibc 2.26, which is sufficiently old to run on RHEL8 or OpenSUSE 15.2.

Using these approaches we now get a pretty portable build of ark.

I thought that we'd also have to solve linking issues with the C++ runtime but that doesn't seem to be the case. In fact I no longer see libstdc++ in the output of `ldd`, which I find very surprising:

```
ldd ark
	linux-vdso.so.1 (0x00007fffd3d71000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6f95b19000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f6f973a1000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6f95800000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f6f9739c000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6f973b3000)
```

I verified that the ark binary produced by https://github.com/posit-dev/ark/actions/runs/10591447650 works on the following fuzzbucket platforms:

```sh
fuzzbucket-client create ubuntu20-ide-prereqs-ci
fuzzbucket-client create ubuntu22-ide-prereqs
fuzzbucket-client create ubuntu24-ide-prereqs-ci
fuzzbucket-client create rhel8-ide-prereqs
fuzzbucket-client create rhel9-ide-prereqs
fuzzbucket-client create opensuse15.2
fuzzbucket-client create opensuse15.5-ide-prereqs-ci
```

Testing method: Connecting with jupyter-console and running `rnorm(1)`.

I removed the debug build from our matrix because statically linking to openssl with debug symbols causes the size of the build to explode to over 230mb. If debug symbols are needed, getting a local build of ark going is a simple matter of `git clone` + `rustup` + `cargo build`, which seems reasonably easy?