### PR TITLE
Add attribute to `repos`, for renv users

### DIFF
--- a/crates/ark/src/modules/positron/options.R
+++ b/crates/ark/src/modules/positron/options.R
@@ -27,8 +27,27 @@ options(device = function() {
 })
 
 # Set cran mirror
-repos <- getOption("repos")
-rstudio_cran <- "https://cran.rstudio.com/"
+set_cran_mirror <- function(repos) {
+    rstudio_cran <- "https://cran.rstudio.com/"
+    if (is.null(repos) || !is.character(repos)) {
+        return(c(CRAN = rstudio_cran))
+    } else {
+        if ("CRAN" %in% names(repos)) {
+            if (identical(repos[["CRAN"]], "@CRAN@")) {
+                repos[["CRAN"]] <- rstudio_cran
+                return(repos)
+            }
+        } else {
+            return(c(CRAN = rstudio_cran, repos))
+        }
+    }
+}
+
+original_repos <- getOption("repos")
+repos <- set_cran_mirror(original_repos)
+attr(repos, "Positron") <- TRUE
+options(repos = repos)
+
 
 if (is.null(repos) || !is.character(repos)) {
     options(repos = c(CRAN = rstudio_cran))

--- a/crates/ark/src/modules/positron/options.R
+++ b/crates/ark/src/modules/positron/options.R
@@ -27,41 +27,21 @@ options(device = function() {
 })
 
 # Set cran mirror
-set_cran_mirror <- function(repos) {
-    rstudio_cran <- "https://cran.rstudio.com/"
-    if (is.null(repos) || !is.character(repos)) {
-        return(c(CRAN = rstudio_cran))
-    } else {
-        if ("CRAN" %in% names(repos)) {
-            if (identical(repos[["CRAN"]], "@CRAN@")) {
-                repos[["CRAN"]] <- rstudio_cran
-                return(repos)
-            }
-        } else {
-            return(c(CRAN = rstudio_cran, repos))
-        }
-    }
-}
-
-original_repos <- getOption("repos")
-repos <- set_cran_mirror(original_repos)
-attr(repos, "Positron") <- TRUE
-options(repos = repos)
-
-
+repos <- getOption("repos")
+rstudio_cran <- "https://cran.rstudio.com/"
 if (is.null(repos) || !is.character(repos)) {
-    options(repos = c(CRAN = rstudio_cran))
+    repos <- c(CRAN = rstudio_cran)
 } else {
     if ("CRAN" %in% names(repos)) {
         if (identical(repos[["CRAN"]], "@CRAN@")) {
             repos[["CRAN"]] <- rstudio_cran
-            options(repos = repos)
         }
     } else {
         repos <- c(CRAN = rstudio_cran, repos)
-        options(repos = repos)
     }
 }
+attr(repos, "Positron") <- TRUE
+options(repos = repos)
 
 # Show Plumber apps in the viewer
 options(plumber.docs.callback = function(url) {

--- a/crates/ark/src/modules/positron/options.R
+++ b/crates/ark/src/modules/positron/options.R
@@ -35,12 +35,12 @@ if (is.null(repos) || !is.character(repos)) {
     if ("CRAN" %in% names(repos)) {
         if (identical(repos[["CRAN"]], "@CRAN@")) {
             repos[["CRAN"]] <- rstudio_cran
+            attr(repos, "IDE") <- TRUE
         }
     } else {
         repos <- c(CRAN = rstudio_cran, repos)
     }
 }
-attr(repos, "Positron") <- TRUE
 options(repos = repos)
 
 # Show Plumber apps in the viewer


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4255

You can check out the approach RStudio takes here: 
https://github.com/rstudio/rstudio/blob/078e21116b0e34aff92addf961699017adb62fc5/src/cpp/r/R/Tools.R#L698

I saw [your note here](https://github.com/rstudio/renv/issues/1963#issuecomment-2272152739) @DavisVaughan. Given that we are unlikely to be able to change this attribute in RStudio, I don't tend to think we will gain much by using `IDE` or `default`. If you have a strong opinion otherwise, happy to change this, though!

## QA Notes

After this PR is merged and ark is bumped, you will see (edited after code review to change name of attribute):

``` r
getOption("repos")
#>                        CRAN 
#> "https://cran.rstudio.com/" 
#> attr(,"IDE")
#> [1] TRUE
```

<sup>Created on 2024-09-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


Notice the new attribute.

Once we get this into a release build, we should update at https://github.com/rstudio/renv/issues/1963.