### PR TITLE
Implement "string subset" completions

### DIFF
--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -5,6 +5,7 @@
 //
 //
 
+mod common;
 mod composite;
 mod unique;
 mod utils;

--- a/crates/ark/src/lsp/completions/sources/common.rs
+++ b/crates/ark/src/lsp/completions/sources/common.rs
@@ -1,0 +1,8 @@
+//
+// common.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+pub(crate) mod subset;

--- a/crates/ark/src/lsp/completions/sources/common/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/common/subset.rs
@@ -1,0 +1,61 @@
+//
+// subset.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use tree_sitter::Node;
+use tree_sitter::Point;
+
+use crate::lsp::traits::point::PointExt;
+use crate::treesitter::NodeType;
+use crate::treesitter::NodeTypeExt;
+
+pub(crate) fn is_within_subset_delimiters(
+    x: &Point,
+    subset_node: &Node,
+    subset_type: &NodeType,
+) -> bool {
+    let (open, close) = match subset_type {
+        NodeType::Subset => ("[", "]"),
+        NodeType::Subset2 => ("[[", "]]"),
+        _ => std::unreachable!(),
+    };
+
+    let Some(arguments) = subset_node.child_by_field_name("arguments") else {
+        return false;
+    };
+
+    let n_children = arguments.child_count();
+
+    if n_children < 2 {
+        return false;
+    }
+
+    let Some(open_node) = arguments.child(1 - 1) else {
+        return false;
+    };
+    let Some(close_node) = arguments.child(n_children - 1) else {
+        return false;
+    };
+
+    // Ensure open and closing nodes are the right type
+    if !matches!(
+        open_node.node_type(),
+        NodeType::Anonymous(kind) if kind == open
+    ) {
+        return false;
+    }
+    if !matches!(
+        close_node.node_type(),
+        NodeType::Anonymous(kind) if kind == close
+    ) {
+        return false;
+    }
+
+    let contains_start = x.is_after_or_equal(open_node.end_position());
+    let contains_end = x.is_before_or_equal(close_node.start_position());
+
+    contains_start && contains_end
+}

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -148,9 +148,11 @@ mod tests {
 
             let completion = completions.get(0).unwrap();
             assert_eq!(completion.label, "b".to_string());
+            assert_eq!(completion.insert_text, Some("\"b\"".to_string()));
 
             let completion = completions.get(1).unwrap();
             assert_eq!(completion.label, "a".to_string());
+            assert_eq!(completion.insert_text, Some("\"a\"".to_string()));
 
             // Right before the `[`
             let point = Point { row: 0, column: 3 };

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -7,12 +7,10 @@
 
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
-use tree_sitter::Node;
-use tree_sitter::Point;
 
+use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
 use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
 use crate::lsp::document_context::DocumentContext;
-use crate::lsp::traits::point::PointExt;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
@@ -71,50 +69,6 @@ pub(super) fn completions_from_subset(
     let text = context.document.contents.node_slice(&child)?.to_string();
 
     completions_from_evaluated_object_names(&text, ENQUOTE)
-}
-
-fn is_within_subset_delimiters(x: &Point, subset_node: &Node, subset_type: &NodeType) -> bool {
-    let (open, close) = match subset_type {
-        NodeType::Subset => ("[", "]"),
-        NodeType::Subset2 => ("[[", "]]"),
-        _ => std::unreachable!(),
-    };
-
-    let Some(arguments) = subset_node.child_by_field_name("arguments") else {
-        return false;
-    };
-
-    let n_children = arguments.child_count();
-
-    if n_children < 2 {
-        return false;
-    }
-
-    let Some(open_node) = arguments.child(1 - 1) else {
-        return false;
-    };
-    let Some(close_node) = arguments.child(n_children - 1) else {
-        return false;
-    };
-
-    // Ensure open and closing nodes are the right type
-    if !matches!(
-        open_node.node_type(),
-        NodeType::Anonymous(kind) if kind == open
-    ) {
-        return false;
-    }
-    if !matches!(
-        close_node.node_type(),
-        NodeType::Anonymous(kind) if kind == close
-    ) {
-        return false;
-    }
-
-    let contains_start = x.is_after_or_equal(open_node.end_position());
-    let contains_end = x.is_before_or_equal(close_node.start_position());
-
-    contains_start && contains_end
 }
 
 #[cfg(test)]

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -12,6 +12,7 @@ mod extractor;
 mod file_path;
 mod namespace;
 mod string;
+mod subset;
 
 use anyhow::Result;
 use colon::completions_from_single_colon;

--- a/crates/ark/src/lsp/completions/sources/unique/file_path.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/file_path.rs
@@ -21,8 +21,10 @@ use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 
-pub(super) fn completions_from_file_path(context: &DocumentContext) -> Result<Vec<CompletionItem>> {
-    log::info!("completions_from_file_path()");
+pub(super) fn completions_from_string_file_path(
+    context: &DocumentContext,
+) -> Result<Vec<CompletionItem>> {
+    log::info!("completions_from_string_file_path()");
 
     let mut completions: Vec<CompletionItem> = vec![];
 

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -1,0 +1,255 @@
+//
+// subset.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use anyhow::Result;
+use ropey::Rope;
+use tower_lsp::lsp_types::CompletionItem;
+use tree_sitter::Node;
+
+use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
+use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
+use crate::lsp::document_context::DocumentContext;
+use crate::lsp::traits::rope::RopeExt;
+use crate::treesitter::NodeTypeExt;
+
+/// Checks for `[` and `[[` completions when the user is inside a `""`
+///
+/// This is a _unique_ completions case where we may show the user the object's names if:
+/// - We are inside a top level string, like `x["<tab>"]`
+/// - We are inside a simple `c()` call, like `x[c("col", "<tab>")]`
+///
+/// The latter is just a useful heuristic. For more complex function calls, we don't want
+/// to populate object names because they won't make sense, like `x[match(foo, "<tab>")]`.
+///
+/// Different from `composite::subset::completions_from_subset()`, which applies outside
+/// of `""`, enquotes its completion items, and is composite so it meshes with other
+/// generic completions. We consider this a completely different path.
+pub(super) fn completions_from_string_subset(
+    context: &DocumentContext,
+) -> Result<Option<Vec<CompletionItem>>> {
+    log::info!("completions_from_string_subset()");
+
+    // Already inside a string
+    const ENQUOTE: bool = false;
+
+    // i.e. find `x` in `x[""]` or `x[c("foo", "")]`
+    let Some(node) = node_find_object_for_string_subset(context.node, context) else {
+        return Ok(None);
+    };
+
+    // It looks like we should provide subset completions. Regardless of what happens
+    // when getting object names, we should at least return an empty set to stop further
+    // completion sources from running.
+    let mut completions: Vec<CompletionItem> = vec![];
+
+    let text = context.document.contents.node_slice(&node)?.to_string();
+
+    if let Some(mut candidates) = completions_from_evaluated_object_names(&text, ENQUOTE)? {
+        completions.append(&mut candidates);
+    }
+
+    Ok(Some(completions))
+}
+
+fn node_find_object_for_string_subset<'tree>(
+    mut node: Node<'tree>,
+    context: &DocumentContext,
+) -> Option<Node<'tree>> {
+    if !node.is_string() {
+        return None;
+    }
+
+    node = match node_find_parent_call(node) {
+        Some(node) => node,
+        None => return None,
+    };
+
+    if node.is_call() {
+        if !node_is_c_call(&node, &context.document.contents) {
+            // Inside a call that isn't `c()`
+            return None;
+        }
+
+        node = match node_find_parent_call(node) {
+            Some(node) => node,
+            None => return None,
+        };
+
+        if !node.is_subset() && !node.is_subset2() {
+            return None;
+        }
+    }
+
+    let node_type = node.node_type();
+
+    // Only provide subset completions if you are actually within `x[<here>]` or `x[[<here>]]`
+    if !is_within_subset_delimiters(&context.point, &node, &node_type) {
+        return None;
+    }
+
+    // We know `node` is the subset or subset2 node of interest. Return its "function",
+    // i.e. likely the object name of interest to extract names for.
+    node = match node.child_by_field_name("function") {
+        Some(node) => node,
+        None => return None,
+    };
+
+    if !node.is_identifier() {
+        return None;
+    }
+
+    return Some(node);
+}
+
+fn node_find_parent_call(x: Node) -> Option<Node> {
+    // Find the `Argument` node
+    let Some(x) = x.parent() else {
+        return None;
+    };
+    if !x.is_argument() {
+        return None;
+    }
+
+    // Find the `Arguments` node
+    let Some(x) = x.parent() else {
+        return None;
+    };
+    if !x.is_arguments() {
+        return None;
+    }
+
+    // Find the call node - can be a generic `Call`, `Subset`, or `Subset2`.
+    // All 3 purposefully share the same tree structure.
+    let Some(x) = x.parent() else {
+        return None;
+    };
+    if !x.is_call() && !x.is_subset() && !x.is_subset2() {
+        return None;
+    }
+
+    Some(x)
+}
+
+fn node_is_c_call(x: &Node, contents: &Rope) -> bool {
+    if !x.is_call() {
+        return false;
+    }
+
+    let Some(x) = x.child_by_field_name("function") else {
+        return false;
+    };
+
+    if !x.is_identifier() {
+        return false;
+    }
+
+    let Ok(text) = contents.node_slice(&x) else {
+        log::error!("Can't slice `contents`.");
+        return false;
+    };
+
+    // Is the call `c()`?
+    text == "c"
+}
+
+#[cfg(test)]
+mod tests {
+    use harp::eval::r_parse_eval;
+    use harp::eval::RParseEvalOptions;
+
+    use crate::lsp::completions::sources::unique::subset::completions_from_string_subset;
+    use crate::lsp::document_context::DocumentContext;
+    use crate::lsp::documents::Document;
+    use crate::test::point_from_cursor;
+    use crate::test::r_test;
+
+    #[test]
+    fn test_string_subset_completions() {
+        r_test(|| {
+            let options = RParseEvalOptions {
+                forbid_function_calls: false,
+                ..Default::default()
+            };
+
+            // Set up a list with names
+            r_parse_eval("foo <- list(b = 1, a = 2)", options.clone()).unwrap();
+
+            // Inside top level `""`
+            let (text, point) = point_from_cursor(r#"foo["@"]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+
+            let completion = completions.get(0).unwrap();
+            assert_eq!(completion.label, "b".to_string());
+            // Not enquoting, so uses `label` directly
+            assert_eq!(completion.insert_text, None);
+
+            let completion = completions.get(1).unwrap();
+            assert_eq!(completion.label, "a".to_string());
+            // Not enquoting, so uses `label` directly
+            assert_eq!(completion.insert_text, None);
+
+            // Inside `""` in `[[`
+            let (text, point) = point_from_cursor(r#"foo[["@"]]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+
+            // Inside `""` as second argument
+            let (text, point) = point_from_cursor(r#"foo[, "@"]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+
+            // Inside `""` inside `c()`
+            let (text, point) = point_from_cursor(r#"foo[c("@")]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+
+            // Inside `""` inside `c()` with another string already specified
+            let (text, point) = point_from_cursor(r#"foo[c("a", "@")]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+
+            // Inside `""` inside `fn()` - no completions from string subset!
+            // Instead file path completions should kick in, because this is an arbitrary
+            // function call so subset completions don't make sense, but file ones might.
+            let (text, point) = point_from_cursor(r#"foo[fn("@")]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap();
+            assert!(completions.is_none());
+
+            // Right before the `[`
+            let (text, point) = point_from_cursor(r#"foo@[""]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap();
+            assert!(completions.is_none());
+
+            // A fake object that we can't get object names for.
+            // It _looks_ like we want string completions though, so we return an empty set.
+            let (text, point) = point_from_cursor(r#"not_real["@"]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert!(completions.is_empty());
+
+            // Clean up
+            r_parse_eval("remove(foo)", options.clone()).unwrap();
+        })
+    }
+}

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -158,8 +158,7 @@ fn node_is_c_call(x: &Node, contents: &Rope) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use harp::eval::r_parse_eval;
-    use harp::eval::RParseEvalOptions;
+    use harp::eval::parse_eval_global;
 
     use crate::lsp::completions::sources::unique::subset::completions_from_string_subset;
     use crate::lsp::document_context::DocumentContext;
@@ -170,13 +169,8 @@ mod tests {
     #[test]
     fn test_string_subset_completions() {
         r_test(|| {
-            let options = RParseEvalOptions {
-                forbid_function_calls: false,
-                ..Default::default()
-            };
-
             // Set up a list with names
-            r_parse_eval("foo <- list(b = 1, a = 2)", options.clone()).unwrap();
+            parse_eval_global("foo <- list(b = 1, a = 2)").unwrap();
 
             // Inside top level `""`
             let (text, point) = point_from_cursor(r#"foo["@"]"#);
@@ -249,21 +243,16 @@ mod tests {
             assert!(completions.is_empty());
 
             // Clean up
-            r_parse_eval("remove(foo)", options.clone()).unwrap();
+            parse_eval_global("remove(foo)").unwrap();
         })
     }
 
     #[test]
     fn test_string_subset_completions_on_matrix() {
         r_test(|| {
-            let options = RParseEvalOptions {
-                forbid_function_calls: false,
-                ..Default::default()
-            };
-
             // Set up a list with names
-            r_parse_eval("foo <- array(1, dim = c(2, 2))", options.clone()).unwrap();
-            r_parse_eval("colnames(foo) <- c('a', 'b')", options.clone()).unwrap();
+            parse_eval_global("foo <- array(1, dim = c(2, 2))").unwrap();
+            parse_eval_global("colnames(foo) <- c('a', 'b')").unwrap();
 
             let (text, point) = point_from_cursor(r#"foo[, "@"]"#);
             let document = Document::new(text.as_str(), None);
@@ -275,7 +264,7 @@ mod tests {
             assert_eq!(completions.get(1).unwrap().label, "b".to_string());
 
             // Clean up
-            r_parse_eval("remove(foo)", options.clone()).unwrap();
+            parse_eval_global("remove(foo)").unwrap();
         })
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -252,4 +252,30 @@ mod tests {
             r_parse_eval("remove(foo)", options.clone()).unwrap();
         })
     }
+
+    #[test]
+    fn test_string_subset_completions_on_matrix() {
+        r_test(|| {
+            let options = RParseEvalOptions {
+                forbid_function_calls: false,
+                ..Default::default()
+            };
+
+            // Set up a list with names
+            r_parse_eval("foo <- array(1, dim = c(2, 2))", options.clone()).unwrap();
+            r_parse_eval("colnames(foo) <- c('a', 'b')", options.clone()).unwrap();
+
+            let (text, point) = point_from_cursor(r#"foo[, "@"]"#);
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+
+            let completions = completions_from_string_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 2);
+            assert_eq!(completions.get(0).unwrap().label, "a".to_string());
+            assert_eq!(completions.get(1).unwrap().label, "b".to_string());
+
+            // Clean up
+            r_parse_eval("remove(foo)", options.clone()).unwrap();
+        })
+    }
 }

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -256,8 +256,7 @@ fn completions_from_object_names_impl(
 
 #[cfg(test)]
 mod tests {
-    use harp::environment::R_ENVS;
-    use harp::eval::r_parse_eval0;
+    use harp::eval::parse_eval_global;
     use tree_sitter::Point;
 
     use crate::lsp::completions::sources::utils::call_node_position_type;
@@ -424,8 +423,8 @@ mod tests {
     fn test_completions_from_evaluated_object_names() {
         r_test(|| {
             // Vector with names
-            r_parse_eval0("x <- 1:2", R_ENVS.global).unwrap();
-            r_parse_eval0("names(x) <- c('a', 'b')", R_ENVS.global).unwrap();
+            parse_eval_global("x <- 1:2").unwrap();
+            parse_eval_global("names(x) <- c('a', 'b')").unwrap();
 
             let completions = completions_from_evaluated_object_names("x", false)
                 .unwrap()
@@ -434,10 +433,10 @@ mod tests {
             assert_eq!(completions.get(0).unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
 
-            r_parse_eval0("remove(x)", R_ENVS.global).unwrap();
+            parse_eval_global("remove(x)").unwrap();
 
             // Data frame
-            r_parse_eval0("x <- data.frame(a = 1, b = 2, c = 3)", R_ENVS.global).unwrap();
+            parse_eval_global("x <- data.frame(a = 1, b = 2, c = 3)").unwrap();
 
             let completions = completions_from_evaluated_object_names("x", false)
                 .unwrap()
@@ -447,11 +446,11 @@ mod tests {
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
             assert_eq!(completions.get(2).unwrap().label, String::from("c"));
 
-            r_parse_eval0("remove(x)", R_ENVS.global).unwrap();
+            parse_eval_global("remove(x)").unwrap();
 
             // 1D array with names
-            r_parse_eval0("x <- array(1:2)", R_ENVS.global).unwrap();
-            r_parse_eval0("names(x) <- c('a', 'b')", R_ENVS.global).unwrap();
+            parse_eval_global("x <- array(1:2)").unwrap();
+            parse_eval_global("names(x) <- c('a', 'b')").unwrap();
 
             let completions = completions_from_evaluated_object_names("x", false)
                 .unwrap()
@@ -460,12 +459,12 @@ mod tests {
             assert_eq!(completions.get(0).unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
 
-            r_parse_eval0("remove(x)", R_ENVS.global).unwrap();
+            parse_eval_global("remove(x)").unwrap();
 
             // Matrix with column names
-            r_parse_eval0("x <- array(1, dim = c(1, 1))", R_ENVS.global).unwrap();
-            r_parse_eval0("rownames(x) <- 'a'", R_ENVS.global).unwrap();
-            r_parse_eval0("colnames(x) <- 'b'", R_ENVS.global).unwrap();
+            parse_eval_global("x <- array(1, dim = c(1, 1))").unwrap();
+            parse_eval_global("rownames(x) <- 'a'").unwrap();
+            parse_eval_global("colnames(x) <- 'b'").unwrap();
 
             let completions = completions_from_evaluated_object_names("x", false)
                 .unwrap()
@@ -473,22 +472,22 @@ mod tests {
             assert_eq!(completions.len(), 1);
             assert_eq!(completions.get(0).unwrap().label, String::from("b"));
 
-            r_parse_eval0("remove(x)", R_ENVS.global).unwrap();
+            parse_eval_global("remove(x)").unwrap();
 
             // 3D array with column names
             // We currently decide not to return any names here. It is typically quite
             // ambiguous which axis's names you'd want when working with >=3D arrays.
             // But we did find an object, so we return an empty vector.
-            r_parse_eval0("x <- array(1, dim = c(1, 1, 1))", R_ENVS.global).unwrap();
-            r_parse_eval0("rownames(x) <- 'a'", R_ENVS.global).unwrap();
-            r_parse_eval0("colnames(x) <- 'b'", R_ENVS.global).unwrap();
+            parse_eval_global("x <- array(1, dim = c(1, 1, 1))").unwrap();
+            parse_eval_global("rownames(x) <- 'a'").unwrap();
+            parse_eval_global("colnames(x) <- 'b'").unwrap();
 
             let completions = completions_from_evaluated_object_names("x", false)
                 .unwrap()
                 .unwrap();
             assert!(completions.is_empty());
 
-            r_parse_eval0("remove(x)", R_ENVS.global).unwrap();
+            parse_eval_global("remove(x)").unwrap();
         })
     }
 }

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -302,10 +302,14 @@ pub trait NodeTypeExt: Sized {
     fn is_identifier_or_string(&self) -> bool;
     fn is_keyword(&self) -> bool;
     fn is_call(&self) -> bool;
+    fn is_subset(&self) -> bool;
+    fn is_subset2(&self) -> bool;
     fn is_comment(&self) -> bool;
     fn is_braced_expression(&self) -> bool;
     fn is_function_definition(&self) -> bool;
     fn is_if_statement(&self) -> bool;
+    fn is_argument(&self) -> bool;
+    fn is_arguments(&self) -> bool;
     fn is_namespace_operator(&self) -> bool;
     fn is_namespace_internal_operator(&self) -> bool;
     fn is_unary_operator(&self) -> bool;
@@ -353,6 +357,14 @@ impl NodeTypeExt for Node<'_> {
         self.node_type() == NodeType::Call
     }
 
+    fn is_subset(&self) -> bool {
+        self.node_type() == NodeType::Subset
+    }
+
+    fn is_subset2(&self) -> bool {
+        self.node_type() == NodeType::Subset2
+    }
+
     fn is_comment(&self) -> bool {
         self.node_type() == NodeType::Comment
     }
@@ -367,6 +379,14 @@ impl NodeTypeExt for Node<'_> {
 
     fn is_if_statement(&self) -> bool {
         self.node_type() == NodeType::IfStatement
+    }
+
+    fn is_argument(&self) -> bool {
+        self.node_type() == NodeType::Argument
+    }
+
+    fn is_arguments(&self) -> bool {
+        self.node_type() == NodeType::Arguments
     }
 
     fn is_namespace_operator(&self) -> bool {

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -193,8 +193,17 @@ pub fn r_is_simple_vector(value: SEXP) -> bool {
     }
 }
 
-pub fn r_is_matrix(value: SEXP) -> bool {
-    unsafe { Rf_isMatrix(value) == Rboolean_TRUE }
+/// Is `object` a matrix?
+///
+/// Notably returns `false` for 1D arrays and >=3D arrays.
+pub fn r_is_matrix(object: SEXP) -> bool {
+    let dim = r_dim(object);
+
+    if dim == r_null() {
+        return false;
+    }
+
+    r_length(dim) == 2
 }
 
 pub fn r_classes(value: SEXP) -> Option<CharacterVector> {


### PR DESCRIPTION
Closes https://github.com/posit-dev/ark/pull/433
Addresses https://github.com/posit-dev/positron/issues/3931

Commits are self contained and probably easiest to read on their own

https://github.com/posit-dev/ark/pull/433 moves string completions from unique -> composite, but I strongly believe that string completions are still a unique case and should not be combined with other generic completion paths.

When I set up string completions, we only had file completions as a possible variant of string completions, but I set it up to be able to extend this with other unique string completion variants. I believe that "string subsetting" is another one of these.

This new string subsetting path is different from the composite subsetting path, with the difference being:
- Unique (string subset): `x["<tab>"]` (this PR)
- Composite (subset): `x[<tab>]` (already had this)

They share a little infrastructure though, so I've extracted out a new `common/` folder to hold it. We already have a `utils.rs` file but it is getting a little messy and I think this is a better way long term.

---

It's a bit tricky to implement this, because 99.9% of the time the correct thing to show when a user does `"<tab>"` are file completions. `x["<tab>"]` is a _very_ special case where names of the `x` object are likely more relevant, so we show those instead.

I've also allowed _very_ simple `c()` calls, like `x[c("foo", "<tab>")]` to trigger these string subset completions as well. This is a heuristic @kevinushey and I talked about. I realize it is not perfect but it should capture lots of use cases.

What we don't want to do is allow string subset completions anytime we are inside a `[` or `[[`. For example, `x[read_file("<tab>")]` and `x[match(foo, "<tab>")]` are two places where completing with the names of `x` make no sense at all, and we are better served just falling back to file name completions like usual. For that reason, I've scoped this feature very tightly to only allow this with:
- "top level" strings inside a `[` or `[[`
- Simple `c()` calls

https://github.com/user-attachments/assets/de6017e0-3197-4141-abd2-dddb67929372


