### PR TITLE
Fix `r_task::initialize()` timing issue

### DIFF
--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -232,7 +232,6 @@ where
     return result.lock().unwrap().take().unwrap();
 }
 
-#[allow(dead_code)] // Currently unused
 pub(crate) fn spawn_idle<F, Fut>(fun: F)
 where
     F: FnOnce() -> Fut + 'static + Send,

--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -260,6 +260,8 @@ where
         return;
     }
 
+    // Note that this blocks until the channels are initialized,
+    // even though these are async tasks!
     let tasks_tx = if only_idle {
         get_tasks_idle_tx()
     } else {


### PR DESCRIPTION
Both `modules::initialize()` and `resource_loaded_namespaces()` call `r_task::spawn_idle()`. Even though that is async, it blocks until the task channels are initialized, so `r_task::initialize()` has to run first!

---

We didn't catch this during testing because `r_task::spawn_idle()` has that escape hatch during testing and just runs immediately. But CI in Positron caught an issue, and it was easy to reproduce by just starting up R with the latest version of ark in Positron. Things crashed immediately.