### PR TITLE
`Originator` is actually not optional how we use it

### DIFF
--- a/crates/amalthea/src/language/shell_handler.rs
+++ b/crates/amalthea/src/language/shell_handler.rs
@@ -50,7 +50,7 @@ pub trait ShellHandler: Send {
     /// Docs: https://jupyter-client.readthedocs.io/en/stable/messaging.html#execute
     async fn handle_execute_request(
         &mut self,
-        originator: Option<Originator>,
+        originator: Originator,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException>;
 

--- a/crates/amalthea/src/socket/shell.rs
+++ b/crates/amalthea/src/socket/shell.rs
@@ -215,7 +215,7 @@ impl Shell {
     ) -> Result<(), Error> {
         log::info!("Received execution request {req:?}");
         let originator = Originator::from(&req);
-        match block_on(handler.handle_execute_request(Some(originator), &req.content)) {
+        match block_on(handler.handle_execute_request(originator, &req.content)) {
             Ok(reply) => {
                 log::info!("Got execution reply, delivering to frontend: {reply:?}");
                 let r = req.send_reply(reply, &self.socket);

--- a/crates/amalthea/src/wire/input_request.rs
+++ b/crates/amalthea/src/wire/input_request.rs
@@ -29,7 +29,7 @@ pub struct InputRequest {
 /// An input request originating from a Shell handler
 pub struct ShellInputRequest {
     /// The identity of the Shell that sent the request
-    pub originator: Option<Originator>,
+    pub originator: Originator,
 
     /// The input request itself
     pub request: InputRequest,
@@ -46,7 +46,7 @@ impl MessageType for InputRequest {
 pub struct UiCommFrontendRequest {
     /// The identity of the currently active `execute_request` that caused this
     /// comm request
-    pub originator: Option<Originator>,
+    pub originator: Originator,
 
     /// The response channel for the request
     pub response_tx: Sender<StdInRpcReply>,

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -60,7 +60,7 @@ pub struct JupyterMessage<T> {
     pub header: JupyterHeader,
 
     /// The header of the message from which this message originated. Optional;
-    /// not all messages have an originator.
+    /// not all messages have a parent.
     pub parent_header: Option<JupyterHeader>,
 
     /// The body (payload) of the message
@@ -339,14 +339,11 @@ where
 
     /// Create a new Jupyter message with a specific ZeroMQ identity.
     pub fn create_with_identity(
-        orig: Option<Originator>,
+        originator: Originator,
         content: T,
         session: &Session,
     ) -> JupyterMessage<T> {
-        let (id, parent_header) = match orig {
-            Some(orig) => (orig.zmq_id, Some(orig.header)),
-            None => (Vec::new(), None),
-        };
+        let (id, parent_header) = (originator.zmq_id, originator.header);
 
         JupyterMessage::<T> {
             zmq_identities: vec![id],
@@ -355,7 +352,7 @@ where
                 session.session_id.clone(),
                 session.username.clone(),
             ),
-            parent_header,
+            parent_header: Some(parent_header),
             content,
         }
     }

--- a/crates/amalthea/tests/shell/mod.rs
+++ b/crates/amalthea/tests/shell/mod.rs
@@ -66,11 +66,11 @@ impl Shell {
     }
 
     // Simluates an input request
-    fn prompt_for_input(&self, originator: Option<Originator>) {
+    fn prompt_for_input(&self, originator: Originator) {
         if let Err(err) = self
             .stdin_request_tx
             .send(StdInRequest::Input(ShellInputRequest {
-                originator: originator.clone(),
+                originator,
                 request: InputRequest {
                     prompt: String::from("Amalthea Echo> "),
                     password: false,
@@ -137,7 +137,7 @@ impl ShellHandler for Shell {
     /// Handles an ExecuteRequest; "executes" the code by echoing it.
     async fn handle_execute_request(
         &mut self,
-        originator: Option<Originator>,
+        originator: Originator,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException> {
         // Increment counter if we are storing this execution in history

--- a/crates/ark/src/request.rs
+++ b/crates/ark/src/request.rs
@@ -17,7 +17,7 @@ use crate::ui::UiCommMessage;
 pub enum RRequest {
     /// Fulfill an execution request from the frontend, producing either a
     /// Reply or an Exception
-    ExecuteCode(ExecuteRequest, Option<Originator>, Sender<ExecuteResponse>),
+    ExecuteCode(ExecuteRequest, Originator, Sender<ExecuteResponse>),
 
     /// Shut down the R execution thread
     Shutdown(bool),

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -204,7 +204,7 @@ impl ShellHandler for Shell {
     /// for processing.
     async fn handle_execute_request(
         &mut self,
-        originator: Option<Originator>,
+        originator: Originator,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException> {
         let (response_tx, response_rx) = unbounded::<ExecuteResponse>();

--- a/crates/echo/src/shell.rs
+++ b/crates/echo/src/shell.rs
@@ -113,7 +113,7 @@ impl ShellHandler for Shell {
     /// Handles an ExecuteRequest; "executes" the code by echoing it.
     async fn handle_execute_request(
         &mut self,
-        _originator: Option<Originator>,
+        _originator: Originator,
         req: &ExecuteRequest,
     ) -> Result<ExecuteReply, ExecuteReplyException> {
         // Increment counter if we are storing this execution in history


### PR DESCRIPTION
Clean up what is possible a historical artifact. `Originator` is not optional anywhere we use it. Making it required in the signatures makes it easier to reason about.