### PR TITLE
Make optional parts of `LanguageInfo` actually optional!

### DIFF
--- a/crates/amalthea/src/wire/language_info.rs
+++ b/crates/amalthea/src/wire/language_info.rs
@@ -24,14 +24,14 @@ pub struct LanguageInfo {
     /// The file extension for script files in the language
     pub file_extension: String,
 
-    /// Pygments lexer (for highlighting), if different than name
-    pub pygments_lexer: String,
+    /// Pygments lexer (for highlighting), if different than `name`
+    pub pygments_lexer: Option<String>,
 
-    /// Codemirror mode (for editing), if different than name
-    pub codemirror_mode: String,
+    /// Codemirror mode (for editing), if different than `name`
+    pub codemirror_mode: Option<String>,
 
-    /// Nbconvert exporter, if not default
-    pub nbconvert_exporter: String,
+    /// Nbconvert exporter, if not the default 'script' exporter
+    pub nbconvert_exporter: Option<String>,
 
     /// Posit extension
     pub positron: Option<LanguageInfoPositron>,

--- a/crates/amalthea/tests/shell/mod.rs
+++ b/crates/amalthea/tests/shell/mod.rs
@@ -93,9 +93,9 @@ impl ShellHandler for Shell {
             version: String::from("1.0"),
             file_extension: String::from(".ech"),
             mimetype: String::from("text/echo"),
-            pygments_lexer: String::new(),
-            codemirror_mode: String::new(),
-            nbconvert_exporter: String::new(),
+            pygments_lexer: None,
+            codemirror_mode: None,
+            nbconvert_exporter: None,
             positron: None,
         };
         Ok(KernelInfoReply {

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -160,9 +160,9 @@ impl ShellHandler for Shell {
             version: kernel_info.version.clone(),
             file_extension: String::from(".R"),
             mimetype: String::from("text/r"),
-            pygments_lexer: String::new(),
-            codemirror_mode: String::new(),
-            nbconvert_exporter: String::new(),
+            pygments_lexer: None,
+            codemirror_mode: None,
+            nbconvert_exporter: None,
             positron: Some(LanguageInfoPositron {
                 input_prompt: kernel_info.input_prompt.clone(),
                 continuation_prompt: kernel_info.continuation_prompt.clone(),

--- a/crates/ark/tests/kernel.rs
+++ b/crates/ark/tests/kernel.rs
@@ -12,6 +12,9 @@ fn test_kernel_info() {
 
     assert_match!(frontend.recv_shell(), Message::KernelInfoReply(reply) => {
         assert_eq!(reply.content.language_info.name, "R");
+        assert_eq!(reply.content.language_info.pygments_lexer, None);
+        assert_eq!(reply.content.language_info.codemirror_mode, None);
+        assert_eq!(reply.content.language_info.nbconvert_exporter, None);
     });
 
     frontend.recv_iopub_busy();

--- a/crates/echo/src/shell.rs
+++ b/crates/echo/src/shell.rs
@@ -69,9 +69,9 @@ impl ShellHandler for Shell {
             version: String::from("1.0"),
             file_extension: String::from(".ech"),
             mimetype: String::from("text/echo"),
-            pygments_lexer: String::new(),
-            codemirror_mode: String::new(),
-            nbconvert_exporter: String::new(),
+            pygments_lexer: None,
+            codemirror_mode: None,
+            nbconvert_exporter: None,
             positron: None,
         };
         Ok(KernelInfoReply {


### PR DESCRIPTION
I noticed in https://github.com/posit-dev/positron/issues/2098#issuecomment-2384064069 that in a jupyter console we get this pygment error:

<img width="1386" alt="Screenshot 2024-09-30 at 4 02 18 PM" src="https://github.com/user-attachments/assets/7a9c0015-5be4-4732-8cf8-73056d0ce2f6">

See that `for language ''`? That implies we are actually sending _the empty string_ over for the `pygments_lexer` part of the `language_info` part of a `kernel_info_reply`!
https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-info

Notice that it says

```
        # Pygments lexer, for highlighting
        # Only needed if it differs from the 'name' field.
        'pygments_lexer': str,
```

I'm interpreting this as meaning that its actually an optional field. We were treating it as a required `String`, but we sent over `String::new()`.

And indeed jupyter_console treats it as an optional field!
https://github.com/jupyter/jupyter_console/blob/fddbc42d2e0be85feace1fe783a05e2b569fceae/jupyter_console/ptshell.py#L541-L542

If `pygments_lexer` is not there, it falls back to `name` of `"R"` which is exactly what we wanted all along.

---

Now for the cool part. In jupyter console, `pygments_lexer` is used to look up syntax highlighting using the pygments library. So fixing this actually enables R syntax highlighting in jupyter console for ark!

It uses this, with the key being `short name: r`
https://pygments.org/docs/lexers/#pygments.lexers.r.SLexer

<img width="538" alt="Screenshot 2024-09-30 at 4 32 06 PM" src="https://github.com/user-attachments/assets/a88b2b4a-0e91-4149-b4e2-8069273ca68c">

