### PR TITLE
Move `IS_TESTING` to stdext

### DIFF
--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -64,7 +64,7 @@ tracing-error = "0.2.0"
 
 [dev-dependencies]
 insta = { version = "1.39.0" }
-harp = { path = "../harp", features = ["testing"]}
+stdext = { path = "../stdext", features = ["testing"]}
 
 [build-dependencies]
 chrono = "0.4.23"

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -1734,7 +1734,7 @@ unsafe extern "C" fn ps_onload_hook(pkg: SEXP, _path: SEXP) -> anyhow::Result<SE
 
 fn do_resource_namespaces() -> bool {
     // Don't slow down integration tests with srcref generation
-    if harp::IS_TESTING {
+    if stdext::IS_TESTING {
         return false;
     }
 

--- a/crates/ark/src/modules.rs
+++ b/crates/ark/src/modules.rs
@@ -76,7 +76,7 @@ pub struct ArkEnvs {
 
 pub fn initialize() -> anyhow::Result<()> {
     // If we are `testing`, set the corresponding R level global option
-    if harp::IS_TESTING {
+    if stdext::IS_TESTING {
         r_poke_option_ark_testing()
     }
 

--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -146,7 +146,7 @@ where
     T: 'env + Send,
 {
     // Escape hatch for unit tests
-    if harp::IS_TESTING {
+    if stdext::IS_TESTING {
         let _lock = unsafe { harp::fixtures::R_TEST_LOCK.lock() };
         r_test_init();
         return f();
@@ -255,7 +255,7 @@ where
     Fut: Future<Output = ()> + 'static,
 {
     // Escape hatch for unit tests
-    if harp::IS_TESTING {
+    if stdext::IS_TESTING {
         let _lock = unsafe { harp::fixtures::R_TEST_LOCK.lock() };
         futures::executor::block_on(fun());
         return;

--- a/crates/ark/src/sys/unix/interface.rs
+++ b/crates/ark/src/sys/unix/interface.rs
@@ -48,7 +48,7 @@ pub fn setup_r(mut args: Vec<*mut c_char>) {
 
         // Initialize the signal blocks and handlers (like interrupts).
         // Don't do that in tests because that makes them uninterruptible.
-        if !harp::IS_TESTING {
+        if !stdext::IS_TESTING {
             initialize_signal_handlers();
         }
 
@@ -78,7 +78,7 @@ pub fn setup_r(mut args: Vec<*mut c_char>) {
         //
         // This must be called _after_ `Rf_initialize_R()`, since that's where R
         // detects the stack size and sets the default limit.
-        if harp::IS_TESTING {
+        if stdext::IS_TESTING {
             libr::set(libr::R_CStackLimit, usize::MAX);
         }
 

--- a/crates/ark/src/thread.rs
+++ b/crates/ark/src/thread.rs
@@ -95,7 +95,7 @@ impl<T> Drop for RThreadSafe<T> {
 }
 
 fn check_on_main_r_thread(f: &str) {
-    if !RMain::on_main_thread() && !harp::IS_TESTING {
+    if !RMain::on_main_thread() && !stdext::IS_TESTING {
         let thread = std::thread::current();
         let name = thread.name().unwrap_or("<unnamed>");
         let message =

--- a/crates/harp/Cargo.toml
+++ b/crates/harp/Cargo.toml
@@ -21,6 +21,7 @@ libloading = "0.8.1"
 libr = { path = "../libr" }
 log = "0.4.17"
 once_cell = "1.17.1"
+parking_lot = "0.12.3"
 regex = "1.7.3"
 semver = "1.0.19"
 stdext = { path = "../stdext" }
@@ -28,7 +29,3 @@ serde = { version = "1.0.183", features = ["derive"] }
 serde_json = { version = "1.0.94", features = ["preserve_order"]}
 rust-embed = "8.2.0"
 tracing-error = "0.2.0"
-parking_lot = "0.12.3"
-
-[features]
-testing = []

--- a/crates/harp/src/fixtures/mod.rs
+++ b/crates/harp/src/fixtures/mod.rs
@@ -25,30 +25,6 @@ use crate::R_MAIN_THREAD_ID;
 // though.
 pub static mut R_TEST_LOCK: parking_lot::ReentrantMutex<()> = parking_lot::ReentrantMutex::new(());
 
-// This global variable is a workaround to enable test-only features or
-// behaviour in integration tests (i.e. tests that live in `crate/tests/` as
-// opposed to tests living in `crate/src/`).
-//
-// - Unfortunately we can't use `cfg(test)` in integration tests because they
-//   are treated as an external crate.
-//
-// - Unfortunately we cannot move some of our integration tests to `src/`
-//   because they must be run in their own process (e.g. because they are
-//   running R).
-//
-// - Unfortunately we can't use the workaround described in
-//   https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
-//   to enable a test-only feature in a self dependency in the dev-deps section
-//   of the manifest file because Rust-Analyzer doesn't support such
-//   circular dependencies: https://github.com/rust-lang/rust-analyzer/issues/14167.
-//   So instead we use the same trick with harp rather than ark, so that there
-//   is no circular dependency, which fixes the issue with Rust-Analyzer.
-//
-// - Unfortunately we can't query the features enabled in a dependency with `cfg`.
-//   So instead we define a global variable here that can then be checked at
-//   runtime in Ark.
-pub static IS_TESTING: bool = cfg!(feature = "testing");
-
 static INIT: Once = Once::new();
 
 /// Run code accessing the R API in a safe context.

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -60,7 +60,6 @@ pub use harp::exec::try_eval;
 pub use harp::exec::try_eval_silent;
 #[cfg(test)]
 pub(crate) use harp::fixtures::r_task;
-pub use harp::fixtures::IS_TESTING;
 pub use harp::object::list_get;
 pub use harp::object::list_poke;
 pub use harp::object::RObject;

--- a/crates/stdext/Cargo.toml
+++ b/crates/stdext/Cargo.toml
@@ -13,4 +13,7 @@ rust-version.workspace = true
 [dependencies]
 log = "0.4.18"
 
+[features]
+testing = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/stdext/src/lib.rs
+++ b/crates/stdext/src/lib.rs
@@ -15,11 +15,13 @@ pub mod ok;
 pub mod push;
 pub mod result;
 pub mod spawn;
+pub mod testing;
 pub mod unwrap;
 
 pub use crate::join::Joined;
 pub use crate::ok::Ok;
 pub use crate::push::Push;
+pub use crate::testing::IS_TESTING;
 pub use crate::unwrap::IntoOption;
 pub use crate::unwrap::IntoResult;
 

--- a/crates/stdext/src/testing.rs
+++ b/crates/stdext/src/testing.rs
@@ -1,0 +1,30 @@
+//
+// testing.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+// This global variable is a workaround to enable test-only features or
+// behaviour in integration tests (i.e. tests that live in `crate/tests/` as
+// opposed to tests living in `crate/src/`).
+//
+// - Unfortunately we can't use `cfg(test)` in integration tests because they
+//   are treated as an external crate.
+//
+// - Unfortunately we cannot move some of our integration tests to `src/`
+//   because they must be run in their own process (e.g. because they are
+//   running R).
+//
+// - Unfortunately we can't use the workaround described in
+//   https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
+//   to enable a test-only feature in a self dependency in the dev-deps section
+//   of the manifest file because Rust-Analyzer doesn't support such
+//   circular dependencies: https://github.com/rust-lang/rust-analyzer/issues/14167.
+//   So instead we use the same trick with stdext rather than ark, so that there
+//   is no circular dependency, which fixes the issue with Rust-Analyzer.
+//
+// - Unfortunately we can't query the features enabled in a dependency with `cfg`.
+//   So instead we define a global variable here that can then be checked at
+//   runtime in Ark.
+pub static IS_TESTING: bool = cfg!(feature = "testing");


### PR DESCRIPTION
So it can be used by amalthea to as needed, which does not depend on harp

May need to be rebased on top of https://github.com/posit-dev/ark/pull/541 after @lionel- merges that, but this is most of the boilerplate work