### PR TITLE
Update `.rs.api.versionInfo()`

### DIFF
--- a/crates/ark/src/modules/rstudio/rstudioapi.R
+++ b/crates/ark/src/modules/rstudio/rstudioapi.R
@@ -16,7 +16,7 @@
                     paste0("Posit team (", current_year, "). "),
                     "Positron: A next generation data science IDE. ",
                     "Posit Software, PBC, Boston, MA. ",
-                    "URL http://www.posit.co/.",
+                    "URL https://www.posit.co/.",
                     sep = ""
                 ),
             mheader = "To cite Positron in publications use:",

--- a/crates/ark/src/modules/rstudio/rstudioapi.R
+++ b/crates/ark/src/modules/rstudio/rstudioapi.R
@@ -10,7 +10,7 @@
             organization = "Posit Software, PBC",
             address      = "Boston, MA",
             year         = current_year,
-            url          = "http://www.posit.co/",
+            url          = "https://www.posit.co/",
             textVersion =
                 paste(
                     paste0("Posit team (", current_year, "). "),

--- a/crates/ark/src/modules/rstudio/rstudioapi.R
+++ b/crates/ark/src/modules/rstudio/rstudioapi.R
@@ -1,20 +1,34 @@
 #' @export
 .rs.api.versionInfo <- function() {
-    # comments are what rstudioapi actually does
-    # https://github.com/rstudio/rstudio/blob/bb729e14867f6f95e26600d8b38e4551402cf7de/src/cpp/r/R/Api.R#L135-L145
-    # info <- list()
+
+    current_year <- format(Sys.Date(), "%Y")
+    positron_citation <-
+        utils::bibentry(
+            "Manual",
+            title = "Positron: A next generation data science IDE",
+            author = utils::person("Posit team"),
+            organization = "Posit Software, PBC",
+            address      = "Boston, MA",
+            year         = current_year,
+            url          = "http://www.posit.co/",
+            textVersion =
+                paste(
+                    paste0("Posit team (", current_year, "). "),
+                    "Positron: A next generation data science IDE. ",
+                    "Posit Software, PBC, Boston, MA. ",
+                    "URL http://www.posit.co/.",
+                    sep = ""
+                ),
+            mheader = "To cite Positron in publications use:",
+            mfooter = ""
+        )
+    class(positron_citation) <- c("citation", "bibentry")
+
     list(
-        # info$citation <- .Call("rs_rstudioCitation", PACKAGE = "(embedding)")
-        citation = NULL,
-        # info$mode <- .Call("rs_rstudioProgramMode", PACKAGE = "(embedding)")
-        mode = "desktop",
-        # info$edition <- .Call("rs_rstudioEdition", PACKAGE = "(embedding)")
-        # info$version <- .Call("rs_rstudioVersion", PACKAGE = "(embedding)")
-        # info$version <- package_version(info$version)
-        version = package_version("2023.3"),
-        # info$long_version <- .Call("rs_rstudioLongVersion", PACKAGE = "(embedding)")
-        long_version = "2023.03.0"
-        # info$release_name <- .Call("rs_rstudioReleaseName", PACKAGE = "(embedding)")
+        citation = positron_citation,
+        mode = Sys.getenv("POSITRON_MODE"),
+        version = package_version(Sys.getenv("POSITRON_VERSION")),
+        long_version = Sys.getenv("POSITRON_LONG_VERSION"),
+        ark_version = .ps.ark.version()
     )
-    #     info
 }


### PR DESCRIPTION
Addresses posit-dev/positron#4081
Addresses posit-dev/positron#4706
Goes together with posit-dev/positron#4703

There are a few differences between what I have in this draft and what `.rs.api.versionInfo()` returns for RStudio, especially on Workbench.

- ~~Currently `mode` will be "web" rather than "server" for non-desktop use. I did this because it is what VS Code uses internally throughout. Is it a problem for us to have something different here? See https://github.com/posit-dev/positron/pull/4703/files#r1764143168~~ We will have `mode` be "server", for consistency with RStudio.
- There is no `edition` or `release_name`, since Positron doesn't have those. The desktop version of RStudio also doesn't have `edition`.

## QA Notes

In the R console, you should see these types of results:

``` r
.rs.api.versionInfo()
#> $citation
#> To cite Positron in publications use:
#> 
#>   Posit team (2024). Positron: A next generation data science IDE.
#>   Posit Software, PBC, Boston, MA. URL https://www.posit.co/.
#> 
#> A BibTeX entry for LaTeX users is
#> 
#>   @Manual{,
#>     title = {Positron: A next generation data science IDE},
#>     author = {{Posit team}},
#>     organization = {Posit Software, PBC},
#>     address = {Boston, MA},
#>     year = {2024},
#>     url = {https://www.posit.co/},
#>   }
#> 
#> $mode
#> [1] "desktop"
#> 
#> $version
#> [1] '2024.9.0'
#> 
#> $long_version
#> [1] "2024.09.0+0"
#> 
#> $ark_version
#>                                              branch 
#>                                              "main" 
#>                                              commit 
#>                                          "8f5040d6" 
#>                                                date 
#>                           "2024-09-17 16:28:06 MDT" 
#>                                              flavor 
#>                                             "debug" 
#>                                                path 
#> "/Users/juliasilge/Work/posit/ark/target/debug/ark" 
#>                                             version 
#>                                           "0.1.136"
```