### PR TITLE
Bump ark to version 0.1.130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.129"
+version = "0.1.130"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.129"
+version = "0.1.130"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
For 

- https://github.com/posit-dev/ark/pull/504
- https://github.com/posit-dev/ark/pull/493