### PR TITLE
Data Explorer: Add basic implementation of "not contains" search type

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -778,6 +778,10 @@ pub enum TextSearchType {
 	#[strum(to_string = "contains")]
 	Contains,
 
+	#[serde(rename = "not_contains")]
+	#[strum(to_string = "not_contains")]
+	NotContains,
+
 	#[serde(rename = "starts_with")]
 	#[strum(to_string = "starts_with")]
 	StartsWith,

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -264,6 +264,12 @@ col_filter_indices <- function(col, idx = NULL) {
         grepl(pattern = escaped_term, col, fixed = FALSE, ignore.case = !params$case_sensitive)
     }
 
+    # Search for the term not contained in the column's values
+    else if (identical(params$search_type, "not_contains")) {
+        escaped_term <- .ps.regex_escape(params$term)
+        !grepl(pattern = escaped_term, col, fixed = FALSE, ignore.case = !params$case_sensitive)
+    }
+
     # Search for the term at the beginning of the column's values
     else if (identical(params$search_type, "starts_with")) {
         escaped_term <- .ps.regex_escape(params$term)


### PR DESCRIPTION
Ark side of https://github.com/posit-dev/positron/pull/4633. The unit tests here for these filters are a bit janky and don't seem to test correctness so I didn't add a test right way. It might make sense to give them a complete working over. 