### PR TITLE
Distinguish whitespace and include syntax error messages

### DIFF
--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -168,6 +168,7 @@ pub fn parse_boundaries(text: &str) -> anyhow::Result<Vec<ParseBoundary>> {
         boundaries.push(ParseBoundary::incomplete(boundary));
     }
     if let Some(boundary) = invalid {
+        // SAFETY: `invalid_message` has to be `Some()` because `invalid` is `Some()`
         boundaries.push(ParseBoundary::invalid(boundary, invalid_message.unwrap()));
     }
 
@@ -235,14 +236,14 @@ fn fill_gaps(
 
     // Fill trailing whitespace between complete expressions and the rest
     // (incomplete, invalid, or eof)
-    let last_boundary = filled.last().map(|b| b.range.end()).unwrap_or(0);
+    let last_complete_boundary = filled.last().map(|b| b.range.end()).unwrap_or(0);
     let next_boundary = incomplete
         .as_ref()
         .or(invalid.as_ref())
         .map(|r| r.start())
         .unwrap_or(n_lines);
 
-    for start in last_boundary..next_boundary {
+    for start in last_complete_boundary..next_boundary {
         filled.push(ParseBoundary::whitespace(range_from(start)))
     }
 

--- a/crates/ark/src/analysis/parse_boundaries.rs
+++ b/crates/ark/src/analysis/parse_boundaries.rs
@@ -334,6 +334,13 @@ mod tests {
                 complete(0, 1),
                 incomplete(1, 2),
             ]);
+
+            assert_eq!(p("#\n# foo\n  # bar \nbaz +  \n # qux"), vec![
+                whitespace(0, 1),
+                whitespace(1, 2),
+                whitespace(2, 3),
+                incomplete(3, 5),
+            ]);
         });
     }
 


### PR DESCRIPTION
We now distinguish between complete inputs and pure whitespace. This way we don't need to send long streaks of empty lines and comments over the network for evaluation, since there is nothing to evaluate.

For the same reason invalid boundaries now carry an error message.

The data types have been reworked so that parse boundaries are now a simple vector of variant types.

Progress towards https://github.com/posit-dev/positron/issues/1326