### PR TITLE
Bump tree-sitter-r 4 - Syntax vs Semantic Diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-r"
 version = "0.20.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f#63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=1370be1ef76a20a57bc38a28a2ab72ebeeab6342#1370be1ef76a20a57bc38a28a2ab72ebeeab6342"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,7 +2218,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2238,7 +2238,7 @@ checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2255,9 +2255,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -3190,21 +3190,29 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.22.6"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+checksum = "20f4cd3642c47a85052a887d86704f4eac272969f61b686bdd3f772122aabaff"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax 0.8.4",
+ "tree-sitter-language",
 ]
 
 [[package]]
+name = "tree-sitter-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
+
+[[package]]
 name = "tree-sitter-r"
-version = "1.0.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0#99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0"
+version = "1.1.0"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=2097fa502efa21349d26af0ffee55d773015e481#2097fa502efa21349d26af0ffee55d773015e481"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,8 +3200,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-r"
-version = "0.20.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=1370be1ef76a20a57bc38a28a2ab72ebeeab6342#1370be1ef76a20a57bc38a28a2ab72ebeeab6342"
+version = "1.0.1"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0#99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.22.6"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "1370be1ef76a20a57bc38a28a2ab72ebeeab6342" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.22.6"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "1370be1ef76a20a57bc38a28a2ab72ebeeab6342" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -47,8 +47,8 @@ serde_json = { version = "1.0.94", features = ["preserve_order"]}
 stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
-tree-sitter = "0.22.6"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0" }
+tree-sitter = "0.23.0"
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "2097fa502efa21349d26af0ffee55d773015e481" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -967,7 +967,7 @@ foo
     #[test]
     fn test_missing_namespace_rhs() {
         r_test(|| {
-            let text = "dplyr::";
+            let text = "base::";
             let document = Document::new(text, None);
             let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -939,14 +939,12 @@ foo
             assert_eq!(diagnostics.len(), 2);
 
             let diagnostic = diagnostics.get(0).unwrap();
-            assert!(diagnostic
-                .message
-                .starts_with("Unmatched closing delimiter"));
+            insta::assert_snapshot!(diagnostic.message);
             assert_eq!(diagnostic.range.start, Position::new(3, 2));
             assert_eq!(diagnostic.range.end, Position::new(3, 3));
 
             let diagnostic = diagnostics.get(1).unwrap();
-            assert!(diagnostic.message.starts_with("No symbol named 'foo'"));
+            insta::assert_snapshot!(diagnostic.message);
             assert_eq!(diagnostic.range.start, Position::new(1, 0));
             assert_eq!(diagnostic.range.end, Position::new(1, 3));
         })
@@ -974,7 +972,7 @@ foo
             let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);
             let diagnostic = diagnostics.get(0).unwrap();
-            assert!(diagnostic.message.contains("Missing a right hand side"));
+            insta::assert_snapshot!(diagnostic.message);
         })
     }
 
@@ -989,10 +987,7 @@ foo
 
             // Diagnostic highlights between the `2` and `3`
             let diagnostic = diagnostics.get(0).unwrap();
-            assert_eq!(
-                diagnostic.message,
-                "Expected ',' between expressions.".to_string()
-            );
+            insta::assert_snapshot!(diagnostic.message);
             assert_eq!(diagnostic.range.start, Position::new(0, 10));
             assert_eq!(diagnostic.range.end, Position::new(0, 11));
         })

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -478,7 +478,7 @@ fn recurse_namespace(
     if !context.installed_packages.contains(package.as_str()) {
         let range = lhs.range();
         let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
-        let message = format!("package '{}' is not installed", package);
+        let message = format!("Package '{}' is not installed.", package);
         let diagnostic = Diagnostic::new_simple(range, message);
         diagnostics.push(diagnostic);
     }
@@ -779,9 +779,9 @@ fn check_invalid_na_comparison(
 
         if matches!(contents, "NA" | "NaN" | "NULL") {
             let message = match contents {
-                "NA" => "consider using `is.na()` to check NA values",
-                "NaN" => "consider using `is.nan()` to check NaN values",
-                "NULL" => "consider using `is.null()` to check NULL values",
+                "NA" => "Consider using `is.na()` to check `NA` values",
+                "NaN" => "Consider using `is.nan()` to check `NaN` values.",
+                "NULL" => "Consider using `is.null()` to check `NULL` values.",
                 _ => continue,
             };
             let range = child.range();
@@ -820,7 +820,7 @@ fn check_unexpected_assignment_in_if_conditional(
 
     let range = condition.range();
     let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
-    let message = "unexpected '='; use '==' to compare values for equality";
+    let message = "Unexpected '='; use '==' to compare values for equality.";
     let diagnostic = Diagnostic::new_simple(range, message.into());
     diagnostics.push(diagnostic);
 
@@ -869,7 +869,7 @@ fn check_symbol_in_scope(
     let range = node.range();
     let range = convert_tree_sitter_range_to_lsp_range(context.contents, range);
     let identifier = context.contents.node_slice(&node)?.to_string();
-    let message = format!("no symbol named '{}' in scope", identifier);
+    let message = format!("No symbol named '{}' in scope.", identifier);
     let mut diagnostic = Diagnostic::new_simple(range, message);
     diagnostic.severity = Some(DiagnosticSeverity::WARNING);
     diagnostics.push(diagnostic);

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -26,7 +26,7 @@ use crate::lsp::encoding::convert_tree_sitter_range_to_lsp_range;
 use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::rope::RopeExt;
-use crate::treesitter::node_has_error;
+use crate::treesitter::node_has_error_or_missing;
 use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
@@ -182,7 +182,7 @@ fn semantic_diagnostics(
     let mut cursor = root.walk();
 
     for child in root.children(&mut cursor) {
-        if node_has_error(&child) {
+        if node_has_error_or_missing(&child) {
             continue;
         }
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -939,7 +939,9 @@ foo
             assert_eq!(diagnostics.len(), 2);
 
             let diagnostic = diagnostics.get(0).unwrap();
-            assert!(diagnostic.message.starts_with("Unmatched closing token"));
+            assert!(diagnostic
+                .message
+                .starts_with("Unmatched closing delimiter"));
             assert_eq!(diagnostic.range.start, Position::new(3, 2));
             assert_eq!(diagnostic.range.end, Position::new(3, 3));
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -20,7 +20,7 @@ use tree_sitter::Node;
 use tree_sitter::Range;
 
 use crate::lsp::declarations::top_level_declare;
-use crate::lsp::diagnostics_syntactic::syntax_diagnostics;
+use crate::lsp::diagnostics_syntax::syntax_diagnostics;
 use crate::lsp::documents::Document;
 use crate::lsp::encoding::convert_tree_sitter_range_to_lsp_range;
 use crate::lsp::indexer;
@@ -479,7 +479,7 @@ fn recurse_namespace(
     // This is really a syntax issue, but the RHS is optional in the grammar,
     // so `dplyr::` is technically allowed and we have to check for this in
     // the semantic path instead.
-    crate::lsp::diagnostics_syntactic::diagnose_missing_namespace_operator(
+    crate::lsp::diagnostics_syntax::diagnose_missing_namespace_operator(
         node,
         context,
         diagnostics,

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -26,6 +26,7 @@ use crate::lsp::encoding::convert_tree_sitter_range_to_lsp_range;
 use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::rope::RopeExt;
+use crate::treesitter::node_has_error;
 use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
@@ -181,7 +182,7 @@ fn semantic_diagnostics(
     let mut cursor = root.walk();
 
     for child in root.children(&mut cursor) {
-        if child.has_error() {
+        if node_has_error(&child) {
             continue;
         }
 
@@ -938,7 +939,7 @@ foo
             assert_eq!(diagnostics.len(), 2);
 
             let diagnostic = diagnostics.get(0).unwrap();
-            assert!(diagnostic.message.starts_with("Syntax error"));
+            assert!(diagnostic.message.starts_with("Unmatched closing token"));
             assert_eq!(diagnostic.range.start, Position::new(3, 2));
             assert_eq!(diagnostic.range.end, Position::new(3, 3));
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -150,7 +150,7 @@ pub(crate) fn generate_diagnostics(doc: Document, state: WorldState) -> Vec<Diag
     let root = doc.ast.root_node();
 
     // Collect syntax related diagnostics for `ERROR` and `MISSING` nodes
-    match syntax_diagnostics(root, &mut context) {
+    match syntax_diagnostics(root, &context) {
         Ok(mut syntax_diagnostics) => diagnostics.append(&mut syntax_diagnostics),
         Err(err) => log::error!("Error while generating syntax diagnostics: {err:?}"),
     }

--- a/crates/ark/src/lsp/diagnostics_syntactic.rs
+++ b/crates/ark/src/lsp/diagnostics_syntactic.rs
@@ -84,23 +84,23 @@ fn diagnose_error(
     }
 
     if report {
-        diagnostics.push(build_syntax_diagnostic(node, context)?);
+        diagnostics.push(syntax_diagnostic(node, context)?);
     }
 
     Ok(())
 }
 
-fn build_syntax_diagnostic(node: Node, context: &DiagnosticContext) -> anyhow::Result<Diagnostic> {
-    if let Some(diagnostic) = build_syntax_diagnostic_missing_open(node, context)? {
+fn syntax_diagnostic(node: Node, context: &DiagnosticContext) -> anyhow::Result<Diagnostic> {
+    if let Some(diagnostic) = syntax_diagnostic_missing_open(node, context)? {
         return Ok(diagnostic);
     }
 
-    Ok(build_syntax_diagnostic_default(node, context))
+    Ok(syntax_diagnostic_default(node, context))
 }
 
 // Use a heuristic that if we see a syntax error and it just contains a `)`, `}`, or `]`,
 // then it is probably a case of missing a matching open token.
-fn build_syntax_diagnostic_missing_open(
+fn syntax_diagnostic_missing_open(
     node: Node,
     context: &DiagnosticContext,
 ) -> anyhow::Result<Option<Diagnostic>> {
@@ -124,12 +124,12 @@ fn build_syntax_diagnostic_missing_open(
     )))
 }
 
-fn build_syntax_diagnostic_default(node: Node, context: &DiagnosticContext) -> Diagnostic {
+fn syntax_diagnostic_default(node: Node, context: &DiagnosticContext) -> Diagnostic {
     let range = node.range();
     let row_span = range.end_point.row - range.start_point.row;
 
     if row_span >= 20 {
-        return build_syntax_diagnostic_truncated_default(range, context);
+        return syntax_diagnostic_truncated_default(range, context);
     }
 
     // The most common case, a localized syntax error that doesn't span too many rows
@@ -139,10 +139,7 @@ fn build_syntax_diagnostic_default(node: Node, context: &DiagnosticContext) -> D
 
 // If the syntax error spans more than 20 rows, just target the starting position
 // to avoid overwhelming the user.
-fn build_syntax_diagnostic_truncated_default(
-    range: Range,
-    context: &DiagnosticContext,
-) -> Diagnostic {
+fn syntax_diagnostic_truncated_default(range: Range, context: &DiagnosticContext) -> Diagnostic {
     // In theory this is an empty range, as they are constructed like `[ )`, but it
     // seems to work for the purpose of diagnostics, and getting the correct
     // coordinates exactly right seems challenging.

--- a/crates/ark/src/lsp/diagnostics_syntactic.rs
+++ b/crates/ark/src/lsp/diagnostics_syntactic.rs
@@ -335,8 +335,8 @@ mod tests {
 
     fn text_diagnostics(text: &str) -> Vec<Diagnostic> {
         let document = Document::new(text, None);
-        let mut context = DiagnosticContext::new(&document.contents);
-        let diagnostics = syntax_diagnostics(document.ast.root_node(), &mut context).unwrap();
+        let context = DiagnosticContext::new(&document.contents);
+        let diagnostics = syntax_diagnostics(document.ast.root_node(), &context).unwrap();
         diagnostics
     }
 

--- a/crates/ark/src/lsp/diagnostics_syntactic.rs
+++ b/crates/ark/src/lsp/diagnostics_syntactic.rs
@@ -18,7 +18,7 @@ use crate::treesitter::NodeTypeExt;
 
 pub(crate) fn syntax_diagnostics(
     root: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
 ) -> anyhow::Result<Vec<Diagnostic>> {
     let mut diagnostics = Vec::new();
 
@@ -29,7 +29,7 @@ pub(crate) fn syntax_diagnostics(
 
 fn recurse(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     if !node_has_error(&node) {
@@ -50,7 +50,7 @@ fn recurse(
 
 fn recurse_children(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     let mut cursor = node.walk();
@@ -67,7 +67,7 @@ fn recurse_children(
 // nodes and only report syntax errors for those.
 fn diagnose_error(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     let mut report = node.is_error();
@@ -90,10 +90,7 @@ fn diagnose_error(
     Ok(())
 }
 
-fn build_syntax_diagnostic(
-    node: Node,
-    context: &mut DiagnosticContext,
-) -> anyhow::Result<Diagnostic> {
+fn build_syntax_diagnostic(node: Node, context: &DiagnosticContext) -> anyhow::Result<Diagnostic> {
     if let Some(diagnostic) = build_syntax_diagnostic_missing_open(node, context)? {
         return Ok(diagnostic);
     }
@@ -136,7 +133,7 @@ fn build_syntax_diagnostic_default(node: Node, context: &DiagnosticContext) -> D
 
 fn diagnose_missing(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     match node.node_type() {
@@ -157,7 +154,7 @@ fn diagnose_missing(
 
 fn diagnose_missing_parameters(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     diagnose_missing_close(node, context, diagnostics, ")")
@@ -165,7 +162,7 @@ fn diagnose_missing_parameters(
 
 fn diagnose_missing_braced_expression(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     diagnose_missing_close(node, context, diagnostics, "}")
@@ -173,7 +170,7 @@ fn diagnose_missing_braced_expression(
 
 fn diagnose_missing_parenthesized_expression(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     diagnose_missing_close(node, context, diagnostics, ")")
@@ -181,7 +178,7 @@ fn diagnose_missing_parenthesized_expression(
 
 fn diagnose_missing_call(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     diagnose_missing_call_like(node, context, diagnostics, ")")
@@ -189,7 +186,7 @@ fn diagnose_missing_call(
 
 fn diagnose_missing_subset(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     diagnose_missing_call_like(node, context, diagnostics, "]")
@@ -197,7 +194,7 @@ fn diagnose_missing_subset(
 
 fn diagnose_missing_subset2(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     diagnose_missing_call_like(node, context, diagnostics, "]]")
@@ -205,7 +202,7 @@ fn diagnose_missing_subset2(
 
 fn diagnose_missing_call_like(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
     close_token: &str,
 ) -> anyhow::Result<()> {
@@ -218,7 +215,7 @@ fn diagnose_missing_call_like(
 
 fn diagnose_missing_binary_operator(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     let Some(rhs) = node.child_by_field_name("rhs") else {
@@ -253,7 +250,7 @@ fn diagnose_missing_binary_operator(
 // in the semantic path.
 pub(crate) fn diagnose_missing_namespace_operator(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> anyhow::Result<()> {
     let None = node.child_by_field_name("rhs") else {
@@ -278,7 +275,7 @@ pub(crate) fn diagnose_missing_namespace_operator(
 // `node` must have required `"open"` and `"close"` fields
 fn diagnose_missing_close(
     node: Node,
-    context: &mut DiagnosticContext,
+    context: &DiagnosticContext,
     diagnostics: &mut Vec<Diagnostic>,
     close_token: &str,
 ) -> anyhow::Result<()> {

--- a/crates/ark/src/lsp/diagnostics_syntactic.rs
+++ b/crates/ark/src/lsp/diagnostics_syntactic.rs
@@ -16,12 +16,12 @@ use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
 pub(crate) fn syntax_diagnostics(
-    node: Node,
+    root: Node,
     context: &mut DiagnosticContext,
 ) -> anyhow::Result<Vec<Diagnostic>> {
     let mut diagnostics = Vec::new();
 
-    recurse(node, context, &mut diagnostics)?;
+    recurse(root, context, &mut diagnostics)?;
 
     Ok(diagnostics)
 }

--- a/crates/ark/src/lsp/diagnostics_syntactic.rs
+++ b/crates/ark/src/lsp/diagnostics_syntactic.rs
@@ -152,7 +152,7 @@ fn syntax_diagnostic_truncated_default(range: Range, context: &DiagnosticContext
 
     // `+1` because it is user facing and editor UI is 1-indexed
     let end_row = range.end_point.row + 1;
-    let message = format!("Syntax error. Starts here and ends on row {end_row}.");
+    let message = format!("Syntax error. Starts here and ends on line {end_row}.");
 
     new_syntax_diagnostic(message, start_range, &context)
 }
@@ -375,7 +375,7 @@ mod tests {
         let diagnostic = diagnostics.get(0).unwrap();
         assert_eq!(
             diagnostic.message,
-            String::from("Syntax error. Starts here and ends on row 21.")
+            String::from("Syntax error. Starts here and ends on line 21.")
         );
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 0));

--- a/crates/ark/src/lsp/diagnostics_syntax.rs
+++ b/crates/ark/src/lsp/diagnostics_syntax.rs
@@ -373,10 +373,7 @@ mod tests {
         let text = String::from("('") + newlines.as_str() + ")";
         let diagnostics = text_diagnostics(text.as_str());
         let diagnostic = diagnostics.get(0).unwrap();
-        assert_eq!(
-            diagnostic.message,
-            String::from("Syntax error. Starts here and ends on line 21.")
-        );
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 0));
     }
@@ -388,21 +385,21 @@ mod tests {
         let diagnostic = diagnostics.get(0).unwrap();
         assert_eq!(diagnostic.range.start, Position::new(0, 5));
         assert_eq!(diagnostic.range.end, Position::new(0, 6));
-        assert!(diagnostic.message.starts_with("Unmatched opening"));
+        insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("foo[a, b");
         assert_eq!(diagnostics.len(), 1);
         let diagnostic = diagnostics.get(0).unwrap();
         assert_eq!(diagnostic.range.start, Position::new(0, 3));
         assert_eq!(diagnostic.range.end, Position::new(0, 4));
-        assert!(diagnostic.message.starts_with("Unmatched opening"));
+        insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("foo[[a, b");
         assert_eq!(diagnostics.len(), 1);
         let diagnostic = diagnostics.get(0).unwrap();
         assert_eq!(diagnostic.range.start, Position::new(0, 3));
         assert_eq!(diagnostic.range.end, Position::new(0, 5));
-        assert!(diagnostic.message.starts_with("Unmatched opening"));
+        insta::assert_snapshot!(diagnostic.message);
     }
 
     #[test]
@@ -421,7 +418,7 @@ identity(1)
 
         // Diagnostic highlights the unmatched `(`
         let diagnostic = diagnostics.get(0).unwrap();
-        assert!(diagnostic.message.starts_with("Unmatched opening"));
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(1, 5));
         assert_eq!(diagnostic.range.end, Position::new(1, 6));
     }
@@ -430,19 +427,13 @@ identity(1)
     fn test_unmatched_braces() {
         let diagnostics = text_diagnostics("{");
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics
-            .get(0)
-            .unwrap()
-            .message
-            .starts_with("Syntax error"));
+        let diagnostic = diagnostics.get(0).unwrap();
+        insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("{ 1 + 2");
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics
-            .get(0)
-            .unwrap()
-            .message
-            .starts_with("Unmatched opening"));
+        let diagnostic = diagnostics.get(0).unwrap();
+        insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("{}");
         assert!(diagnostics.is_empty());
@@ -455,19 +446,13 @@ identity(1)
     fn test_unmatched_parentheses() {
         let diagnostics = text_diagnostics("(");
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics
-            .get(0)
-            .unwrap()
-            .message
-            .starts_with("Syntax error"));
+        let diagnostic = diagnostics.get(0).unwrap();
+        insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("( 1 + 2");
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics
-            .get(0)
-            .unwrap()
-            .message
-            .starts_with("Unmatched opening"));
+        let diagnostic = diagnostics.get(0).unwrap();
+        insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("()");
         assert!(diagnostics.is_empty());
@@ -483,31 +468,25 @@ identity(1)
         let diagnostics = text_diagnostics("sum(1 * 2 + )");
         assert_eq!(diagnostics.len(), 1);
         let diagnostic = diagnostics.get(0).unwrap();
-        assert_eq!(
-            diagnostic.message,
-            "Unmatched closing delimiter. Missing an opening '('."
-        );
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 12));
         assert_eq!(diagnostic.range.end, Position::new(0, 13));
     }
 
     #[test]
     fn test_unmatched_closing_token() {
-        let open = vec!["{", "(", "["];
         let close = vec!["}", ")", "]"];
-        let iter = std::iter::zip(open.iter(), close.iter());
 
-        for (open, close) in iter {
+        for delimiter in close.iter() {
             // i.e. `1 + 1 }`
-            let text = format!("1 + 1 {close}");
+            let text = format!("1 + 1 {delimiter}");
 
             let diagnostics = text_diagnostics(text.as_str());
             assert_eq!(diagnostics.len(), 1);
 
             // Diagnostic highlights the `{delimiter}`
-            let message = format!("Unmatched closing delimiter. Missing an opening '{open}'.");
             let diagnostic = diagnostics.get(0).unwrap();
-            assert_eq!(diagnostic.message, message);
+            insta::assert_snapshot!(diagnostic.message);
             assert_eq!(diagnostic.range.start, Position::new(0, 6));
             assert_eq!(diagnostic.range.end, Position::new(0, 7));
         }
@@ -520,9 +499,7 @@ identity(1)
         let text = "1 + }";
         let diagnostics = text_diagnostics(text);
         let diagnostic = diagnostics.get(0).unwrap();
-        assert!(diagnostic
-            .message
-            .starts_with("Unmatched closing delimiter"));
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 4));
         assert_eq!(diagnostic.range.end, Position::new(0, 5));
     }
@@ -540,10 +517,7 @@ identity(1)
         assert_eq!(diagnostics.len(), 1);
 
         let diagnostic = diagnostics.get(0).unwrap();
-        assert_eq!(
-            diagnostic.message,
-            String::from("Unmatched closing delimiter. Missing an opening '{'.")
-        );
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(3, 0));
         assert_eq!(diagnostic.range.end, Position::new(3, 1));
     }
@@ -561,14 +535,12 @@ function(x {
         assert_eq!(diagnostics.len(), 2);
 
         let diagnostic = diagnostics.get(0).unwrap();
-        assert!(diagnostic.message.starts_with("Syntax error"));
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(1, 11));
         assert_eq!(diagnostic.range.end, Position::new(1, 12));
 
         let diagnostic = diagnostics.get(1).unwrap();
-        assert!(diagnostic
-            .message
-            .starts_with("Unmatched closing delimiter"));
+        insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(3, 0));
         assert_eq!(diagnostic.range.end, Position::new(3, 1));
     }

--- a/crates/ark/src/lsp/diagnostics_syntax.rs
+++ b/crates/ark/src/lsp/diagnostics_syntax.rs
@@ -332,7 +332,7 @@ fn new_missing_open_diagnostic(
     range: Range,
     context: &DiagnosticContext,
 ) -> Diagnostic {
-    let message = format!("Unmatched closing token. Missing an opening '{open_token}'.");
+    let message = format!("Unmatched closing delimiter. Missing an opening '{open_token}'.");
     new_syntax_diagnostic(message, range, context)
 }
 
@@ -341,7 +341,7 @@ fn new_missing_close_diagnostic(
     range: Range,
     context: &DiagnosticContext,
 ) -> Diagnostic {
-    let message = format!("Unmatched opening token. Missing a closing '{close_token}'.");
+    let message = format!("Unmatched opening delimiter. Missing a closing '{close_token}'.");
     new_syntax_diagnostic(message, range, context)
 }
 
@@ -485,7 +485,7 @@ identity(1)
         let diagnostic = diagnostics.get(0).unwrap();
         assert_eq!(
             diagnostic.message,
-            "Unmatched closing token. Missing an opening '('."
+            "Unmatched closing delimiter. Missing an opening '('."
         );
         assert_eq!(diagnostic.range.start, Position::new(0, 12));
         assert_eq!(diagnostic.range.end, Position::new(0, 13));
@@ -504,8 +504,8 @@ identity(1)
             let diagnostics = text_diagnostics(text.as_str());
             assert_eq!(diagnostics.len(), 1);
 
-            // Diagnostic highlights the `{token}`
-            let message = format!("Unmatched closing token. Missing an opening '{open}'.");
+            // Diagnostic highlights the `{delimiter}`
+            let message = format!("Unmatched closing delimiter. Missing an opening '{open}'.");
             let diagnostic = diagnostics.get(0).unwrap();
             assert_eq!(diagnostic.message, message);
             assert_eq!(diagnostic.range.start, Position::new(0, 6));
@@ -520,7 +520,9 @@ identity(1)
         let text = "1 + }";
         let diagnostics = text_diagnostics(text);
         let diagnostic = diagnostics.get(0).unwrap();
-        assert!(diagnostic.message.starts_with("Unmatched closing token"));
+        assert!(diagnostic
+            .message
+            .starts_with("Unmatched closing delimiter"));
         assert_eq!(diagnostic.range.start, Position::new(0, 4));
         assert_eq!(diagnostic.range.end, Position::new(0, 5));
     }
@@ -540,7 +542,7 @@ identity(1)
         let diagnostic = diagnostics.get(0).unwrap();
         assert_eq!(
             diagnostic.message,
-            String::from("Unmatched closing token. Missing an opening '{'.")
+            String::from("Unmatched closing delimiter. Missing an opening '{'.")
         );
         assert_eq!(diagnostic.range.start, Position::new(3, 0));
         assert_eq!(diagnostic.range.end, Position::new(3, 1));
@@ -564,7 +566,9 @@ function(x {
         assert_eq!(diagnostic.range.end, Position::new(1, 12));
 
         let diagnostic = diagnostics.get(1).unwrap();
-        assert!(diagnostic.message.starts_with("Unmatched closing token"));
+        assert!(diagnostic
+            .message
+            .starts_with("Unmatched closing delimiter"));
         assert_eq!(diagnostic.range.start, Position::new(3, 0));
         assert_eq!(diagnostic.range.end, Position::new(3, 1));
     }

--- a/crates/ark/src/lsp/diagnostics_syntax.rs
+++ b/crates/ark/src/lsp/diagnostics_syntax.rs
@@ -1,5 +1,5 @@
 //
-// diagnostics_syntactic.rs
+// diagnostics_syntax.rs
 //
 // Copyright (C) 2024 Posit Software, PBC. All rights reserved.
 //
@@ -356,7 +356,7 @@ mod tests {
     use tower_lsp::lsp_types::Position;
 
     use crate::lsp::diagnostics::DiagnosticContext;
-    use crate::lsp::diagnostics_syntactic::syntax_diagnostics;
+    use crate::lsp::diagnostics_syntax::syntax_diagnostics;
     use crate::lsp::documents::Document;
 
     fn text_diagnostics(text: &str) -> Vec<Diagnostic> {

--- a/crates/ark/src/lsp/documents.rs
+++ b/crates/ark/src/lsp/documents.rs
@@ -64,9 +64,10 @@ impl Document {
     pub fn new(contents: &str, version: Option<i32>) -> Self {
         // A one-shot parser, assumes the `Document` won't be incrementally reparsed.
         // Useful for testing, `with_document()`, and `index_file()`.
-        let language = tree_sitter_r::language();
         let mut parser = Parser::new();
-        parser.set_language(&language).unwrap();
+        parser
+            .set_language(&tree_sitter_r::LANGUAGE.into())
+            .unwrap();
 
         Self::new_with_parser(contents, &mut parser, version)
     }
@@ -223,5 +224,12 @@ mod tests {
 
         let point = compute_point(Point::new(0, 0), "abcdefghi\n");
         assert_eq!(point, Point::new(1, 0));
+    }
+
+    #[test]
+    fn test_document_starts_at_0_0_with_leading_whitespace() {
+        let document = Document::new("\n\n# hi there", None);
+        let root = document.ast.root_node();
+        assert_eq!(root.start_position(), Point::new(0, 0));
     }
 }

--- a/crates/ark/src/lsp/help_topic.rs
+++ b/crates/ark/src/lsp/help_topic.rs
@@ -105,11 +105,9 @@ mod tests {
 
     #[test]
     fn test_locate_help_node() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         // On the RHS

--- a/crates/ark/src/lsp/mod.rs
+++ b/crates/ark/src/lsp/mod.rs
@@ -12,7 +12,7 @@ mod config;
 mod declarations;
 pub mod definitions;
 pub mod diagnostics;
-pub mod diagnostics_syntactic;
+pub mod diagnostics_syntax;
 pub mod document_context;
 pub mod documents;
 pub mod encoding;

--- a/crates/ark/src/lsp/mod.rs
+++ b/crates/ark/src/lsp/mod.rs
@@ -12,6 +12,7 @@ mod config;
 mod declarations;
 pub mod definitions;
 pub mod diagnostics;
+pub mod diagnostics_syntactic;
 pub mod document_context;
 pub mod documents;
 pub mod encoding;

--- a/crates/ark/src/lsp/selection_range.rs
+++ b/crates/ark/src/lsp/selection_range.rs
@@ -139,11 +139,9 @@ mod tests {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();
@@ -158,7 +156,7 @@ mod tests {
         assert_eq!(selection.range.end_point, Point::new(3, 1));
 
         let selection = selection.parent.as_ref().unwrap();
-        assert_eq!(selection.range.start_point, Point::new(1, 0));
+        assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
     }
@@ -176,11 +174,9 @@ mod tests {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();
@@ -191,7 +187,7 @@ mod tests {
 
         // Just 1 selection, the whole document
         let selection = selections.get(0).unwrap();
-        assert_eq!(selection.range.start_point, Point::new(1, 0));
+        assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
     }
@@ -209,12 +205,10 @@ fn <- function(x, arg) {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         // create a parser for this document
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();
@@ -250,7 +244,7 @@ fn <- function(x, arg) {
 
         // Whole document
         let selection = selection.parent.as_ref().unwrap();
-        assert_eq!(selection.range.start_point, Point::new(1, 0));
+        assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
     }
@@ -258,11 +252,9 @@ fn <- function(x, arg) {
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_assignment() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let text = "
@@ -295,11 +287,9 @@ fn <- function() {
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_call_arguments() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "
@@ -337,11 +327,9 @@ fn(@a, b, c)
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_subset_arguments() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "
@@ -384,11 +372,9 @@ x[a, @fn(), c]
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_subset2_arguments() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "
@@ -431,11 +417,9 @@ x[[a, @fn(), c]]
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_namespaced_calls() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__expression_after_call_argument.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__expression_after_call_argument.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics.rs
+expression: diagnostic.message
+---
+Expected ',' between expressions.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__missing_namespace_rhs.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__missing_namespace_rhs.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics.rs
+expression: diagnostic.message
+---
+Invalid namespace operator '::'. Missing a right hand side.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__mixed_syntax_and_semantic_diagnostics-2.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__mixed_syntax_and_semantic_diagnostics-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics.rs
+expression: diagnostic.message
+---
+No symbol named 'foo' in scope.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__mixed_syntax_and_semantic_diagnostics.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics__tests__mixed_syntax_and_semantic_diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '{'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__error_precision.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__error_precision.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '('.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__syntax_error_truncation.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__syntax_error_truncation.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Syntax error. Starts here and ends on line 21.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_binary_operator.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_binary_operator.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '{'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_braces-2.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_braces-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched opening delimiter. Missing a closing '}'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_braces.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_braces.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Syntax error

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter-2.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched opening delimiter. Missing a closing ']'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter-3.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter-3.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched opening delimiter. Missing a closing ']]'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched opening delimiter. Missing a closing ')'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter_with_trailing_info.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_call_delimiter_with_trailing_info.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched opening delimiter. Missing a closing ')'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token-2.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '('.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token-3.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token-3.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '['.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '{'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token_precision.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_closing_token_precision.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '{'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_function_parameters_parentheses-2.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_function_parameters_parentheses-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched closing delimiter. Missing an opening '{'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_function_parameters_parentheses.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_function_parameters_parentheses.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Syntax error

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_parentheses-2.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_parentheses-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Unmatched opening delimiter. Missing a closing ')'.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_parentheses.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__diagnostics_syntax__tests__unmatched_parentheses.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/diagnostics_syntax.rs
+expression: diagnostic.message
+---
+Syntax error

--- a/crates/ark/src/lsp/snapshots/indent.R
+++ b/crates/ark/src/lsp/snapshots/indent.R
@@ -553,29 +553,27 @@ object[(
 }
 
 ## 3
-# TODO: Needs https://github.com/r-lib/tree-sitter-r/pull/142 first.
-# {
-#   if (condition)
-#   {
-#     stuff1
-#   } else
-#   {
-#     stuff2
-#   }
-# }
+{
+  if (condition)
+  {
+    stuff1
+  } else
+  {
+    stuff2
+  }
+}
 
 ## 4
-# TODO: Needs https://github.com/r-lib/tree-sitter-r/pull/142 first.
-# {
-#   if (condition)
-#   {
-#     stuff1
-#   }
-#   else
-#   {
-#     stuff2
-#   }
-# }
+{
+  if (condition)
+  {
+    stuff1
+  }
+  else
+  {
+    stuff2
+  }
+}
 
 ## 5
 {

--- a/crates/ark/src/lsp/snapshots/indent.R
+++ b/crates/ark/src/lsp/snapshots/indent.R
@@ -1098,11 +1098,11 @@ fun_call(object1 + object2 ~ object3 +
            argument)
 
 ## 32
-fun_call(object ~
+fun_call(~ object
   )
 
 ## 33
-fun_call(object +
+fun_call(object + object2
   )
 
 ## 34

--- a/crates/ark/src/lsp/snapshots/indent.R
+++ b/crates/ark/src/lsp/snapshots/indent.R
@@ -471,7 +471,7 @@ fun_call(argument,
     
     stuff
   }
-}
+)
 
 ## 22
 function_call()
@@ -519,7 +519,7 @@ object[(
   ][
     argument4,
     fun_call1(argument1,
-      argument2)
+      argument2),
     argument5
   ][
     argument6,
@@ -553,27 +553,29 @@ object[(
 }
 
 ## 3
-{
-  if (condition)
-  {
-    stuff1
-  } else
-  {
-    stuff2
-  }
-}
+# TODO: Needs https://github.com/r-lib/tree-sitter-r/pull/142 first.
+# {
+#   if (condition)
+#   {
+#     stuff1
+#   } else
+#   {
+#     stuff2
+#   }
+# }
 
 ## 4
-{
-  if (condition)
-  {
-    stuff1
-  }
-  else
-  {
-    stuff2
-  }
-}
+# TODO: Needs https://github.com/r-lib/tree-sitter-r/pull/142 first.
+# {
+#   if (condition)
+#   {
+#     stuff1
+#   }
+#   else
+#   {
+#     stuff2
+#   }
+# }
 
 ## 5
 {
@@ -585,7 +587,7 @@ object[(
 
 ## 6
 {
-  for (sequence) {
+  for (i in sequence) {
     stuff
   }
 }
@@ -595,7 +597,7 @@ if (condition)
   stuff
 
 ## 8
-for (sequence)
+for (i in sequence)
   stuff
 
 ## 9
@@ -755,13 +757,13 @@ else
 ## 23
 if (cond1)
   if (cond2)
-    for (sequence1)
+    for (i in sequence1)
       if (cond3)
         stuff1
 else
   stuff2
 else if (cond4)
-  for (sequence2)
+  for (i in sequence2)
     stuff3
 else
   if (cond5)
@@ -1292,8 +1294,3 @@ fun_call(
     ifelse(condition2, argument2,
       ifelse))
 )
-
-## 11
-1:10 |>
-  x => 2 ** x %>%
-  sum()

--- a/crates/ark/src/lsp/snapshots/indent.R
+++ b/crates/ark/src/lsp/snapshots/indent.R
@@ -697,19 +697,23 @@ while(condition)
   stuff
 
 ## 18
-if (condition1)
-  stuff1
-else
-  if (condition2) {
-    stuff2
-  }
+{
+  if (condition1)
+    stuff1
+  else
+    if (condition2) {
+      stuff2
+    }
+}
 
 ## 19
-object <-
-  if (condition)
-    fun_call()[index]
-else
-  stuff
+{
+  object <-
+    if (condition)
+      fun_call()[index]
+  else
+    stuff
+}
 
 ## 20
 funcall({
@@ -728,58 +732,64 @@ fun_call(argument,
   })
 
 ## 22
-if (cond1)
-  if (cond2)
-    if (cond3)
-      stuff1
-else if (cond4)
-  stuff2
-else
-  if (cond5)
-    stuff3
-else
-  stuff4
-else if (cond6)
-  stuff5
-else
-  if (cond7)
-    stuff6
-else
-  stuff7
-else if (cond8)
-  stuff8
-else
-  if (cond9)
-    stuff9
-else
-  stuff10
-
-## 23
-if (cond1)
-  if (cond2)
-    for (i in sequence1)
+{
+  if (cond1)
+    if (cond2)
       if (cond3)
         stuff1
-else
-  stuff2
-else if (cond4)
-  for (i in sequence2)
-    stuff3
-else
-  if (cond5)
-    fun_call(
-      argument
-    )
-else
-  stuff5
-else
-  stuff6
+  else if (cond4)
+    stuff2
+  else
+    if (cond5)
+      stuff3
+  else
+    stuff4
+  else if (cond6)
+    stuff5
+  else
+    if (cond7)
+      stuff6
+  else
+    stuff7
+  else if (cond8)
+    stuff8
+  else
+    if (cond9)
+      stuff9
+  else
+    stuff10
+}
+
+## 23
+{
+  if (cond1)
+    if (cond2)
+      for (i in sequence1)
+        if (cond3)
+          stuff1
+  else
+    stuff2
+  else if (cond4)
+    for (i in sequence2)
+      stuff3
+  else
+    if (cond5)
+      fun_call(
+        argument
+      )
+  else
+    stuff5
+  else
+    stuff6
+}
 
 ## 24
-object <- if(cond)
-            stuff1
-else
-  stuff2
+{
+  object <- if(cond)
+              stuff1
+  else
+    stuff2
+}
 
 ## 25
 if (condition) {
@@ -798,11 +808,13 @@ if (condition) {
 }
 
 ## 27
-object <- if (condition) {
-  stuff1
-}
-else {
-  stuff2
+{
+  object <- if (condition) {
+    stuff1
+  }
+  else {
+    stuff2
+  }
 }
 
 ## 28
@@ -811,15 +823,16 @@ if (condition)
     stuff
 
 ## 29
-if (condition1)
-  object <-
-    if (condition2)
-      stuff1
-else
-  stuff2
-else
-  stuff3
-
+{
+  if (condition1)
+    object <-
+      if (condition2)
+        stuff1
+  else
+    stuff2
+  else
+    stuff3
+}
 
 ### Continuation lines
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -165,9 +165,10 @@ pub(crate) fn did_open(
     let uri = params.text_document.uri;
     let version = params.text_document.version;
 
-    let language = tree_sitter_r::language();
     let mut parser = Parser::new();
-    parser.set_language(&language).unwrap();
+    parser
+        .set_language(&tree_sitter_r::LANGUAGE.into())
+        .unwrap();
 
     let document = Document::new_with_parser(contents, &mut parser, Some(version));
 

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -509,6 +509,8 @@ fn test_statement_range() {
     // by tree-sitter. It is generally best to left align the string against the
     // far left margin to avoid unexpected whitespace and mimic real life.
     fn statement_range_test(x: &str) {
+        let original = x;
+
         let lines = x.split("\n").collect::<Vec<&str>>();
 
         let mut cursor: Option<Point> = None;
@@ -649,11 +651,9 @@ fn test_statement_range() {
         let x = x.replace("@", "");
         let x = x.replace(">>", "");
 
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("Failed to create parser");
 
         let ast = parser.parse(x, None).unwrap();
@@ -662,8 +662,8 @@ fn test_statement_range() {
 
         let node = find_statement_range_node(&root, cursor.unwrap().row).unwrap();
 
-        assert_eq!(node.start_position(), sel_start.unwrap());
-        assert_eq!(node.end_position(), sel_end.unwrap());
+        assert_eq!(node.start_position(), sel_start.unwrap(), "Failed on test {original}");
+        assert_eq!(node.end_position(), sel_end.unwrap(), "Failed on test {original}");
     }
 
     // Simple test
@@ -1286,10 +1286,9 @@ test_that('stuff', {
 
 
 ";
-    let language = tree_sitter_r::language();
     let mut parser = Parser::new();
     parser
-        .set_language(&language)
+        .set_language(&tree_sitter_r::LANGUAGE.into())
         .expect("Failed to create parser");
     let ast = parser.parse(contents, None).unwrap();
     let root = ast.root_node();
@@ -1304,10 +1303,9 @@ test_that('stuff', {
 
 }
 ";
-    let language = tree_sitter_r::language();
     let mut parser = Parser::new();
     parser
-        .set_language(&language)
+        .set_language(&tree_sitter_r::LANGUAGE.into())
         .expect("Failed to create parser");
     let ast = parser.parse(contents, None).unwrap();
     let root = ast.root_node();

--- a/crates/ark/src/lsp/traits/node.rs
+++ b/crates/ark/src/lsp/traits/node.rs
@@ -287,12 +287,10 @@ fn <- function(x, arg) {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         // create a parser for this document
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -392,7 +392,7 @@ pub(crate) fn node_text(node: &Node, contents: &ropey::Rope) -> Option<String> {
     contents.node_slice(node).ok().map(|f| f.to_string())
 }
 
-pub(crate) fn node_has_error(node: &Node) -> bool {
+pub(crate) fn node_has_error_or_missing(node: &Node) -> bool {
     // According to the docs, `node.has_error()` should return `true`
     // if `node` is itself an error, or if it contains any errors, but that
     // doesn't seem to be the case for terminal ERROR nodes.

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -401,15 +401,13 @@ pub(crate) fn node_has_error(node: &Node) -> bool {
 }
 
 pub(crate) fn node_find_string<'a>(node: &'a Node) -> Option<Node<'a>> {
-    if node.is_string() {
-        // Already on a string
-        return Some(*node);
-    }
     // If we are on one of the following, we return the string parent:
     // - Anonymous node inside a string, like `"'"`
     // - `NodeType::StringContent`
     // - `NodeType::EscapeSequence`
-    node.ancestors().find(|parent| parent.is_string())
+    // Note that `ancestors()` is actually inclusive, so the original `node`
+    // is also considered as a potential string here.
+    node.ancestors().find(|node| node.is_string())
 }
 
 pub(crate) fn node_in_string(node: &Node) -> bool {

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -44,7 +44,6 @@ pub enum NodeType {
     Na(NaType),
     Comment,
     Comma,
-    UnmatchedDelimiter(UnmatchedDelimiterType),
     Error,
     Anonymous(String),
 }
@@ -90,7 +89,6 @@ fn node_type(x: &Node) -> NodeType {
         "na" => NodeType::Na(na_type(x)),
         "comment" => NodeType::Comment,
         "comma" => NodeType::Comma,
-        "unmatched_delimiter" => NodeType::UnmatchedDelimiter(unmatched_delimiter_type(x)),
         "ERROR" => NodeType::Error,
         anonymous => NodeType::Anonymous(anonymous.to_string()),
     }
@@ -274,27 +272,6 @@ fn na_type(x: &Node) -> NaType {
         "NA_complex_" => NaType::Complex,
         "NA_character_" => NaType::Character,
         _ => panic!("Unknown `na` kind {}.", x.kind()),
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum UnmatchedDelimiterType {
-    /// `}`
-    Brace,
-    /// `)`
-    Parenthesis,
-    /// `]`
-    Bracket,
-}
-
-fn unmatched_delimiter_type(x: &Node) -> UnmatchedDelimiterType {
-    let x = x.child(0).unwrap();
-
-    match x.kind() {
-        "}" => UnmatchedDelimiterType::Brace,
-        ")" => UnmatchedDelimiterType::Parenthesis,
-        "]" => UnmatchedDelimiterType::Bracket,
-        _ => panic!("Unknown `unmatched_delimiter` kind {}.", x.kind()),
     }
 }
 

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -392,6 +392,14 @@ pub(crate) fn node_text(node: &Node, contents: &ropey::Rope) -> Option<String> {
     contents.node_slice(node).ok().map(|f| f.to_string())
 }
 
+pub(crate) fn node_has_error(node: &Node) -> bool {
+    // According to the docs, `node.has_error()` should return `true`
+    // if `node` is itself an error, or if it contains any errors, but that
+    // doesn't seem to be the case for terminal ERROR nodes.
+    // https://github.com/tree-sitter/tree-sitter/issues/3623
+    node.is_error() || node.has_error()
+}
+
 pub(crate) fn node_find_string<'a>(node: &'a Node) -> Option<Node<'a>> {
     if node.is_string() {
         // Already on a string


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2943

This PR also contains https://github.com/posit-dev/ark/pull/529 which was merged into it

Pulls in a whopping 34 more commits from tree-sitter-r https://github.com/r-lib/tree-sitter-r/compare/63ee9b10de3b1e4dfaf40e36b45e9ae3c9ed8a4f...99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0. It's really only 3 main changes. We pull in all 3 at once because they are a bit intermingled with each other.

- https://github.com/r-lib/tree-sitter-r/pull/92
    - Improves tree-sitter's error recovery by better allowing it to "recover" missing `)`, `}`, and `]` tokens
- https://github.com/r-lib/tree-sitter-r/pull/119
    - Helpful for targeting by field name 
- https://github.com/r-lib/tree-sitter-r/pull/132
    - Improves tree-sitter's error recovery by removing a massive amount of grammar ambiguity / states

With these 3 changes, I was able to greatly improve our diagnostics engine.

It has been split into two parts - a syntax path, and a semantic path:
- `diagnostics.rs` holds the entrypoint and the semantic path
- `diagnostics_syntactic.rs` holds the syntax path

In a future PR I'll do a mostly pure "rearrangement" PR to clean this structure up a bit more. I haven't done that yet to make it clear what has been moved out of `diagnostics.rs`.

## Syntax diagnostics

Diagnostics based purely on `ERROR` and `MISSING` nodes in the tree-sitter AST.

- `MISSING` nodes give us a nice way of detecting missing closing delimiters like `}` or `)` and seems to work nicely

- `ERROR` nodes allow us to report syntax errors in general. We don't get that much info from tree-sitter about exactly what went wrong, so I just report `Syntax error` most of the time.

A few more improvements in this realm:

- If a syntax error spans > 20 lines, it is now truncated to only show a squiggle on the `start_point` of the range, and it states that this is a `Syntax error. Starts here and ends on row {row}`. This helps us avoid overwhelming the user in the (very few!) cases where this can still happen. In my experience, mostly when they have an unmatched string delimiter like a stray `"` that causes everything after it to look like a weird unclosed string.

- `ERROR` nodes are no longer "recursively" reported. i.e. it is very common for an `ERROR` node in tree-sitter to have _children_ that are also `ERROR` nodes. Like what you see below. Previously we actually reported both `ERROR`s! This was particularly problematic because those outer `ERROR` nodes often span a huge number of lines, while the inner `ERROR` nodes can be very precise and target the exact problem quite nicely. We now only report what I call "terminal" `ERROR` nodes that don't have any `ERROR` children. This greatly improved that "aggressive diagnostic" issue where the whole file would light up in squiggles.

```r
#> ── Text ────────────────────────────────────────────────────────────────────────
#> 1 + }
#> 
#> ── S-Expression ────────────────────────────────────────────────────────────────
#> (program [(0, 0), (0, 5)]
#>   (float [(0, 0), (0, 1)])
#>   (ERROR [(0, 2), (0, 5)]
#>     "+" [(0, 2), (0, 3)]
#>     (ERROR [(0, 4), (0, 5)])
#>   )
#> )
```

## Semantic diagnostics

Semantic diagnostics are now run in a separate path from syntax diagnostics, this has the following really nice benefit - we only run semantic diagnostics on top level expressions (i.e. children of `root`) that `node.has_error()` returns `false` for. In other words, we only consider running semantic diagnostics down a section of the tree if we _know_ that section of the tree does not contain any syntax errors.

This actually works quite nicely in practice.
- Top level expressions with no syntax issues get semantic diagnostics
    - And, importantly, all the code in the semantic path can be written _knowing_ there aren't any potential `ERROR` nodes to be wary of 
- Top level expressions with syntax issues get syntax diagnostics
    - Once the user fixes the syntax issues, they get semantic diagnostics for that fixed chunk too 
- The whole file still gets a mix of both semantic and syntax diagnostics, depending on what could be parsed

## Improvement examples

This shows the "truncation" idea once a _syntax_ error spans >20 rows

https://github.com/user-attachments/assets/cb3d80cc-0712-4294-ac07-2f2b6fa0128d

This shows improvements in the example in https://github.com/posit-dev/positron/issues/2943, which used to light up the whole file

https://github.com/user-attachments/assets/bd6fab72-888b-492e-9289-f84c5b4ed124

This is a tree-sitter-r test file, with many syntax errors. Note that 1) it doesn't light up the whole file and 2) it still shows some semantic issues too (symbol not found errors)

https://github.com/user-attachments/assets/40cc5fca-e87d-49cd-9709-eb34a97181df

Improvements on the example from https://github.com/posit-dev/positron/discussions/4177. We often target the missing opening/closing node now. At the very end it shows that `}` doesn't have a matching opening `{`, and I do think that is still a _technically_ correct syntax error message, even if we'd like to show the unmatched `(` (Positron does at least highlight that unmatched `(` in red here, which is nice)

https://github.com/user-attachments/assets/b622440a-dc48-47ba-94a0-627d7815fe28

