### PR TITLE
Add `ParseData` type

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -45,6 +45,7 @@ use harp::vector::names::Names;
 use harp::vector::CharacterVector;
 use harp::vector::IntegerVector;
 use harp::vector::Vector;
+use harp::TableDim;
 use itertools::Itertools;
 use libr::*;
 use stdext::local;
@@ -96,7 +97,15 @@ impl WorkspaceVariableDisplayValue {
     }
 
     fn from_data_frame(value: SEXP) -> Self {
-        let dim = harp::df_dim(value);
+        let dim = match unsafe { harp::df_dim(value) } {
+            Ok(dim) => dim,
+            // FIXME: Needs more type safety
+            Err(_) => TableDim {
+                num_rows: -1,
+                num_cols: -1,
+            },
+        };
+
         let class = match r_classes(value) {
             None => String::from(""),
             Some(classes) => match classes.get_unchecked(0) {

--- a/crates/harp/harp-macros/src/lib.rs
+++ b/crates/harp/harp-macros/src/lib.rs
@@ -63,7 +63,7 @@ pub fn vector(_attr: TokenStream, item: TokenStream) -> TokenStream {
         impl std::convert::TryFrom<libr::SEXP> for #ident {
             type Error = crate::error::Error;
             fn try_from(value: libr::SEXP) -> Result<Self, Self::Error> {
-                unsafe { Self::new(value) }
+                super::try_r_vector_from_r_sexp(value)
             }
         }
 

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -18,11 +18,13 @@ impl DataFrame {
         harp::assert_class(sexp, "data.frame")?;
 
         let Some(dim) = list.obj.dim()? else {
-            return Err(harp::anyhow!("Data frame doesn't have dimensions"));
+            return Err(harp::unexpected_structure!(
+                "Data frame doesn't have dimensions"
+            ));
         };
 
         if dim.len() != 2 {
-            return Err(harp::anyhow!(
+            return Err(harp::unexpected_structure!(
                 "Data frame must have 2 dimensions, instead it has {}",
                 dim.len()
             ));
@@ -34,10 +36,10 @@ impl DataFrame {
         let obj = RObject::view(sexp);
 
         let Some(names) = obj.names() else {
-            return Err(harp::anyhow!("Data frame doesn't have names"));
+            return Err(harp::unexpected_structure!("Data frame doesn't have names"));
         };
         let Ok(names) = harp::assert_non_optional(names) else {
-            return Err(harp::anyhow!("Data frame has missing names"));
+            return Err(harp::unexpected_structure!("Data frame has missing names"));
         };
 
         Ok(Self {

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -2,6 +2,12 @@ use crate::vector::Vector;
 use crate::List;
 use crate::RObject;
 
+/// Typed data frame
+///
+/// Type guarantees:
+/// - Storage type is list.
+/// - Class is `"data.frame"`.
+/// - All columns are vectors and the same size as the data frame.
 #[derive(Debug)]
 pub struct DataFrame {
     pub list: List,
@@ -33,6 +39,23 @@ impl DataFrame {
             ));
         };
 
+        // Validate columns
+        for obj in list.iter() {
+            let obj = RObject::view(obj);
+
+            if unsafe { libr::Rf_isVector(obj.sexp) == 0 } {
+                return Err(harp::unexpected_structure!(
+                    "Data frame column must be a vector"
+                ));
+            }
+
+            if obj.length() as usize != nrow {
+                return Err(harp::unexpected_structure!(
+                    "Data frame column must be the same size as the number of rows"
+                ));
+            }
+        }
+
         Ok(Self {
             list,
             obj,
@@ -46,8 +69,12 @@ impl DataFrame {
 #[cfg(test)]
 mod tests {
     use crate::assert_match;
+    use crate::r_alloc_integer;
     use crate::r_chr_poke;
+    use crate::r_list_poke;
     use crate::test::r_test;
+    use crate::vector::IntegerVector;
+    use crate::vector::Vector;
     use crate::DataFrame;
     use crate::List;
     use crate::RObject;
@@ -94,6 +121,37 @@ mod tests {
             assert_match!(df, harp::Result::Err(err) => {
                 assert_match!(err, harp::Error::UnexpectedStructure(..));
                 assert!(format!("{err}").contains("missing names"))
+            });
+        })
+    }
+
+    #[test]
+    fn test_data_frame_bad_column_type() {
+        r_test(|| {
+            let df = harp::parse_eval_base("data.frame(x = 1:2, y = 3:4)").unwrap();
+            r_list_poke(df.sexp, 0, RObject::null().sexp);
+
+            let df = DataFrame::new(df.sexp);
+
+            assert_match!(df, harp::Result::Err(err) => {
+                assert_match!(err, harp::Error::UnexpectedStructure(..));
+                assert!(format!("{err}").contains("must be a vector"))
+            });
+        })
+    }
+
+    #[test]
+    fn test_data_frame_bad_column_size() {
+        r_test(|| {
+            let df = harp::parse_eval_base("data.frame(x = 1:2, y = 3:4)").unwrap();
+            let bad_col = r_alloc_integer(3);
+            r_list_poke(df.sexp, 0, bad_col);
+
+            let df = DataFrame::new(df.sexp);
+
+            assert_match!(df, harp::Result::Err(err) => {
+                assert_match!(err, harp::Error::UnexpectedStructure(..));
+                assert!(format!("{err}").contains("must be the same size"))
             });
         })
     }

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -20,7 +20,7 @@ pub struct DataFrame {
 
 impl DataFrame {
     pub fn new(sexp: libr::SEXP) -> harp::Result<Self> {
-        let list = unsafe { List::new(sexp) }?;
+        let list = List::new(sexp)?;
         harp::assert_class(sexp, "data.frame")?;
 
         // SAFETY: Protected by `list`

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -1,0 +1,42 @@
+use crate::vector::Vector;
+use crate::List;
+use crate::RObject;
+
+#[derive(Debug)]
+pub struct DataFrame {
+    pub list: List,
+    pub obj: RObject,
+
+    pub nrow: usize,
+    pub ncol: usize,
+}
+
+impl DataFrame {
+    pub fn new(sexp: libr::SEXP) -> harp::Result<Self> {
+        let list = unsafe { List::new(sexp) }?;
+        harp::assert_class(sexp, "data.frame")?;
+
+        let Some(dim) = list.obj.dim()? else {
+            return Err(harp::anyhow!("Data frame doesn't have dimensions"));
+        };
+
+        if dim.len() != 2 {
+            return Err(harp::anyhow!(
+                "Data frame must have 2 dimensions, instead it has {}",
+                dim.len()
+            ));
+        }
+        let nrow = *dim.get(0).unwrap();
+        let ncol = *dim.get(1).unwrap();
+
+        // SAFETY: Protected by `list`
+        let obj = RObject::view(sexp);
+
+        Ok(Self {
+            list,
+            obj,
+            nrow,
+            ncol,
+        })
+    }
+}

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -23,14 +23,11 @@ impl DataFrame {
         let list = List::new(sexp)?;
         harp::assert_class(sexp, "data.frame")?;
 
-        // SAFETY: Protected by `list`
-        let obj = RObject::view(sexp);
-
-        let dim = unsafe { harp::df_dim(obj.sexp) }?;
+        let dim = unsafe { harp::df_dim(list.obj.sexp) }?;
         let nrow = dim.num_rows as usize;
         let ncol = list.obj.length() as usize;
 
-        let Some(names) = obj.names() else {
+        let Some(names) = list.obj.names() else {
             return Err(harp::anyhow!("Data frame must have names"));
         };
         let Ok(names) = harp::assert_non_optional(names) else {
@@ -51,6 +48,9 @@ impl DataFrame {
                 ));
             }
         }
+
+        // SAFETY: Protected by `list`
+        let obj = RObject::view(sexp);
 
         Ok(Self {
             list,

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -31,12 +31,10 @@ impl DataFrame {
         let ncol = list.obj.length() as usize;
 
         let Some(names) = obj.names() else {
-            return Err(harp::unexpected_structure!("Data frame must have names"));
+            return Err(harp::anyhow!("Data frame must have names"));
         };
         let Ok(names) = harp::assert_non_optional(names) else {
-            return Err(harp::unexpected_structure!(
-                "Data frame can't have missing names"
-            ));
+            return Err(harp::anyhow!("Data frame can't have missing names"));
         };
 
         // Validate columns
@@ -44,13 +42,11 @@ impl DataFrame {
             let obj = RObject::view(obj);
 
             if unsafe { libr::Rf_isVector(obj.sexp) == 0 } {
-                return Err(harp::unexpected_structure!(
-                    "Data frame column must be a vector"
-                ));
+                return Err(harp::anyhow!("Data frame column must be a vector"));
             }
 
             if obj.length() as usize != nrow {
-                return Err(harp::unexpected_structure!(
+                return Err(harp::anyhow!(
                     "Data frame column must be the same size as the number of rows"
                 ));
             }
@@ -73,8 +69,6 @@ mod tests {
     use crate::r_chr_poke;
     use crate::r_list_poke;
     use crate::test::r_test;
-    use crate::vector::IntegerVector;
-    use crate::vector::Vector;
     use crate::DataFrame;
     use crate::List;
     use crate::RObject;
@@ -102,7 +96,6 @@ mod tests {
             let df = DataFrame::new(df.sexp);
 
             assert_match!(df, harp::Result::Err(err) => {
-                assert_match!(err, harp::Error::UnexpectedStructure(..));
                 assert!(format!("{err}").contains("must have names"))
             });
         })
@@ -119,7 +112,6 @@ mod tests {
             let df = DataFrame::new(df.sexp);
 
             assert_match!(df, harp::Result::Err(err) => {
-                assert_match!(err, harp::Error::UnexpectedStructure(..));
                 assert!(format!("{err}").contains("missing names"))
             });
         })
@@ -134,7 +126,6 @@ mod tests {
             let df = DataFrame::new(df.sexp);
 
             assert_match!(df, harp::Result::Err(err) => {
-                assert_match!(err, harp::Error::UnexpectedStructure(..));
                 assert!(format!("{err}").contains("must be a vector"))
             });
         })
@@ -150,7 +141,6 @@ mod tests {
             let df = DataFrame::new(df.sexp);
 
             assert_match!(df, harp::Result::Err(err) => {
-                assert_match!(err, harp::Error::UnexpectedStructure(..));
                 assert!(format!("{err}").contains("must be the same size"))
             });
         })

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -7,6 +7,7 @@ pub struct DataFrame {
     pub list: List,
     pub obj: RObject,
 
+    pub names: Vec<String>,
     pub nrow: usize,
     pub ncol: usize,
 }
@@ -32,9 +33,17 @@ impl DataFrame {
         // SAFETY: Protected by `list`
         let obj = RObject::view(sexp);
 
+        let Some(names) = obj.names() else {
+            return Err(harp::anyhow!("Data frame doesn't have names"));
+        };
+        let Ok(names) = harp::assert_non_optional(names) else {
+            return Err(harp::anyhow!("Data frame has missing names"));
+        };
+
         Ok(Self {
             list,
             obj,
+            names,
             nrow,
             ncol,
         })

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
         line: i32,
     },
     MissingValueError,
+    MissingColumnError {
+        name: String,
+    },
     MissingBindingError {
         name: String,
     },
@@ -217,8 +220,12 @@ impl fmt::Display for Error {
                 write!(f, "{err:?}")
             },
 
+            Error::MissingColumnError { name } => {
+                write!(f, "Can't find column `{name}` in data frame")
+            },
+
             Error::MissingBindingError { name } => {
-                write!(f, "Can't find binding {name} in environment")
+                write!(f, "Can't find binding `{name}` in environment")
             },
 
             Error::OutOfMemory { size } => {
@@ -236,6 +243,14 @@ macro_rules! anyhow {
     ($($rest: expr),*) => {{
         let message = anyhow::anyhow!($($rest, )*);
         crate::error::Error::Anyhow(message)
+    }}
+}
+
+#[macro_export]
+macro_rules! unreachable {
+    ($($rest: expr),*) => {{
+        let message = format!($($rest, )*);
+        harp::anyhow!("Internal error: {message}")
     }}
 }
 

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -37,6 +37,7 @@ pub enum Error {
     UnsafeEvaluationError(String),
     UnexpectedLength(usize, usize),
     UnexpectedType(u32, Vec<u32>),
+    UnexpectedClass(Option<Vec<String>>, String),
     ValueOutOfRange {
         value: i64,
         min: i64,
@@ -169,6 +170,18 @@ impl fmt::Display for Error {
                     f,
                     "Unexpected vector type (expected {}; got {})",
                     expected, actual
+                )
+            },
+
+            Error::UnexpectedClass(actual, expected) => {
+                let actual = if let Some(actual) = actual {
+                    actual.join("/")
+                } else {
+                    String::from("_unclassed_")
+                };
+                write!(
+                    f,
+                    "Unexpected class for R object (expected {expected}; got {actual})",
                 )
             },
 

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -38,12 +38,6 @@ pub enum Error {
     UnexpectedLength(usize, usize),
     UnexpectedType(u32, Vec<u32>),
     UnexpectedClass(Option<Vec<String>>, String),
-    /// Something in the structure of the object is unexpected, but that
-    /// something is described as an error message rather than as an enum
-    /// variant. `UnexpectedStructure` is more specific than an `Error::Anyhow`
-    /// in that it describes a problem in the internal structure of a classed
-    /// object.
-    UnexpectedStructure(String),
     ValueOutOfRange {
         value: i64,
         min: i64,
@@ -191,10 +185,6 @@ impl fmt::Display for Error {
                 )
             },
 
-            Error::UnexpectedStructure(message) => {
-                write!(f, "Unexpected structure for R object: {message}",)
-            },
-
             Error::ValueOutOfRange { value, min, max } => {
                 write!(
                     f,
@@ -246,14 +236,6 @@ macro_rules! anyhow {
     ($($rest: expr),*) => {{
         let message = anyhow::anyhow!($($rest, )*);
         crate::error::Error::Anyhow(message)
-    }}
-}
-
-#[macro_export]
-macro_rules! unexpected_structure {
-    ($($rest: expr),*) => {{
-        let message = format!($($rest, )*);
-        crate::error::Error::UnexpectedStructure(message)
     }}
 }
 

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -38,6 +38,12 @@ pub enum Error {
     UnexpectedLength(usize, usize),
     UnexpectedType(u32, Vec<u32>),
     UnexpectedClass(Option<Vec<String>>, String),
+    /// Something in the structure of the object is unexpected, but that
+    /// something is described as an error message rather than as an enum
+    /// variant. `UnexpectedStructure` is more specific than an `Error::Anyhow`
+    /// in that it describes a problem in the internal structure of a classed
+    /// object.
+    UnexpectedStructure(String),
     ValueOutOfRange {
         value: i64,
         min: i64,
@@ -185,6 +191,10 @@ impl fmt::Display for Error {
                 )
             },
 
+            Error::UnexpectedStructure(message) => {
+                write!(f, "Unexpected structure for R object: {message}",)
+            },
+
             Error::ValueOutOfRange { value, min, max } => {
                 write!(
                     f,
@@ -236,6 +246,14 @@ macro_rules! anyhow {
     ($($rest: expr),*) => {{
         let message = anyhow::anyhow!($($rest, )*);
         crate::error::Error::Anyhow(message)
+    }}
+}
+
+#[macro_export]
+macro_rules! unexpected_structure {
+    ($($rest: expr),*) => {{
+        let message = format!($($rest, )*);
+        crate::error::Error::UnexpectedStructure(message)
     }}
 }
 

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -6,6 +6,7 @@
 //
 pub mod attrib;
 pub mod call;
+pub mod data_frame;
 pub mod environment;
 pub mod environment_iter;
 pub mod error;

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -40,6 +40,7 @@ pub mod vec_format;
 pub mod vector;
 
 // Reexport API
+pub use data_frame::*;
 pub use eval::*;
 pub use object::*;
 pub use parse::*;

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -122,7 +122,7 @@ impl AsRef<SEXP> for RObject {
 }
 
 pub trait RObjectExt<T> {
-    unsafe fn elt(&self, index: T) -> crate::error::Result<RObject>;
+    fn elt(&self, index: T) -> crate::error::Result<RObject>;
 }
 
 impl PartialEq for RObject {
@@ -135,7 +135,7 @@ impl PartialEq for RObject {
 impl Eq for RObject {}
 
 impl<T: Into<RObject>> RObjectExt<T> for RObject {
-    unsafe fn elt(&self, index: T) -> crate::error::Result<RObject> {
+    fn elt(&self, index: T) -> crate::error::Result<RObject> {
         let index: RObject = index.into();
         RFunction::new("base", "[[")
             .add(self.sexp)
@@ -451,7 +451,7 @@ impl RObject {
     /// attribute). Returns `None` if the object's value(s) don't have names.
     pub fn names(&self) -> Option<Vec<Option<String>>> {
         let names = unsafe { Rf_getAttrib(self.sexp, R_NamesSymbol) };
-        let names = RObject::view(names);
+        let names = RObject::from(names);
         match names.kind() {
             STRSXP => Vec::<Option<String>>::try_from(names).ok(),
             _ => None,

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -20,6 +20,7 @@ use crate::error::Error;
 use crate::exec::RFunction;
 use crate::exec::RFunctionExt;
 use crate::protect::RProtect;
+use crate::r_inherits;
 use crate::r_symbol;
 use crate::size::r_size;
 use crate::utils::r_assert_capacity;
@@ -472,6 +473,24 @@ impl RObject {
             Rf_setAttrib(self.sexp, r_symbol!(name), value);
             Rf_unprotect(1);
         }
+    }
+
+    pub fn inherits(&self, class: &str) -> bool {
+        return r_inherits(self.sexp, class);
+    }
+
+    pub fn class(&self) -> harp::Result<Option<Vec<String>>> {
+        let Some(class) = self.attr("class") else {
+            return Ok(None);
+        };
+
+        if !r_is_object(self.sexp) {
+            return Err(harp::anyhow!(
+                "Object has a class vector but `OBJECT` attribute is unset"
+            ));
+        }
+
+        Ok(Some(class.try_into()?))
     }
 
     pub fn duplicate(&self) -> RObject {

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -498,7 +498,7 @@ impl RObject {
     pub fn dim(&self) -> harp::Result<Option<Vec<usize>>> {
         let dim: RObject = r_dim(self.sexp).into();
 
-        if dim.sexp == RObject::null().sexp {
+        if dim.sexp == harp::r_null() {
             return Ok(None);
         }
 

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -126,6 +126,8 @@ pub trait RObjectExt<T> {
 }
 
 impl PartialEq for RObject {
+    // FIXME: At call sites, not obvious that this is doing identity comparisons.
+    // Can we require explicit `FOO.sexp == BAR.sexp`?
     fn eq(&self, other: &Self) -> bool {
         self.sexp == other.sexp
     }
@@ -491,6 +493,19 @@ impl RObject {
         }
 
         Ok(Some(class.try_into()?))
+    }
+
+    pub fn dim(&self) -> harp::Result<Option<Vec<usize>>> {
+        let dim: RObject = r_dim(self.sexp).into();
+
+        if dim.sexp == RObject::null().sexp {
+            return Ok(None);
+        }
+
+        let dim: Vec<i32> = dim.try_into()?;
+        let dim = dim.into_iter().map(|d| d as usize).collect();
+
+        Ok(Some(dim))
     }
 
     pub fn duplicate(&self) -> RObject {

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -33,7 +33,6 @@ use crate::utils::r_is_object;
 use crate::utils::r_is_s4;
 use crate::utils::r_str_to_owned_utf8;
 use crate::utils::r_typeof;
-use crate::vector::Vector;
 
 // Objects are protected using a doubly-linked list,
 // allowing for quick insertion and removal of objects.
@@ -914,28 +913,28 @@ impl TryFrom<RObject> for Vec<i32> {
 impl TryFrom<&RObject> for Vec<bool> {
     type Error = harp::Error;
     fn try_from(value: &RObject) -> harp::Result<Self> {
-        (&harp::vector::LogicalVector::new(value.sexp)?).try_into()
+        (&harp::vector::LogicalVector::try_from(value.sexp)?).try_into()
     }
 }
 
 impl TryFrom<&RObject> for Vec<i32> {
     type Error = harp::Error;
     fn try_from(value: &RObject) -> harp::Result<Self> {
-        (&harp::vector::IntegerVector::new(value.sexp)?).try_into()
+        (&harp::vector::IntegerVector::try_from(value.sexp)?).try_into()
     }
 }
 
 impl TryFrom<&RObject> for Vec<f64> {
     type Error = crate::error::Error;
     fn try_from(value: &RObject) -> Result<Self, Self::Error> {
-        (&harp::vector::NumericVector::new(value.sexp)?).try_into()
+        (&harp::vector::NumericVector::try_from(value.sexp)?).try_into()
     }
 }
 
 impl TryFrom<&RObject> for Vec<u8> {
     type Error = crate::error::Error;
     fn try_from(value: &RObject) -> Result<Self, Self::Error> {
-        (&harp::vector::RawVector::new(value.sexp)?).try_into()
+        (&harp::vector::RawVector::try_from(value.sexp)?).try_into()
     }
 }
 
@@ -950,7 +949,7 @@ impl TryFrom<RObject> for Vec<String> {
 impl TryFrom<&RObject> for Vec<String> {
     type Error = crate::error::Error;
     fn try_from(value: &RObject) -> Result<Self, Self::Error> {
-        (&harp::vector::CharacterVector::new(value.sexp)?).try_into()
+        (&harp::vector::CharacterVector::try_from(value.sexp)?).try_into()
     }
 }
 
@@ -981,7 +980,7 @@ impl TryFrom<RObject> for Vec<RObject> {
 impl TryFrom<&RObject> for Vec<RObject> {
     type Error = crate::error::Error;
     fn try_from(value: &RObject) -> Result<Self, Self::Error> {
-        (&harp::vector::List::new(value.sexp)?).try_into()
+        (&harp::vector::List::try_from(value.sexp)?).try_into()
     }
 }
 

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -916,14 +916,14 @@ impl TryFrom<RObject> for Vec<i32> {
 impl TryFrom<&RObject> for Vec<bool> {
     type Error = harp::Error;
     fn try_from(value: &RObject) -> harp::Result<Self> {
-        unsafe { LogicalVector::new(value.sexp) }?.try_into()
+        LogicalVector::new(value.sexp)?.try_into()
     }
 }
 
 impl TryFrom<&RObject> for Vec<i32> {
     type Error = harp::Error;
     fn try_from(value: &RObject) -> harp::Result<Self> {
-        unsafe { IntegerVector::new(value.sexp) }?.try_into()
+        IntegerVector::new(value.sexp)?.try_into()
     }
 }
 

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -33,6 +33,8 @@ use crate::utils::r_is_object;
 use crate::utils::r_is_s4;
 use crate::utils::r_str_to_owned_utf8;
 use crate::utils::r_typeof;
+use crate::vector::LogicalVector;
+use crate::vector::Vector;
 
 // Objects are protected using a doubly-linked list,
 // allowing for quick insertion and removal of objects.
@@ -953,6 +955,35 @@ impl TryFrom<RObject> for Vec<i32> {
                     return Err(Error::MissingValueError);
                 }
                 result.push(res);
+            }
+
+            return Ok(result);
+        }
+    }
+}
+
+// TODO(harp-try-from-robject-ref): Move `RObject` method here
+impl TryFrom<&RObject> for Vec<i32> {
+    type Error = crate::error::Error;
+    fn try_from(value: &RObject) -> Result<Self, Self::Error> {
+        value.clone().try_into()
+    }
+}
+
+// TODO: Generalise this implementation for other vector types
+impl TryFrom<&RObject> for Vec<bool> {
+    type Error = crate::error::Error;
+
+    fn try_from(value: &RObject) -> Result<Self, Self::Error> {
+        unsafe {
+            let vec = LogicalVector::new(value.sexp)?;
+            let mut result: Vec<bool> = Vec::with_capacity(vec.len());
+
+            for val in vec.iter() {
+                let Some(x) = val else {
+                    return Err(Error::MissingValueError);
+                };
+                result.push(x);
             }
 
             return Ok(result);

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -30,7 +30,7 @@ pub enum ParseResult {
 
 pub enum ParseInput<'a> {
     Text(&'a str),
-    SrcFile(srcref::SrcFile),
+    SrcFile(&'a srcref::SrcFile),
 }
 
 impl Default for RParseOptions {
@@ -65,7 +65,7 @@ pub fn parse_exprs(text: &str) -> crate::Result<RObject> {
 /// Same but creates srcrefs
 pub fn parse_exprs_with_srcrefs(text: &str) -> crate::Result<RObject> {
     let srcfile = srcref::SrcFile::new_virtual(text)?;
-    parse_exprs_ext(&ParseInput::SrcFile(srcfile))
+    parse_exprs_ext(&ParseInput::SrcFile(&srcfile))
 }
 
 fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
@@ -73,7 +73,7 @@ fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
     match status {
         ParseResult::Complete(x) => Ok(RObject::from(x)),
         ParseResult::Incomplete => Err(crate::Error::ParseError {
-            code: parse_input_as_string(input).unwrap_or(String::from("Concersion error")),
+            code: parse_input_as_string(input).unwrap_or(String::from("Conversion error")),
             message: String::from("Incomplete code"),
         }),
     }
@@ -229,7 +229,7 @@ mod tests {
 
             let input = srcref::SrcFile::new_virtual("foo\nbar").unwrap();
             assert_eq!(
-                parse_input_as_string(&ParseInput::SrcFile(input)).unwrap(),
+                parse_input_as_string(&ParseInput::SrcFile(&input)).unwrap(),
                 "foo\nbar"
             );
         }

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -68,7 +68,7 @@ pub fn parse_exprs_with_srcrefs(text: &str) -> crate::Result<RObject> {
     parse_exprs_ext(&ParseInput::SrcFile(&srcfile))
 }
 
-pub(crate) fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
+pub fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
     let status = parse_status(input)?;
     match status {
         ParseResult::Complete(x) => Ok(RObject::from(x)),

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -68,7 +68,7 @@ pub fn parse_exprs_with_srcrefs(text: &str) -> crate::Result<RObject> {
     parse_exprs_ext(&ParseInput::SrcFile(&srcfile))
 }
 
-fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
+pub(crate) fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
     let status = parse_status(input)?;
     match status {
         ParseResult::Complete(x) => Ok(RObject::from(x)),
@@ -81,7 +81,9 @@ fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
 
 pub fn parse_status<'a>(input: &ParseInput<'a>) -> crate::Result<ParseResult> {
     unsafe {
-        // TODO: set keep.parse.data
+        // If we're parsing with srcrefs, keep parse data as well. This is the
+        // default but it might have been overridden by the user.
+        let _guard = harp::raii::RLocalOptionBoolean::new("keep.parse.data", true);
 
         let mut status: libr::ParseStatus = libr::ParseStatus_PARSE_NULL;
 

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -126,7 +126,7 @@ fn parse_input_as_string<'a>(input: &ParseInput<'a>) -> crate::Result<String> {
         ParseInput::Text(text) => text.to_string(),
         ParseInput::SrcFile(srcfile) => {
             let lines = srcfile.lines()?;
-            let lines = unsafe { CharacterVector::new(lines)? };
+            let lines = CharacterVector::new(lines)?;
 
             lines
                 .iter()

--- a/crates/harp/src/parser/mod.rs
+++ b/crates/harp/src/parser/mod.rs
@@ -1,1 +1,2 @@
+pub mod parse_data;
 pub mod srcref;

--- a/crates/harp/src/parser/parse_data.rs
+++ b/crates/harp/src/parser/parse_data.rs
@@ -1,0 +1,152 @@
+use crate::exec::RFunction;
+use crate::exec::RFunctionExt;
+
+#[derive(Clone, Debug)]
+pub struct ParseData {
+    pub nodes: Vec<ParseDataNode>,
+}
+
+/// `text` is not included because long strings are not stored by the
+/// parser.
+#[derive(Clone, Debug)]
+pub struct ParseDataNode {
+    /// Unlike `SrcRef`, parse data nodes don't include virtual line information
+    /// created by `#line` directives. 0-based `[ )` range.
+    pub line: std::ops::Range<usize>,
+
+    /// Parse data nodes only contain column offset according to the text
+    /// encoding used by the parser. 0-based `[ )` range.
+    pub column: std::ops::Range<usize>,
+
+    /// 0-based indices into the storage vector.
+    pub id: usize,
+    pub parent: usize,
+
+    /// Node kind.
+    pub kind: ParseDataKind,
+}
+
+#[derive(Clone, Debug)]
+pub enum ParseDataKind {
+    Node,
+    Token(String),
+}
+
+impl ParseData {
+    pub fn from_srcfile(srcfile: &harp::srcref::SrcFile) -> harp::Result<Self> {
+        let data = RFunction::new("utils", "getParseData")
+            .add(srcfile.inner.sexp)
+            .call()?;
+        let data = harp::DataFrame::new(data.sexp)?;
+
+        let mut nodes: Vec<ParseDataNode> = Vec::with_capacity(data.nrow);
+
+        let line1: Vec<i32> = (&data.col("line1")?).try_into()?;
+        let line2: Vec<i32> = (&data.col("line2")?).try_into()?;
+        let col1: Vec<i32> = (&data.col("col1")?).try_into()?;
+        let col2: Vec<i32> = (&data.col("col2")?).try_into()?;
+        let id: Vec<i32> = (&data.col("id")?).try_into()?;
+        let parent: Vec<i32> = (&data.col("parent")?).try_into()?;
+        let token: Vec<String> = (&data.col("token")?).try_into()?;
+        let terminal: Vec<bool> = (&data.col("terminal")?).try_into()?;
+
+        // The srcref values are adjusted to produce a `[ )` range as expected
+        // by `std::ops::Range` that counts from 0. This is in contrast to the
+        // ranges in `srcref` vectors which are 1-based `[ ]`.
+
+        // Change from 1-based to 0-based counting
+        let adjust_start = |i| (i - 1) as usize;
+
+        // Change from 1-based to 0-based counting (-1) and make it an exclusive
+        // boundary (+1). So essentially a no-op.
+        let adjust_end = |i| i as usize;
+
+        let row_iter = itertools::izip!(
+            line1.into_iter(),
+            line2.into_iter(),
+            col1.into_iter(),
+            col2.into_iter(),
+            id.into_iter(),
+            parent.into_iter(),
+            token.into_iter(),
+            terminal.into_iter(),
+        );
+
+        for row in row_iter {
+            let line1 = row.0;
+            let line2 = row.1;
+            let col1 = row.2;
+            let col2 = row.3;
+            let id = row.4;
+            let parent = row.5;
+            let token = row.6;
+            let terminal = row.7;
+
+            let node = ParseDataNode {
+                line: std::ops::Range {
+                    start: adjust_start(line1),
+                    end: adjust_end(line2),
+                },
+                column: std::ops::Range {
+                    start: adjust_start(col1),
+                    end: adjust_end(col2),
+                },
+                id: id as usize,
+                parent: parent as usize,
+                kind: if terminal {
+                    ParseDataKind::Token(token)
+                } else {
+                    ParseDataKind::Node
+                },
+            };
+
+            nodes.push(node);
+        }
+
+        Ok(Self { nodes })
+    }
+
+    pub fn filter_top_level(mut self) -> Self {
+        let nodes = std::mem::take(&mut self.nodes);
+        self.nodes = nodes.into_iter().filter(|node| node.parent == 0).collect();
+        self
+    }
+}
+
+impl harp::srcref::SrcFile {
+    pub fn parse_data(&self) -> harp::Result<ParseData> {
+        ParseData::from_srcfile(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use harp::parse;
+    use harp::srcref;
+
+    use crate::parse_data::ParseData;
+    use crate::test::r_test;
+
+    #[test]
+    fn test_parse_data() {
+        r_test(|| {
+            let srcfile = srcref::SrcFile::new_virtual("foo\nbar").unwrap();
+            let exprs = parse::parse_exprs_ext(&parse::ParseInput::SrcFile(&srcfile)).unwrap();
+            let srcrefs: Vec<harp::srcref::SrcRef> = exprs.srcrefs().unwrap();
+
+            let parse_data = ParseData::from_srcfile(&srcfile).unwrap();
+            let top_level = parse_data.filter_top_level();
+
+            let parse_first = top_level.nodes.get(0).unwrap();
+            let parse_second = top_level.nodes.get(1).unwrap();
+            let srcref_first = srcrefs.get(0).unwrap();
+            let srcref_second = srcrefs.get(1).unwrap();
+
+            assert_eq!(parse_first.line, srcref_first.line);
+            assert_eq!(parse_first.column, srcref_first.column);
+
+            assert_eq!(parse_second.line, srcref_second.line);
+            assert_eq!(parse_second.column, srcref_second.column);
+        })
+    }
+}

--- a/crates/harp/src/parser/srcref.rs
+++ b/crates/harp/src/parser/srcref.rs
@@ -44,12 +44,10 @@ impl RObject {
             return Err(anyhow!("Can't find `srcref` attribute"));
         });
 
-        unsafe {
-            crate::List::new(srcref.sexp)?
-                .iter()
-                .map(|x| SrcRef::try_from(RObject::view(x)))
-                .collect()
-        }
+        crate::List::new(srcref.sexp)?
+            .iter()
+            .map(|x| SrcRef::try_from(RObject::view(x)))
+            .collect()
     }
 }
 
@@ -61,7 +59,7 @@ impl TryFrom<RObject> for SrcRef {
         crate::r_assert_type(value.sexp, &[libr::INTSXP])?;
         crate::r_assert_capacity(value.sexp, 6)?;
 
-        let value = unsafe { IntegerVector::new(value)? };
+        let value = IntegerVector::new(value)?;
 
         // The srcref values are adjusted to produce a `[ )` range as expected
         // by `std::ops::Range` that counts from 0. This is in contrast to the

--- a/crates/harp/src/parser/srcref.rs
+++ b/crates/harp/src/parser/srcref.rs
@@ -8,7 +8,6 @@
 use core::f64;
 
 use anyhow::anyhow;
-use libr::SEXP;
 use stdext::unwrap;
 
 use crate::exec::RFunction;
@@ -30,6 +29,11 @@ pub struct SrcRef {
     /// Bytes and columns may be different due to multibyte characters.
     pub column: std::ops::Range<usize>,
     pub column_byte: std::ops::Range<usize>,
+}
+
+#[derive(Debug)]
+pub struct SrcFile {
+    pub inner: RObject,
 }
 
 // Takes user-facing object as input. The srcrefs are retrieved from
@@ -115,20 +119,24 @@ impl TryFrom<RObject> for SrcRef {
 
 /// Creates the same sort of srcfile object as with `parse(text = )`.
 /// Takes code as an R string containing newlines, or as a R vector of lines.
-pub fn new_srcfile_virtual(text: &str) -> crate::Result<RObject> {
-    let input = crate::as_parse_text(text);
-    RFunction::new("base", "srcfilecopy")
-        .param("filename", "<text>")
-        .param("lines", input)
-        .call()
-}
+impl SrcFile {
+    pub fn new_virtual(text: &str) -> harp::Result<Self> {
+        let input = crate::as_parse_text(text);
+        let inner = RFunction::new("base", "srcfilecopy")
+            .param("filename", "<text>")
+            .param("lines", input)
+            .call()?;
 
-pub fn srcfile_lines(srcfile: SEXP) -> crate::Result<RObject> {
-    RFunction::new("base", "getSrcLines")
-        .add(srcfile)
-        .param("first", 1)
-        .param("last", f64::INFINITY)
-        .call()
+        Ok(Self { inner })
+    }
+
+    pub fn lines(&self) -> harp::Result<RObject> {
+        RFunction::new("base", "getSrcLines")
+            .add(self.inner.sexp)
+            .param("first", 1)
+            .param("last", f64::INFINITY)
+            .call()
+    }
 }
 
 #[cfg(test)]

--- a/crates/harp/src/raii.rs
+++ b/crates/harp/src/raii.rs
@@ -74,7 +74,8 @@ where
 }
 
 impl RLocalOption {
-    pub fn new(option: crate::RSymbol, new_value: libr::SEXP) -> RLocalOption {
+    pub fn new(option: &str, new_value: libr::SEXP) -> RLocalOption {
+        let option = crate::RSymbol::new_unchecked(unsafe { crate::r_symbol!(option) });
         let old_value = crate::r_poke_option(option.sexp, new_value);
 
         Self {
@@ -130,7 +131,7 @@ impl RLocalSandbox {
 }
 
 impl RLocalOptionBoolean {
-    pub fn new(option: crate::RSymbol, value: bool) -> Self {
+    pub fn new(option: &str, value: bool) -> Self {
         let new_value: crate::RObject = value.into();
 
         Self {
@@ -142,10 +143,7 @@ impl RLocalOptionBoolean {
 impl RLocalShowErrorMessageOption {
     pub fn new(value: bool) -> Self {
         Self {
-            _raii: RLocalOptionBoolean::new(
-                unsafe { crate::RSymbol::new_unchecked(crate::r_symbol!("show.error.messages")) },
-                value,
-            ),
+            _raii: RLocalOptionBoolean::new("show.error.messages", value),
         }
     }
 }

--- a/crates/harp/src/table.rs
+++ b/crates/harp/src/table.rs
@@ -106,13 +106,13 @@ pub unsafe fn df_dim(data: SEXP) -> harp::Result<TableDim> {
         .unwrap();
 
     let Ok(_) = r_assert_type(dims.sexp, &[libr::INTSXP]) else {
-        return Err(harp::unexpected_structure!(
+        return Err(harp::anyhow!(
             "Data frame dimensions must be an integer vector, instead it has type `{}`",
             harp::r_type2char(dims.kind())
         ));
     };
     if dims.length() != 2 {
-        return Err(harp::unexpected_structure!(
+        return Err(harp::anyhow!(
             "Data frame must have 2 dimensions, instead it has {}",
             dims.length()
         ));

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -151,6 +151,15 @@ pub fn r_assert_length(object: SEXP, expected: usize) -> Result<usize> {
     Ok(actual)
 }
 
+pub fn assert_class(object: SEXP, expected: &str) -> Result<()> {
+    if !RObject::view(object).inherits(expected) {
+        let actual = RObject::view(object).class()?;
+        return Err(Error::UnexpectedClass(actual, expected.into()));
+    }
+
+    Ok(())
+}
+
 pub fn r_is_data_frame(object: SEXP) -> bool {
     r_typeof(object) == VECSXP && r_inherits(object, "data.frame")
 }
@@ -342,7 +351,7 @@ pub fn get_option(name: &str) -> RObject {
 
 pub fn r_inherits(object: SEXP, class: &str) -> bool {
     let class = CString::new(class).unwrap();
-    unsafe { Rf_inherits(object, class.as_ptr()) != 0 }
+    unsafe { libr::Rf_inherits(object, class.as_ptr()) != 0 }
 }
 
 pub fn r_is_function(object: SEXP) -> bool {

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -160,6 +160,13 @@ pub fn assert_class(object: SEXP, expected: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn assert_non_optional<T>(object: Vec<Option<T>>) -> harp::Result<Vec<T>> {
+    let Some(non_optional): Option<Vec<T>> = object.into_iter().collect() else {
+        return Err(harp::anyhow!("Values are unexpectedly missing"));
+    };
+    Ok(non_optional)
+}
+
 pub fn r_is_data_frame(object: SEXP) -> bool {
     r_typeof(object) == VECSXP && r_inherits(object, "data.frame")
 }

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -43,12 +43,7 @@ use crate::vector::CharacterVector;
 use crate::vector::IntegerVector;
 use crate::vector::Vector;
 
-pub fn init_utils() {
-    unsafe {
-        let options_fn = Rf_eval(r_symbol!("options"), R_BaseEnv);
-        OPTIONS_FN = Some(options_fn);
-    }
-}
+pub fn init_utils() {}
 
 // NOTE: Regex::new() is quite slow to compile, so it's much better to keep
 // a single singleton pattern and use that repeatedly for matches.
@@ -679,15 +674,13 @@ where
     return false;
 }
 
-static mut OPTIONS_FN: Option<SEXP> = None;
-
 // Note this might throw if wrong data types are passed in. The C-level
 // implementation of `options()` type-checks some base options.
 pub fn r_poke_option(sym: SEXP, value: SEXP) -> SEXP {
     unsafe {
         let mut protect = RProtect::new();
 
-        let call = r_lang!(OPTIONS_FN.unwrap_unchecked(), !!sym = value);
+        let call = r_lang!(r_symbol!("options"), !!sym = value);
         protect.add(call);
 
         // `options()` is guaranteed by R to return a list

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -1,7 +1,7 @@
 //
 // character_vector.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -157,5 +157,13 @@ mod test {
             assert_eq!(s, alphabet);
 
         }
+    }
+}
+
+impl TryFrom<&CharacterVector> for Vec<String> {
+    type Error = harp::Error;
+
+    fn try_from(value: &CharacterVector) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
     }
 }

--- a/crates/harp/src/vector/integer_vector.rs
+++ b/crates/harp/src/vector/integer_vector.rs
@@ -1,7 +1,7 @@
 //
 // integer_vector.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -74,10 +74,10 @@ impl Vector for IntegerVector {
     }
 }
 
-impl TryFrom<IntegerVector> for Vec<i32> {
+impl TryFrom<&IntegerVector> for Vec<i32> {
     type Error = harp::Error;
 
-    fn try_from(value: IntegerVector) -> harp::Result<Self> {
+    fn try_from(value: &IntegerVector) -> harp::Result<Self> {
         super::try_vec_from_r_vector(value)
     }
 }

--- a/crates/harp/src/vector/integer_vector.rs
+++ b/crates/harp/src/vector/integer_vector.rs
@@ -73,3 +73,11 @@ impl Vector for IntegerVector {
         x.to_string()
     }
 }
+
+impl TryFrom<IntegerVector> for Vec<i32> {
+    type Error = harp::Error;
+
+    fn try_from(value: IntegerVector) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
+    }
+}

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -165,3 +165,11 @@ mod test {
         }
     }
 }
+
+impl TryFrom<&List> for Vec<RObject> {
+    type Error = harp::Error;
+
+    fn try_from(value: &List) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
+    }
+}

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -13,9 +13,11 @@ use crate::object::r_list_poke;
 use crate::object::RObject;
 use crate::r_typeof;
 
+#[derive(Debug)]
 pub struct List {
-    inner: RObject,
-    ptr: *const SEXP,
+    pub inner: RObject,
+    pub sexp: SEXP,
+    pub ptr: *const SEXP,
 }
 
 pub struct ListIter {
@@ -44,6 +46,7 @@ impl super::Vector for List {
 
         Self {
             inner: object.into(),
+            sexp: object,
             ptr,
         }
     }
@@ -75,8 +78,8 @@ impl super::Vector for List {
         let mut data = data.into_iter();
 
         let size = data.len();
-        let inner = crate::alloc_list(size).unwrap();
-        let inner: RObject = inner.into();
+        let sexp = crate::alloc_list(size).unwrap();
+        let inner: RObject = sexp.into();
 
         for i in 0..size {
             unsafe {
@@ -88,7 +91,7 @@ impl super::Vector for List {
 
         let ptr = crate::list_cbegin(inner.sexp);
 
-        Self { inner, ptr }
+        Self { inner, ptr, sexp }
     }
 
     fn format_one(&self, _x: Self::Type, _options: Option<&super::FormatOptions>) -> String {

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -15,7 +15,7 @@ use crate::r_typeof;
 
 #[derive(Debug)]
 pub struct List {
-    pub inner: RObject,
+    pub obj: RObject,
     pub sexp: SEXP,
     pub ptr: *const SEXP,
 }
@@ -29,7 +29,7 @@ pub struct ListIter {
 
 impl List {
     pub fn iter(&self) -> ListIter {
-        unsafe { ListIter::new_unchecked(self.inner.sexp) }
+        unsafe { ListIter::new_unchecked(self.obj.sexp) }
     }
 }
 
@@ -45,14 +45,14 @@ impl super::Vector for List {
         let ptr = crate::list_cbegin(object);
 
         Self {
-            inner: object.into(),
+            obj: object.into(),
             sexp: object,
             ptr,
         }
     }
 
     fn data(&self) -> SEXP {
-        self.inner.sexp
+        self.obj.sexp
     }
 
     // Never missing. We can't treat `NULL` as missing because it would cause
@@ -91,7 +91,11 @@ impl super::Vector for List {
 
         let ptr = crate::list_cbegin(inner.sexp);
 
-        Self { inner, ptr, sexp }
+        Self {
+            obj: inner,
+            ptr,
+            sexp,
+        }
     }
 
     fn format_one(&self, _x: Self::Type, _options: Option<&super::FormatOptions>) -> String {

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -78,24 +78,20 @@ impl super::Vector for List {
         let mut data = data.into_iter();
 
         let size = data.len();
-        let sexp = crate::alloc_list(size).unwrap();
-        let inner: RObject = sexp.into();
+        let obj = RObject::new(harp::alloc_list(size).unwrap());
+        let sexp = obj.sexp;
 
         for i in 0..size {
             unsafe {
                 let value = data.next().unwrap_unchecked();
                 let value = value.as_ref();
-                r_list_poke(inner.sexp, i as libr::R_xlen_t, *value)
+                r_list_poke(sexp, i as libr::R_xlen_t, *value)
             }
         }
 
-        let ptr = crate::list_cbegin(inner.sexp);
+        let ptr = crate::list_cbegin(sexp);
 
-        Self {
-            obj: inner,
-            ptr,
-            sexp,
-        }
+        Self { obj, ptr, sexp }
     }
 
     fn format_one(&self, _x: Self::Type, _options: Option<&super::FormatOptions>) -> String {

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -166,9 +166,15 @@ mod test {
     }
 }
 
+impl TryFrom<SEXP> for List {
+    type Error = harp::Error;
+    fn try_from(value: SEXP) -> harp::Result<Self> {
+        super::try_r_vector_from_r_sexp(value)
+    }
+}
+
 impl TryFrom<&List> for Vec<RObject> {
     type Error = harp::Error;
-
     fn try_from(value: &List) -> harp::Result<Self> {
         super::try_vec_from_r_vector(value)
     }

--- a/crates/harp/src/vector/logical_vector.rs
+++ b/crates/harp/src/vector/logical_vector.rs
@@ -1,7 +1,7 @@
 //
 // logical_vector.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -78,10 +78,10 @@ impl Vector for LogicalVector {
     }
 }
 
-impl TryFrom<LogicalVector> for Vec<bool> {
+impl TryFrom<&LogicalVector> for Vec<bool> {
     type Error = harp::Error;
 
-    fn try_from(value: LogicalVector) -> harp::Result<Self> {
+    fn try_from(value: &LogicalVector) -> harp::Result<Self> {
         super::try_vec_from_r_vector(value)
     }
 }

--- a/crates/harp/src/vector/logical_vector.rs
+++ b/crates/harp/src/vector/logical_vector.rs
@@ -77,3 +77,11 @@ impl Vector for LogicalVector {
         }
     }
 }
+
+impl TryFrom<LogicalVector> for Vec<bool> {
+    type Error = harp::Error;
+
+    fn try_from(value: LogicalVector) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
+    }
+}

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -161,3 +161,24 @@ where
         Some(item)
     }
 }
+
+// Can we integrate this in a generic `TryFrom` impl for `Vector` objects?
+pub(crate) fn try_vec_from_r_vector<VectorType>(
+    value: VectorType,
+) -> harp::Result<Vec<VectorType::Type>>
+where
+    VectorType: Vector,
+{
+    unsafe {
+        let mut result: Vec<VectorType::Type> = Vec::with_capacity(value.len());
+
+        for val in value.iter() {
+            let Some(x) = val else {
+                return Err(harp::Error::MissingValueError);
+            };
+            result.push(x);
+        }
+
+        return Ok(result);
+    }
+}

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -81,13 +81,13 @@ pub trait Vector: Sized {
         Ok(value)
     }
 
-    unsafe fn new(object: impl Into<SEXP>) -> Result<Self>
+    fn new(object: impl Into<SEXP>) -> Result<Self>
     where
         Self: Sized,
     {
         let object = object.into();
         r_assert_type(object, &[Self::SEXPTYPE])?;
-        Ok(Self::new_unchecked(object))
+        unsafe { Ok(Self::new_unchecked(object)) }
     }
 
     unsafe fn with_length(size: usize) -> Self

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -183,3 +183,14 @@ where
         return Ok(result);
     }
 }
+
+pub(crate) fn try_r_vector_from_r_sexp<VectorType>(value: SEXP) -> harp::Result<VectorType>
+where
+    VectorType: Vector,
+{
+    if value == harp::RObject::null().sexp {
+        return Ok(unsafe { VectorType::with_length(0) });
+    }
+
+    VectorType::new(value)
+}

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -14,6 +14,7 @@ use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
 
 pub mod list;
+pub use list::List;
 
 pub mod character_vector;
 pub use character_vector::CharacterVector;
@@ -164,7 +165,7 @@ where
 
 // Can we integrate this in a generic `TryFrom` impl for `Vector` objects?
 pub(crate) fn try_vec_from_r_vector<VectorType>(
-    value: VectorType,
+    value: &VectorType,
 ) -> harp::Result<Vec<VectorType::Type>>
 where
     VectorType: Vector,

--- a/crates/harp/src/vector/numeric_vector.rs
+++ b/crates/harp/src/vector/numeric_vector.rs
@@ -1,7 +1,7 @@
 //
 // numeric_vector.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -71,5 +71,13 @@ impl Vector for NumericVector {
 
     fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         x.to_string()
+    }
+}
+
+impl TryFrom<&NumericVector> for Vec<f64> {
+    type Error = harp::Error;
+
+    fn try_from(value: &NumericVector) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
     }
 }

--- a/crates/harp/src/vector/raw_vector.rs
+++ b/crates/harp/src/vector/raw_vector.rs
@@ -1,7 +1,7 @@
 //
 // raw_vector.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -70,5 +70,13 @@ impl Vector for RawVector {
 
     fn format_one(&self, x: Self::Type, _option: Option<&FormatOptions>) -> String {
         format!("{:02x}", x)
+    }
+}
+
+impl TryFrom<&RawVector> for Vec<u8> {
+    type Error = harp::Error;
+
+    fn try_from(value: &RawVector) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
     }
 }


### PR DESCRIPTION
This new type wraps the data frame of parse information generated by the R parser when:

- A source file environment is provided to the parser (which is the case at R level when `getOption("keep.source")` is `TRUE`).
- `getOption("keep.parse.data")` is `TRUE` (the default).

This parse data is interesting for the task of determining expression boundaries in a string because it is written by the parser even in the case of an incomplete or invalid input. Unfortunately there is no information about parse failures that we can use, but knowing the boundaries of valid expressions will prove very useful as it allows the following strategy:

- Use parse data to figure out boundaries of complete expressions.
- If there was an error, do a binary search with `R_ParseVector()` to figure out the boundaries of incomplete and invalid inputs in the last expression.

Progress towards posit-dev/positron#1326.

This work is supported by the following infrastructure improvements that are also part of this PR:

- New `DataFrame` type that validates its input. Once constructed, the following guarantees are provided:
    - List storage and `"data.frame"` class
    - Dimensions and valid names
    - All columns are vectors and the same size as the data frame

- There is a new `Error::MissingColumnError` returned from `DataFrame::col()` when an expected column is missing.

- New `harp::assert_class()` returns a new `Error::UnexpectedClass`.

- New `harp::unreachable!()` macro returns an `Error::AnyhowError`.

- New `.inherits()`, `.class()`, and `.dim()` methods for `RObject`.
 
- New coercion methods from `&RObject` to `Vec<T>` used to validate column types. These use a generic helper. I tried to integrate this helper in the `Vector` trait but couldn't solve compiler errors. Alternatively we could generate them with `vector_macros` but unless it saves a of work or substantially reduces the chance of undry typos we're probably better off with explicit code.

- The `iter()` method is no longer generated by `vector_macros`, it's now part of the `Vector` trait. This allows generic implementations to create vector iterators.

- The `TryFrom` methods for `SEXP -> impl Vector` now create empty vectors if passed `NULL`. This in turn is used in `&RObject -> Vec<T>` (this was necessary because the existing conversion method for `RObject -> Vec<i32>` now uses the new helper for `&RObject` and it supports `NULL` inputs, which seems reasonable enough for a conversion method).