### PR TITLE
Data explorer: Allow for optional summary stats for dates

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -383,38 +383,38 @@ pub struct SummaryStatsString {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SummaryStatsDate {
 	/// The exact number of distinct values
-	pub num_unique: i64,
+	pub num_unique: Option<i64>,
 
 	/// Minimum date value as string
-	pub min_date: String,
+	pub min_date: Option<String>,
 
 	/// Average date value as string
-	pub mean_date: String,
+	pub mean_date: Option<String>,
 
 	/// Sample median (50% value) date value as string
-	pub median_date: String,
+	pub median_date: Option<String>,
 
 	/// Maximum date value as string
-	pub max_date: String
+	pub max_date: Option<String>
 }
 
 /// SummaryStatsDatetime in Schemas
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SummaryStatsDatetime {
 	/// The exact number of distinct values
-	pub num_unique: i64,
+	pub num_unique: Option<i64>,
 
 	/// Minimum date value as string
-	pub min_date: String,
+	pub min_date: Option<String>,
 
 	/// Average date value as string
-	pub mean_date: String,
+	pub mean_date: Option<String>,
 
 	/// Sample median (50% value) date value as string
-	pub median_date: String,
+	pub median_date: Option<String>,
 
 	/// Maximum date value as string
-	pub max_date: String,
+	pub max_date: Option<String>,
 
 	/// Time zone for timestamp with time zone
 	pub timezone: Option<String>

--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use core::fmt;
 use std::collections::HashMap;
 
 use amalthea::comm::data_explorer_comm;
@@ -164,13 +165,14 @@ fn empty_column_summary_stats() -> data_explorer_comm::ColumnSummaryStats {
 fn get_stat<Return, T: Clone>(stats: &HashMap<String, T>, name: &str) -> anyhow::Result<Return>
 where
     Return: TryFrom<T>,
+    Return::Error: fmt::Debug,
 {
     let value = stats.get(name);
 
     match value {
         Some(value) => {
-            let value: Return = unwrap!(value.clone().try_into(), Err(_) => {
-                return Err(anyhow!("Can't cast to return type."))
+            let value: Return = unwrap!(value.clone().try_into(), Err(err) => {
+                return Err(anyhow!("Can't cast to return type. {err:?}"))
             });
             Ok(value)
         },

--- a/crates/ark/src/data_explorer/summary_stats.rs
+++ b/crates/ark/src/data_explorer/summary_stats.rs
@@ -309,4 +309,21 @@ mod tests {
             assert_eq!(stats.datetime_stats, Some(expected));
         })
     }
+
+    #[test]
+    fn test_date_all_na() {
+        r_test(|| {
+            let column = harp::parse_eval_base("as.Date(NA)").unwrap();
+            let stats =
+                summary_stats(column.sexp, ColumnDisplayType::Date, &default_options()).unwrap();
+            let expected = SummaryStatsDate {
+                num_unique: Some(1),
+                min_date: None,
+                mean_date: None,
+                median_date: None,
+                max_date: None,
+            };
+            assert_eq!(stats.date_stats, Some(expected));
+        })
+    }
 }

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -78,14 +78,29 @@ summary_stats_date <- function(col) {
     # When calling `min` on `x` would raise a warning.
     # Turns out, some Parquet files might generate malformed timezones too.
     suppressWarnings({
+        # When all values in the column are NA's, there min and max return -Inf and +Inf,
+        # mean returns NaN and median returns NA. We make everything return `NULL` so we
+        # correctly display the values in the front-end.
+        min_date <- finite_or_null(min(col, na.rm = TRUE))
+        max_date <- finite_or_null(max(col, na.rm = TRUE))
+        mean_date <- finite_or_null(mean(col, na.rm = TRUE))
+        median_date <- finite_or_null(stats::median(col, na.rm = TRUE))
         list(
-            min_date = as.character(min(col, na.rm = TRUE)),
-            mean_date = as.character(mean(col, na.rm = TRUE)),
-            median_date = as.character(stats::median(col, na.rm = TRUE)),
-            max_date = as.character(max(col, na.rm = TRUE)),
+            min_date = as.character(min_date),
+            mean_date = as.character(mean_date),
+            median_date = as.character(median_date),
+            max_date = as.character(max_date),
             num_unique = length(unique(col))
         )
     })
+}
+
+finite_or_null <- function(x) {
+    if (!is.finite(x)) {
+        NULL
+    } else {
+        x
+    }
 }
 
 summary_stats_get_timezone <- function(x) {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4356
Pairs with: https://github.com/posit-dev/positron/pull/4564

This makes the output more consistent with the numbers summary statistics which are all optional and are not displayed when an error happens during the computation.