### PR TITLE
Teach the comm manager how to handle info requests

### DIFF
--- a/crates/amalthea/src/comm/event.rs
+++ b/crates/amalthea/src/comm/event.rs
@@ -5,6 +5,7 @@
  *
  */
 
+use crossbeam::channel::Sender;
 use serde_json::Value;
 
 use crate::comm::comm_channel::CommMsg;
@@ -27,18 +28,24 @@ pub enum CommManagerEvent {
 
     /// A Comm was closed
     Closed(String),
+
+    /// A comm manager request
+    Request(CommManagerRequest),
 }
 
 /**
- * Enumeration of events that can be sent by the comm manager. These notify
- * other parts of the application that a comm was opened or closed, so that they
- * can update their state.
+ * Enumeration of requests that can be received by the comm manager.
  */
-pub enum CommShellEvent {
-    /// A new comm was opened. The first value is the comm ID, and the second
-    /// value is the comm name.
-    Added(String, String),
+pub enum CommManagerRequest {
+    /// Open comm information
+    Info(Sender<CommManagerInfoReply>),
+}
 
-    /// A comm was removed. The value is the comm ID.
-    Removed(String),
+pub struct CommManagerInfoReply {
+    pub comms: Vec<CommInfo>,
+}
+
+pub struct CommInfo {
+    pub id: String,
+    pub name: String,
 }

--- a/crates/amalthea/src/kernel.rs
+++ b/crates/amalthea/src/kernel.rs
@@ -19,7 +19,6 @@ use stdext::unwrap;
 
 use crate::comm::comm_manager::CommManager;
 use crate::comm::event::CommManagerEvent;
-use crate::comm::event::CommShellEvent;
 use crate::connection_file::ConnectionFile;
 use crate::error::Error;
 use crate::language::control_handler::ControlHandler;
@@ -126,7 +125,7 @@ impl Kernel {
         // Create the comm manager thread
         let iopub_tx = self.create_iopub_tx();
         let comm_manager_rx = self.comm_manager_rx.clone();
-        let comm_changed_rx = CommManager::start(iopub_tx, comm_manager_rx);
+        CommManager::start(iopub_tx, comm_manager_rx);
 
         // Create the Shell ROUTER/DEALER socket and start a thread to listen
         // for client messages.
@@ -149,7 +148,6 @@ impl Kernel {
                 shell_socket,
                 iopub_tx_clone,
                 comm_manager_tx_clone,
-                comm_changed_rx,
                 shell_clone,
                 lsp_handler_clone,
                 dap_handler_clone,
@@ -311,7 +309,6 @@ impl Kernel {
         socket: Socket,
         iopub_tx: Sender<IOPubMessage>,
         comm_manager_tx: Sender<CommManagerEvent>,
-        comm_changed_rx: Receiver<CommShellEvent>,
         shell_handler: Arc<Mutex<dyn ShellHandler>>,
         lsp_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
         dap_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
@@ -320,7 +317,6 @@ impl Kernel {
             socket,
             iopub_tx.clone(),
             comm_manager_tx,
-            comm_changed_rx,
             shell_handler,
             lsp_handler,
             dap_handler,


### PR DESCRIPTION
In the past I have occasionally seen this on our Linux CI, and it seems to occur quite often on our Windows CI

```
---- test_kernel stdout ----
thread 'test_kernel' panicked at crates\amalthea\tests\client.rs:437:13:
assertion failed: !comms.contains_key(comm_id)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_kernel

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.58s

error: test failed, to rerun pass `-p amalthea --test client`
```

If we go look at that test, it looks like this:

```rust
    // Test closing the comm we just opened
    info!("Sending comm close request to the kernel");
    frontend.send_shell(CommClose {
        comm_id: comm_id.to_string(),
    });

    // Absorb the IOPub messages that the kernel sends back during the
    // processing of the above `CommClose` request
    info!("Receiving comm close IOPub messages from the kernel");
    frontend.recv_iopub(); // Busy
    frontend.recv_iopub(); // Idle

    // Test to see if the comm is still in the list of comms after closing it
    // (it should not be)
    info!("Requesting comm info from the kernel (to test closing)");
    frontend.send_shell(CommInfoRequest {
        target_name: "variables".to_string(),
    });
    let reply = frontend.recv_shell();
    match reply {
        Message::CommInfoReply(request) => {
            info!("Got comm info: {:?}", request);
            // Ensure the comm we just closed not present in the list of comms
            let comms = request.content.comms;
            assert!(!comms.contains_key(comm_id));
        },
        _ => {
            panic!(
                "Unexpected message received (expected comm info): {:?}",
                reply
            );
        },
    }
```

Here's what was happening:
- Both `Shell` and the `CommManager` maintain a list of `open_comms` that _should_ be mirror images of one another
- `Shell` gets `CommClose` and forwards that to `CommManager`
- In theory, `CommManager`:
    - Processes that event
    - Drops the comm from its list of `open_comms`
    - Sends `Shell` back a `CommShellEvent::Close` so `Shell` can also drop that comm from its `open_comms`
-  `Shell` gets `CommInfoRequest` and does _not_ forward that to `CommManager`. It uses its internal list of `open_comms` to reply to this request with.

The problem is that sometimes the `CommManager` sends back `CommShellEvent::Close` too slowly, and `Shell` gets that `CommInfoRequest` before its been told by the comm manager that the comm has actually closed. So the `open_comms` of `Shell` are temporarily out of sync with the `open_comms` of `CommManager`, and the test fails because `Shell`'s list of `open_comms` _do_ still contain that key.

I've reworked this by allowing `CommManager` to accept one off _requests_. In this case, a special `Info` request that comes with its own `tx` that it sends the reply back over. Our `Shell` no longer manages `open_comms`, and instead makes an `Info` request whenever it needs to report on the list of open comms - making `CommManager` the "source of truth" for the open comms. I believe this should solve the issue.