### PR TITLE
Add integration test for R errors

### DIFF
--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -12,11 +12,11 @@ use crate::connection_file::ConnectionFile;
 use crate::session::Session;
 use crate::socket::socket::Socket;
 use crate::wire::execute_input::ExecuteInput;
-use crate::wire::execute_reply::ExecuteReply;
 use crate::wire::execute_request::ExecuteRequest;
 use crate::wire::jupyter_message::JupyterMessage;
 use crate::wire::jupyter_message::Message;
 use crate::wire::jupyter_message::ProtocolMessage;
+use crate::wire::jupyter_message::Status;
 use crate::wire::status::ExecutionState;
 use crate::wire::wire_message::WireMessage;
 
@@ -161,11 +161,11 @@ impl DummyFrontend {
     }
 
     /// Receive from Shell and assert ExecuteReply message
-    pub fn recv_shell_execute_reply(&self) -> ExecuteReply {
+    pub fn recv_shell_execute_reply(&self) -> Status {
         let msg = self.recv_shell();
 
         assert_match!(msg, Message::ExecuteReply(data) => {
-            data.content
+            data.content.status
         })
     }
 

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -160,21 +160,25 @@ impl DummyFrontend {
         Message::read_from_socket(&self.shell_socket).unwrap()
     }
 
-    /// Receive from Shell and assert ExecuteReply message
-    pub fn recv_shell_execute_reply(&self) -> Status {
+    /// Receive from Shell and assert `ExecuteReply` message.
+    /// Returns `execution_count`.
+    pub fn recv_shell_execute_reply(&self) -> u32 {
         let msg = self.recv_shell();
 
         assert_match!(msg, Message::ExecuteReply(data) => {
-            data.content.status
+            assert_eq!(data.content.status, Status::Ok);
+            data.content.execution_count
         })
     }
 
-    /// Receive from Shell and assert ExecuteReplyException message
-    pub fn recv_shell_execute_reply_exception(&self) -> Status {
-        let msg = Message::read_from_socket(&self.shell_socket).unwrap();
+    /// Receive from Shell and assert `ExecuteReplyException` message.
+    /// Returns `execution_count`.
+    pub fn recv_shell_execute_reply_exception(&self) -> u32 {
+        let msg = self.recv_shell();
 
         assert_match!(msg, Message::ExecuteReplyException(data) => {
-            data.content.status
+            assert_eq!(data.content.status, Status::Error);
+            data.content.execution_count
         })
     }
 

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -169,6 +169,15 @@ impl DummyFrontend {
         })
     }
 
+    /// Receive from Shell and assert ExecuteReplyException message
+    pub fn recv_shell_execute_reply_exception(&self) -> Status {
+        let msg = Message::read_from_socket(&self.shell_socket).unwrap();
+
+        assert_match!(msg, Message::ExecuteReplyException(data) => {
+            data.content.status
+        })
+    }
+
     /// Receives a Jupyter message from the IOPub socket
     pub fn recv_iopub(&self) -> Message {
         Message::read_from_socket(&self.iopub_socket).unwrap()

--- a/crates/amalthea/src/socket/shell.rs
+++ b/crates/amalthea/src/socket/shell.rs
@@ -221,6 +221,8 @@ impl Shell {
                 let r = req.send_reply(reply, &self.socket);
                 r
             },
+            // FIXME: Ark already created an `ExecuteReplyException` so we use
+            // `.send_reply()` instead of `.send_error()`. Can we streamline this?
             Err(err) => req.send_reply(err, &self.socket),
         }
     }

--- a/crates/amalthea/src/wire/error_reply.rs
+++ b/crates/amalthea/src/wire/error_reply.rs
@@ -13,7 +13,11 @@ use crate::wire::jupyter_message::MessageType;
 use crate::wire::jupyter_message::Status;
 
 /// Represents an error that occurred after processing a request on a
-/// ROUTER/DEALER socket
+/// ROUTER/DEALER socket.
+///
+/// This is the payload of a response to a request. Note that, as an exception,
+/// responses to `"execute_request"` include an `execution_count` field. We
+/// represent these with an `ExecuteReplyException`.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ErrorReply {
     /// The status; always Error
@@ -25,9 +29,11 @@ pub struct ErrorReply {
 }
 
 /// Note that the message type of an error reply is generally adjusted to match
-/// its request type (e.g. foo_request => foo_reply)
+/// its request type (e.g. foo_request => foo_reply). The message type
+/// implemented here is only a placeholder and should not appear in any
+/// serialized/deserialized message.
 impl MessageType for ErrorReply {
     fn message_type() -> String {
-        String::from("error")
+        String::from("*error payload*")
     }
 }

--- a/crates/amalthea/src/wire/execute_error.rs
+++ b/crates/amalthea/src/wire/execute_error.rs
@@ -11,7 +11,10 @@ use serde::Serialize;
 use crate::wire::exception::Exception;
 use crate::wire::jupyter_message::MessageType;
 
-/// Represents an exception that occurred while executing code
+/// Represents an exception that occurred while executing code.
+/// This is sent to IOPub. Not to be confused with `ExecuteReplyException`
+/// which is a special case of a message of type `"execute_reply"` sent to Shell
+/// in response to an `"execute_request"`.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ExecuteError {
     /// The exception that occurred during execution

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -187,6 +187,12 @@ impl TryFrom<&WireMessage> for Message {
         if kind == InspectReply::message_type() {
             return Ok(Message::InspectReply(JupyterMessage::try_from(msg)?));
         }
+        if kind == ExecuteReplyException::message_type() {
+            if let Ok(data) = JupyterMessage::try_from(msg) {
+                return Ok(Message::ExecuteReplyException(data));
+            }
+            // else fallthrough to try `ExecuteRequest` which has the same message type
+        }
         if kind == ExecuteRequest::message_type() {
             return Ok(Message::ExecuteRequest(JupyterMessage::try_from(msg)?));
         }
@@ -195,6 +201,9 @@ impl TryFrom<&WireMessage> for Message {
         }
         if kind == ExecuteResult::message_type() {
             return Ok(Message::ExecuteResult(JupyterMessage::try_from(msg)?));
+        }
+        if kind == ExecuteError::message_type() {
+            return Ok(Message::ExecuteError(JupyterMessage::try_from(msg)?));
         }
         if kind == ExecuteInput::message_type() {
             return Ok(Message::ExecuteInput(JupyterMessage::try_from(msg)?));

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -168,57 +168,83 @@ impl TryFrom<&WireMessage> for Message {
     /// messages that are received from the frontend.
     fn try_from(msg: &WireMessage) -> Result<Self, Error> {
         let kind = msg.header.msg_type.clone();
+
         if kind == KernelInfoRequest::message_type() {
             return Ok(Message::KernelInfoRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == KernelInfoReply::message_type() {
+        }
+        if kind == KernelInfoReply::message_type() {
             return Ok(Message::KernelInfoReply(JupyterMessage::try_from(msg)?));
-        } else if kind == IsCompleteRequest::message_type() {
+        }
+        if kind == IsCompleteRequest::message_type() {
             return Ok(Message::IsCompleteRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == IsCompleteReply::message_type() {
+        }
+        if kind == IsCompleteReply::message_type() {
             return Ok(Message::IsCompleteReply(JupyterMessage::try_from(msg)?));
-        } else if kind == InspectRequest::message_type() {
+        }
+        if kind == InspectRequest::message_type() {
             return Ok(Message::InspectRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == InspectReply::message_type() {
+        }
+        if kind == InspectReply::message_type() {
             return Ok(Message::InspectReply(JupyterMessage::try_from(msg)?));
-        } else if kind == ExecuteRequest::message_type() {
+        }
+        if kind == ExecuteRequest::message_type() {
             return Ok(Message::ExecuteRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == ExecuteReply::message_type() {
+        }
+        if kind == ExecuteReply::message_type() {
             return Ok(Message::ExecuteReply(JupyterMessage::try_from(msg)?));
-        } else if kind == ExecuteResult::message_type() {
+        }
+        if kind == ExecuteResult::message_type() {
             return Ok(Message::ExecuteResult(JupyterMessage::try_from(msg)?));
-        } else if kind == ExecuteInput::message_type() {
+        }
+        if kind == ExecuteInput::message_type() {
             return Ok(Message::ExecuteInput(JupyterMessage::try_from(msg)?));
-        } else if kind == CompleteRequest::message_type() {
+        }
+        if kind == CompleteRequest::message_type() {
             return Ok(Message::CompleteRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == CompleteReply::message_type() {
+        }
+        if kind == CompleteReply::message_type() {
             return Ok(Message::CompleteReply(JupyterMessage::try_from(msg)?));
-        } else if kind == ShutdownRequest::message_type() {
+        }
+        if kind == ShutdownRequest::message_type() {
             return Ok(Message::ShutdownRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == KernelStatus::message_type() {
+        }
+        if kind == KernelStatus::message_type() {
             return Ok(Message::Status(JupyterMessage::try_from(msg)?));
-        } else if kind == CommInfoRequest::message_type() {
+        }
+        if kind == CommInfoRequest::message_type() {
             return Ok(Message::CommInfoRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == CommInfoReply::message_type() {
+        }
+        if kind == CommInfoReply::message_type() {
             return Ok(Message::CommInfoReply(JupyterMessage::try_from(msg)?));
-        } else if kind == CommOpen::message_type() {
+        }
+        if kind == CommOpen::message_type() {
             return Ok(Message::CommOpen(JupyterMessage::try_from(msg)?));
-        } else if kind == CommWireMsg::message_type() {
+        }
+        if kind == CommWireMsg::message_type() {
             return Ok(Message::CommMsg(JupyterMessage::try_from(msg)?));
-        } else if kind == CommClose::message_type() {
+        }
+        if kind == CommClose::message_type() {
             return Ok(Message::CommClose(JupyterMessage::try_from(msg)?));
-        } else if kind == InterruptRequest::message_type() {
+        }
+        if kind == InterruptRequest::message_type() {
             return Ok(Message::InterruptRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == InterruptReply::message_type() {
+        }
+        if kind == InterruptReply::message_type() {
             return Ok(Message::InterruptReply(JupyterMessage::try_from(msg)?));
-        } else if kind == InputReply::message_type() {
+        }
+        if kind == InputReply::message_type() {
             return Ok(Message::InputReply(JupyterMessage::try_from(msg)?));
-        } else if kind == InputRequest::message_type() {
+        }
+        if kind == InputRequest::message_type() {
             return Ok(Message::InputRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == StreamOutput::message_type() {
+        }
+        if kind == StreamOutput::message_type() {
             return Ok(Message::StreamOutput(JupyterMessage::try_from(msg)?));
-        } else if kind == UiFrontendRequest::message_type() {
+        }
+        if kind == UiFrontendRequest::message_type() {
             return Ok(Message::CommRequest(JupyterMessage::try_from(msg)?));
-        } else if kind == JsonRpcReply::message_type() {
+        }
+        if kind == JsonRpcReply::message_type() {
             return Ok(Message::CommReply(JupyterMessage::try_from(msg)?));
         }
         return Err(Error::UnknownMessageType(kind));

--- a/crates/ark/tests/kernel.rs
+++ b/crates/ark/tests/kernel.rs
@@ -35,3 +35,18 @@ fn test_execute_request() {
 
     assert_eq!(frontend.recv_shell_execute_reply(), Status::Ok);
 }
+
+#[test]
+fn test_execute_request_error() {
+    let frontend = DummyArkFrontend::lock();
+
+    frontend.send_execute_request("stop('foobar')");
+    frontend.recv_iopub_busy();
+
+    assert_eq!(frontend.recv_iopub_execute_input().code, "stop('foobar')");
+    assert!(frontend.recv_iopub_execute_error().contains("foobar"));
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply_exception(), Status::Error);
+}

--- a/crates/ark/tests/kernel.rs
+++ b/crates/ark/tests/kernel.rs
@@ -1,5 +1,4 @@
 use amalthea::wire::jupyter_message::Message;
-use amalthea::wire::jupyter_message::Status;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use ark::fixtures::DummyArkFrontend;
 use stdext::assert_match;
@@ -28,12 +27,13 @@ fn test_execute_request() {
     frontend.send_execute_request("42");
     frontend.recv_iopub_busy();
 
-    assert_eq!(frontend.recv_iopub_execute_input().code, "42");
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, "42");
     assert_eq!(frontend.recv_iopub_execute_result(), "[1] 42");
 
     frontend.recv_iopub_idle();
 
-    assert_eq!(frontend.recv_shell_execute_reply(), Status::Ok);
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
 }
 
 #[test]
@@ -43,10 +43,14 @@ fn test_execute_request_error() {
     frontend.send_execute_request("stop('foobar')");
     frontend.recv_iopub_busy();
 
-    assert_eq!(frontend.recv_iopub_execute_input().code, "stop('foobar')");
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, "stop('foobar')");
     assert!(frontend.recv_iopub_execute_error().contains("foobar"));
 
     frontend.recv_iopub_idle();
 
-    assert_eq!(frontend.recv_shell_execute_reply_exception(), Status::Error);
+    assert_eq!(
+        frontend.recv_shell_execute_reply_exception(),
+        input.execution_count
+    );
 }

--- a/crates/ark/tests/kernel.rs
+++ b/crates/ark/tests/kernel.rs
@@ -33,6 +33,5 @@ fn test_execute_request() {
 
     frontend.recv_iopub_idle();
 
-    let reply = frontend.recv_shell_execute_reply();
-    assert_eq!(reply.status, Status::Ok);
+    assert_eq!(frontend.recv_shell_execute_reply(), Status::Ok);
 }


### PR DESCRIPTION
Branched from #542 

I was confused for a while trying to make tests for execution errors because of some puzzling ambiguities:

- In the Jupyter protocol all replies have nominally one type (`foo_reply` with `foo` corresponding to the request name, e.g. `foo_request`), but they each have two different structural types. When the `status` field is "error", all fields are omitted and instead the exception fields (`ename`, `evalue`, `stacktrace`, represented by the Rust type `Exception`) are included.  The contents of the error variants of these messages are represented by the Rust type `ErrorReply`, which currently has `"error"` as `message_type()`.

- As special case, the error variant of `"execute_reply"` messages must also preserve the `execution_count` field.  This is represented by the Rust type `ExecuteReplyException`.
  
  Ark handles this downstream and for this reason (I think) we don't use `send_error()` in Amalthea's Shell socket, we use `send_reply()` in both cases, which is also confusing: https://github.com/posit-dev/ark/blob/1c7a78f95c187294e17511f76fe10732a993261a/crates/amalthea/src/socket/shell.rs#L235

- Execution errors are also signaled on IOPub with messages of type `"error"`. These are represented by the Rust type `ExecuteError`.

Things changed in this PR:

- I was confused by `ErrorReply` having the same `message_type()` (https://github.com/posit-dev/ark/blob/eef44b6d5fe0dee9f297b530c04a890864ba3fbb/crates/amalthea/src/wire/error_reply.rs#L31) as IOPub's `ExecuteError` messages (https://github.com/posit-dev/ark/blob/eef44b6d5fe0dee9f297b530c04a890864ba3fbb/crates/amalthea/src/wire/execute_error.rs#L24). AFAICT this message type is never used. The payload is included as is by `error_reply()`, see https://github.com/posit-dev/ark/blob/1c7a78f95c187294e17511f76fe10732a993261a/crates/amalthea/src/wire/jupyter_message.rs#L347. It only needs a `message_type()` method for type reasons involving expected traits. So I set the message type to `"*error payload*"` to better reflect it's only a placeholder.

- We now take precautions in the `try_from()` method that deserialises Jupyter messages to disambiguate between the regular and error variants of `"execute_reply"`.

- The error situation is now better documented so it's not as confusing the next time we have to deal with Jupyter errors.