### PR TITLE
Recognize non-function pages in `RHtmlHelp` and split it into topic vs function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "harp",
  "home",
  "http 0.2.9",
+ "insta",
  "itertools",
  "lazy_static",
  "libc",
@@ -517,6 +518,18 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -848,6 +861,12 @@ dependencies = [
  "vswhom",
  "winreg",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1391,6 +1410,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
 ]
 
 [[package]]
@@ -2595,6 +2626,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -63,6 +63,9 @@ tracing-appender = "0.2.3"
 rustc-hash = "1.2.0"
 tracing-error = "0.2.0"
 
+[dev-dependencies]
+insta = { version = "1.39.0" }
+
 [build-dependencies]
 chrono = "0.4.23"
 embed-resource = "2.4.0"

--- a/crates/ark/src/lsp/completions/resolve.rs
+++ b/crates/ark/src/lsp/completions/resolve.rs
@@ -51,7 +51,7 @@ unsafe fn resolve_package_completion_item(
     package: &str,
 ) -> Result<bool> {
     let topic = join!(package, "-package");
-    let help = unwrap!(RHtmlHelp::new(topic.as_str(), Some(package))?, None => {
+    let help = unwrap!(RHtmlHelp::from_topic(topic.as_str(), Some(package))?, None => {
         return Ok(false);
     });
 
@@ -72,7 +72,7 @@ unsafe fn resolve_function_completion_item(
     name: &str,
     package: Option<&str>,
 ) -> Result<bool> {
-    let help = unwrap!(RHtmlHelp::new(name, package)?, None => {
+    let help = unwrap!(RHtmlHelp::from_function(name, package)?, None => {
         return Ok(false);
     });
 
@@ -95,7 +95,7 @@ unsafe fn resolve_parameter_completion_item(
     function: &str,
 ) -> Result<bool> {
     // Get help for this function.
-    let help = unwrap!(RHtmlHelp::new(function, None)?, None => {
+    let help = unwrap!(RHtmlHelp::from_function(function, None)?, None => {
         return Ok(false);
     });
 

--- a/crates/ark/src/lsp/completions/resolve.rs
+++ b/crates/ark/src/lsp/completions/resolve.rs
@@ -16,7 +16,7 @@ use tower_lsp::lsp_types::MarkupKind;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::help::RHtmlHelp;
 
-pub unsafe fn resolve_completion(item: &mut CompletionItem) -> Result<bool> {
+pub fn resolve_completion(item: &mut CompletionItem) -> Result<bool> {
     let Some(data) = item.data.clone() else {
         bail!("Completion '{}' has no associated data", item.label);
     };
@@ -46,10 +46,7 @@ pub unsafe fn resolve_completion(item: &mut CompletionItem) -> Result<bool> {
     }
 }
 
-unsafe fn resolve_package_completion_item(
-    item: &mut CompletionItem,
-    package: &str,
-) -> Result<bool> {
+fn resolve_package_completion_item(item: &mut CompletionItem, package: &str) -> Result<bool> {
     let topic = join!(package, "-package");
     let help = unwrap!(RHtmlHelp::from_topic(topic.as_str(), Some(package))?, None => {
         return Ok(false);
@@ -67,7 +64,7 @@ unsafe fn resolve_package_completion_item(
     Ok(true)
 }
 
-unsafe fn resolve_function_completion_item(
+fn resolve_function_completion_item(
     item: &mut CompletionItem,
     name: &str,
     package: Option<&str>,
@@ -89,7 +86,7 @@ unsafe fn resolve_function_completion_item(
 }
 
 // TODO: Include package as well here?
-unsafe fn resolve_parameter_completion_item(
+fn resolve_parameter_completion_item(
     item: &mut CompletionItem,
     name: &str,
     function: &str,

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -75,7 +75,7 @@ pub fn completions_from_custom_source_impl(
     let node = context.node;
 
     // Use the signature help tools to figure out the necessary pieces.
-    let signatures = unsafe { r_signature_help(context)? };
+    let signatures = r_signature_help(context)?;
     let Some(signatures) = signatures else {
         return Ok(None);
     };

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -191,7 +191,7 @@ pub(crate) fn handle_completion(
 pub(crate) fn handle_completion_resolve(
     mut item: CompletionItem,
 ) -> anyhow::Result<CompletionItem> {
-    r_task(|| unsafe { resolve_completion(&mut item) })?;
+    r_task(|| resolve_completion(&mut item))?;
     Ok(item)
 }
 
@@ -210,7 +210,7 @@ pub(crate) fn handle_hover(
     let context = DocumentContext::new(&document, point, None);
 
     // request hover information
-    let result = r_task(|| unsafe { r_hover(&context) });
+    let result = r_task(|| r_hover(&context));
 
     // unwrap errors
     let result = unwrap!(result, Err(err) => {
@@ -244,7 +244,7 @@ pub(crate) fn handle_signature_help(
     let context = DocumentContext::new(&document, point, None);
 
     // request signature help
-    let result = r_task(|| unsafe { r_signature_help(&context) });
+    let result = r_task(|| r_signature_help(&context));
 
     // unwrap errors
     let result = unwrap!(result, Err(err) => {

--- a/crates/ark/src/lsp/help.rs
+++ b/crates/ark/src/lsp/help.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::*;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::utils::r_typeof;
@@ -24,6 +23,9 @@ use crate::lsp::markdown::*;
 
 pub struct RHtmlHelp {
     html: Html,
+
+    /// Is this help page known to be for a function?
+    function: bool,
 }
 
 pub enum Status {
@@ -32,7 +34,31 @@ pub enum Status {
 }
 
 impl RHtmlHelp {
-    pub unsafe fn new(topic: &str, package: Option<&str>) -> Result<Option<Self>> {
+    pub unsafe fn from_topic(topic: &str, package: Option<&str>) -> anyhow::Result<Option<Self>> {
+        Self::get_help(topic, package).map(|html| {
+            html.map(|html| Self {
+                html,
+                function: false,
+            })
+        })
+    }
+
+    pub unsafe fn from_function(name: &str, package: Option<&str>) -> anyhow::Result<Option<Self>> {
+        Self::get_help(name, package).map(|html| {
+            html.and_then(|html| {
+                if Self::is_function(&html) {
+                    Some(Self {
+                        html,
+                        function: true,
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+    }
+
+    unsafe fn get_help(topic: &str, package: Option<&str>) -> anyhow::Result<Option<Html>> {
         // trim off a package prefix if necessary
         let package = package.map(|s| s.replace("package:", ""));
 
@@ -42,12 +68,10 @@ impl RHtmlHelp {
             .param("package", package)
             .call();
 
-        if let Err(error) = contents {
-            log::error!("{}", error);
+        let contents = unwrap!(contents, Err(err) => {
+            log::error!("{err:?}");
             return Ok(None);
-        };
-
-        let contents = contents.unwrap_unchecked();
+        });
 
         // check for NULL (implies no help available)
         if r_typeof(*contents) == NILSXP {
@@ -57,7 +81,22 @@ impl RHtmlHelp {
         // parse as html
         let contents = contents.to::<String>()?;
         let html = Html::parse_document(contents.as_str());
-        Ok(Some(Self { html }))
+
+        Ok(Some(html))
+    }
+
+    /// Is this a help page for a function?
+    ///
+    /// Uses a heuristic of looking for a `Usage` section to determine if this looks like
+    /// function help or not. Can't look for `Arguments`, as some functions don't have
+    /// any!
+    fn is_function(x: &Html) -> bool {
+        // Find all h3 headers in the document
+        let selector = Selector::parse("h3").unwrap();
+        let mut headers = x.select(&selector);
+
+        // Do any have a usage section?
+        headers.any(|header| header.html() == "<h3>Usage</h3>")
     }
 
     pub fn topic(&self) -> Option<String> {
@@ -121,22 +160,32 @@ impl RHtmlHelp {
         Some(elements)
     }
 
+    /// Find and parse the arguments in the HTML help
+    ///
+    /// The help file has the structure:
+    ///
+    /// <h3>Arguments</h3>
+    ///
+    /// <table>
+    /// <tr style="vertical-align: top;"><td><code>parameter</code></td>
+    /// <td>
+    /// Parameter documentation.
+    /// </td></tr>
+    ///
+    /// Note that parameters might be parsed as part of different, multiple tables;
+    /// we need to iterate over all tables after the Arguments header.
+    ///
+    /// SAFETY: Errors if `self.function` is `false`.
     pub fn parameters(
         &self,
         mut callback: impl FnMut(&Vec<&str>, &ElementRef) -> Status,
-    ) -> Result<()> {
-        // Find and parse the arguments in the HTML help. The help file has the structure:
-        //
-        // <h3>Arguments</h3>
-        //
-        // <table>
-        // <tr style="vertical-align: top;"><td><code>parameter</code></td>
-        // <td>
-        // Parameter documentation.
-        // </td></tr>
-        //
-        // Note that parameters might be parsed as part of different, multiple tables;
-        // we need to iterate over all tables after the Arguments header.
+    ) -> anyhow::Result<()> {
+        if !self.function {
+            return Err(anyhow::anyhow!(
+                "Called `parameters()` on a topic that isn't a function."
+            ));
+        }
+
         let selector = Selector::parse("h3").unwrap();
         let mut headers = self.html.select(&selector);
         let header = headers
@@ -191,8 +240,18 @@ impl RHtmlHelp {
         Ok(())
     }
 
-    pub fn parameter(&self, name: &str) -> Result<Option<MarkupContent>> {
+    /// Extract content for an individual parameter by name
+    ///
+    /// SAFETY: Errors if `self.function` is `false`.
+    pub fn parameter(&self, name: &str) -> anyhow::Result<Option<MarkupContent>> {
+        if !self.function {
+            return Err(anyhow::anyhow!(
+                "Called `parameter()` on a topic that isn't a function."
+            ));
+        }
+
         let mut result = None;
+
         self.parameters(|params, node| {
             for param in params {
                 if *param == name {
@@ -210,7 +269,7 @@ impl RHtmlHelp {
         Ok(result)
     }
 
-    pub fn markdown(&self) -> Result<String> {
+    pub fn markdown(&self) -> anyhow::Result<String> {
         let mut markdown = String::new();
 
         // add topic

--- a/crates/ark/src/lsp/hover.rs
+++ b/crates/ark/src/lsp/hover.rs
@@ -80,12 +80,14 @@ pub(crate) unsafe fn r_hover(context: &DocumentContext) -> anyhow::Result<Option
         return Ok(None);
     });
 
+    // Currently, `hover_context()` restricts to only showing hover docs for functions,
+    // so we also use `RHtmlHelp::new_function()` here
     let help = match ctx {
         HoverContext::QualifiedTopic { package, topic } => {
-            RHtmlHelp::new(topic.as_str(), Some(package.as_str()))?
+            RHtmlHelp::from_function(topic.as_str(), Some(package.as_str()))?
         },
 
-        HoverContext::Topic { topic } => RHtmlHelp::new(topic.as_str(), None)?,
+        HoverContext::Topic { topic } => RHtmlHelp::from_function(topic.as_str(), None)?,
     };
 
     let help = unwrap!(help, None => {

--- a/crates/ark/src/lsp/hover.rs
+++ b/crates/ark/src/lsp/hover.rs
@@ -66,7 +66,7 @@ fn hover_context(node: Node, context: &DocumentContext) -> Result<Option<HoverCo
     Ok(None)
 }
 
-pub(crate) unsafe fn r_hover(context: &DocumentContext) -> anyhow::Result<Option<MarkupContent>> {
+pub(crate) fn r_hover(context: &DocumentContext) -> anyhow::Result<Option<MarkupContent>> {
     // get the node
     let node = &context.node;
 

--- a/crates/ark/src/lsp/hover.rs
+++ b/crates/ark/src/lsp/hover.rs
@@ -81,7 +81,7 @@ pub(crate) fn r_hover(context: &DocumentContext) -> anyhow::Result<Option<Markup
     });
 
     // Currently, `hover_context()` restricts to only showing hover docs for functions,
-    // so we also use `RHtmlHelp::new_function()` here
+    // so we also use `RHtmlHelp::from_function()` here
     let help = match ctx {
         HoverContext::QualifiedTopic { package, topic } => {
             RHtmlHelp::from_function(topic.as_str(), Some(package.as_str()))?

--- a/crates/ark/src/lsp/signature_help.rs
+++ b/crates/ark/src/lsp/signature_help.rs
@@ -41,9 +41,7 @@ use crate::treesitter::NodeTypeExt;
 // that is a bit hard to follow.
 
 /// SAFETY: Requires access to the R runtime.
-pub(crate) unsafe fn r_signature_help(
-    context: &DocumentContext,
-) -> anyhow::Result<Option<SignatureHelp>> {
+pub(crate) fn r_signature_help(context: &DocumentContext) -> anyhow::Result<Option<SignatureHelp>> {
     // Get document AST + completion position.
     let ast = &context.document.ast;
 
@@ -534,7 +532,7 @@ mod tests {
             let document = Document::new(&text, None);
             let context = DocumentContext::new(&document, point, None);
 
-            let help = unsafe { r_signature_help(&context) };
+            let help = r_signature_help(&context);
             let help = help.unwrap().unwrap();
             assert_eq!(help.signatures.len(), 1);
 
@@ -551,14 +549,14 @@ mod tests {
             let (text, point) = point_from_cursor("library@()");
             let document = Document::new(&text, None);
             let context = DocumentContext::new(&document, point, None);
-            let help = unsafe { r_signature_help(&context) };
+            let help = r_signature_help(&context);
             let help = help.unwrap();
             assert!(help.is_none());
 
             let (text, point) = point_from_cursor("library()@");
             let document = Document::new(&text, None);
             let context = DocumentContext::new(&document, point, None);
-            let help = unsafe { r_signature_help(&context) };
+            let help = r_signature_help(&context);
             let help = help.unwrap();
             assert!(help.is_none());
         })
@@ -586,7 +584,7 @@ fn <- function(
             let (text, point) = point_from_cursor("fn(@)");
             let document = Document::new(&text, None);
             let context = DocumentContext::new(&document, point, None);
-            let help = unsafe { r_signature_help(&context) };
+            let help = r_signature_help(&context);
             let help = help.unwrap().unwrap();
 
             // Check expected signature label

--- a/crates/ark/src/lsp/signature_help.rs
+++ b/crates/ark/src/lsp/signature_help.rs
@@ -210,13 +210,13 @@ pub(crate) unsafe fn r_signature_help(
         let package = callee.child_by_field_name("lhs").into_result()?;
         let package = context.document.contents.node_slice(&package)?.to_string();
 
-        let topic = callee.child_by_field_name("rhs").into_result()?;
-        let topic = context.document.contents.node_slice(&topic)?.to_string();
+        let name = callee.child_by_field_name("rhs").into_result()?;
+        let name = context.document.contents.node_slice(&name)?.to_string();
 
-        RHtmlHelp::new(topic.as_str(), Some(package.as_str()))
+        RHtmlHelp::from_function(name.as_str(), Some(package.as_str()))
     } else {
-        let topic = context.document.contents.node_slice(&callee)?.to_string();
-        RHtmlHelp::new(topic.as_str(), None)
+        let name = context.document.contents.node_slice(&callee)?.to_string();
+        RHtmlHelp::from_function(name.as_str(), None)
     };
 
     // The signature label. We generate this as we walk through the

--- a/crates/ark/src/lsp/snapshots/ark__lsp__help__tests__parameter_on_non_functions.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__help__tests__parameter_on_non_functions.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/help.rs
+expression: "help.parameter(\"foo\").unwrap_err()"
+---
+Called `parameter()` on a topic that isn't a function.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__help__tests__parameters_on_non_functions.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__help__tests__parameters_on_non_functions.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/help.rs
+expression: "help.parameters(|_, _| Status::Done).unwrap_err()"
+---
+Called `parameters()` on a topic that isn't a function.

--- a/crates/ark/src/modules/positron/help.R
+++ b/crates/ark/src/modules/positron/help.R
@@ -135,6 +135,8 @@ getHtmlHelpContentsInstalled <- function(helpFiles, package) {
     return(NULL)
   }
 
+  # If there are multiple hits for the same topic, right now we just choose the first
+  # (which I believe goes with the most recently loaded package)
   helpFile <- helpFiles[[1L]]
 
   rd <- utils:::.getHelpFile(helpFile)

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -705,16 +705,23 @@ impl TryFrom<RObject> for Option<bool> {
 impl TryFrom<RObject> for Option<String> {
     type Error = crate::error::Error;
     fn try_from(value: RObject) -> Result<Self, Self::Error> {
+        Option::<String>::try_from(&value)
+    }
+}
+
+impl TryFrom<&RObject> for Option<String> {
+    type Error = crate::error::Error;
+    fn try_from(value: &RObject) -> Result<Self, Self::Error> {
         unsafe {
-            let charsexp = match r_typeof(*value) {
-                CHARSXP => *value,
+            let charsexp = match r_typeof(value.sexp) {
+                CHARSXP => value.sexp,
                 STRSXP => {
-                    r_assert_length(*value, 1)?;
-                    STRING_ELT(*value, 0)
+                    r_assert_length(value.sexp, 1)?;
+                    STRING_ELT(value.sexp, 0)
                 },
-                SYMSXP => PRINTNAME(*value),
+                SYMSXP => PRINTNAME(value.sexp),
                 _ => {
-                    return Err(Error::UnexpectedType(r_typeof(*value), vec![
+                    return Err(Error::UnexpectedType(r_typeof(value.sexp), vec![
                         CHARSXP, STRSXP, SYMSXP,
                     ]))
                 },
@@ -807,6 +814,13 @@ impl TryFrom<RObject> for Option<f64> {
 impl TryFrom<RObject> for String {
     type Error = crate::error::Error;
     fn try_from(value: RObject) -> Result<Self, Self::Error> {
+        String::try_from(&value)
+    }
+}
+
+impl TryFrom<&RObject> for String {
+    type Error = crate::error::Error;
+    fn try_from(value: &RObject) -> Result<Self, Self::Error> {
         match Option::<String>::try_from(value)? {
             Some(x) => Ok(x),
             None => Err(Error::MissingValueError),


### PR DESCRIPTION
Closes https://github.com/posit-dev/ark/pull/431 - alternate approach

Addresses https://github.com/posit-dev/positron/issues/3467#issuecomment-2213963654 (meaning we can close the issue after this)

Example from https://github.com/posit-dev/ark/pull/431:

```r
bar <- function(...) {}

bar()
#   ^
#   get errors when moving a cursor to here
```

When you get to `bar(<here>)`, we try to look up help documentation for `?bar`. That actually gets mapped to `?plotmath`, a pure topic page (i.e. no functions on there). This was causing our `RHtmlHelp::parameters()` function to freak out, because it was only to be used on function pages.

`RHtmlHelp` is a generic help engine, so it should be able to look up non-function arbitrary topics. And in fact we do this for package pages, i.e. `"dplyr-package"` in `resolve_package_completion_item()`, so we can't just throw out any help page that doesn't look like function help (which was the #431 approach).

Instead, I've split `RHtmlHelp` into:
- `from_topic()`, which sets `function = false` internally
- `from_function()`, which sets `function = true` internally

`from_function()` also returns `None` if a new `is_function()` internal helper returns `false` on the found HTML. It uses the approach from #431 which was to detect a `Usage` section, which should only apply to functions.

We now use `from_function()` everywhere except `resolve_package_completion_item()`, but I see us potentially using `from_topic()` more in the future too.

The new internal `function: bool` flag is useful because it allows us to error immediately in `RHtmlHelp::parameter()` and `RHtmlHelp::parameters()` if we don't give it function related help. We could try to encode this into the type system but that seemed like overkill for now.

---

I've also introduced snapshot testing through the insta crate in this PR. It was useful for catching an expected error message, and I think we are going to want to use it elsewhere too.