### PR TITLE
Turn histograms on by default

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -1048,19 +1048,19 @@ impl RDataExplorer {
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::SmallHistogram,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Supported,
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::SmallFrequencyTable,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Supported,
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::LargeHistogram,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Supported,
                         },
                         ColumnProfileTypeSupportStatus {
                             profile_type: ColumnProfileType::LargeFrequencyTable,
-                            support_status: SupportStatus::Experimental,
+                            support_status: SupportStatus::Supported,
                         },
                     ],
                 },


### PR DESCRIPTION
Discussed on the Data Explorer meeting that we want to turn this on by default, even though https://github.com/posit-dev/ark/pull/473 is not merged yet.