### PR TITLE
Truncate error calls and backtraces

### DIFF
--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -101,7 +101,7 @@ impl fmt::Display for Error {
                 ..
             } => {
                 if let Some(code) = code {
-                    let code = truncate_lines(code.clone(), 10);
+                    let code = truncate_lines(code.clone(), 50);
                     write!(f, "Error evaluating '{code}': {message}")?;
                 } else {
                     write!(f, "{message}")?;

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -101,6 +101,7 @@ impl fmt::Display for Error {
                 ..
             } => {
                 if let Some(code) = code {
+                    let code = truncate_lines(code.clone(), 10);
                     write!(f, "Error evaluating '{code}': {message}")?;
                 } else {
                     write!(f, "{message}")?;
@@ -111,6 +112,7 @@ impl fmt::Display for Error {
                 // https://users.rust-lang.org/t/why-doesnt-anyhows-debug-formatter-include-the-underlying-debug-formatting/44227
 
                 if !r_trace.is_empty() {
+                    let r_trace = truncate_lines(r_trace.clone(), 500);
                     writeln!(f, "\n\nR backtrace:\n{r_trace}")?;
                 }
 
@@ -265,4 +267,16 @@ impl From<Utf8Error> for Error {
     fn from(error: Utf8Error) -> Self {
         Self::InvalidUtf8(error)
     }
+}
+
+fn truncate_lines(text: String, max_lines: usize) -> String {
+    let n_lines = text.lines().count();
+    if n_lines <= max_lines {
+        return text;
+    }
+
+    let mut text: String = text.lines().take(max_lines).collect();
+    text.push_str(&format!("... *Truncated {} lines*", n_lines - max_lines));
+
+    text
 }

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -276,7 +276,7 @@ fn truncate_lines(text: String, max_lines: usize) -> String {
     }
 
     let mut text: String = text.lines().take(max_lines).collect();
-    text.push_str(&format!("... *Truncated {} lines*", n_lines - max_lines));
+    text.push_str(&format!("\n... *Truncated {} lines*", n_lines - max_lines));
 
     text
 }

--- a/crates/harp/src/error.rs
+++ b/crates/harp/src/error.rs
@@ -101,7 +101,7 @@ impl fmt::Display for Error {
                 ..
             } => {
                 if let Some(code) = code {
-                    let code = truncate_lines(code.clone(), 50);
+                    let code = truncate_lines(code.to_owned(), 50);
                     write!(f, "Error evaluating '{code}': {message}")?;
                 } else {
                     write!(f, "{message}")?;
@@ -112,7 +112,7 @@ impl fmt::Display for Error {
                 // https://users.rust-lang.org/t/why-doesnt-anyhows-debug-formatter-include-the-underlying-debug-formatting/44227
 
                 if !r_trace.is_empty() {
-                    let r_trace = truncate_lines(r_trace.clone(), 500);
+                    let r_trace = truncate_lines(r_trace.to_owned(), 500);
                     writeln!(f, "\n\nR backtrace:\n{r_trace}")?;
                 }
 


### PR DESCRIPTION
The logs in https://github.com/posit-dev/positron/issues/4686 can't be read because the error calls and backtraces include 1000s of lines of inlined data.

To prevent this, we now truncate error calls to ~10~ 50 lines and R backtraces to 500 lines.