### PR TITLE
Bump tree-sitter-r 2 - Add support for `StringContent` and `EscapeSequence` nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-r"
 version = "0.20.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=bc8919d3c38b816652e1e2d1a1be037cf74364cb#bc8919d3c38b816652e1e2d1a1be037cf74364cb"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=9d1a68f8f239bc3749a481ac85e2163e24f6362c#9d1a68f8f239bc3749a481ac85e2163e24f6362c"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.22.6"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "bc8919d3c38b816652e1e2d1a1be037cf74364cb" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "9d1a68f8f239bc3749a481ac85e2163e24f6362c" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -20,6 +20,7 @@ use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::rope::RopeExt;
 use crate::lsp::traits::string::StringExt;
+use crate::treesitter::node_find_string;
 use crate::treesitter::NodeTypeExt;
 
 pub(super) fn completions_from_workspace(
@@ -41,8 +42,8 @@ pub(super) fn completions_from_workspace(
         }
     }
 
-    if node.is_string() {
-        log::error!("Should have already been handled by file path completions source");
+    if node_find_string(&node).is_some() {
+        log::error!("Should have already been handled by string completions source");
         return Ok(None);
     }
 

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -20,7 +20,7 @@ use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::rope::RopeExt;
 use crate::lsp::traits::string::StringExt;
-use crate::treesitter::node_find_string;
+use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
 pub(super) fn completions_from_workspace(
@@ -42,7 +42,7 @@ pub(super) fn completions_from_workspace(
         }
     }
 
-    if node_find_string(&node).is_some() {
+    if node_in_string(&node) {
         log::error!("Should have already been handled by string completions source");
         return Ok(None);
     }

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -28,7 +28,7 @@ use crate::lsp::completions::sources::utils::CallNodePositionType;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::signature_help::r_signature_help;
-use crate::treesitter::node_find_string;
+use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
 pub fn completions_from_custom_source(
@@ -191,9 +191,7 @@ pub fn completions_from_custom_source_impl(
                     continue;
                 });
 
-                let in_string = node_find_string(&node).is_some();
-
-                if enquote && !in_string {
+                if enquote && !node_in_string(&node) {
                     item.insert_text = Some(format!("\"{value}\""));
                 } else {
                     let mut insert_text = sym_quote_invalid(value.as_str());

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -28,6 +28,7 @@ use crate::lsp::completions::sources::utils::CallNodePositionType;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::signature_help::r_signature_help;
+use crate::treesitter::node_find_string;
 use crate::treesitter::NodeTypeExt;
 
 pub fn completions_from_custom_source(
@@ -190,7 +191,9 @@ pub fn completions_from_custom_source_impl(
                     continue;
                 });
 
-                if enquote && !node.is_string() {
+                let in_string = node_find_string(&node).is_some();
+
+                if enquote && !in_string {
                     item.insert_text = Some(format!("\"{value}\""));
                 } else {
                     let mut insert_text = sym_quote_invalid(value.as_str());

--- a/crates/ark/src/lsp/completions/sources/unique/file_path.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/file_path.rs
@@ -15,6 +15,7 @@ use harp::utils::r_normalize_path;
 use stdext::unwrap;
 use stdext::IntoResult;
 use tower_lsp::lsp_types::CompletionItem;
+use tree_sitter::Node;
 
 use crate::lsp::completions::completion_item::completion_item_from_direntry;
 use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
@@ -22,6 +23,7 @@ use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 
 pub(super) fn completions_from_string_file_path(
+    node: &Node,
     context: &DocumentContext,
 ) -> Result<Vec<CompletionItem>> {
     log::info!("completions_from_string_file_path()");
@@ -33,11 +35,7 @@ pub(super) fn completions_from_string_file_path(
     // NOTE: This includes the quotation characters on the string, and so
     // also includes any internal escapes! We need to decode the R string
     // before searching the path entries.
-    let token = context
-        .document
-        .contents
-        .node_slice(&context.node)?
-        .to_string();
+    let token = context.document.contents.node_slice(&node)?.to_string();
     let contents = unsafe { r_string_decode(token.as_str()).into_result()? };
     log::info!("String value (decoded): {}", contents);
 

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -427,6 +427,10 @@ pub(crate) fn node_find_string<'a>(node: &'a Node) -> Option<Node<'a>> {
     node.ancestors().find(|parent| parent.is_string())
 }
 
+pub(crate) fn node_in_string(node: &Node) -> bool {
+    node_find_string(node).is_some()
+}
+
 pub(crate) fn node_is_call(node: &Node, name: &str, contents: &ropey::Rope) -> bool {
     if !node.is_call() {
         return false;


### PR DESCRIPTION
Bumps us one more commit in tree-sitter-r to support the new `string_content` and `escape_sequence` children of a `string` node https://github.com/r-lib/tree-sitter-r/compare/bc8919d3c38b816652e1e2d1a1be037cf74364cb...9d1a68f8f239bc3749a481ac85e2163e24f6362c.

These are nice tree-sitter features but are a bit annoying for us. It means that `DocumentContext` will drill allllllll the way down to one of the following, rather than finding and stopping at just a `NodeType::String` like before:
- `Anonymous("'")` or `Anonymous("\"")`
- `StringContent`
- `EscapeSequence`

This means we have to walk back up the tree a bit when we need to work with or detect the `String` node. I think I've found all the places we do this.

I'm hoping this is the most annoying tree-sitter related tweak I'll have to do.