### PR TITLE
Primitive functionality to display comment sections in outlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 0.1.9000
 
+- Added partial support for outline headers in comments (@kv9898, posit-dev/positron#3822).
+
 - Sending long inputs of more than 4096 bytes no longer fails (posit-dev/positron#4745).
 
 - Jupyter: Fixed a bug in the kernel-info reply where the `pygments_lexer` field

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -55,7 +55,7 @@ type DocumentSymbolIndex = HashMap<DocumentSymbol, IndexEntry>;
 type WorkspaceIndex = Arc<Mutex<HashMap<DocumentPath, DocumentSymbolIndex>>>;
 
 static WORKSPACE_INDEX: LazyLock<WorkspaceIndex> = LazyLock::new(|| Default::default());
-static RE_COMMENT_SECTION: LazyLock<Regex> =
+pub static RE_COMMENT_SECTION: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(#+)\s*(.*?)\s*[#=-]{4,}\s*$").unwrap());
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -146,7 +146,7 @@ fn index_node(
         let comment_text = contents.node_slice(&node)?.to_string();
 
         // Check if the comment starts with one or more '#' followed by any text and ends with 4+ punctuations
-        if let Some((level, title)) = parse_comment_as_section(&comment_text) {
+        if let Some((_level, title)) = parse_comment_as_section(&comment_text) {
             // Create a symbol based on the parsed comment
             let start = convert_point_to_position(contents, node.start_position());
             let end = convert_point_to_position(contents, node.end_position());

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -60,7 +60,7 @@ pub fn symbols(params: &WorkspaceSymbolParams) -> anyhow::Result<Vec<SymbolInfor
             IndexEntryData::Section { level: _, title } => {
                 info.push(SymbolInformation {
                     name: title.to_string(),
-                    kind: SymbolKind::MODULE,
+                    kind: SymbolKind::STRING,
                     location: Location {
                         uri: Url::from_file_path(path).unwrap(),
                         range: entry.range,

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -170,7 +170,6 @@ fn index_node(
         }
     }
 
-    // Existing code for indexing assignments or other nodes...
     if matches!(
         node.node_type(),
         NodeType::BinaryOperator(BinaryOperatorType::LeftAssignment) |

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -124,9 +124,7 @@ fn is_indexable(node: &Node) -> bool {
 fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
     // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
     // Ensure that there's actual content between the start and the trailing symbols.
-    let comment_re = regex::Regex::new(r"^(#+)\s*([^\s#-].+?)\s*(#{4,}|-{4,}|={4,})$").unwrap();
-
-    if let Some(caps) = comment_re.captures(comment) {
+    if let Some(caps) = indexer::RE_COMMENT_SECTION.captures(comment) {
         let hashes = caps.get(1)?.as_str().len(); // Count the number of '#'
         let title = caps.get(2)?.as_str().trim().to_string(); // Extract the title text without trailing punctuations
         return Some((hashes, title)); // Return the level based on the number of '#' and the title

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -127,9 +127,9 @@ fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
     let comment_re = regex::Regex::new(r"^(#+)\s*([^\s#-].+?)\s*(#{4,}|-{4,}|={4,})$").unwrap();
 
     if let Some(caps) = comment_re.captures(comment) {
-        let hashes = caps.get(1)?.as_str().len();  // Count the number of '#'
-        let title = caps.get(2)?.as_str().trim().to_string();  // Extract the title text without trailing punctuations
-        return Some((hashes, title));  // Return the level based on the number of '#' and the title
+        let hashes = caps.get(1)?.as_str().len(); // Count the number of '#'
+        let title = caps.get(2)?.as_str().trim().to_string(); // Extract the title text without trailing punctuations
+        return Some((hashes, title)); // Return the level based on the number of '#' and the title
     }
 
     None
@@ -152,10 +152,10 @@ fn index_node(
             let end = convert_point_to_position(contents, node.end_position());
 
             let symbol = DocumentSymbol {
-                name: title,  // Use the title without the trailing '####' or '----'
-                kind: SymbolKind::STRING,  // Treat it as a string section
-                detail: None,  // No need to display level details
-                children: Some(Vec::new()),  // Prepare for child symbols if any
+                name: title,                // Use the title without the trailing '####' or '----'
+                kind: SymbolKind::STRING,   // Treat it as a string section
+                detail: None,               // No need to display level details
+                children: Some(Vec::new()), // Prepare for child symbols if any
                 deprecated: None,
                 tags: None,
                 range: Range { start, end },
@@ -173,15 +173,15 @@ fn index_node(
     // Existing code for indexing assignments or other nodes...
     if matches!(
         node.node_type(),
-        NodeType::BinaryOperator(BinaryOperatorType::LeftAssignment)
-            | NodeType::BinaryOperator(BinaryOperatorType::EqualsAssignment)
+        NodeType::BinaryOperator(BinaryOperatorType::LeftAssignment) |
+            NodeType::BinaryOperator(BinaryOperatorType::EqualsAssignment)
     ) {
         match index_assignment(node, contents, parent, symbols) {
             Ok(handled) => {
                 if handled {
                     return Ok(true);
                 }
-            }
+            },
             Err(error) => error!("{:?}", error),
         }
     }

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -120,29 +120,73 @@ fn is_indexable(node: &Node) -> bool {
     true
 }
 
+// Function to parse a comment and return the section level and title
+fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
+    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-' or '#'
+    // Ensure that there's actual content between the start and the trailing symbols.
+    let comment_re = regex::Regex::new(r"^(#+)\s*([^\s#-].+?)\s*(#{4,}|-{4,}|={4,})$").unwrap();
+
+    if let Some(caps) = comment_re.captures(comment) {
+        let hashes = caps.get(1)?.as_str().len();  // Count the number of '#'
+        let title = caps.get(2)?.as_str().trim().to_string();  // Extract the title text without trailing punctuations
+        return Some((hashes, title));  // Return the level based on the number of '#' and the title
+    }
+
+    None
+}
+
 fn index_node(
     node: &Node,
     contents: &Rope,
     parent: &mut DocumentSymbol,
     symbols: &mut Vec<DocumentSymbol>,
 ) -> Result<bool> {
-    // if we find an assignment, index it
+    // Check if the node is a comment and matches the markdown-style comment patterns
+    if node.node_type() == NodeType::Comment {
+        let comment_text = contents.node_slice(&node)?.to_string();
+
+        // Check if the comment starts with one or more '#' followed by any text and ends with 4+ punctuations
+        if let Some((level, title)) = parse_comment_as_section(&comment_text) {
+            // Create a symbol based on the parsed comment
+            let start = convert_point_to_position(contents, node.start_position());
+            let end = convert_point_to_position(contents, node.end_position());
+
+            let symbol = DocumentSymbol {
+                name: title,  // Use the title without the trailing '####' or '----'
+                kind: SymbolKind::STRING,  // Treat it as a string section
+                detail: None,  // No need to display level details
+                children: Some(Vec::new()),  // Prepare for child symbols if any
+                deprecated: None,
+                tags: None,
+                range: Range { start, end },
+                selection_range: Range { start, end },
+            };
+
+            // Add the symbol to the parent node
+            parent.children.as_mut().unwrap().push(symbol);
+
+            // Return early to avoid further processing
+            return Ok(true);
+        }
+    }
+
+    // Existing code for indexing assignments or other nodes...
     if matches!(
         node.node_type(),
-        NodeType::BinaryOperator(BinaryOperatorType::LeftAssignment) |
-            NodeType::BinaryOperator(BinaryOperatorType::EqualsAssignment)
+        NodeType::BinaryOperator(BinaryOperatorType::LeftAssignment)
+            | NodeType::BinaryOperator(BinaryOperatorType::EqualsAssignment)
     ) {
         match index_assignment(node, contents, parent, symbols) {
             Ok(handled) => {
                 if handled {
                     return Ok(true);
                 }
-            },
+            }
             Err(error) => error!("{:?}", error),
         }
     }
 
-    // by default, recurse into children
+    // Recurse into children
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if is_indexable(&child) {

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -122,7 +122,7 @@ fn is_indexable(node: &Node) -> bool {
 
 // Function to parse a comment and return the section level and title
 fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
-    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-' or '#'
+    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
     // Ensure that there's actual content between the start and the trailing symbols.
     let comment_re = regex::Regex::new(r"^(#+)\s*([^\s#-].+?)\s*(#{4,}|-{4,}|={4,})$").unwrap();
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -1,7 +1,7 @@
 //
 // symbols.rs
 //
-// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 //
 //
 


### PR DESCRIPTION
Attempt to (partly) fix https://github.com/posit-dev/positron/issues/3822

![image](https://github.com/user-attachments/assets/066589b4-46be-44a9-b21e-0ed61b821117)

I've managed to make comments which are in the shape of "## Title ####/----/====" appear in the outline with the changes in this pull request, but I struggled to make them appear in a hierarchical form/foldable.