### PR TITLE
Expose environment variables from R process

### DIFF
--- a/crates/ark/src/modules/positron/system.R
+++ b/crates/ark/src/modules/positron/system.R
@@ -21,3 +21,11 @@ has_x11 <- function() {
     out <- as.list(vapply(cats, Sys.getlocale, "string", USE.NAMES = TRUE))
     c(LANG = Sys.getenv("LANG"), out)
 }
+
+#' Reports a vector of environment variables for the R process.
+#' @returns Named character vector of env vars that start with the given regex.
+#' @export
+.ps.rpc.get_env_vars <- function(pattern) {
+    matches <- grep(pattern, names(Sys.getenv()), value = TRUE)
+    as.list(vapply(matches, Sys.getenv, "string"))
+}

--- a/crates/ark/src/modules/positron/system.R
+++ b/crates/ark/src/modules/positron/system.R
@@ -28,5 +28,5 @@ has_x11 <- function() {
 #' @returns Values of the environment variables as a list.
 #' @export
 .ps.rpc.get_env_vars <- function(x = NULL) {
-    as.list(Sys.getenv(x))
+    as.list(Sys.getenv(x, names = TRUE))
 }

--- a/crates/ark/src/modules/positron/system.R
+++ b/crates/ark/src/modules/positron/system.R
@@ -22,11 +22,12 @@ has_x11 <- function() {
     c(LANG = Sys.getenv("LANG"), out)
 }
 
-#' Reports a vector of environment variables for the R process.
-#' @returns Named character vector of env vars that start with the given regex.
+#' Reports a list of environment variables for the R process.
+#' @returns List of all env vars, or optionally the subset that start with the
+#' given regex.
 #' @export
 .ps.rpc.get_env_vars <- function(pattern = NULL) {
-  ev <- as.list(Sys.getenv())
-  m <- if (is.null(pattern)) TRUE else grep(pattern, names(ev))
-  ev[m]
-}
+    ev <- as.list(Sys.getenv())
+    m <- if (is.null(pattern)) TRUE else grep(pattern, names(ev))
+    ev[m]
+  }

--- a/crates/ark/src/modules/positron/system.R
+++ b/crates/ark/src/modules/positron/system.R
@@ -25,7 +25,8 @@ has_x11 <- function() {
 #' Reports a vector of environment variables for the R process.
 #' @returns Named character vector of env vars that start with the given regex.
 #' @export
-.ps.rpc.get_env_vars <- function(pattern) {
-    matches <- grep(pattern, names(Sys.getenv()), value = TRUE)
-    as.list(vapply(matches, Sys.getenv, "string"))
+.ps.rpc.get_env_vars <- function(pattern = NULL) {
+  ev <- as.list(Sys.getenv())
+  m <- if (is.null(pattern)) TRUE else grep(pattern, names(ev))
+  ev[m]
 }

--- a/crates/ark/src/modules/positron/system.R
+++ b/crates/ark/src/modules/positron/system.R
@@ -23,11 +23,10 @@ has_x11 <- function() {
 }
 
 #' Reports a list of environment variables for the R process.
-#' @returns List of all env vars, or optionally the subset that start with the
-#' given regex.
+#' @param x A character vector of environment variables. The default `NULL`
+#' will return *all* environment variables.
+#' @returns Values of the environment variables as a list.
 #' @export
-.ps.rpc.get_env_vars <- function(pattern = NULL) {
-    ev <- as.list(Sys.getenv())
-    m <- if (is.null(pattern)) TRUE else grep(pattern, names(ev))
-    ev[m]
-  }
+.ps.rpc.get_env_vars <- function(x = NULL) {
+    as.list(Sys.getenv(x))
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2723

With this new function (callable via `call_method()` in Positron) we can get the values for a set of environment variables starting with a given regex from the R process:

``` r
.ps.rpc.get_env_vars("POSITRON")
#> $POSITRON
#> [1] "1"
#> 
#> $POSITRON_VERSION
#> [1] "2024.09.0"
```

If you need more than one set, you can do something like `.ps.rpc.get_env_vars("POSITRON|VSCODE")`.
