### PR TITLE
Bump tree-sitter-r 3 - New `"open"`/`"close"` fields, can use `node.is_missing()`, no more `..i` diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-r"
 version = "0.20.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=9d1a68f8f239bc3749a481ac85e2163e24f6362c#9d1a68f8f239bc3749a481ac85e2163e24f6362c"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f#63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.22.6"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "9d1a68f8f239bc3749a481ac85e2163e24f6362c" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/src/lsp/completions/sources/common/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/common/subset.rs
@@ -9,53 +9,21 @@ use tree_sitter::Node;
 use tree_sitter::Point;
 
 use crate::lsp::traits::point::PointExt;
-use crate::treesitter::NodeType;
-use crate::treesitter::NodeTypeExt;
 
-pub(crate) fn is_within_subset_delimiters(
-    x: &Point,
-    subset_node: &Node,
-    subset_type: &NodeType,
-) -> bool {
-    let (open, close) = match subset_type {
-        NodeType::Subset => ("[", "]"),
-        NodeType::Subset2 => ("[[", "]]"),
-        _ => std::unreachable!(),
-    };
-
+pub(crate) fn is_within_subset_delimiters(x: &Point, subset_node: &Node) -> bool {
     let Some(arguments) = subset_node.child_by_field_name("arguments") else {
         return false;
     };
 
-    let n_children = arguments.child_count();
-
-    if n_children < 2 {
-        return false;
-    }
-
-    let Some(open_node) = arguments.child(1 - 1) else {
+    let Some(open) = arguments.child_by_field_name("open") else {
         return false;
     };
-    let Some(close_node) = arguments.child(n_children - 1) else {
+    let Some(close) = arguments.child_by_field_name("close") else {
         return false;
     };
 
-    // Ensure open and closing nodes are the right type
-    if !matches!(
-        open_node.node_type(),
-        NodeType::Anonymous(kind) if kind == open
-    ) {
-        return false;
-    }
-    if !matches!(
-        close_node.node_type(),
-        NodeType::Anonymous(kind) if kind == close
-    ) {
-        return false;
-    }
-
-    let contains_start = x.is_after_or_equal(open_node.end_position());
-    let contains_end = x.is_before_or_equal(close_node.start_position());
+    let contains_start = x.is_after_or_equal(open.end_position());
+    let contains_end = x.is_before_or_equal(close.start_position());
 
     contains_start && contains_end
 }

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -27,13 +27,13 @@ pub(super) fn completions_from_subset(
     const ENQUOTE: bool = true;
 
     let mut node = context.node;
-    let mut subset_type = None;
+    let mut needs_completions = false;
 
     loop {
         let node_type = node.node_type();
 
         if matches!(node_type, NodeType::Subset | NodeType::Subset2) {
-            subset_type = Some(node_type);
+            needs_completions = true;
             break;
         }
 
@@ -49,14 +49,14 @@ pub(super) fn completions_from_subset(
         };
     }
 
-    let Some(subset_type) = subset_type else {
+    if !needs_completions {
         // Didn't detect anything worth completing in this context,
         // let other sources add their own candidates instead
         return Ok(None);
     };
 
     // Only provide subset completions if you are actually within `x[<here>]` or `x[[<here>]]`
-    if !is_within_subset_delimiters(&context.point, &node, &subset_type) {
+    if !is_within_subset_delimiters(&context.point, &node) {
         return Ok(None);
     }
 

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -85,10 +85,8 @@ fn node_find_object_for_string_subset<'tree>(
         }
     }
 
-    let node_type = node.node_type();
-
     // Only provide subset completions if you are actually within `x[<here>]` or `x[[<here>]]`
-    if !is_within_subset_delimiters(&context.point, &node, &node_type) {
+    if !is_within_subset_delimiters(&context.point, &node) {
         return None;
     }
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1121,6 +1121,18 @@ mod tests {
     }
 
     #[test]
+    fn test_no_diagnostic_for_dot_dot_i() {
+        r_test(|| {
+            let text = "..1 + ..2 + 3";
+            let document = Document::new(text, None);
+
+            let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
+
+            assert!(diagnostics.is_empty());
+        })
+    }
+
+    #[test]
     fn test_no_diagnostic_for_rhs_of_extractor() {
         r_test(|| {
             let options = RParseEvalOptions {

--- a/crates/ark/src/lsp/signature_help.rs
+++ b/crates/ark/src/lsp/signature_help.rs
@@ -327,21 +327,12 @@ fn is_within_call_parentheses(x: &Point, node: &Node) -> bool {
         return false;
     };
 
-    let n_children = arguments.child_count();
-    if n_children < 2 {
-        log::error!("`arguments` node only has {n_children} children.");
+    let Some(open) = arguments.child_by_field_name("open") else {
         return false;
-    }
-
-    let open = arguments.child(1 - 1).unwrap();
-    let close = arguments.child(n_children - 1).unwrap();
-
-    if open.node_type() != NodeType::Anonymous(String::from("(")) {
+    };
+    let Some(close) = arguments.child_by_field_name("close") else {
         return false;
-    }
-    if close.node_type() != NodeType::Anonymous(String::from(")")) {
-        return false;
-    }
+    };
 
     x.is_after_or_equal(open.end_position()) && x.is_before_or_equal(close.start_position())
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3632

Includes these 11 commits from tree-sitter-r https://github.com/r-lib/tree-sitter-r/compare/9d1a68f8f239bc3749a481ac85e2163e24f6362c...63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f

Three notable ones:
- https://github.com/r-lib/tree-sitter-r/pull/110 (greatly simplifies some existing code around this)
- https://github.com/r-lib/tree-sitter-r/pull/112 (allows us to actually use `node.is_missing()`, fixing one of our diagnostics)
- https://github.com/r-lib/tree-sitter-r/pull/118 (fixes `..i` diagnostic)