### PR TITLE
Use lobstr implementation of object_size

### DIFF
--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -23,6 +23,7 @@ pub mod r_version;
 pub mod raii;
 pub mod routines;
 pub mod session;
+pub mod size;
 pub mod string;
 pub mod symbol;
 pub mod sys;

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -21,6 +21,7 @@ use crate::exec::RFunction;
 use crate::exec::RFunctionExt;
 use crate::protect::RProtect;
 use crate::r_symbol;
+use crate::size::r_size;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_length;
 use crate::utils::r_assert_type;
@@ -129,26 +130,6 @@ impl<T: Into<RObject>> RObjectExt<T> for RObject {
             .add(self.sexp)
             .add(index)
             .call()
-    }
-}
-
-// TODO: borrow implementation from lobstr instead
-//       of calling object.size()
-fn r_size(x: SEXP) -> usize {
-    if r_is_null(x) {
-        return 0;
-    }
-    if r_is_altrep(x) {
-        return unsafe { r_size(R_altrep_data1(x)) + r_size(R_altrep_data2(x)) };
-    }
-    let size = RFunction::new("utils", "object.size").add(x).call();
-
-    match size {
-        Err(_) => 0,
-        Ok(size) => {
-            let value = unsafe { REAL_ELT(*size, 0) };
-            value as usize
-        },
     }
 }
 

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -1,0 +1,647 @@
+//
+// size.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::collections::HashSet;
+use std::ffi::c_void;
+use std::os::raw::c_int;
+use std::ptr::null;
+use std::u32;
+
+use libc::c_double;
+use libr::R_BaseEnv;
+use libr::R_EmptyEnv;
+use libr::R_GlobalEnv;
+use libr::R_MissingArg;
+use libr::Rcomplex;
+use libr::BCODESXP;
+use libr::BUILTINSXP;
+use libr::CHARSXP;
+use libr::CLOSXP;
+use libr::CPLXSXP;
+use libr::DOTSXP;
+use libr::ENVSXP;
+use libr::EXPRSXP;
+use libr::EXTPTRSXP;
+use libr::INTSXP;
+use libr::LANGSXP;
+use libr::LGLSXP;
+use libr::LISTSXP;
+use libr::NILSXP;
+use libr::PROMSXP;
+use libr::RAWSXP;
+use libr::REALSXP;
+use libr::S4SXP;
+use libr::SEXP;
+use libr::SPECIALSXP;
+use libr::STRSXP;
+use libr::SYMSXP;
+use libr::VECSXP;
+use libr::WEAKREFSXP;
+
+use crate::eval::r_parse_eval0;
+use crate::list_get;
+use crate::object::r_chr_get;
+use crate::object::r_length;
+use crate::r_is_altrep;
+use crate::r_is_vector;
+use crate::r_symbol;
+use crate::r_type2char;
+use crate::r_typeof;
+
+// A re-implementation of lobstr obj_size
+// https://github.com/r-lib/lobstr/blob/9ee1481c9d322fe0a5c798f3f20e608622ddc257/src/size.cpp#L201
+//
+// `utils::object.size()` is too slow on large datasets and this code path is used trough the
+// variables pane which required more performance.
+// See for more info.
+pub fn r_size(x: SEXP) -> usize {
+    let mut seen: HashSet<SEXP> = HashSet::new();
+
+    let sizeof_node: f64 = r_parse_eval0("as.vector(utils::object.size(quote(expr = )))", unsafe {
+        R_BaseEnv
+    })
+    .map_or(0., |x| x.try_into().unwrap_or(0.));
+
+    let sizeof_vector: f64 = r_parse_eval0("as.vector(utils::object.size(logical()))", unsafe {
+        R_BaseEnv
+    })
+    .map_or(0., |x| x.try_into().unwrap_or(0.));
+
+    obj_size_tree(
+        x,
+        unsafe { R_GlobalEnv },
+        sizeof_node as usize,
+        sizeof_vector as usize,
+        &mut seen,
+        0,
+    )
+}
+
+fn obj_size_tree(
+    x: SEXP,
+    base_env: SEXP,
+    sizeof_node: usize,
+    sizeof_vector: usize,
+    seen: &mut HashSet<SEXP>,
+    depth: u32,
+) -> usize {
+    // NILSXP is a singleton, so occupies no space. Similarly SPECIAL and
+    // BUILTIN are fixed and unchanging
+    match r_typeof(x) {
+        NILSXP | SPECIALSXP | BUILTINSXP => return 0,
+        _ => {},
+    };
+
+    // Don't count objects that we've seen before
+    if !seen.insert(x) {
+        return 0;
+    };
+
+    // Use sizeof(SEXPREC) and sizeof(VECTOR_SEXPREC) computed in R.
+    // CHARSXP are treated as vectors for this purpose
+    let mut size = if r_is_vector(x) || r_typeof(x) == CHARSXP {
+        sizeof_vector
+    } else {
+        sizeof_node
+    };
+
+    if r_is_altrep(x) {
+        let klass = unsafe { libr::ALTREP_CLASS(x) };
+        size += 3 * size_of::<SEXP>();
+
+        size += obj_size_tree(klass, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+        let data1 = unsafe { libr::R_altrep_data1(x) };
+        if !data1.is_null() {
+            size += obj_size_tree(
+                unsafe { libr::R_altrep_data1(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        }
+
+        let data2 = unsafe { libr::R_altrep_data2(x) };
+        if !data2.is_null() {
+            size += obj_size_tree(data2, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+        }
+
+        return size;
+    }
+
+    if r_typeof(x) != CHARSXP {
+        size += obj_size_tree(
+            unsafe { libr::ATTRIB(x) },
+            base_env,
+            sizeof_node,
+            sizeof_vector,
+            seen,
+            depth + 1,
+        );
+    }
+
+    match r_typeof(x) {
+        LGLSXP | INTSXP => {
+            size += v_size(r_length(x) as usize, size_of::<c_int>());
+        },
+        REALSXP => {
+            size += v_size(r_length(x) as usize, size_of::<c_double>());
+        },
+        CPLXSXP => {
+            size += v_size(r_length(x) as usize, size_of::<Rcomplex>());
+        },
+        RAWSXP => {
+            size += v_size(r_length(x) as usize, 1);
+        },
+        // Strings
+        STRSXP => {
+            size += v_size(r_length(x) as usize, size_of::<SEXP>());
+            for i in 0..r_length(x) {
+                let char = r_chr_get(x, i);
+                if char.is_null() {
+                    continue;
+                }
+                size += obj_size_tree(
+                    r_chr_get(x, i),
+                    base_env,
+                    sizeof_node,
+                    sizeof_vector,
+                    seen,
+                    depth + 1,
+                );
+            }
+        },
+        CHARSXP => {
+            size += v_size(r_length(x) as usize + 1, 1);
+        },
+        // Generic vectors
+        VECSXP | EXPRSXP | WEAKREFSXP => {
+            size += v_size(r_length(x) as usize, size_of::<SEXP>());
+            for i in 0..r_length(x) {
+                size += obj_size_tree(
+                    list_get(x, i),
+                    base_env,
+                    sizeof_node,
+                    sizeof_vector,
+                    seen,
+                    depth + 1,
+                )
+            }
+        },
+        // Nodes
+        // https://github.com/wch/r-source/blob/master/src/include/Rinternals.h#L237-L249
+        // All have enough space for three SEXP pointers
+        DOTSXP | LISTSXP | LANGSXP => {
+            // Needed for DOTSXP
+            if unsafe { x != R_MissingArg } {
+                let mut cons = x;
+                while is_linked_list(cons) {
+                    if cons != x {
+                        size += sizeof_node
+                    }
+                    size += obj_size_tree(
+                        unsafe { libr::TAG(cons) },
+                        base_env,
+                        sizeof_node,
+                        sizeof_vector,
+                        seen,
+                        depth + 1,
+                    );
+                    size += obj_size_tree(
+                        unsafe { libr::CAR(cons) },
+                        base_env,
+                        sizeof_node,
+                        sizeof_vector,
+                        seen,
+                        depth + 1,
+                    );
+                    cons = unsafe { libr::CDR(cons) };
+                }
+                // Handle non-nil CDRs
+                size += obj_size_tree(cons, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            }
+        },
+        BCODESXP => {
+            size += obj_size_tree(
+                unsafe { libr::TAG(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::CAR(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::CDR(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        },
+        // Environments
+        ENVSXP => {
+            if unsafe {
+                x == R_BaseEnv ||
+                    x == R_GlobalEnv ||
+                    x == R_EmptyEnv ||
+                    x == base_env ||
+                    is_namespace(x)
+            } {
+                return 0;
+            }
+
+            size += obj_size_tree(
+                unsafe { libr::FRAME(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::ENCLOS(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::HASHTAB(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        },
+        // Functions
+        CLOSXP => {
+            size += obj_size_tree(
+                unsafe { libr::FORMALS(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            // BODY is either an expression or byte code
+            size += obj_size_tree(
+                unsafe { libr::BODY(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::CLOENV(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        },
+        PROMSXP => {
+            size += obj_size_tree(
+                unsafe { libr::PRVALUE(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::PRCODE(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::PRENV(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        },
+        EXTPTRSXP => {
+            size += size_of::<*mut c_void>(); // the actual pointer
+            size += obj_size_tree(
+                unsafe { libr::EXTPTR_PROT(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                unsafe { libr::EXTPTR_TAG(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        },
+        S4SXP => {
+            size += obj_size_tree(
+                unsafe { libr::TAG(x) },
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+        },
+        SYMSXP => {},
+        _ => {},
+    }
+    size
+}
+
+fn is_linked_list(x: SEXP) -> bool {
+    match r_typeof(x) {
+        DOTSXP | LISTSXP | LANGSXP => true,
+        _ => false,
+    }
+}
+
+fn is_namespace(x: SEXP) -> bool {
+    unsafe {
+        x == libr::R_BaseNamespace ||
+            (libr::Rf_findVarInFrame(x, r_symbol!(".__NAMESPACE__.")) != libr::R_UnboundValue)
+    }
+}
+
+fn v_size(n: usize, element_size: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+
+    let vec_size = std::cmp::max(size_of::<SEXP>(), size_of::<c_double>()) as f64;
+    let elements_per_byte = vec_size / element_size as f64;
+    let n_bytes = (n as f64 / elements_per_byte).ceil() as usize;
+
+    let mut size: usize = 0;
+    if n_bytes > 16 {
+        size = n_bytes * 8;
+    } else if n_bytes > 8 {
+        size = 128;
+    } else if n_bytes > 6 {
+        size = 64;
+    } else if n_bytes > 4 {
+        size = 48;
+    } else if n_bytes > 2 {
+        size = 32;
+    } else if n_bytes > 1 {
+        size = 16;
+    } else if n_bytes > 0 {
+        size = 8;
+    }
+
+    size
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::environment::R_ENVS;
+    use crate::eval::r_parse_eval0;
+    use crate::r_test;
+    use crate::size::r_size;
+
+    fn object_size(code: &str) -> usize {
+        let object = r_parse_eval0(code, R_ENVS.global).unwrap();
+        r_size(object.sexp)
+    }
+
+    fn expect_size(code: &str, expected: usize) {
+        let size_act = object_size(code);
+        assert_eq!(size_act, expected);
+    }
+
+    fn expect_same(code: &str) {
+        let size_expected: f64 = r_parse_eval0(
+            format!("utils::object.size({code})").as_str(),
+            R_ENVS.global,
+        )
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+        expect_size(code, size_expected as usize);
+    }
+
+    #[test]
+    fn test_length_one_vectors() {
+        r_test!({
+            expect_same("1L");
+            expect_same("'abc'");
+            expect_same("paste(rep('banana', 100), collapse = '')");
+            expect_same("charToRaw('a')");
+            expect_same("5 + 1i");
+        })
+    }
+
+    // size scales correctly with length (accounting for vector pool)
+    #[test]
+    fn test_sizes_scale_correctly() {
+        r_test!({
+            expect_same("numeric()");
+            expect_same("1");
+            expect_same("2");
+            expect_same("c(1:10)");
+            expect_same("c(1:1000)");
+        })
+    }
+
+    #[test]
+    fn test_size_of_lists() {
+        r_test!({
+            expect_same("list()");
+            expect_same("as.list(1)");
+            expect_same("as.list(1:2)");
+            expect_same("as.list(1:3)");
+
+            expect_same("list(list(list(list(list()))))");
+        })
+    }
+
+    #[test]
+    fn test_size_of_symbols() {
+        r_test!({
+            expect_same("quote(x)");
+            expect_same("quote(asfsadfasdfasdfds)");
+        })
+    }
+
+    #[test]
+    fn test_pairlists() {
+        r_test!({
+            expect_same("pairlist()");
+            expect_same("pairlist(1)");
+            expect_same("pairlist(1, 2)");
+            expect_same("pairlist(1, 2, 3)");
+            expect_same("pairlist(1, 2, 3, 4)");
+        })
+    }
+
+    #[test]
+    fn test_s4_classes() {
+        r_test!(expect_same(
+            "methods::setClass('Z', slots = c(x = 'integer'))(x=1L)",
+        ))
+    }
+
+    #[test]
+    fn test_size_attributes() {
+        r_test!({
+            expect_same("c(x = 1)");
+            expect_same("list(x = 1)");
+            expect_same("c(x = 'y')");
+        })
+    }
+
+    #[test]
+    fn test_duplicated_charsxps_counted_once() {
+        r_test!({
+            expect_same("'x'");
+            expect_same("c('x', 'y', 'x')");
+            expect_same("c('banana', 'banana', 'banana')");
+        })
+    }
+
+    #[test]
+    fn test_shared_components_once() {
+        r_test!({
+            let size1 = object_size(
+                "local({
+                x <- 1:1e3
+                z <- list(x, x, x)})",
+            );
+
+            let size2 = object_size("1:1e3");
+            let size3 = object_size("vector('list', 3)");
+
+            assert_eq!(size1, size2 + size3)
+        })
+    }
+
+    #[test]
+    fn test_size_closures() {
+        r_test!({
+            let code = "local({
+                f <- function() NULL
+                attributes(f) <- NULL # zap srcrefs
+                environment(f) <- emptyenv()
+                f
+            })";
+            expect_same(code);
+        })
+    }
+
+    #[test]
+    fn test_works_for_altrep() {
+        r_test!({
+            let size = object_size("1:1e6");
+            // Currently reported size is 640 B
+            // If regular vector would be 4,000,040 B
+            // This test is conservative so shouldn't fail in case representation
+            // changes in the future
+            assert!(size < 10000)
+        })
+    }
+
+    #[test]
+    fn test_compute_size_defered_strings() {
+        r_test!({
+            let code = "local({
+                x <- 1:64
+                names(x) <- x
+                y <- names(x)
+                y
+            })";
+
+            // Just don't crash
+            object_size(code);
+        })
+    }
+
+    #[test]
+    fn test_terminal_envs_have_size_zero() {
+        r_test!({
+            expect_size("globalenv()", 0);
+            expect_size("baseenv()", 0);
+            expect_size("emptyenv()", 0);
+            expect_size("asNamespace('stats')", 0);
+        })
+    }
+
+    #[test]
+    fn test_env_size_recursive() {
+        r_test!({
+            let e_size = object_size("new.env(parent = emptyenv())");
+
+            let f_size = object_size(
+                "local({
+                e <- new.env(parent = emptyenv())
+                f <- new.env(parent = e)
+            })",
+            );
+
+            assert_eq!(f_size, 2 * e_size);
+        })
+    }
+
+    #[test]
+    fn test_size_of_functions_include_envs() {
+        r_test!({
+            let code = "local({
+              f <- function() {
+                y <- 1:1e3 + 1L
+                a ~ b
+              }
+              f()
+            })";
+
+            assert!(object_size(code) > object_size("1:1e3 + 1L"));
+
+            let code = "local({
+                g <- function() {
+                  y <- 1:1e3 + 1L
+                  function() 10
+                }
+                g()
+            })";
+
+            assert!(object_size(code) > object_size("1:1e3 + 1L"));
+        })
+    }
+
+    #[test]
+    fn test_support_dots() {
+        r_test!({
+            // Check it doesn't error
+            let size = object_size("(function(...) function() NULL)(foo)");
+            assert!(size != 0)
+        })
+    }
+}

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -62,11 +62,10 @@ pub fn r_size(x: SEXP) -> usize {
     let sizeof_node: f64 = r_parse_eval0("as.vector(utils::object.size(quote(expr = )))", unsafe {
         R_BaseEnv
     })
-    .map_or(0., |x| x.try_into().unwrap_or(0.));
+    .and_then(|x| x.try_into())
+    .unwrap_or(0.);
 
-    let sizeof_vector: f64 = r_parse_eval0("as.vector(utils::object.size(logical()))", unsafe {
-        R_BaseEnv
-    })
+    let sizeof_vector: f64 = r_parse_eval0("as.vector(utils::object.size(logical()))", R_ENVS.global)
     .map_or(0., |x| x.try_into().unwrap_or(0.));
 
     obj_size_tree(

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -199,10 +199,6 @@ pub fn r_is_matrix(value: SEXP) -> bool {
     unsafe { Rf_isMatrix(value) == Rboolean_TRUE }
 }
 
-pub fn r_is_vector(value: SEXP) -> bool {
-    unsafe { Rf_isVector(value) == Rboolean_TRUE }
-}
-
 pub fn r_classes(value: SEXP) -> Option<CharacterVector> {
     unsafe {
         let classes = RObject::from(Rf_getAttrib(value, R_ClassSymbol));

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -199,6 +199,10 @@ pub fn r_is_matrix(value: SEXP) -> bool {
     unsafe { Rf_isMatrix(value) == Rboolean_TRUE }
 }
 
+pub fn r_is_vector(value: SEXP) -> bool {
+    unsafe { Rf_isVector(value) == Rboolean_TRUE }
+}
+
 pub fn r_classes(value: SEXP) -> Option<CharacterVector> {
     unsafe {
         let classes = RObject::from(Rf_getAttrib(value, R_ClassSymbol));

--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -152,6 +152,8 @@ functions::generate! {
 
     pub fn Rf_isString(s: SEXP) -> Rboolean;
 
+    pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
+
     pub fn Rf_lang1(arg1: SEXP) -> SEXP;
 
     pub fn Rf_lang2(arg1: SEXP, arg2: SEXP) -> SEXP;
@@ -211,6 +213,10 @@ functions::generate! {
     pub fn DATAPTR(x: SEXP) -> *mut std::ffi::c_void;
 
     pub fn ENCLOS(x: SEXP) -> SEXP;
+
+    pub fn EXTPTR_PROT(x: SEXP) -> SEXP;
+
+    pub fn EXTPTR_TAG(x: SEXP) -> SEXP;
 
     pub fn SET_ENCLOS(x: SEXP, v: SEXP) -> SEXP;
 


### PR DESCRIPTION
Implements `object_size` as a port of the lobstr implementation, which should be more resilient to ALTREP objects, although it also:

- Accounts for all types of shared values, not just strings in the global string pool.
- Includes the size of environments (up to env)

It fixes issues that can be observed in: https://github.com/posit-dev/positron/issues/4512