### PR TITLE
Bump tree-sitter-r 5 - Leading newline skipping, tree-sitter 0.23.0 update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,7 @@ checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 [[package]]
 name = "tree-sitter-r"
 version = "1.1.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=f0679b90d0e154e21d7219f7ff0ec9683a39f97b#f0679b90d0e154e21d7219f7ff0ec9683a39f97b"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=2097fa502efa21349d26af0ffee55d773015e481#2097fa502efa21349d26af0ffee55d773015e481"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,7 +2218,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2238,7 +2238,7 @@ checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2255,9 +2255,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -3190,21 +3190,29 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.22.6"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+checksum = "20f4cd3642c47a85052a887d86704f4eac272969f61b686bdd3f772122aabaff"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax 0.8.4",
+ "tree-sitter-language",
 ]
 
 [[package]]
+name = "tree-sitter-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
+
+[[package]]
 name = "tree-sitter-r"
-version = "1.0.1"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0#99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0"
+version = "1.1.0"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=4279b699c47fa87956045980c46c7d30f8c0121b#4279b699c47fa87956045980c46c7d30f8c0121b"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,7 @@ checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 [[package]]
 name = "tree-sitter-r"
 version = "1.1.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=4279b699c47fa87956045980c46c7d30f8c0121b#4279b699c47fa87956045980c46c7d30f8c0121b"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=f0679b90d0e154e21d7219f7ff0ec9683a39f97b#f0679b90d0e154e21d7219f7ff0ec9683a39f97b"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.23.0"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "f0679b90d0e154e21d7219f7ff0ec9683a39f97b" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "2097fa502efa21349d26af0ffee55d773015e481" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -47,8 +47,8 @@ serde_json = { version = "1.0.94", features = ["preserve_order"]}
 stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
-tree-sitter = "0.22.6"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0" }
+tree-sitter = "0.23.0"
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "4279b699c47fa87956045980c46c7d30f8c0121b" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -48,7 +48,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.23.0"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "4279b699c47fa87956045980c46c7d30f8c0121b" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "f0679b90d0e154e21d7219f7ff0ec9683a39f97b" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/src/lsp/documents.rs
+++ b/crates/ark/src/lsp/documents.rs
@@ -225,4 +225,11 @@ mod tests {
         let point = compute_point(Point::new(0, 0), "abcdefghi\n");
         assert_eq!(point, Point::new(1, 0));
     }
+
+    #[test]
+    fn test_document_starts_at_0_0_with_leading_whitespace() {
+        let document = Document::new("\n\n# hi there", None);
+        let root = document.ast.root_node();
+        assert_eq!(root.start_position(), Point::new(0, 0));
+    }
 }

--- a/crates/ark/src/lsp/documents.rs
+++ b/crates/ark/src/lsp/documents.rs
@@ -64,9 +64,10 @@ impl Document {
     pub fn new(contents: &str, version: Option<i32>) -> Self {
         // A one-shot parser, assumes the `Document` won't be incrementally reparsed.
         // Useful for testing, `with_document()`, and `index_file()`.
-        let language = tree_sitter_r::language();
         let mut parser = Parser::new();
-        parser.set_language(&language).unwrap();
+        parser
+            .set_language(&tree_sitter_r::LANGUAGE.into())
+            .unwrap();
 
         Self::new_with_parser(contents, &mut parser, version)
     }

--- a/crates/ark/src/lsp/help_topic.rs
+++ b/crates/ark/src/lsp/help_topic.rs
@@ -105,11 +105,9 @@ mod tests {
 
     #[test]
     fn test_locate_help_node() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         // On the RHS

--- a/crates/ark/src/lsp/selection_range.rs
+++ b/crates/ark/src/lsp/selection_range.rs
@@ -156,7 +156,7 @@ mod tests {
         assert_eq!(selection.range.end_point, Point::new(3, 1));
 
         let selection = selection.parent.as_ref().unwrap();
-        assert_eq!(selection.range.start_point, Point::new(1, 0));
+        assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
     }
@@ -187,7 +187,7 @@ mod tests {
 
         // Just 1 selection, the whole document
         let selection = selections.get(0).unwrap();
-        assert_eq!(selection.range.start_point, Point::new(1, 0));
+        assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
     }
@@ -244,7 +244,7 @@ fn <- function(x, arg) {
 
         // Whole document
         let selection = selection.parent.as_ref().unwrap();
-        assert_eq!(selection.range.start_point, Point::new(1, 0));
+        assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
     }

--- a/crates/ark/src/lsp/selection_range.rs
+++ b/crates/ark/src/lsp/selection_range.rs
@@ -139,11 +139,9 @@ mod tests {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();
@@ -176,11 +174,9 @@ mod tests {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();
@@ -209,12 +205,10 @@ fn <- function(x, arg) {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         // create a parser for this document
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();
@@ -258,11 +252,9 @@ fn <- function(x, arg) {
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_assignment() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let text = "
@@ -295,11 +287,9 @@ fn <- function() {
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_call_arguments() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "
@@ -337,11 +327,9 @@ fn(@a, b, c)
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_subset_arguments() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "
@@ -384,11 +372,9 @@ x[a, @fn(), c]
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_subset2_arguments() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "
@@ -431,11 +417,9 @@ x[[a, @fn(), c]]
     #[test]
     #[rustfmt::skip]
     fn test_selection_range_namespaced_calls() {
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
 
         let text = "

--- a/crates/ark/src/lsp/snapshots/indent.R
+++ b/crates/ark/src/lsp/snapshots/indent.R
@@ -1098,11 +1098,11 @@ fun_call(object1 + object2 ~ object3 +
            argument)
 
 ## 32
-fun_call(object ~
+fun_call(~ object
   )
 
 ## 33
-fun_call(object +
+fun_call(object + object2
   )
 
 ## 34

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -165,9 +165,10 @@ pub(crate) fn did_open(
     let uri = params.text_document.uri;
     let version = params.text_document.version;
 
-    let language = tree_sitter_r::language();
     let mut parser = Parser::new();
-    parser.set_language(&language).unwrap();
+    parser
+        .set_language(&tree_sitter_r::LANGUAGE.into())
+        .unwrap();
 
     let document = Document::new_with_parser(contents, &mut parser, Some(version));
 

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -509,6 +509,8 @@ fn test_statement_range() {
     // by tree-sitter. It is generally best to left align the string against the
     // far left margin to avoid unexpected whitespace and mimic real life.
     fn statement_range_test(x: &str) {
+        let original = x;
+
         let lines = x.split("\n").collect::<Vec<&str>>();
 
         let mut cursor: Option<Point> = None;
@@ -660,8 +662,8 @@ fn test_statement_range() {
 
         let node = find_statement_range_node(&root, cursor.unwrap().row).unwrap();
 
-        assert_eq!(node.start_position(), sel_start.unwrap());
-        assert_eq!(node.end_position(), sel_end.unwrap());
+        assert_eq!(node.start_position(), sel_start.unwrap(), "Failed on test {original}");
+        assert_eq!(node.end_position(), sel_end.unwrap(), "Failed on test {original}");
     }
 
     // Simple test

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -649,11 +649,9 @@ fn test_statement_range() {
         let x = x.replace("@", "");
         let x = x.replace(">>", "");
 
-        let language = tree_sitter_r::language();
-
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("Failed to create parser");
 
         let ast = parser.parse(x, None).unwrap();
@@ -1286,10 +1284,9 @@ test_that('stuff', {
 
 
 ";
-    let language = tree_sitter_r::language();
     let mut parser = Parser::new();
     parser
-        .set_language(&language)
+        .set_language(&tree_sitter_r::LANGUAGE.into())
         .expect("Failed to create parser");
     let ast = parser.parse(contents, None).unwrap();
     let root = ast.root_node();
@@ -1304,10 +1301,9 @@ test_that('stuff', {
 
 }
 ";
-    let language = tree_sitter_r::language();
     let mut parser = Parser::new();
     parser
-        .set_language(&language)
+        .set_language(&tree_sitter_r::LANGUAGE.into())
         .expect("Failed to create parser");
     let ast = parser.parse(contents, None).unwrap();
     let root = ast.root_node();

--- a/crates/ark/src/lsp/traits/node.rs
+++ b/crates/ark/src/lsp/traits/node.rs
@@ -287,12 +287,10 @@ fn <- function(x, arg) {
 
         let (text, point) = point_from_cursor(text);
 
-        let language = tree_sitter_r::language();
-
         // create a parser for this document
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(&tree_sitter_r::LANGUAGE.into())
             .expect("failed to create parser");
 
         let tree = parser.parse(text, None).unwrap();


### PR DESCRIPTION
Contains these commits https://github.com/r-lib/tree-sitter-r/compare/99bf614d9d7e6ac9c7445fa7dc54a590fcdf3ce0...2097fa502efa21349d26af0ffee55d773015e481, most importantly:
- https://github.com/r-lib/tree-sitter-r/pull/134 to fix some panics we'd see in `Document::new()` when there are leading newlines before the first actual token in a document - I can't find a linked issue for it, but I added a test, and there are many on the tree-sitter-r side
- https://github.com/r-lib/tree-sitter-r/issues/141 to fix an edge case with if/else and newlines
- https://github.com/r-lib/tree-sitter-r/pull/145 to fix an edge case with functions and newlines