### PR TITLE
Bump tree-sitter-r 1 - no grammar changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,11 +478,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
+ "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1448,6 +1450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2569,6 +2580,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3136,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.21.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705bf7c0958d0171dd7d3a6542f2f4f21d87ed5f1dc8db52919d3a6bed9a359a"
+checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
 dependencies = [
  "cc",
  "regex",
@@ -3147,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-r"
 version = "0.20.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=de0d37623f918be0325e2c8ab746b0c1c9a624a6#de0d37623f918be0325e2c8ab746b0c1c9a624a6"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=bc8919d3c38b816652e1e2d1a1be037cf74364cb#bc8919d3c38b816652e1e2d1a1be037cf74364cb"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -47,8 +47,8 @@ serde_json = { version = "1.0.94", features = ["preserve_order"]}
 stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
-tree-sitter = "0.21.0"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "de0d37623f918be0325e2c8ab746b0c1c9a624a6" }
+tree-sitter = "0.22.6"
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "bc8919d3c38b816652e1e2d1a1be037cf74364cb" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"


### PR DESCRIPTION
Pulls in these 36 commits that don't touch the grammar in any way https://github.com/r-lib/tree-sitter-r/compare/de0d37623f918be0325e2c8ab746b0c1c9a624a6...bc8919d3c38b816652e1e2d1a1be037cf74364cb. There should be no changes required to ark with this PR. Potential for changes start after this PR.