### PR TITLE
Extending the variables pane - Inspect

### DIFF
--- a/crates/ark/src/methods.rs
+++ b/crates/ark/src/methods.rs
@@ -33,6 +33,12 @@ pub enum ArkGenerics {
 
     #[strum(serialize = "ark_positron_variable_kind")]
     VariableKind,
+
+    #[strum(serialize = "ark_positron_variable_get_child_at")]
+    VariableGetChildAt,
+
+    #[strum(serialize = "ark_positron_variable_get_children")]
+    VariableGetChildren,
 }
 
 impl ArkGenerics {

--- a/crates/ark/src/modules/positron/methods.R
+++ b/crates/ark/src/modules/positron/methods.R
@@ -10,6 +10,8 @@ ark_methods_table$ark_positron_variable_display_value <- new.env(parent = emptye
 ark_methods_table$ark_positron_variable_display_type <- new.env(parent = emptyenv())
 ark_methods_table$ark_positron_variable_has_children <- new.env(parent = emptyenv())
 ark_methods_table$ark_positron_variable_kind <- new.env(parent = emptyenv())
+ark_methods_table$ark_positron_variable_get_child_at <- new.env(parent = emptyenv())
+ark_methods_table$ark_positron_variable_get_children <- new.env(parent = emptyenv())
 lockEnvironment(ark_methods_table, TRUE)
 
 ark_methods_allowed_packages <- c("torch", "reticulate")

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -820,8 +820,8 @@ impl PositronVariable {
             EnvironmentVariableNode::R6Node { object, name } => match name.as_str() {
                 "<private>" => {
                     let env = Environment::new(object);
-                    let enclos = Environment::new(RObject::view(env.find(".__enclos_env__")?));
-                    let private = RObject::view(enclos.find("private")?);
+                    let enclos = Environment::new(RObject::new(env.find(".__enclos_env__")?));
+                    let private = RObject::new(enclos.find("private")?);
 
                     Self::inspect_environment(private)
                 },

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1431,28 +1431,9 @@ impl PositronVariable {
                 let list = List::new(value.sexp)?;
                 let n = unsafe { list.len() };
 
-                let r_names = unsafe { RObject::new(Rf_getAttrib(value.sexp, R_NamesSymbol)) };
-                let names = if r_is_null(r_names.sexp) {
-                    vec![None; n]
-                } else {
-                    let names = unsafe { CharacterVector::new_unchecked(r_names) };
-                    if unsafe { names.len() } != n {
-                        vec![None; n]
-                    } else {
-                        names
-                            .iter()
-                            .map(|v| match v {
-                                None => None,
-                                Some(s) => {
-                                    if s.len() == 0 {
-                                        None
-                                    } else {
-                                        Some(s)
-                                    }
-                                },
-                            })
-                            .collect()
-                    }
+                let names = match value.names() {
+                    None => vec![None; n],
+                    Some(names) => names,
                 };
 
                 let variables = list

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1408,7 +1408,7 @@ impl PositronVariable {
         Ok(out)
     }
 
-    fn try_inspect_custom_method(value: SEXP) -> Result<Option<Vec<Variable>>, harp::Error> {
+    fn try_inspect_custom_method(value: SEXP) -> anyhow::Result<Option<Vec<Variable>>> {
         let result: Option<RObject> = ArkGenerics::VariableGetChildren
             .try_dispatch(value, vec![])
             .map_err(|err| harp::Error::Anyhow(err))?;
@@ -1418,10 +1418,10 @@ impl PositronVariable {
             Some(value) => {
                 // Make sure value is a list before using inspect_list
                 if !r_typeof(value.sexp) == LISTSXP {
-                    return Err(harp::Error::Anyhow(anyhow!(
+                    return Err(anyhow!(
                         "Expected `{}` to return a list.",
                         ArkGenerics::VariableGetChildren.to_string()
-                    )));
+                    ));
                 }
 
                 // This is essentially the same as Self::inspect_list but with modified `access_key`

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1097,10 +1097,7 @@ impl PositronVariable {
             EnvironmentVariableNode::Matrixcolumn { object, index } => unsafe {
                 let dim = IntegerVector::new(Rf_getAttrib(object.sexp, R_DimSymbol))?;
                 let n_row = dim.get_unchecked(0).unwrap() as isize;
-
-                // TODO: use ? here, but this does not return a crate::error::Error, so
-                //       maybe use anyhow here instead ?
-                let row_index = path_elt.parse::<isize>().unwrap();
+                let row_index = parse_index(path_elt)?;
 
                 Ok(EnvironmentVariableNode::AtomicVectorElement {
                     object,


### PR DESCRIPTION
This a follow up for #560. See there for more details.

This PR adds support for custom inspect behavior using the `ark_variable_get_child()` and `ark_variable_get_children()` methods. It's made in a separate PR as the large diff is confusing to review. Most of it though, is a refactor to make the recursive behavior of `resolve_object_from_path()` more explicit. 