### PR TITLE
Clean up failed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,10 +174,34 @@ jobs:
                   asset_name: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-linux-arm64.zip
                   asset_content_type: application/octet-stream
 
+    cleanup:
+        name: Clean up Failed Releases
+        if: ${{ failure() }}
+        runs-on: ubuntu-latest
+        needs: [upload_release_binaries, get_version]
+        steps:
+            # `gh` operates on the git repo
+            - name: Checkout sources
+              uses: actions/checkout@v4
+
+            - name: Delete failed release if any
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  TAG=${{ needs.get_version.outputs.ARK_VERSION }}
+                  if gh release view $TAG > /dev/null 2>&1; then
+                      echo "Cleaning up release $TAG"
+                      gh release delete $TAG -y --cleanup-tag
+                  else
+                      echo "No release to clean up"
+                  fi
+
+    # Keep this at the very end of the workflow tree and without any other
+    # steps to ensure we get a Slack report when something failed
     status:
         if: ${{ failure() }}
         runs-on: ubuntu-latest
-        needs: [build_macos, build_windows, get_version]
+        needs: [cleanup, get_version]
         steps:
             - name: Notify slack if build fails
               uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
It's currently possible for our workflows to leave a new release in a failed or incomplete state:

- A release build completes
- We create a new release
- But then we either fail to download release artifacts from build jobs, or fail to upload a release asset

To avoid this, we now clean up releases in case of propagated failure.

Another change made here is that the Slack failure report will now also be sent if an upload-release step fails. Previously we would only report build failures.

Making sure we don't create partial releases should help with https://github.com/posit-dev/positron/issues/4815.

Approach: This uses the `gh` CLI tool to check for existence of a release and delete it if any.