### PR TITLE
Upkeep for release builds

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -54,7 +54,7 @@ jobs:
                   popd
 
             - name: Upload archive
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-linux-x64-archive
                   path: ark-${{ inputs.version }}-${{ matrix.flavor }}-linux-x64.zip

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -88,7 +88,7 @@ jobs:
 
             # Create build artifact
             - name: Upload client archive
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-darwin-${{ matrix.arch }}-archive
                   path: ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-darwin-${{ matrix.arch }}.zip

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,94 @@
+name: "Build Ark macOS Release"
+
+on:
+    workflow_call:
+      inputs:
+        version:
+          required: false
+          description: "The Ark version"
+          default: ${{ github.sha }}
+          type: string
+    workflow_dispatch:
+
+jobs:
+    # Build ARK for macOS. Both arm64 (Apple Silicon) and x64 (Intel) hosts.
+    build_macos:
+        name: Build macOS
+        runs-on: [self-hosted-production, macos, arm64]
+        timeout-minutes: 40
+
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        strategy:
+            max-parallel: 1
+            matrix:
+                arch: [arm64, x64]
+                flavor: [debug, release]
+                include:
+                    - arch: arm64
+                      arch_terminal: arm64
+                      homebrew_folder: /opt/homebrew
+                      rust_target_prefix: aarch64
+                    - arch: x64
+                      arch_terminal: x86_64
+                      homebrew_folder: /usr/local
+                      rust_target_prefix: x86_64
+
+        steps:
+            - name: Install Rust toolchain
+              run: |
+                rustup update --no-self-update stable
+                rustup default stable
+
+            # Checkout sources
+            - name: Checkout sources
+              uses: actions/checkout@v4
+
+            # These are already installed for both architectures, but would be required if we switch off
+            # a self-hosted runner, so we may as well leave them in
+            - name: Install zeromq dependencies
+              id: install_zeromq_dependencies
+              run: |
+                  arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install pkg-config"
+                  arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install libsodium"
+
+            # Zeromq calls whatever pkg-config version is findable on the PATH to be able to locate
+            # libsodium, so we have to ensure the x86_64 version is first on the PATH when compiling for
+            # that architecture, so that it finds the x86_64 version of libsodium for zeromq to link against.
+            - name: Update PATH to pkg-config for zeromq
+              id: update_path_for_zeromq
+              if: matrix.arch == 'x64'
+              run: |
+                  echo "${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
+
+            # Compile
+            - name: Compile ARK (${{ matrix.arch }})
+              env:
+                  npm_config_arch: ${{ matrix.arch }}
+                  ARK_BUILD_TYPE: ${{ matrix.flavor }}
+                  RUST_TARGET: ${{ matrix.rust_target_prefix }}-apple-darwin
+                  CARGO_FLAGS:
+                  PKG_CONFIG_ALLOW_CROSS: 1
+              run: |
+                  cargo clean
+                  cargo build ${{ matrix.flavor == 'release' && '--release' || '' }} --target ${{ matrix.rust_target_prefix }}-apple-darwin
+
+            # Compress kernel to a zip file
+            - name: Create archive
+              run: |
+                  # Enter the build directory
+                  pushd target/${{ matrix.rust_target_prefix }}-apple-darwin/${{ matrix.flavor }}
+
+                  # Compress the kernel to an archive
+                  ARCHIVE="$GITHUB_WORKSPACE/ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-darwin-${{ matrix.arch }}.zip"
+                  zip -Xry $ARCHIVE ark
+
+                  popd
+
+            # Create build artifact
+            - name: Upload client archive
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ark-${{ matrix.flavor }}-darwin-${{ matrix.arch }}-archive
+                  path: ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-darwin-${{ matrix.arch }}.zip

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,57 @@
+name: "Build Ark Windows Release"
+
+on:
+    workflow_call:
+      inputs:
+        version:
+          required: false
+          description: "The Ark version"
+          default: ${{ github.sha }}
+          type: string
+    workflow_dispatch:
+
+jobs:
+    build_windows:
+        name: Build Windows
+        runs-on: windows-latest
+        timeout-minutes: 40
+
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        strategy:
+            matrix:
+                arch: [x64]
+                flavor: [debug, release]
+                include:
+                    - arch: x64
+                      rust_target_prefix: x86_64
+
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v4
+
+            - name: Compile ARK
+              env:
+                  ARK_BUILD_TYPE: ${{ matrix.flavor }}
+                  RUST_TARGET: ${{ matrix.rust_target_prefix }}-pc-windows-msvc
+              shell: cmd
+              run: |
+                  cargo clean
+                  cargo build ${{ matrix.flavor == 'release' && '--release' || '' }} --target ${{ matrix.rust_target_prefix }}-pc-windows-msvc
+
+            - name: Create archive
+              shell: pwsh
+              run: |
+                  # Compress the kernel to an archive
+                  $params = @{
+                    Path = "target\${{ matrix.rust_target_prefix }}-pc-windows-msvc\${{ matrix.flavor }}\ark.exe", "LICENSE", "crates\ark\NOTICE"
+                    DestinationPath = "ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-windows-${{ matrix.arch }}.zip"
+                  }
+                  Compress-Archive @params
+
+            - name: Upload client archive
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ark-${{ matrix.flavor }}-windows-${{ matrix.arch }}-archive
+                  path: ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-windows-${{ matrix.arch }}.zip

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -51,7 +51,7 @@ jobs:
                   Compress-Archive @params
 
             - name: Upload client archive
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-windows-${{ matrix.arch }}-archive
                   path: ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-windows-${{ matrix.arch }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,22 +115,22 @@ jobs:
         steps:
             # Download all binaries
             - name: Download macOS arm64 kernel (${{ matrix.flavor }})
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-darwin-arm64-archive
 
             - name: Download macOS x64 kernel (${{ matrix.flavor}})
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-darwin-x64-archive
 
             - name: Download Windows x64 kernel (${{ matrix.flavor}})
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-windows-x64-archive
 
             - name: Download Linux x64 kernel (${{ matrix.flavor}})
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ark-${{ matrix.flavor }}-linux-x64-archive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,131 +58,19 @@ jobs:
     # Build ARK for macOS. Both arm64 (Apple Silicon) and x64 (Intel) hosts.
     build_macos:
         name: Build macOS
-        runs-on: [self-hosted-production, macos, arm64]
+        uses: ./.github/workflows/release-macos.yml
         needs: [do_release, get_version]
-        timeout-minutes: 40
-
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        strategy:
-            max-parallel: 1
-            matrix:
-                arch: [arm64, x64]
-                flavor: [debug, release]
-                include:
-                    - arch: arm64
-                      arch_terminal: arm64
-                      homebrew_folder: /opt/homebrew
-                      rust_target_prefix: aarch64
-                    - arch: x64
-                      arch_terminal: x86_64
-                      homebrew_folder: /usr/local
-                      rust_target_prefix: x86_64
-
-        steps:
-            - name: Install Rust toolchain
-              run: |
-                rustup update --no-self-update stable
-                rustup default stable
-
-            # Checkout sources
-            - name: Checkout sources
-              uses: actions/checkout@v4
-
-            # These are already installed for both architectures, but would be required if we switch off
-            # a self-hosted runner, so we may as well leave them in
-            - name: Install zeromq dependencies
-              id: install_zeromq_dependencies
-              run: |
-                  arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install pkg-config"
-                  arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install libsodium"
-
-            # Zeromq calls whatever pkg-config version is findable on the PATH to be able to locate
-            # libsodium, so we have to ensure the x86_64 version is first on the PATH when compiling for
-            # that architecture, so that it finds the x86_64 version of libsodium for zeromq to link against.
-            - name: Update PATH to pkg-config for zeromq
-              id: update_path_for_zeromq
-              if: matrix.arch == 'x64'
-              run: |
-                  echo "${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
-
-            # Compile
-            - name: Compile ARK (${{ matrix.arch }})
-              env:
-                  npm_config_arch: ${{ matrix.arch }}
-                  ARK_BUILD_TYPE: ${{ matrix.flavor }}
-                  RUST_TARGET: ${{ matrix.rust_target_prefix }}-apple-darwin
-                  CARGO_FLAGS:
-                  PKG_CONFIG_ALLOW_CROSS: 1
-              run: |
-                  cargo clean
-                  cargo build ${{ matrix.flavor == 'release' && '--release' || '' }} --target ${{ matrix.rust_target_prefix }}-apple-darwin
-
-            # Compress kernel to a zip file
-            - name: Create archive
-              run: |
-                  # Enter the build directory
-                  pushd target/${{ matrix.rust_target_prefix }}-apple-darwin/${{ matrix.flavor }}
-
-                  # Compress the kernel to an archive
-                  ARCHIVE="$GITHUB_WORKSPACE/ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-darwin-${{ matrix.arch }}.zip"
-                  zip -Xry $ARCHIVE ark
-
-                  popd
-
-            # Create build artifact
-            - name: Upload client archive
-              uses: actions/upload-artifact@v3
-              with:
-                  name: ark-${{ matrix.flavor }}-darwin-${{ matrix.arch }}-archive
-                  path: ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-darwin-${{ matrix.arch }}.zip
+        secrets: inherit
+        with:
+            version: ${{ needs.get_version.outputs.ARK_VERSION }}
 
     build_windows:
         name: Build Windows
-        runs-on: windows-latest
-        timeout-minutes: 40
+        uses: ./.github/workflows/release-windows.yml
         needs: [do_release, get_version]
-
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        strategy:
-            matrix:
-                arch: [x64]
-                flavor: [debug, release]
-                include:
-                    - arch: x64
-                      rust_target_prefix: x86_64
-
-        steps:
-            - name: Checkout sources
-              uses: actions/checkout@v4
-
-            - name: Compile ARK
-              env:
-                  ARK_BUILD_TYPE: ${{ matrix.flavor }}
-                  RUST_TARGET: ${{ matrix.rust_target_prefix }}-pc-windows-msvc
-              shell: cmd
-              run: |
-                  cargo clean
-                  cargo build ${{ matrix.flavor == 'release' && '--release' || '' }} --target ${{ matrix.rust_target_prefix }}-pc-windows-msvc
-
-            - name: Create archive
-              shell: pwsh
-              run: |
-                  # Compress the kernel to an archive
-                  $params = @{
-                    Path = "target\${{ matrix.rust_target_prefix }}-pc-windows-msvc\${{ matrix.flavor }}\ark.exe", "LICENSE", "crates\ark\NOTICE"
-                    DestinationPath = "ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-windows-${{ matrix.arch }}.zip"
-                  }
-                  Compress-Archive @params
-
-            - name: Upload client archive
-              uses: actions/upload-artifact@v3
-              with:
-                  name: ark-${{ matrix.flavor }}-windows-${{ matrix.arch }}-archive
-                  path: ark-${{ needs.get_version.outputs.ARK_VERSION }}-${{ matrix.flavor }}-windows-${{ matrix.arch }}.zip
+        secrets: inherit
+        with:
+            version: ${{ needs.get_version.outputs.ARK_VERSION }}
 
     build_linux:
         name: "Build Linux"


### PR DESCRIPTION
- Move release builds to own files so they can be triggered independently during development and without causing side effects (assets, slack notifications).

- Update artifacts action from deprecated v3 to v4.