### PR TITLE
Protect against errors in `r_size()`

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -492,6 +492,14 @@ impl PositronVariable {
 
         let kind = Self::variable_kind(x);
 
+        let size = match RObject::view(x).size() {
+            Ok(size) => size as i64,
+            Err(err) => {
+                log::warn!("Can't compute size of object: {err}");
+                0
+            },
+        };
+
         Self {
             var: Variable {
                 access_key,
@@ -501,7 +509,7 @@ impl PositronVariable {
                 type_info,
                 kind,
                 length: Self::variable_length(x) as i64,
-                size: RObject::view(x).size() as i64,
+                size,
                 has_children: has_children(x),
                 is_truncated,
                 has_viewer: r_is_data_frame(x) || r_is_matrix(x),

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -345,7 +345,7 @@ impl RObject {
         r_is_object(self.sexp)
     }
 
-    pub fn size(&self) -> usize {
+    pub fn size(&self) -> harp::Result<usize> {
         r_size(self.sexp)
     }
 

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -30,13 +30,10 @@ use crate::r_typeof;
 pub fn r_size(x: SEXP) -> harp::Result<usize> {
     let mut seen: HashSet<SEXP> = HashSet::new();
 
-    let sizeof_node: f64 = harp::parse_eval0(
-        "as.vector(utils::object.size(quote(expr = )))",
-        R_ENVS.global,
-    )
-    .and_then(|x| x.try_into())?;
+    let sizeof_node: f64 = harp::parse_eval_base("as.vector(utils::object.size(quote(expr = )))")
+        .and_then(|x| x.try_into())?;
 
-    let sizeof_vector: f64 = harp::parse_eval_global("as.vector(utils::object.size(logical()))")
+    let sizeof_vector: f64 = harp::parse_eval_base("as.vector(utils::object.size(logical()))")
         .and_then(|x| x.try_into())?;
 
     harp::try_catch(|| {

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -36,6 +36,9 @@ pub fn r_size(x: SEXP) -> harp::Result<usize> {
     let sizeof_vector: f64 = harp::parse_eval_base("as.vector(utils::object.size(logical()))")
         .and_then(|x| x.try_into())?;
 
+    // The tree-walking implementation potentially violates R internals,
+    // so we protect against errors thrown by R (and hope for no crash).
+    // https://github.com/posit-dev/positron/issues/4686
     harp::try_catch(|| {
         obj_size_tree(
             x,

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -27,28 +27,28 @@ use crate::r_typeof;
 // `utils::object.size()` is too slow on large datasets and this code path is used trough the
 // variables pane which required more performance.
 // See for more info.
-pub fn r_size(x: SEXP) -> usize {
+pub fn r_size(x: SEXP) -> harp::Result<usize> {
     let mut seen: HashSet<SEXP> = HashSet::new();
 
     let sizeof_node: f64 = harp::parse_eval0(
         "as.vector(utils::object.size(quote(expr = )))",
         R_ENVS.global,
     )
-    .and_then(|x| x.try_into())
-    .unwrap_or(0.);
+    .and_then(|x| x.try_into())?;
 
     let sizeof_vector: f64 = harp::parse_eval_global("as.vector(utils::object.size(logical()))")
-        .and_then(|x| x.try_into())
-        .unwrap_or(0.);
+        .and_then(|x| x.try_into())?;
 
-    obj_size_tree(
-        x,
-        R_ENVS.global,
-        sizeof_node as usize,
-        sizeof_vector as usize,
-        &mut seen,
-        0,
-    )
+    harp::try_catch(|| {
+        obj_size_tree(
+            x,
+            R_ENVS.global,
+            sizeof_node as usize,
+            sizeof_vector as usize,
+            &mut seen,
+            0,
+        )
+    })
 }
 
 fn obj_size_tree(
@@ -399,7 +399,7 @@ mod tests {
 
     fn object_size(code: &str) -> usize {
         let object = harp::parse_eval_global(code).unwrap();
-        r_size(object.sexp)
+        r_size(object.sexp).unwrap()
     }
 
     fn expect_size(code: &str, expected: usize) {


### PR DESCRIPTION
Addresses the crash part of https://github.com/posit-dev/positron/issues/4686 but not the underlying error. It's now turned into a log warning:

<img width="709" alt="Screenshot 2024-09-16 at 12 02 46" src="https://github.com/user-attachments/assets/19573334-9182-4813-865e-afe65c24b4a6">
