### PR TITLE
Fix `Sys.getenv()` completions, support `Sys.unsetenv()` too

### DIFF
--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -235,7 +235,7 @@ mod tests {
     fn test_completion_custom_library() {
         r_test(|| {
             let n_packages = {
-                let n = harp::parse_eval_global("length(base::.packages(TRUE))").unwrap();
+                let n = harp::parse_eval_base("length(base::.packages(TRUE))").unwrap();
                 let n = i32::try_from(n).unwrap();
                 usize::try_from(n).unwrap()
             };
@@ -267,7 +267,7 @@ mod tests {
         r_test(|| {
             let name = "ARK_TEST_ENVVAR";
 
-            harp::parse_eval_global(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
+            harp::parse_eval_base(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
 
             let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
                 let document = Document::new(text, None);
@@ -307,7 +307,7 @@ mod tests {
             let completions = completions_from_custom_source(&context).unwrap();
             assert!(completions.is_none());
 
-            harp::parse_eval_global(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
+            harp::parse_eval_base(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
         })
     }
 
@@ -316,7 +316,7 @@ mod tests {
         r_test(|| {
             let name = "ARK_TEST_ENVVAR";
 
-            harp::parse_eval_global(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
+            harp::parse_eval_base(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
 
             let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
                 let document = Document::new(text, None);
@@ -353,7 +353,7 @@ mod tests {
             let completions = completions_from_custom_source(&context).unwrap();
             assert!(completions.is_none());
 
-            harp::parse_eval_global(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
+            harp::parse_eval_base(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
         })
     }
 
@@ -362,7 +362,7 @@ mod tests {
         r_test(|| {
             let name = "ARK_TEST_ENVVAR";
 
-            harp::parse_eval_global(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
+            harp::parse_eval_base(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
 
             let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
                 let document = Document::new(text, None);
@@ -391,7 +391,7 @@ mod tests {
             let (text, point) = point_from_cursor("Sys.setenv(foo = 'bar', @)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
-            harp::parse_eval_global(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
+            harp::parse_eval_base(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
         })
     }
 
@@ -400,7 +400,7 @@ mod tests {
         r_test(|| {
             let name = "ARK_TEST_OPTION";
 
-            harp::parse_eval_global(format!("options({name} = '1')").as_str()).unwrap();
+            harp::parse_eval_base(format!("options({name} = '1')").as_str()).unwrap();
 
             let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
                 let document = Document::new(text, None);
@@ -440,7 +440,7 @@ mod tests {
             let completions = completions_from_custom_source(&context).unwrap();
             assert!(completions.is_none());
 
-            harp::parse_eval_global(format!("options({name} = NULL)").as_str()).unwrap();
+            harp::parse_eval_base(format!("options({name} = NULL)").as_str()).unwrap();
         })
     }
 
@@ -449,7 +449,7 @@ mod tests {
         r_test(|| {
             let name = "ARK_TEST_OPTION";
 
-            harp::parse_eval_global(format!("options({name} = '1')").as_str()).unwrap();
+            harp::parse_eval_base(format!("options({name} = '1')").as_str()).unwrap();
 
             let assert_has_ark_test_option_completion = |text: &str, point: Point| {
                 let document = Document::new(text, None);
@@ -478,7 +478,7 @@ mod tests {
             let (text, point) = point_from_cursor("options(foo = 'bar', @)");
             assert_has_ark_test_option_completion(text.as_str(), point);
 
-            harp::parse_eval_global(format!("options({name} = NULL)").as_str()).unwrap();
+            harp::parse_eval_base(format!("options({name} = NULL)").as_str()).unwrap();
         })
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -109,7 +109,7 @@ pub fn completions_from_custom_source_impl(
     // Argument text typically contains the argument name and its default value if there is one.
     // Extract out just the argument name for matching purposes.
     let argument = match argument.find("=") {
-        Some(byte) => &argument[..byte].trim(),
+        Some(loc) => &argument[..loc].trim(),
         None => argument.as_str(),
     };
 

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -288,6 +288,10 @@ mod tests {
             let (text, point) = point_from_cursor("Sys.getenv(@)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
+            // Named argument
+            let (text, point) = point_from_cursor("Sys.getenv(x = @)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
             // Typed some and then requested completions
             let (text, point) = point_from_cursor("Sys.getenv(ARK_@)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
@@ -331,6 +335,10 @@ mod tests {
 
             // Inside the parentheses
             let (text, point) = point_from_cursor("Sys.unsetenv(@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Named argument
+            let (text, point) = point_from_cursor("Sys.unsetenv(x = @)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
             // Typed some and then requested completions
@@ -411,6 +419,10 @@ mod tests {
 
             // Inside the parentheses
             let (text, point) = point_from_cursor("getOption(@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Named argument
+            let (text, point) = point_from_cursor("getOption(x = @)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
             // Typed some and then requested completions

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -91,13 +91,13 @@ pub fn completions_from_custom_source_impl(
     //
     // cf. https://github.com/posit-dev/positron/issues/3467
     if index >= parameters.len() {
-        lsp::log_error!("Index {index} is out of bounds of the arguments of `{name}`");
+        lsp::log_error!("Index {index} is out of bounds of the parameters of `{name}`");
         return Ok(None);
     }
     let parameter = parameters.get(index).into_result()?;
 
-    // Extract the argument text.
-    let argument = match parameter.label.clone() {
+    // Extract the parameter text.
+    let parameter = match parameter.label.clone() {
         tower_lsp::lsp_types::ParameterLabel::LabelOffsets([start, end]) => {
             let label = signature.label.as_str();
             let substring = label.get((start as usize)..(end as usize));
@@ -106,14 +106,14 @@ pub fn completions_from_custom_source_impl(
         tower_lsp::lsp_types::ParameterLabel::Simple(string) => string,
     };
 
-    // Argument text typically contains the argument name and its default value if there is one.
-    // Extract out just the argument name for matching purposes.
-    let argument = match argument.find("=") {
-        Some(loc) => &argument[..loc].trim(),
-        None => argument.as_str(),
+    // Parameter text typically contains the parameter name and its default value if there is one.
+    // Extract out just the parameter name for matching purposes.
+    let parameter = match parameter.find("=") {
+        Some(loc) => &parameter[..loc].trim(),
+        None => parameter.as_str(),
     };
 
-    // Trim off the function arguments from the signature.
+    // Trim off the function parameters from the signature.
     if let Some(index) = name.find('(') {
         name = name[0..index].to_string();
     }
@@ -152,7 +152,7 @@ pub fn completions_from_custom_source_impl(
         // Call our custom completion function.
         let r_completions = RFunction::from(".ps.completions.getCustomCallCompletions")
             .param("name", name)
-            .param("argument", argument)
+            .param("argument", parameter)
             .param("position", position)
             .call()?;
 

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -106,6 +106,13 @@ pub fn completions_from_custom_source_impl(
         tower_lsp::lsp_types::ParameterLabel::Simple(string) => string,
     };
 
+    // Argument text typically contains the argument name and its default value if there is one.
+    // Extract out just the argument name for matching purposes.
+    let argument = match argument.find("=") {
+        Some(byte) => &argument[..byte].trim(),
+        None => argument.as_str(),
+    };
+
     // Trim off the function arguments from the signature.
     if let Some(index) = name.find('(') {
         name = name[0..index].to_string();

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -225,9 +225,10 @@ pub fn completions_from_custom_source_impl(
 mod tests {
     use tree_sitter::Point;
 
-    use crate::lsp::completions::sources::unique::custom::completions_from_custom_source_impl;
+    use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
+    use crate::test::point_from_cursor;
     use crate::test::r_test;
 
     #[test]
@@ -243,7 +244,7 @@ mod tests {
             let document = Document::new("library()", None);
             let context = DocumentContext::new(&document, point, None);
 
-            let n_compls = completions_from_custom_source_impl(&context)
+            let n_compls = completions_from_custom_source(&context)
                 .unwrap()
                 .unwrap()
                 .len();
@@ -255,11 +256,175 @@ mod tests {
             let document = Document::new("library(uti)", None);
             let context = DocumentContext::new(&document, point, None);
 
-            let compls = completions_from_custom_source_impl(&context)
-                .unwrap()
-                .unwrap();
+            let compls = completions_from_custom_source(&context).unwrap().unwrap();
 
             assert!(compls.iter().any(|c| c.label == "utils"));
+        })
+    }
+
+    #[test]
+    fn test_completion_custom_sys_getenv() {
+        r_test(|| {
+            let name = "ARK_TEST_ENVVAR";
+
+            harp::parse_eval_global(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
+
+            let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
+                let document = Document::new(text, None);
+                let context = DocumentContext::new(&document, point, None);
+
+                let completions = completions_from_custom_source(&context).unwrap().unwrap();
+                let completion = completions
+                    .into_iter()
+                    .find(|completion| completion.label == name);
+                assert!(completion.is_some());
+
+                // Insert text is quoted!
+                let completion = completion.unwrap();
+                assert_eq!(completion.insert_text.unwrap(), format!("\"{name}\""));
+            };
+
+            // Inside the parentheses
+            let (text, point) = point_from_cursor("Sys.getenv(@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Typed some and then requested completions
+            let (text, point) = point_from_cursor("Sys.getenv(ARK_@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // After a named argument
+            let (text, point) = point_from_cursor("Sys.getenv(unset = '1', @)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Should not have it here
+            let (text, point) = point_from_cursor("Sys.getenv('foo', @)");
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_custom_source(&context).unwrap();
+            assert!(completions.is_none());
+
+            harp::parse_eval_global(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
+        })
+    }
+
+    #[test]
+    fn test_completion_custom_sys_setenv() {
+        r_test(|| {
+            let name = "ARK_TEST_ENVVAR";
+
+            harp::parse_eval_global(format!("Sys.setenv({name} = '1')").as_str()).unwrap();
+
+            let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
+                let document = Document::new(text, None);
+                let context = DocumentContext::new(&document, point, None);
+
+                let completions = completions_from_custom_source(&context).unwrap().unwrap();
+                let completion = completions
+                    .into_iter()
+                    .find(|completion| completion.label == name);
+                assert!(completion.is_some());
+
+                // Insert text is NOT quoted! And we get an ` = ` appended.
+                let completion = completion.unwrap();
+                assert_eq!(completion.insert_text.unwrap(), format!("{name} = "));
+            };
+
+            // Inside the parentheses
+            let (text, point) = point_from_cursor("Sys.setenv(@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Typed some and then requested completions
+            let (text, point) = point_from_cursor("Sys.setenv(ARK_@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Should have it here too, this takes `...`
+            let (text, point) = point_from_cursor("Sys.setenv(foo = 'bar', @)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            harp::parse_eval_global(format!("Sys.unsetenv('{name}')").as_str()).unwrap();
+        })
+    }
+
+    #[test]
+    fn test_completion_custom_get_option() {
+        r_test(|| {
+            let name = "ARK_TEST_OPTION";
+
+            harp::parse_eval_global(format!("options({name} = '1')").as_str()).unwrap();
+
+            let assert_has_ark_test_envvar_completion = |text: &str, point: Point| {
+                let document = Document::new(text, None);
+                let context = DocumentContext::new(&document, point, None);
+
+                let completions = completions_from_custom_source(&context).unwrap().unwrap();
+                let completion = completions
+                    .into_iter()
+                    .find(|completion| completion.label == name);
+                assert!(completion.is_some());
+
+                // Insert text is quoted!
+                let completion = completion.unwrap();
+                assert_eq!(completion.insert_text.unwrap(), format!("\"{name}\""));
+            };
+
+            // Inside the parentheses
+            let (text, point) = point_from_cursor("getOption(@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Typed some and then requested completions
+            let (text, point) = point_from_cursor("getOption(ARK_@)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // After a named argument
+            let (text, point) = point_from_cursor("getOption(default = '1', @)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Should not have it here
+            let (text, point) = point_from_cursor("getOption('foo', @)");
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_custom_source(&context).unwrap();
+            assert!(completions.is_none());
+
+            harp::parse_eval_global(format!("options({name} = NULL)").as_str()).unwrap();
+        })
+    }
+
+    #[test]
+    fn test_completion_custom_options() {
+        r_test(|| {
+            let name = "ARK_TEST_OPTION";
+
+            harp::parse_eval_global(format!("options({name} = '1')").as_str()).unwrap();
+
+            let assert_has_ark_test_option_completion = |text: &str, point: Point| {
+                let document = Document::new(text, None);
+                let context = DocumentContext::new(&document, point, None);
+
+                let completions = completions_from_custom_source(&context).unwrap().unwrap();
+                let completion = completions
+                    .into_iter()
+                    .find(|completion| completion.label == name);
+                assert!(completion.is_some());
+
+                // Insert text is NOT quoted! And we get an ` = ` appended.
+                let completion = completion.unwrap();
+                assert_eq!(completion.insert_text.unwrap(), format!("{name} = "));
+            };
+
+            // Inside the parentheses
+            let (text, point) = point_from_cursor("options(@)");
+            assert_has_ark_test_option_completion(text.as_str(), point);
+
+            // Typed some and then requested completions
+            let (text, point) = point_from_cursor("options(ARK_@)");
+            assert_has_ark_test_option_completion(text.as_str(), point);
+
+            // Should have it here too, this takes `...`
+            let (text, point) = point_from_cursor("options(foo = 'bar', @)");
+            assert_has_ark_test_option_completion(text.as_str(), point);
+
+            harp::parse_eval_global(format!("options({name} = NULL)").as_str()).unwrap();
         })
     }
 }

--- a/crates/ark/src/modules/positron/completions.R
+++ b/crates/ark/src/modules/positron/completions.R
@@ -82,6 +82,15 @@ customCompletionHandlers <- new.env(parent = emptyenv())
     )
 })
 
+.ps.completions.registerCustomCompletionHandler("base", "Sys.unsetenv", "x", function(position) {
+    .ps.completions.createCustomCompletions(
+        values  = names(Sys.getenv()),
+        kind    = "unknown",
+        enquote = TRUE,
+        append  = ""
+    )
+})
+
 .ps.completions.registerCustomCompletionHandler("base", "Sys.setenv", "...", function(position) {
 
     if (position != "name")


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4677

I think I accidentally broke this with https://github.com/posit-dev/ark/pull/439 because I didn't know we were relying on the argument labels _only_ containing the argument name (they now also contain the default value where applicable).

I _feel_ like the LSP `SignatureHelp` data structure is probably not completely appropriate for what we want here since it is used for UI purposes, and we need something that is still useful for static analysis in other places besides the LSP request handler. But I'm not ready to shave that yak right now.

I've added lots of tests for all the custom completion types we support, so we can't accidentally break this in the future.