### PR TITLE
Always pass all zmq identities through the `Originator`

### DIFF
--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -343,16 +343,14 @@ where
         content: T,
         session: &Session,
     ) -> JupyterMessage<T> {
-        let (id, parent_header) = (originator.zmq_id, originator.header);
-
         JupyterMessage::<T> {
-            zmq_identities: vec![id],
+            zmq_identities: originator.zmq_identities,
             header: JupyterHeader::create(
                 T::message_type(),
                 session.session_id.clone(),
                 session.username.clone(),
             ),
-            parent_header: Some(parent_header),
+            parent_header: Some(originator.header),
             content,
         }
     }

--- a/crates/amalthea/src/wire/originator.rs
+++ b/crates/amalthea/src/wire/originator.rs
@@ -10,14 +10,14 @@ use crate::wire::jupyter_message::JupyterMessage;
 
 #[derive(Debug, Clone)]
 pub struct Originator {
-    pub zmq_id: Vec<u8>,
+    pub zmq_identities: Vec<Vec<u8>>,
     pub header: JupyterHeader,
 }
 
 impl<T> From<&JupyterMessage<T>> for Originator {
     fn from(msg: &JupyterMessage<T>) -> Originator {
         Originator {
-            zmq_id: msg.zmq_identities[0].clone(),
+            zmq_identities: msg.zmq_identities.clone(),
             header: msg.header.clone(),
         }
     }


### PR DESCRIPTION
We don't think this is going to have any practical impact, but felt like a code smell since there is no reason not to do this