### PR TITLE
Detect boundaries of parse inputs

### DIFF
--- a/crates/ark/src/analysis/mod.rs
+++ b/crates/ark/src/analysis/mod.rs
@@ -1,0 +1,8 @@
+//
+// mod.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+pub mod parse_boundaries;

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -1,0 +1,98 @@
+//
+// parse_boundaries.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use harp::parse;
+use harp::parse_data::ParseData;
+use harp::srcref;
+
+use crate::lsp::offset::ArkPoint;
+use crate::lsp::offset::ArkRange;
+
+#[derive(Debug)]
+pub struct ParseBoundaries {
+    pub complete: Vec<ArkRange>,
+    pub incomplete: Option<ArkRange>,
+    pub error: Option<ArkRange>,
+}
+
+pub fn parse_boundaries(text: &str) -> anyhow::Result<ParseBoundaries> {
+    let srcfile = srcref::SrcFile::new_virtual(text)?;
+
+    // Fill parse data in `srcfile` by side effect
+    let _status = parse::parse_status(&parse::ParseInput::SrcFile(&srcfile));
+
+    let parse_data = ParseData::from_srcfile(&srcfile)?;
+    let top_level = parse_data.filter_top_level();
+
+    let ranges: Vec<ArkRange> = top_level
+        .nodes
+        .iter()
+        .map(|n| n.as_point_range())
+        .map(|r| point_range_as_ark_range(r))
+        .collect();
+
+    let boundaries = ParseBoundaries {
+        complete: ranges,
+        incomplete: None,
+        error: None,
+    };
+
+    Ok(boundaries)
+}
+
+fn point_range_as_ark_range(range: std::ops::Range<(usize, usize)>) -> ArkRange {
+    ArkRange {
+        start: ArkPoint {
+            row: range.start.0,
+            column: range.start.1,
+        },
+        end: ArkPoint {
+            row: range.end.0,
+            column: range.end.1,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use harp::assert_match;
+
+    use crate::analysis::parse_boundaries::*;
+    use crate::test::r_test;
+
+    #[test]
+    fn test_parse_boundaries_complete() {
+        r_test(|| {
+            let boundaries = parse_boundaries("").unwrap();
+            let expected_complete: Vec<ArkRange> = vec![];
+            assert_eq!(boundaries.complete, expected_complete);
+            assert_match!(boundaries.incomplete, None);
+            assert_match!(boundaries.error, None);
+
+            let boundaries = parse_boundaries("\n\n  ").unwrap();
+            let expected_complete: Vec<ArkRange> = vec![];
+            assert_eq!(boundaries.complete, expected_complete);
+            assert_match!(boundaries.incomplete, None);
+            assert_match!(boundaries.error, None);
+
+            let boundaries = parse_boundaries("foo\nbarbaz").unwrap();
+            let expected_complete = vec![
+                ArkRange {
+                    start: ArkPoint { row: 0, column: 0 },
+                    end: ArkPoint { row: 1, column: 3 },
+                },
+                ArkRange {
+                    start: ArkPoint { row: 1, column: 0 },
+                    end: ArkPoint { row: 2, column: 6 },
+                },
+            ];
+            assert_eq!(boundaries.complete, expected_complete);
+            assert_match!(boundaries.incomplete, None);
+            assert_match!(boundaries.error, None);
+        })
+    }
+}

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -6,6 +6,7 @@
 //
 
 use harp::ParseResult;
+use harp::RObject;
 
 use crate::lsp::offset::ArkPoint;
 use crate::lsp::offset::ArkRange;
@@ -18,36 +19,106 @@ pub struct ParseBoundaries {
 }
 
 pub fn parse_boundaries(text: &str) -> anyhow::Result<ParseBoundaries> {
-    let (status, parse_data) = harp::parse_with_parse_data(text)?;
-    let top_level = parse_data.filter_top_level();
-
-    let ranges: Vec<ArkRange> = top_level
-        .nodes
-        .iter()
-        .map(|n| n.as_point_range())
-        .map(|r| point_range_as_ark_range(r))
+    let mut newlines: Vec<usize> = text
+        .chars()
+        .enumerate()
+        .filter(|(_, c)| *c == '\n')
+        .map(|(i, _)| i)
         .collect();
 
-    let boundaries = ParseBoundaries {
-        complete: ranges,
-        incomplete: None,
-        error: None,
+    // Include last line
+    if let Some(last) = newlines.last() {
+        if *last < text.len() - 1 {
+            newlines.push(text.len() - 1)
+        }
+    }
+
+    let n_lines = newlines.len();
+
+    let mut complete: Vec<ArkRange> = vec![];
+    let mut incomplete: Option<ArkRange> = None;
+    let mut error: Option<ArkRange> = None;
+
+    let mut incomplete_end: Option<ArkPoint> = None;
+    let mut error_end: Option<ArkPoint> = None;
+
+    let get_line_width = |line| text.lines().nth(line).unwrap().len();
+    let get_line_point = |line| ArkPoint {
+        row: line,
+        column: get_line_width(line),
     };
 
-    Ok(boundaries)
-}
+    for (i, current_end) in newlines.iter().rev().enumerate() {
+        let current_row = n_lines - i;
+        let current_point = || ArkPoint {
+            row: n_lines - i - 1,
+            column: get_line_width(n_lines - i - 1),
+        };
 
-fn point_range_as_ark_range(range: std::ops::Range<(usize, usize)>) -> ArkRange {
-    ArkRange {
-        start: ArkPoint {
-            row: range.start.0,
-            column: range.start.1,
-        },
-        end: ArkPoint {
-            row: range.end.0,
-            column: range.end.1,
-        },
+        let mut record_error = || {
+            if matches!(error, Some(_)) {
+                return;
+            }
+            let Some(end) = error_end else {
+                return;
+            };
+            error = Some(ArkRange {
+                start: current_point(),
+                end,
+            });
+        };
+
+        let mut record_incomplete = || {
+            let Some(end) = incomplete_end else {
+                return;
+            };
+            incomplete = Some(ArkRange {
+                start: current_point(),
+                end,
+            });
+        };
+
+        let mut record_complete = |exprs: RObject| -> anyhow::Result<()> {
+            let srcrefs = exprs.srcrefs()?;
+            let mut ranges: Vec<ArkRange> =
+                srcrefs.into_iter().map(|srcref| srcref.into()).collect();
+            complete.append(&mut ranges);
+            Ok(())
+        };
+
+        // Grab all code up to current line. Include `\n` as there might be a trailing `\r`.
+        let subset = &text[..current_end + 1];
+
+        // Parse within source file to get source references
+        let srcfile = harp::srcref::SrcFile::new_virtual(subset)?;
+
+        match harp::parse_status(&harp::ParseInput::SrcFile(&srcfile))? {
+            ParseResult::Complete(exprs) => {
+                record_error();
+                record_incomplete();
+                record_complete(exprs)?;
+                break;
+            },
+
+            ParseResult::Incomplete => {
+                record_error();
+
+                // Declare incomplete
+                incomplete_end = incomplete_end.or_else(|| Some(get_line_point(current_row)));
+            },
+
+            ParseResult::SyntaxError { .. } => {
+                // Declare error
+                error_end = error_end.or_else(|| Some(get_line_point(n_lines - 1)));
+            },
+        };
     }
+
+    Ok(ParseBoundaries {
+        complete,
+        incomplete,
+        error,
+    })
 }
 
 #[cfg(test)]
@@ -68,6 +139,15 @@ mod tests {
 
             let boundaries = parse_boundaries("\n\n  ").unwrap();
             let expected_complete: Vec<ArkRange> = vec![];
+            assert_eq!(boundaries.complete, expected_complete);
+            assert_match!(boundaries.incomplete, None);
+            assert_match!(boundaries.error, None);
+
+            let boundaries = parse_boundaries("\n  foo\n  \n\n").unwrap();
+            let expected_complete = vec![ArkRange {
+                start: ArkPoint { row: 1, column: 2 },
+                end: ArkPoint { row: 2, column: 5 },
+            }];
             assert_eq!(boundaries.complete, expected_complete);
             assert_match!(boundaries.incomplete, None);
             assert_match!(boundaries.error, None);

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -5,9 +5,7 @@
 //
 //
 
-use harp::parse;
-use harp::parse_data::ParseData;
-use harp::srcref;
+use harp::ParseResult;
 
 use crate::lsp::offset::ArkPoint;
 use crate::lsp::offset::ArkRange;
@@ -20,12 +18,7 @@ pub struct ParseBoundaries {
 }
 
 pub fn parse_boundaries(text: &str) -> anyhow::Result<ParseBoundaries> {
-    let srcfile = srcref::SrcFile::new_virtual(text)?;
-
-    // Fill parse data in `srcfile` by side effect
-    let _status = parse::parse_status(&parse::ParseInput::SrcFile(&srcfile));
-
-    let parse_data = ParseData::from_srcfile(&srcfile)?;
+    let (status, parse_data) = harp::parse_with_parse_data(text)?;
     let top_level = parse_data.filter_top_level();
 
     let ranges: Vec<ArkRange> = top_level

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -373,6 +373,14 @@ mod tests {
                 Some(std::ops::Range { start: 1, end: 2 })
             );
             assert_eq!(boundaries.error, Some(std::ops::Range { start: 2, end: 3 }));
+
+            let boundaries = parse_boundaries("foo +\n  bar +;").unwrap();
+            assert_eq!(boundaries.complete.len(), 0);
+            assert_eq!(
+                boundaries.incomplete,
+                Some(std::ops::Range { start: 0, end: 1 })
+            );
+            assert_eq!(boundaries.error, Some(std::ops::Range { start: 1, end: 2 }));
         });
     }
 }

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -83,9 +83,13 @@ pub fn parse_boundaries(text: &str) -> anyhow::Result<ParseBoundaries> {
             Ok(())
         };
 
-        // Grab all code up to current line
-        let subset = &lines_r.slice()[..=current_line];
-        let subset = CharacterVector::try_from(subset)?;
+        // Grab all code up to current line. We don't slice the vector in the
+        // first iteration as it's not needed.
+        let subset = if current_line == n_lines - 1 {
+            lines_r.clone()
+        } else {
+            CharacterVector::try_from(&lines_r.slice()[..=current_line])?
+        };
 
         // Parse within source file to get source references
         let srcfile = harp::srcref::SrcFile::try_from(&subset)?;

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -207,7 +207,8 @@ fn fill_gaps(mut boundaries: ParseBoundaries, n_lines: usize) -> ParseBoundaries
         filled.push(range);
     }
 
-    // Fill trailing whitespace (between complete and incomplete|error\eof)
+    // Fill trailing whitespace between complete expressions and the rest
+    // (incomplete, error, or eof)
     let last_boundary = filled.last().map(|r| r.end).unwrap_or(0);
     let next_boundary = boundaries
         .incomplete

--- a/crates/ark/src/lib.rs
+++ b/crates/ark/src/lib.rs
@@ -5,6 +5,7 @@
 //
 //
 
+pub mod analysis;
 pub mod browser;
 pub mod connections;
 pub mod control;

--- a/crates/ark/src/lsp/offset.rs
+++ b/crates/ark/src/lsp/offset.rs
@@ -20,6 +20,21 @@ pub struct ArkRange {
     pub end: ArkPoint,
 }
 
+impl From<harp::srcref::SrcRef> for ArkRange {
+    fn from(value: harp::srcref::SrcRef) -> Self {
+        ArkRange {
+            start: ArkPoint {
+                row: value.line.start,
+                column: value.column.start,
+            },
+            end: ArkPoint {
+                row: value.line.end,
+                column: value.column.end,
+            },
+        }
+    }
+}
+
 /// Like `TextEdit` from the lsp_types crate, but doen't expect positions to be
 /// encoded in UTF-16.
 #[derive(Clone, Debug)]

--- a/crates/ark/src/lsp/offset.rs
+++ b/crates/ark/src/lsp/offset.rs
@@ -14,7 +14,7 @@ pub use tree_sitter::Point as ArkPoint;
 
 use crate::lsp::encoding::convert_point_to_position;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ArkRange {
     pub start: ArkPoint,
     pub end: ArkPoint,

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -124,7 +124,7 @@ impl Shell {
                 status: IsComplete::Incomplete,
                 indent: String::from("+"),
             }),
-            Err(_) => Ok(IsCompleteReply {
+            Err(_) | Ok(ParseResult::SyntaxError { .. }) => Ok(IsCompleteReply {
                 status: IsComplete::Invalid,
                 indent: String::from(""),
             }),

--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -280,7 +280,7 @@ impl RVariables {
      * Clear the environment. Uses rm(envir = <env>, list = ls(<env>, all.names = TRUE))
      */
     fn delete(&mut self, variables: Vec<String>) -> Result<(), harp::error::Error> {
-        r_task(|| unsafe {
+        r_task(|| {
             let variables: Vec<&str> = variables.iter().map(|s| s as &str).collect();
 
             let env = self.env.get().clone();

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -47,6 +47,7 @@ pub use parse::*;
 pub use parser::*;
 pub use source::*;
 pub use table::*;
+pub use vector::character_vector::*;
 pub use vector::list::*;
 
 // Necessary for the `harp::` references in macros, e.g. `harp::register`, to

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -248,6 +248,10 @@ pub fn r_dbl_begin(x: SEXP) -> *mut f64 {
     unsafe { REAL(x) }
 }
 
+pub unsafe fn chr_cbegin(x: SEXP) -> *const SEXP {
+    libr::DATAPTR_RO(x) as *const SEXP
+}
+
 pub fn list_cbegin(x: SEXP) -> *const SEXP {
     unsafe { libr::DATAPTR_RO(x) as *const SEXP }
 }

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 
 use crate::line_ending::convert_line_endings;
 use crate::line_ending::LineEnding;
+use crate::parse_data::ParseData;
 use crate::protect::RProtect;
 use crate::r_string;
 use crate::srcref;
@@ -82,6 +83,18 @@ pub fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
             Err(crate::Error::ParseSyntaxError { message, line })
         },
     }
+}
+
+// Return type would be clearer if syntax error was integrated in `ParseResult`
+pub fn parse_with_parse_data(text: &str) -> crate::Result<(ParseResult, ParseData)> {
+    let srcfile = srcref::SrcFile::new_virtual(text)?;
+
+    // Fill parse data in `srcfile` by side effect
+    let status = parse_status(&ParseInput::SrcFile(&srcfile))?;
+
+    let parse_data = ParseData::from_srcfile(&srcfile)?;
+
+    Ok((status, parse_data))
 }
 
 pub fn parse_status<'a>(input: &ParseInput<'a>) -> crate::Result<ParseResult> {

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -85,7 +85,6 @@ pub fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
     }
 }
 
-// Return type would be clearer if syntax error was integrated in `ParseResult`
 pub fn parse_with_parse_data(text: &str) -> crate::Result<(ParseResult, ParseData)> {
     let srcfile = srcref::SrcFile::try_from(text)?;
 

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -67,7 +67,7 @@ pub fn parse_exprs(text: &str) -> crate::Result<RObject> {
 
 /// Same but creates srcrefs
 pub fn parse_exprs_with_srcrefs(text: &str) -> crate::Result<RObject> {
-    let srcfile = srcref::SrcFile::new_virtual(text)?;
+    let srcfile = srcref::SrcFile::try_from(text)?;
     parse_exprs_ext(&ParseInput::SrcFile(&srcfile))
 }
 
@@ -87,7 +87,7 @@ pub fn parse_exprs_ext<'a>(input: &ParseInput<'a>) -> crate::Result<RObject> {
 
 // Return type would be clearer if syntax error was integrated in `ParseResult`
 pub fn parse_with_parse_data(text: &str) -> crate::Result<(ParseResult, ParseData)> {
-    let srcfile = srcref::SrcFile::new_virtual(text)?;
+    let srcfile = srcref::SrcFile::try_from(text)?;
 
     // Fill parse data in `srcfile` by side effect
     let status = parse_status(&ParseInput::SrcFile(&srcfile))?;
@@ -248,7 +248,7 @@ mod tests {
                 "foo\nbar"
             );
 
-            let input = srcref::SrcFile::new_virtual("foo\nbar").unwrap();
+            let input = srcref::SrcFile::try_from("foo\nbar").unwrap();
             assert_eq!(
                 parse_input_as_string(&ParseInput::SrcFile(&input)).unwrap(),
                 "foo\nbar"

--- a/crates/harp/src/parser/parse_data.rs
+++ b/crates/harp/src/parser/parse_data.rs
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn test_parse_data() {
         r_test(|| {
-            let srcfile = srcref::SrcFile::new_virtual("foo\nbar").unwrap();
+            let srcfile = srcref::SrcFile::try_from("foo\nbar").unwrap();
             let exprs = parse::parse_exprs_ext(&parse::ParseInput::SrcFile(&srcfile)).unwrap();
             let srcrefs: Vec<harp::srcref::SrcRef> = exprs.srcrefs().unwrap();
 

--- a/crates/harp/src/parser/srcref.rs
+++ b/crates/harp/src/parser/srcref.rs
@@ -118,7 +118,7 @@ impl TryFrom<RObject> for SrcRef {
 /// Creates the same sort of srcfile object as with `parse(text = )`.
 /// Takes code as an R string containing newlines, or as a R vector of lines.
 impl SrcFile {
-    pub fn new_virtual(text: RObject) -> harp::Result<Self> {
+    fn new_virtual(text: RObject) -> harp::Result<Self> {
         let inner = RFunction::new("base", "srcfilecopy")
             .param("filename", "<text>")
             .param("lines", text)

--- a/crates/harp/src/parser/srcref.rs
+++ b/crates/harp/src/parser/srcref.rs
@@ -118,11 +118,10 @@ impl TryFrom<RObject> for SrcRef {
 /// Creates the same sort of srcfile object as with `parse(text = )`.
 /// Takes code as an R string containing newlines, or as a R vector of lines.
 impl SrcFile {
-    pub fn new_virtual(text: &str) -> harp::Result<Self> {
-        let input = crate::as_parse_text(text);
+    pub fn new_virtual(text: RObject) -> harp::Result<Self> {
         let inner = RFunction::new("base", "srcfilecopy")
             .param("filename", "<text>")
-            .param("lines", input)
+            .param("lines", text)
             .call()?;
 
         Ok(Self { inner })
@@ -134,6 +133,23 @@ impl SrcFile {
             .param("first", 1)
             .param("last", f64::INFINITY)
             .call()
+    }
+}
+
+impl TryFrom<&str> for SrcFile {
+    type Error = harp::Error;
+
+    fn try_from(value: &str) -> harp::Result<Self> {
+        let input = crate::as_parse_text(value);
+        SrcFile::new_virtual(input)
+    }
+}
+
+impl TryFrom<&harp::CharacterVector> for SrcFile {
+    type Error = harp::Error;
+
+    fn try_from(value: &harp::CharacterVector) -> harp::Result<Self> {
+        SrcFile::new_virtual(value.object.clone())
     }
 }
 

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -24,6 +24,7 @@ use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
+#[derive(Clone)]
 pub struct CharacterVector {
     pub object: RObject,
 }

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -114,13 +114,10 @@ impl TryFrom<&[SEXP]> for CharacterVector {
         unsafe {
             let vec = Self::with_length(value.len());
             let sexp = vec.object.sexp;
-            let mut iter = value.into_iter();
 
-            for i in 0..value.len() {
-                let value = iter.next().unwrap_unchecked();
-                r_assert_type(*value, &[libr::CHARSXP])?;
-
-                r_chr_poke(sexp, i as R_xlen_t, *value);
+            for (i, elt) in value.into_iter().enumerate() {
+                r_assert_type(*elt, &[libr::CHARSXP])?;
+                r_chr_poke(sexp, i as R_xlen_t, *elt);
             }
 
             Ok(vec)

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -43,30 +43,32 @@ impl Vector for CharacterVector {
         }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        // convert into iterator
-        let mut data = data.into_iter();
+        unsafe {
+            // convert into iterator
+            let mut data = data.into_iter();
 
-        // build our character vector
-        let n = data.len();
-        let vector = CharacterVector::with_length(n);
-        for i in 0..data.len() {
-            let value = data.next().unwrap_unchecked();
-            let value = value.as_ref();
-            let charsexp = Rf_mkCharLenCE(
-                value.as_ptr() as *const c_char,
-                value.len() as i32,
-                cetype_t_CE_UTF8,
-            );
-            SET_STRING_ELT(vector.data(), i as R_xlen_t, charsexp);
+            // build our character vector
+            let n = data.len();
+            let vector = CharacterVector::with_length(n);
+            for i in 0..data.len() {
+                let value = data.next().unwrap_unchecked();
+                let value = value.as_ref();
+                let charsexp = Rf_mkCharLenCE(
+                    value.as_ptr() as *const c_char,
+                    value.len() as i32,
+                    cetype_t_CE_UTF8,
+                );
+                SET_STRING_ELT(vector.data(), i as R_xlen_t, charsexp);
+            }
+
+            vector
         }
-
-        vector
     }
 
     fn is_na(x: &Self::UnderlyingType) -> bool {

--- a/crates/harp/src/vector/complex_vector.rs
+++ b/crates/harp/src/vector/complex_vector.rs
@@ -48,22 +48,24 @@ impl Vector for ComplexVector {
         }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        let it = data.into_iter();
-        let count = it.len();
+        unsafe {
+            let it = data.into_iter();
+            let count = it.len();
 
-        let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
-        let dataptr = DATAPTR(vector) as *mut Self::Type;
-        it.enumerate().for_each(|(index, value)| {
-            *(dataptr.offset(index as isize)) = *value.as_ref();
-        });
+            let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
+            let dataptr = DATAPTR(vector) as *mut Self::Type;
+            it.enumerate().for_each(|(index, value)| {
+                *(dataptr.offset(index as isize)) = *value.as_ref();
+            });
 
-        Self::new_unchecked(vector)
+            Self::new_unchecked(vector)
+        }
     }
 
     fn data(&self) -> SEXP {

--- a/crates/harp/src/vector/factor.rs
+++ b/crates/harp/src/vector/factor.rs
@@ -16,8 +16,8 @@ use libr::SEXP;
 
 use crate::object::RObject;
 use crate::r_symbol;
-use crate::vector::FormatOptions;
 use crate::vector::CharacterVector;
+use crate::vector::FormatOptions;
 use crate::vector::Vector;
 
 #[harp_macros::vector]
@@ -40,22 +40,24 @@ impl Vector for Factor {
         Self { object, levels }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        let it = data.into_iter();
-        let count = it.len();
+        unsafe {
+            let it = data.into_iter();
+            let count = it.len();
 
-        let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
-        let dataptr = DATAPTR(vector) as *mut Self::Type;
-        it.enumerate().for_each(|(index, value)| {
-            *(dataptr.offset(index as isize)) = *value.as_ref();
-        });
+            let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
+            let dataptr = DATAPTR(vector) as *mut Self::Type;
+            it.enumerate().for_each(|(index, value)| {
+                *(dataptr.offset(index as isize)) = *value.as_ref();
+            });
 
-        Self::new_unchecked(vector)
+            Self::new_unchecked(vector)
+        }
     }
 
     fn data(&self) -> SEXP {

--- a/crates/harp/src/vector/integer_vector.rs
+++ b/crates/harp/src/vector/integer_vector.rs
@@ -35,22 +35,24 @@ impl Vector for IntegerVector {
         }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        let it = data.into_iter();
-        let count = it.len();
+        unsafe {
+            let it = data.into_iter();
+            let count = it.len();
 
-        let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
-        let dataptr = DATAPTR(vector) as *mut Self::Type;
-        it.enumerate().for_each(|(index, value)| {
-            *(dataptr.offset(index as isize)) = *value.as_ref();
-        });
+            let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
+            let dataptr = DATAPTR(vector) as *mut Self::Type;
+            it.enumerate().for_each(|(index, value)| {
+                *(dataptr.offset(index as isize)) = *value.as_ref();
+            });
 
-        Self::new_unchecked(vector)
+            Self::new_unchecked(vector)
+        }
     }
 
     fn data(&self) -> SEXP {

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -69,7 +69,7 @@ impl super::Vector for List {
         (*x).into()
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,

--- a/crates/harp/src/vector/logical_vector.rs
+++ b/crates/harp/src/vector/logical_vector.rs
@@ -35,22 +35,24 @@ impl Vector for LogicalVector {
         }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        let it = data.into_iter();
-        let count = it.len();
+        unsafe {
+            let it = data.into_iter();
+            let count = it.len();
 
-        let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
-        let dataptr = DATAPTR(vector) as *mut Self::Type;
-        it.enumerate().for_each(|(index, value)| {
-            *(dataptr.offset(index as isize)) = *value.as_ref();
-        });
+            let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
+            let dataptr = DATAPTR(vector) as *mut Self::Type;
+            it.enumerate().for_each(|(index, value)| {
+                *(dataptr.offset(index as isize)) = *value.as_ref();
+            });
 
-        Self::new_unchecked(vector)
+            Self::new_unchecked(vector)
+        }
     }
 
     fn data(&self) -> SEXP {

--- a/crates/harp/src/vector/mod.rs
+++ b/crates/harp/src/vector/mod.rs
@@ -99,7 +99,7 @@ pub trait Vector: Sized {
         Self::new_unchecked(data)
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,

--- a/crates/harp/src/vector/numeric_vector.rs
+++ b/crates/harp/src/vector/numeric_vector.rs
@@ -35,22 +35,24 @@ impl Vector for NumericVector {
         }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        let it = data.into_iter();
-        let count = it.len();
+        unsafe {
+            let it = data.into_iter();
+            let count = it.len();
 
-        let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
-        let dataptr = DATAPTR(vector) as *mut Self::Type;
-        it.enumerate().for_each(|(index, value)| {
-            *(dataptr.offset(index as isize)) = *value.as_ref();
-        });
+            let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
+            let dataptr = DATAPTR(vector) as *mut Self::Type;
+            it.enumerate().for_each(|(index, value)| {
+                *(dataptr.offset(index as isize)) = *value.as_ref();
+            });
 
-        Self::new_unchecked(vector)
+            Self::new_unchecked(vector)
+        }
     }
 
     fn data(&self) -> SEXP {

--- a/crates/harp/src/vector/raw_vector.rs
+++ b/crates/harp/src/vector/raw_vector.rs
@@ -34,22 +34,24 @@ impl Vector for RawVector {
         }
     }
 
-    unsafe fn create<T>(data: T) -> Self
+    fn create<T>(data: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::IntoIter: ExactSizeIterator,
         <T as IntoIterator>::Item: AsRef<Self::Item>,
     {
-        let it = data.into_iter();
-        let count = it.len();
+        unsafe {
+            let it = data.into_iter();
+            let count = it.len();
 
-        let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
-        let dataptr = DATAPTR(vector) as *mut Self::Type;
-        it.enumerate().for_each(|(index, value)| {
-            *(dataptr.offset(index as isize)) = *value.as_ref();
-        });
+            let vector = Rf_allocVector(Self::SEXPTYPE, count as R_xlen_t);
+            let dataptr = DATAPTR(vector) as *mut Self::Type;
+            it.enumerate().for_each(|(index, value)| {
+                *(dataptr.offset(index as isize)) = *value.as_ref();
+            });
 
-        Self::new_unchecked(vector)
+            Self::new_unchecked(vector)
+        }
     }
 
     fn data(&self) -> SEXP {


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/positron/issues/1326.

`parse_boundaries()` uses the R parser to detect the line boundaries of:

- Complete inputs (zero or more)
- Incomplete inputs (optional)
- Invalid inputs (optional)

The boundaries are for _lines of inputs_ rather than _expressions_. For instance, `foo; bar` has one input whereas `foo\nbar` has two inputs.

Invariants:
- Empty lines and lines containing only whitespace or comments are complete inputs.
- There is always at least one range since the empty string is a complete input.
- The ranges are sorted and non-overlapping.
- Inputs are classified in complete, incomplete, and error sections. The
  sections are sorted in this order (there cannot be complete inputs after
  an incomplete or error one, there cannot be an incomplete input after
  an error one, and error inputs are always trailing).
- There is only one incomplete and one error input in a set of inputs.

Approach:

I originally thought I'd use the parse data artifacts created by side effects to detect boundaries of complete expressions in case of incomplete and invalid inputs (see infrastructure implemented in #508). The goal was to avoid non-linear performance as the number of lines increases. I didn't end up doing that because the parse data is actually unusable for more complex cases than what I tried during my exploration.

Instead, I had to resort to parsing line by line. I start with the entire set of lines and back up one line at a time until the parse fully completes. Along the way I keep track of the error and incomplete sections of the input. In the most common cases (valid inputs, short incomplete input at the end), this should only require one or a few iterations. The boundaries of complete expressions are retrieved from the source references of the parsed expressions (using infrastructure from #482) and then transformed to complete inputs.

Supporting infrastructure:

- New `CharacterVector::slice()` method that returns a `&[SEXP]` and a corresponding `CharacterVector::TryFrom<&[SEXP]>` method. (Eventually `List` should gain those as well.) These methods make it easy to slice character vectors from the Rust side. I use this to shorten the vector of lines without having to start from a `&str` and reallocate `CHARSXP`s everytime.

- `SrcFile` can now be constructed from a `CharacterVector` with `TryFrom`.

- `Vector::create()` is no longer `unsafe`.

- `ArkRange::TryFrom<SrcRef>` method, although I didn't end up using it.