### PR TITLE
Add support for alternative `RegistrationFile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,6 @@ dependencies = [
  "hmac",
  "log",
  "nix",
- "portpicker",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1998,15 +1997,6 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "powerfmt"

--- a/crates/amalthea/Cargo.toml
+++ b/crates/amalthea/Cargo.toml
@@ -19,7 +19,6 @@ hex = "0.4.3"
 hmac = "0.12.1"
 log = "0.4.17"
 nix = "0.26.2"
-portpicker = "0.1.1"
 rand = "0.8.5"
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = { version = "1.0.94", features = ["preserve_order"]}

--- a/crates/amalthea/src/error.rs
+++ b/crates/amalthea/src/error.rs
@@ -44,6 +44,7 @@ pub enum Error {
     InvalidCommMessage(String, String, String),
     InvalidInputRequest(String),
     InvalidConsoleInput(String),
+    Anyhow(anyhow::Error),
 }
 
 impl std::error::Error for Error {}
@@ -197,6 +198,9 @@ impl fmt::Display for Error {
             Error::InvalidConsoleInput(message) => {
                 write!(f, "{message}")
             },
+            Error::Anyhow(err) => {
+                write!(f, "{err:?}")
+            },
         }
     }
 }
@@ -205,4 +209,12 @@ impl<T: std::fmt::Debug> From<SendError<T>> for Error {
     fn from(err: SendError<T>) -> Self {
         Self::SendError(format!("Could not send {:?} to channel.", err.0))
     }
+}
+
+#[macro_export]
+macro_rules! anyhow {
+    ($($rest: expr),*) => {{
+        let message = anyhow::anyhow!($($rest, )*);
+        crate::error::Error::Anyhow(message)
+    }}
 }

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -185,6 +185,15 @@ impl DummyFrontend {
         )
         .unwrap();
 
+        // TODO!: Without this sleep, `IOPub` `Busy` messages sporadically
+        // don't arrive when running integration tests. I believe this is a result
+        // of PUB sockets dropping messages while in a "mute" state (i.e. no subscriber
+        // connected yet). Even though we run `iopub_socket.subscribe()` to subscribe,
+        // it seems like we can return from this function even before our socket
+        // has fully subscribed, causing messages to get dropped.
+        // https://libzmq.readthedocs.io/en/latest/zmq_socket.html
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
         Self {
             _control_socket,
             shell_socket,

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -54,7 +54,7 @@ impl DummyFrontend {
         let shell_id = rand::thread_rng().gen::<[u8; 16]>();
 
         // Create a new kernel session from the key
-        let session = Session::create(key.clone()).unwrap();
+        let session = Session::create(&key).unwrap();
 
         let ctx = zmq::Context::new();
 

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -6,13 +6,16 @@
  */
 
 use assert_matches::assert_matches;
+use rand::Rng;
 use serde_json::Value;
 
 use crate::connection_file::ConnectionFile;
+use crate::registration_file::RegistrationFile;
 use crate::session::Session;
 use crate::socket::socket::Socket;
 use crate::wire::execute_input::ExecuteInput;
 use crate::wire::execute_request::ExecuteRequest;
+use crate::wire::handshake_reply::HandshakeReply;
 use crate::wire::input_reply::InputReply;
 use crate::wire::jupyter_message::JupyterMessage;
 use crate::wire::jupyter_message::Message;
@@ -22,6 +25,13 @@ use crate::wire::status::ExecutionState;
 use crate::wire::stream::Stream;
 use crate::wire::wire_message::WireMessage;
 
+pub struct DummyConnection {
+    pub registration_socket: Socket,
+    pub ctx: zmq::Context,
+    pub session: Session,
+    pub key: String,
+}
+
 pub struct DummyFrontend {
     pub _control_socket: Socket,
     pub shell_socket: Socket,
@@ -29,119 +39,155 @@ pub struct DummyFrontend {
     pub stdin_socket: Socket,
     pub heartbeat_socket: Socket,
     session: Session,
-    key: String,
-    control_port: u16,
-    shell_port: u16,
-    iopub_port: u16,
-    stdin_port: u16,
-    heartbeat_port: u16,
 }
 
 pub struct ExecuteRequestOptions {
     pub allow_stdin: bool,
 }
 
-impl DummyFrontend {
+impl DummyConnection {
     pub fn new() -> Self {
-        use rand::Rng;
-
         // Create a random HMAC key for signing messages.
         let key_bytes = rand::thread_rng().gen::<[u8; 16]>();
         let key = hex::encode(key_bytes);
+
+        // Create a new kernel session from the key
+        let session = Session::create(&key).unwrap();
+
+        // Create a zmq context for all sockets we create in this session
+        let ctx = zmq::Context::new();
+
+        // Bind to a random port using `:0`
+        let endpoint = String::from("tcp://127.0.0.1:0");
+
+        let registration_socket = Socket::new(
+            session.clone(),
+            ctx.clone(),
+            String::from("Registration"),
+            zmq::REP,
+            None,
+            endpoint,
+        )
+        .unwrap();
+
+        Self {
+            registration_socket,
+            ctx,
+            session,
+            key,
+        }
+    }
+
+    /// Gets a connection file for the Amalthea kernel that will connect it to
+    /// this synthetic frontend. Uses a handshake through a registration
+    /// file to avoid race conditions related to port binding.
+    pub fn get_connection_files(&self) -> (ConnectionFile, RegistrationFile) {
+        let ip = String::from("127.0.0.1");
+        let transport = String::from("tcp");
+        let signature_scheme = String::from("hmac-sha256");
+        let key = self.key.clone();
+        let registration_port = crate::kernel::port_from_socket(&self.registration_socket).unwrap();
+
+        let registration_file = RegistrationFile {
+            ip,
+            transport,
+            signature_scheme,
+            key,
+            registration_port,
+        };
+
+        let connection_file = registration_file.as_connection_file();
+
+        (connection_file, registration_file)
+    }
+}
+
+impl DummyFrontend {
+    pub fn from_connection(connection: DummyConnection) -> Self {
+        // Wait to receive the handshake request so we know what ports to connect on
+        let message = Self::recv(&connection.registration_socket);
+        let handshake = assert_matches!(message, Message::HandshakeRequest(message) => {
+            message.content
+        });
+
+        // Immediately send back a handshake reply so the kernel can start up
+        Self::send(
+            &connection.registration_socket,
+            &connection.session,
+            HandshakeReply { status: Status::Ok },
+        );
 
         // Create a random socket identity for the shell and stdin sockets. Per
         // the Jupyter specification, these must share a ZeroMQ identity.
         let shell_id = rand::thread_rng().gen::<[u8; 16]>();
 
-        // Create a new kernel session from the key
-        let session = Session::create(&key).unwrap();
-
-        let ctx = zmq::Context::new();
-
-        let control_port = portpicker::pick_unused_port().unwrap();
-        let control = Socket::new(
-            session.clone(),
-            ctx.clone(),
+        let _control_socket = Socket::new(
+            connection.session.clone(),
+            connection.ctx.clone(),
             String::from("Control"),
             zmq::DEALER,
             None,
-            format!("tcp://127.0.0.1:{}", control_port),
+            format!("tcp://127.0.0.1:{}", handshake.control_port),
         )
         .unwrap();
 
-        let shell_port = portpicker::pick_unused_port().unwrap();
-        let shell = Socket::new(
-            session.clone(),
-            ctx.clone(),
+        let shell_socket = Socket::new(
+            connection.session.clone(),
+            connection.ctx.clone(),
             String::from("Shell"),
             zmq::DEALER,
             Some(&shell_id),
-            format!("tcp://127.0.0.1:{}", shell_port),
+            format!("tcp://127.0.0.1:{}", handshake.shell_port),
         )
         .unwrap();
 
-        let iopub_port = portpicker::pick_unused_port().unwrap();
-        let iopub = Socket::new(
-            session.clone(),
-            ctx.clone(),
+        let iopub_socket = Socket::new(
+            connection.session.clone(),
+            connection.ctx.clone(),
             String::from("IOPub"),
             zmq::SUB,
             None,
-            format!("tcp://127.0.0.1:{}", iopub_port),
+            format!("tcp://127.0.0.1:{}", handshake.iopub_port),
         )
         .unwrap();
 
-        let stdin_port = portpicker::pick_unused_port().unwrap();
-        let stdin = Socket::new(
-            session.clone(),
-            ctx.clone(),
+        // Subscribe to IOPub!
+        iopub_socket.subscribe().unwrap();
+
+        let stdin_socket = Socket::new(
+            connection.session.clone(),
+            connection.ctx.clone(),
             String::from("Stdin"),
             zmq::DEALER,
             Some(&shell_id),
-            format!("tcp://127.0.0.1:{}", stdin_port),
+            format!("tcp://127.0.0.1:{}", handshake.stdin_port),
         )
         .unwrap();
 
-        let heartbeat_port = portpicker::pick_unused_port().unwrap();
-        let heartbeat = Socket::new(
-            session.clone(),
-            ctx.clone(),
+        let heartbeat_socket = Socket::new(
+            connection.session.clone(),
+            connection.ctx.clone(),
             String::from("Heartbeat"),
             zmq::REQ,
             None,
-            format!("tcp://127.0.0.1:{}", heartbeat_port),
+            format!("tcp://127.0.0.1:{}", handshake.hb_port),
         )
         .unwrap();
 
         Self {
-            session,
-            key,
-            control_port,
-            _control_socket: control,
-            shell_port,
-            shell_socket: shell,
-            iopub_port,
-            iopub_socket: iopub,
-            stdin_port,
-            stdin_socket: stdin,
-            heartbeat_port,
-            heartbeat_socket: heartbeat,
+            _control_socket,
+            shell_socket,
+            iopub_socket,
+            stdin_socket,
+            heartbeat_socket,
+            session: connection.session,
         }
-    }
-
-    /// Completes initialization of the frontend (usually done after the kernel
-    /// is ready and connected)
-    pub fn complete_initialization(&self) {
-        self.iopub_socket.subscribe().unwrap();
     }
 
     /// Sends a Jupyter message on the Shell socket; returns the ID of the newly
     /// created message
     pub fn send_shell<T: ProtocolMessage>(&self, msg: T) -> String {
-        let message = JupyterMessage::create(msg, None, &self.session);
-        let id = message.header.msg_id.clone();
-        message.send(&self.shell_socket).unwrap();
-        id
+        Self::send(&self.shell_socket, &self.session, msg)
     }
 
     pub fn send_execute_request(&self, code: &str, options: ExecuteRequestOptions) -> String {
@@ -157,11 +203,17 @@ impl DummyFrontend {
 
     /// Sends a Jupyter message on the Stdin socket
     pub fn send_stdin<T: ProtocolMessage>(&self, msg: T) {
-        let message = JupyterMessage::create(msg, None, &self.session);
-        message.send(&self.stdin_socket).unwrap();
+        Self::send(&self.stdin_socket, &self.session, msg);
     }
 
-    pub fn recv(&self, socket: &Socket) -> Message {
+    fn send<T: ProtocolMessage>(socket: &Socket, session: &Session, msg: T) -> String {
+        let message = JupyterMessage::create(msg, None, session);
+        let id = message.header.msg_id.clone();
+        message.send(socket).unwrap();
+        id
+    }
+
+    pub fn recv(socket: &Socket) -> Message {
         // It's important to wait with a timeout because the kernel thread might
         // have panicked, preventing it from sending the expected message. The
         // tests would then hang indefinitely.
@@ -177,17 +229,17 @@ impl DummyFrontend {
 
     /// Receives a Jupyter message from the Shell socket
     pub fn recv_shell(&self) -> Message {
-        self.recv(&self.shell_socket)
+        Self::recv(&self.shell_socket)
     }
 
     /// Receives a Jupyter message from the IOPub socket
     pub fn recv_iopub(&self) -> Message {
-        self.recv(&self.iopub_socket)
+        Self::recv(&self.iopub_socket)
     }
 
     /// Receives a Jupyter message from the Stdin socket
     pub fn recv_stdin(&self) -> Message {
-        self.recv(&self.stdin_socket)
+        Self::recv(&self.stdin_socket)
     }
 
     /// Receive from Shell and assert `ExecuteReply` message.
@@ -332,22 +384,6 @@ impl DummyFrontend {
     /// Sends a (raw) message to the heartbeat socket
     pub fn send_heartbeat(&self, msg: zmq::Message) {
         self.heartbeat_socket.send(msg).unwrap();
-    }
-
-    /// Gets a connection file for the Amalthea kernel that will connect it to
-    /// this synthetic frontend.
-    pub fn get_connection_file(&self) -> ConnectionFile {
-        ConnectionFile {
-            control_port: self.control_port,
-            shell_port: self.shell_port,
-            stdin_port: self.stdin_port,
-            iopub_port: self.iopub_port,
-            hb_port: self.heartbeat_port,
-            transport: String::from("tcp"),
-            signature_scheme: String::from("hmac-sha256"),
-            ip: String::from("127.0.0.1"),
-            key: self.key.clone(),
-        }
     }
 
     /// Asserts that no socket has incoming data

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -64,16 +64,14 @@ impl DummyConnection {
         let transport = String::from("tcp");
         let signature_scheme = String::from("hmac-sha256");
 
-        // Bind to a random port using `:0`
-        let endpoint = String::from("{transport}://{ip}:0");
-
+        // Bind to a random port using `0`
         let registration_socket = Socket::new(
             session.clone(),
             ctx.clone(),
             String::from("Registration"),
             zmq::REP,
             None,
-            endpoint,
+            Self::endpoint_from_parts(&transport, &ip, 0),
         )
         .unwrap();
 
@@ -104,6 +102,14 @@ impl DummyConnection {
 
         (connection_file, registration_file)
     }
+
+    fn endpoint(&self, port: u16) -> String {
+        Self::endpoint_from_parts(&self.transport, &self.ip, port)
+    }
+
+    fn endpoint_from_parts(transport: &str, ip: &str, port: u16) -> String {
+        format!("{transport}://{ip}:{port}")
+    }
 }
 
 impl DummyFrontend {
@@ -131,7 +137,7 @@ impl DummyFrontend {
             String::from("Control"),
             zmq::DEALER,
             None,
-            format!("tcp://127.0.0.1:{}", handshake.control_port),
+            connection.endpoint(handshake.control_port),
         )
         .unwrap();
 
@@ -141,7 +147,7 @@ impl DummyFrontend {
             String::from("Shell"),
             zmq::DEALER,
             Some(&shell_id),
-            format!("tcp://127.0.0.1:{}", handshake.shell_port),
+            connection.endpoint(handshake.shell_port),
         )
         .unwrap();
 
@@ -151,7 +157,7 @@ impl DummyFrontend {
             String::from("IOPub"),
             zmq::SUB,
             None,
-            format!("tcp://127.0.0.1:{}", handshake.iopub_port),
+            connection.endpoint(handshake.iopub_port),
         )
         .unwrap();
 
@@ -165,7 +171,7 @@ impl DummyFrontend {
             String::from("Stdin"),
             zmq::DEALER,
             Some(&shell_id),
-            format!("tcp://127.0.0.1:{}", handshake.stdin_port),
+            connection.endpoint(handshake.stdin_port),
         )
         .unwrap();
 
@@ -175,7 +181,7 @@ impl DummyFrontend {
             String::from("Heartbeat"),
             zmq::REQ,
             None,
-            format!("tcp://127.0.0.1:{}", handshake.hb_port),
+            connection.endpoint(handshake.hb_port),
         )
         .unwrap();
 

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -114,7 +114,8 @@ impl DummyConnection {
 
 impl DummyFrontend {
     pub fn from_connection(connection: DummyConnection) -> Self {
-        // Wait to receive the handshake request so we know what ports to connect on
+        // Wait to receive the handshake request so we know what ports to connect on.
+        // Note that `recv()` times out.
         let message = Self::recv(&connection.registration_socket);
         let handshake = assert_matches!(message, Message::HandshakeRequest(message) => {
             message.content

--- a/crates/amalthea/src/kernel.rs
+++ b/crates/amalthea/src/kernel.rs
@@ -276,6 +276,8 @@ pub fn connect(
 /// the remaining port informtation back to after we have bound to the ports ourselves.
 /// The `ConnectionFile` we return in this case temporarily has `0`s as the port numbers,
 /// which tells zeromq to bind to whatever random port the OS sees as free.
+///
+/// See https://github.com/jupyter/enhancement-proposals/pull/66.
 pub fn read_connection(connection_file: &str) -> (ConnectionFile, Option<RegistrationFile>) {
     match ConnectionFile::from_file(connection_file) {
         Ok(connection) => {

--- a/crates/amalthea/src/kernel.rs
+++ b/crates/amalthea/src/kernel.rs
@@ -5,6 +5,7 @@
  *
  */
 
+use core::panic;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -23,6 +24,7 @@ use crate::error::Error;
 use crate::language::control_handler::ControlHandler;
 use crate::language::server_handler::ServerHandler;
 use crate::language::shell_handler::ShellHandler;
+use crate::registration_file::RegistrationFile;
 use crate::session::Session;
 use crate::socket::control::Control;
 use crate::socket::heartbeat::Heartbeat;
@@ -33,40 +35,15 @@ use crate::socket::socket::Socket;
 use crate::socket::stdin::StdInRequest;
 use crate::socket::stdin::Stdin;
 use crate::stream_capture::StreamCapture;
+use crate::wire::handshake_request::HandshakeRequest;
 use crate::wire::input_reply::InputReply;
+use crate::wire::jupyter_message::JupyterMessage;
 use crate::wire::jupyter_message::Message;
 use crate::wire::jupyter_message::OutboundMessage;
+use crate::wire::jupyter_message::Status;
 
 macro_rules! report_error {
     ($($arg:tt)+) => (if cfg!(debug_assertions) { panic!($($arg)+) } else { log::error!($($arg)+) })
-}
-
-/// A Kernel represents a unique Jupyter kernel session and is the host for all
-/// execution and messaging threads.
-pub struct Kernel {
-    /// The name of the kernel.
-    name: String,
-
-    /// The connection metadata.
-    connection: ConnectionFile,
-
-    /// The unique session information for this kernel session.
-    session: Session,
-
-    /// Sends messages to the IOPub socket. This field is used throughout the
-    /// kernel codebase to send events to the frontend; use `create_iopub_tx`
-    /// to access it.
-    iopub_tx: Sender<IOPubMessage>,
-
-    /// Receives message sent to the IOPub socket
-    iopub_rx: Option<Receiver<IOPubMessage>>,
-
-    /// Sends notifications about comm changes and events to the comm manager.
-    /// Use `create_comm_manager_tx` to access it.
-    comm_manager_tx: Sender<CommManagerEvent>,
-
-    /// Receives notifications about comm changes and events
-    comm_manager_rx: Receiver<CommManagerEvent>,
 }
 
 /// Possible behaviors for the stream capture thread. When set to `Capture`,
@@ -78,418 +55,496 @@ pub enum StreamBehavior {
     None,
 }
 
-impl Kernel {
-    /// Create a new Kernel, given a connection file from a frontend.
-    pub fn new(name: &str, file: ConnectionFile) -> Result<Kernel, Error> {
-        let key = file.key.clone();
+/// Connects the Kernel to the frontend
+pub fn connect(
+    name: &str,
+    connection_file: &str,
+    shell_handler: Arc<Mutex<dyn ShellHandler>>,
+    control_handler: Arc<Mutex<dyn ControlHandler>>,
+    lsp_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
+    dap_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
+    stream_behavior: StreamBehavior,
+    iopub_tx: Sender<IOPubMessage>,
+    iopub_rx: Receiver<IOPubMessage>,
+    comm_manager_tx: Sender<CommManagerEvent>,
+    comm_manager_rx: Receiver<CommManagerEvent>,
+    // Receiver channel for the stdin socket; when input is needed, the
+    // language runtime can request it by sending an StdInRequest::Input to
+    // this channel. The frontend will prompt the user for input and
+    // the reply will be delivered via `stdin_reply_tx`.
+    // https://jupyter-client.readthedocs.io/en/stable/messaging.html#messages-on-the-stdin-router-dealer-channel.
+    // Note that we've extended the StdIn socket to support synchronous requests
+    // from a comm, see `StdInRequest::Comm`.
+    stdin_request_rx: Receiver<StdInRequest>,
+    // Transmission channel for StdIn replies
+    stdin_reply_tx: Sender<crate::Result<InputReply>>,
+) -> Result<(), Error> {
+    let ctx = zmq::Context::new();
 
-        let (iopub_tx, iopub_rx) = bounded::<IOPubMessage>(10);
-
-        // Create the pair of channels that will be used to relay messages from
-        // the open comms
-        let (comm_manager_tx, comm_manager_rx) = bounded::<CommManagerEvent>(10);
-
-        Ok(Self {
-            name: name.to_string(),
-            connection: file,
-            session: Session::create(key)?,
-            iopub_tx,
-            iopub_rx: Some(iopub_rx),
-            comm_manager_tx,
-            comm_manager_rx,
-        })
-    }
-
-    /// Connects the Kernel to the frontend
-    pub fn connect(
-        &mut self,
-        shell_handler: Arc<Mutex<dyn ShellHandler>>,
-        control_handler: Arc<Mutex<dyn ControlHandler>>,
-        lsp_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
-        dap_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
-        stream_behavior: StreamBehavior,
-        // Receiver channel for the stdin socket; when input is needed, the
-        // language runtime can request it by sending an StdInRequest::Input to
-        // this channel. The frontend will prompt the user for input and
-        // the reply will be delivered via `stdin_reply_tx`.
-        // https://jupyter-client.readthedocs.io/en/stable/messaging.html#messages-on-the-stdin-router-dealer-channel.
-        // Note that we've extended the StdIn socket to support synchronous requests
-        // from a comm, see `StdInRequest::Comm`.
-        stdin_request_rx: Receiver<StdInRequest>,
-        // Transmission channel for StdIn replies
-        stdin_reply_tx: Sender<crate::Result<InputReply>>,
-    ) -> Result<(), Error> {
-        let ctx = zmq::Context::new();
-
-        // Channels for communication of outbound messages between the
-        // socket threads and the 0MQ forwarding thread
-        let (outbound_tx, outbound_rx) = unbounded();
-
-        // Create the comm manager thread
-        let iopub_tx = self.create_iopub_tx();
-        let comm_manager_rx = self.comm_manager_rx.clone();
-        CommManager::start(iopub_tx, comm_manager_rx);
-
-        // Create the Shell ROUTER/DEALER socket and start a thread to listen
-        // for client messages.
-        let shell_socket = Socket::new(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("Shell"),
-            zmq::ROUTER,
-            None,
-            self.connection.endpoint(self.connection.shell_port),
-        )?;
-
-        let shell_clone = shell_handler.clone();
-        let iopub_tx_clone = self.create_iopub_tx();
-        let comm_manager_tx_clone = self.comm_manager_tx.clone();
-        let lsp_handler_clone = lsp_handler.clone();
-        let dap_handler_clone = dap_handler.clone();
-        spawn!(format!("{}-shell", self.name), move || {
-            Self::shell_thread(
-                shell_socket,
-                iopub_tx_clone,
-                comm_manager_tx_clone,
-                shell_clone,
-                lsp_handler_clone,
-                dap_handler_clone,
-            )
-        });
-
-        // Create the IOPub PUB/SUB socket and start a thread to broadcast to
-        // the client. IOPub only broadcasts messages, so it listens to other
-        // threads on a Receiver<Message> instead of to the client.
-        let iopub_socket = Socket::new(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("IOPub"),
-            zmq::PUB,
-            None,
-            self.connection.endpoint(self.connection.iopub_port),
-        )?;
-        let iopub_rx = self.iopub_rx.take().unwrap();
-        spawn!(format!("{}-iopub", self.name), move || {
-            Self::iopub_thread(iopub_socket, iopub_rx)
-        });
-
-        // Create the heartbeat socket and start a thread to listen for
-        // heartbeat messages.
-        let heartbeat_socket = Socket::new(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("Heartbeat"),
-            zmq::REP,
-            None,
-            self.connection.endpoint(self.connection.hb_port),
-        )?;
-        spawn!(format!("{}-heartbeat", self.name), move || {
-            Self::heartbeat_thread(heartbeat_socket)
-        });
-
-        // Create the stdin socket and start a thread to listen for stdin
-        // messages. These are used by the kernel to request input from the
-        // user, and so flow in the opposite direction to the other sockets.
-        let stdin_socket = Socket::new(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("Stdin"),
-            zmq::ROUTER,
-            None,
-            self.connection.endpoint(self.connection.stdin_port),
-        )?;
-
-        let (stdin_inbound_tx, stdin_inbound_rx) = unbounded();
-        let (stdin_interrupt_tx, stdin_interrupt_rx) = bounded(1);
-        let stdin_session = stdin_socket.session.clone();
-
-        spawn!(format!("{}-stdin", self.name), move || {
-            Self::stdin_thread(
-                stdin_inbound_rx,
-                outbound_tx,
-                stdin_request_rx,
-                stdin_reply_tx,
-                stdin_interrupt_rx,
-                stdin_session,
-            )
-        });
-
-        // Create the thread that handles stdout and stderr, if requested
-        if stream_behavior == StreamBehavior::Capture {
-            let iopub_tx = self.create_iopub_tx();
-            spawn!(format!("{}-output-capture", self.name), move || {
-                Self::output_capture_thread(iopub_tx)
-            });
-        }
-
-        // Create the Control ROUTER/DEALER socket
-        let control_socket = Socket::new(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("Control"),
-            zmq::ROUTER,
-            None,
-            self.connection.endpoint(self.connection.control_port),
-        )?;
-
-        // Internal sockets for notifying the 0MQ forwarding
-        // thread that new outbound messages are available
-        let outbound_notif_socket_tx = Socket::new_pair(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("OutboundNotifierTx"),
-            None,
-            String::from("inproc://outbound_notif"),
-            true,
-        )?;
-        let outbound_notif_socket_rx = Socket::new_pair(
-            self.session.clone(),
-            ctx.clone(),
-            String::from("OutboundNotifierRx"),
-            None,
-            String::from("inproc://outbound_notif"),
-            false,
-        )?;
-
-        let outbound_rx_clone = outbound_rx.clone();
-
-        // Forwarding thread that bridges 0MQ sockets and Amalthea
-        // channels. Currently only used by StdIn.
-        spawn!(format!("{}-zmq-forwarding", self.name), move || {
-            Self::zmq_forwarding_thread(
-                outbound_notif_socket_rx,
-                stdin_socket,
-                stdin_inbound_tx,
-                outbound_rx_clone,
-            )
-        });
-
-        // The notifier thread watches Amalthea channels of outgoing
-        // messages for readiness. When a channel is hot, it notifies the
-        // forwarding thread through a 0MQ socket.
-        spawn!(format!("{}-zmq-notifier", self.name), move || {
-            Self::zmq_notifier_thread(outbound_notif_socket_tx, outbound_rx)
-        });
-
-        let iopub_tx = self.create_iopub_tx();
-
-        spawn!(format!("{}-control", self.name), || {
-            Self::control_thread(
-                control_socket,
-                iopub_tx,
-                control_handler,
-                stdin_interrupt_tx,
+    let (connection, session, registration) = match ConnectionFile::from_file(connection_file) {
+        Ok(connection) => {
+            log::info!("Loaded connection information from frontend in {connection_file}");
+            log::info!("Connection data: {connection:?}");
+            let session = Session::create(connection.key.as_str())?;
+            (connection, session, None)
+        },
+        Err(err) => {
+            log::info!(
+                "Failed to load `ConnectionFile`, trying to load as `RegistrationFile`:\n{err:?}"
             );
-            log::error!("Control thread exited");
-        });
 
-        Ok(())
-    }
-
-    /// Returns a copy of the IOPub sending channel.
-    pub fn create_iopub_tx(&self) -> Sender<IOPubMessage> {
-        self.iopub_tx.clone()
-    }
-
-    /// Returns a copy of the comm manager sending channel.
-    pub fn create_comm_manager_tx(&self) -> Sender<CommManagerEvent> {
-        self.comm_manager_tx.clone()
-    }
-
-    /// Starts the control thread
-    fn control_thread(
-        socket: Socket,
-        iopub_tx: Sender<IOPubMessage>,
-        handler: Arc<Mutex<dyn ControlHandler>>,
-        stdin_interrupt_tx: Sender<bool>,
-    ) {
-        let control = Control::new(socket, iopub_tx, handler, stdin_interrupt_tx);
-        control.listen();
-    }
-
-    /// Starts the shell thread.
-    fn shell_thread(
-        socket: Socket,
-        iopub_tx: Sender<IOPubMessage>,
-        comm_manager_tx: Sender<CommManagerEvent>,
-        shell_handler: Arc<Mutex<dyn ShellHandler>>,
-        lsp_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
-        dap_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
-    ) -> Result<(), Error> {
-        let mut shell = Shell::new(
-            socket,
-            iopub_tx.clone(),
-            comm_manager_tx,
-            shell_handler,
-            lsp_handler,
-            dap_handler,
-        );
-        shell.listen();
-        Ok(())
-    }
-
-    /// Starts the IOPub thread.
-    fn iopub_thread(socket: Socket, receiver: Receiver<IOPubMessage>) -> Result<(), Error> {
-        let mut iopub = IOPub::new(socket, receiver);
-        iopub.listen();
-        Ok(())
-    }
-
-    /// Starts the heartbeat thread.
-    fn heartbeat_thread(socket: Socket) -> Result<(), Error> {
-        let heartbeat = Heartbeat::new(socket);
-        heartbeat.listen();
-        Ok(())
-    }
-
-    /// Starts the stdin thread.
-    fn stdin_thread(
-        inbound_rx: Receiver<crate::Result<Message>>,
-        outbound_tx: Sender<OutboundMessage>,
-        stdin_request_rx: Receiver<StdInRequest>,
-        stdin_reply_tx: Sender<crate::Result<InputReply>>,
-        interrupt_rx: Receiver<bool>,
-        session: Session,
-    ) -> Result<(), Error> {
-        let stdin = Stdin::new(inbound_rx, outbound_tx, session);
-        stdin.listen(stdin_request_rx, stdin_reply_tx, interrupt_rx);
-        Ok(())
-    }
-
-    /// Starts the thread that forwards 0MQ messages to Amalthea channels
-    /// and vice versa.
-    fn zmq_forwarding_thread(
-        outbound_notif_socket: Socket,
-        stdin_socket: Socket,
-        stdin_inbound_tx: Sender<crate::Result<Message>>,
-        outbound_rx: Receiver<OutboundMessage>,
-    ) {
-        // This function checks for notifications that an outgoing message
-        // is ready to be read on an Amalthea channel. It returns
-        // immediately whether a message is ready or not.
-        let has_outbound = || -> bool {
-            if let Ok(n) = outbound_notif_socket.socket.poll(zmq::POLLIN, 0) {
-                if n == 0 {
-                    return false;
-                }
-                // Consume notification
-                let _ = unwrap!(outbound_notif_socket.socket.recv_bytes(0), Err(err) => {
-                    report_error!("Could not consume outbound notification socket: {}", err);
-                    return false;
-                });
-
-                true
-            } else {
-                false
-            }
-        };
-
-        // This function checks that a 0MQ message from the frontend is ready.
-        let has_inbound = || -> bool {
-            match stdin_socket.socket.poll(zmq::POLLIN, 0) {
-                Ok(n) if n > 0 => true,
-                _ => false,
-            }
-        };
-
-        // Forwards channel message from Amalthea to the frontend via the
-        // corresponding 0MQ socket. Should consume exactly 1 message and
-        // notify back the notifier thread to keep the mechanism synchronised.
-        let forward_outbound = || -> anyhow::Result<()> {
-            // Consume message and forward it
-            let outbound_msg = outbound_rx.recv()?;
-            match outbound_msg {
-                OutboundMessage::StdIn(msg) => msg.send(&stdin_socket)?,
+            let registration = match RegistrationFile::from_file(connection_file) {
+                Ok(registration) => registration,
+                Err(err) => panic!(
+                    "Failed to load as both `ConnectionFile` and `RegistrationFile`:\n{err:?}"
+                ),
             };
+            let session = Session::create(registration.key.as_str())?;
+            let connection = registration.as_connection_file();
+            (connection, session, Some(registration))
+        },
+    };
 
-            // Notify back
-            outbound_notif_socket.send(zmq::Message::new())?;
+    // Channels for communication of outbound messages between the
+    // socket threads and the 0MQ forwarding thread
+    let (outbound_tx, outbound_rx) = unbounded();
 
-            Ok(())
-        };
+    // Create the comm manager thread
+    CommManager::start(iopub_tx.clone(), comm_manager_rx);
 
-        // Forwards 0MQ message from the frontend to the corresponding
-        // Amalthea channel.
-        let forward_inbound = || -> anyhow::Result<()> {
-            let msg = Message::read_from_socket(&stdin_socket);
-            stdin_inbound_tx.send(msg)?;
-            Ok(())
-        };
+    // Create the Shell ROUTER/DEALER socket and start a thread to listen
+    // for client messages.
+    let shell_socket = Socket::new(
+        session.clone(),
+        ctx.clone(),
+        String::from("Shell"),
+        zmq::ROUTER,
+        None,
+        connection.endpoint(connection.shell_port),
+    )?;
+    let shell_port = port_finalize(&shell_socket, connection.shell_port);
 
-        // Create poll items necessary to call `zmq_poll()`
-        let mut poll_items = {
-            let outbound_notif_poll_item = outbound_notif_socket.socket.as_poll_item(zmq::POLLIN);
-            let stdin_poll_item = stdin_socket.socket.as_poll_item(zmq::POLLIN);
-            vec![outbound_notif_poll_item, stdin_poll_item]
-        };
+    let shell_clone = shell_handler.clone();
+    let iopub_tx_clone = iopub_tx.clone();
+    let lsp_handler_clone = lsp_handler.clone();
+    let dap_handler_clone = dap_handler.clone();
+    spawn!(format!("{name}-shell"), move || {
+        shell_thread(
+            shell_socket,
+            iopub_tx_clone,
+            comm_manager_tx,
+            shell_clone,
+            lsp_handler_clone,
+            dap_handler_clone,
+        )
+    });
 
-        loop {
-            let n = unwrap!(
-                zmq::poll(&mut poll_items, -1),
-                Err(err) => {
-                    report_error!("While polling 0MQ items: {}", err);
-                    0
-                }
-            );
+    // Create the IOPub PUB/SUB socket and start a thread to broadcast to
+    // the client. IOPub only broadcasts messages, so it listens to other
+    // threads on a Receiver<Message> instead of to the client.
+    let iopub_socket = Socket::new(
+        session.clone(),
+        ctx.clone(),
+        String::from("IOPub"),
+        zmq::PUB,
+        None,
+        connection.endpoint(connection.iopub_port),
+    )?;
+    let iopub_port = port_finalize(&iopub_socket, connection.iopub_port);
+    spawn!(format!("{name}-iopub"), move || {
+        iopub_thread(iopub_socket, iopub_rx)
+    });
 
-            for _ in 0..n {
-                if has_outbound() {
-                    unwrap!(
-                        forward_outbound(),
-                        Err(err) => report_error!("While forwarding outbound message: {}", err)
-                    );
-                    continue;
-                }
+    // Create the heartbeat socket and start a thread to listen for
+    // heartbeat messages.
+    let heartbeat_socket = Socket::new(
+        session.clone(),
+        ctx.clone(),
+        String::from("Heartbeat"),
+        zmq::REP,
+        None,
+        connection.endpoint(connection.hb_port),
+    )?;
+    let hb_port = port_finalize(&heartbeat_socket, connection.hb_port);
+    spawn!(format!("{name}-heartbeat"), move || {
+        heartbeat_thread(heartbeat_socket)
+    });
 
-                if has_inbound() {
-                    unwrap!(
-                        forward_inbound(),
-                        Err(err) => report_error!("While forwarding inbound message: {}", err)
-                    );
-                    continue;
-                }
+    // Create the stdin socket and start a thread to listen for stdin
+    // messages. These are used by the kernel to request input from the
+    // user, and so flow in the opposite direction to the other sockets.
+    let stdin_socket = Socket::new(
+        session.clone(),
+        ctx.clone(),
+        String::from("Stdin"),
+        zmq::ROUTER,
+        None,
+        connection.endpoint(connection.stdin_port),
+    )?;
+    let stdin_port = port_finalize(&stdin_socket, connection.stdin_port);
 
-                report_error!("Could not find readable message");
+    let (stdin_inbound_tx, stdin_inbound_rx) = unbounded();
+    let (stdin_interrupt_tx, stdin_interrupt_rx) = bounded(1);
+    let stdin_session = stdin_socket.session.clone();
+
+    spawn!(format!("{name}-stdin"), move || {
+        stdin_thread(
+            stdin_inbound_rx,
+            outbound_tx,
+            stdin_request_rx,
+            stdin_reply_tx,
+            stdin_interrupt_rx,
+            stdin_session,
+        )
+    });
+
+    // Create the thread that handles stdout and stderr, if requested
+    if stream_behavior == StreamBehavior::Capture {
+        let iopub_tx_clone = iopub_tx.clone();
+        spawn!(format!("{name}-output-capture"), move || {
+            output_capture_thread(iopub_tx_clone)
+        });
+    }
+
+    // Create the Control ROUTER/DEALER socket
+    let control_socket = Socket::new(
+        session.clone(),
+        ctx.clone(),
+        String::from("Control"),
+        zmq::ROUTER,
+        None,
+        connection.endpoint(connection.control_port),
+    )?;
+    let control_port = port_finalize(&control_socket, connection.control_port);
+
+    // Internal sockets for notifying the 0MQ forwarding
+    // thread that new outbound messages are available
+    let outbound_notif_socket_tx = Socket::new_pair(
+        session.clone(),
+        ctx.clone(),
+        String::from("OutboundNotifierTx"),
+        None,
+        String::from("inproc://outbound_notif"),
+        true,
+    )?;
+    let outbound_notif_socket_rx = Socket::new_pair(
+        session.clone(),
+        ctx.clone(),
+        String::from("OutboundNotifierRx"),
+        None,
+        String::from("inproc://outbound_notif"),
+        false,
+    )?;
+
+    let outbound_rx_clone = outbound_rx.clone();
+
+    // Forwarding thread that bridges 0MQ sockets and Amalthea
+    // channels. Currently only used by StdIn.
+    spawn!(format!("{name}-zmq-forwarding"), move || {
+        zmq_forwarding_thread(
+            outbound_notif_socket_rx,
+            stdin_socket,
+            stdin_inbound_tx,
+            outbound_rx_clone,
+        )
+    });
+
+    // The notifier thread watches Amalthea channels of outgoing
+    // messages for readiness. When a channel is hot, it notifies the
+    // forwarding thread through a 0MQ socket.
+    spawn!(format!("{name}-zmq-notifier"), move || {
+        zmq_notifier_thread(outbound_notif_socket_tx, outbound_rx)
+    });
+
+    let iopub_tx_clone = iopub_tx.clone();
+
+    spawn!(format!("{name}-control"), || {
+        control_thread(
+            control_socket,
+            iopub_tx_clone,
+            control_handler,
+            stdin_interrupt_tx,
+        );
+        log::error!("Control thread exited");
+    });
+
+    if let Some(registration) = registration {
+        handshake(
+            registration,
+            &ctx,
+            &session,
+            control_port,
+            shell_port,
+            stdin_port,
+            iopub_port,
+            hb_port,
+        )?;
+    };
+
+    Ok(())
+}
+
+/// Starts the control thread
+fn control_thread(
+    socket: Socket,
+    iopub_tx: Sender<IOPubMessage>,
+    handler: Arc<Mutex<dyn ControlHandler>>,
+    stdin_interrupt_tx: Sender<bool>,
+) {
+    let control = Control::new(socket, iopub_tx, handler, stdin_interrupt_tx);
+    control.listen();
+}
+
+/// Starts the shell thread.
+fn shell_thread(
+    socket: Socket,
+    iopub_tx: Sender<IOPubMessage>,
+    comm_manager_tx: Sender<CommManagerEvent>,
+    shell_handler: Arc<Mutex<dyn ShellHandler>>,
+    lsp_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
+    dap_handler: Option<Arc<Mutex<dyn ServerHandler>>>,
+) -> Result<(), Error> {
+    let mut shell = Shell::new(
+        socket,
+        iopub_tx.clone(),
+        comm_manager_tx,
+        shell_handler,
+        lsp_handler,
+        dap_handler,
+    );
+    shell.listen();
+    Ok(())
+}
+
+/// Starts the IOPub thread.
+fn iopub_thread(socket: Socket, receiver: Receiver<IOPubMessage>) -> Result<(), Error> {
+    let mut iopub = IOPub::new(socket, receiver);
+    iopub.listen();
+    Ok(())
+}
+
+/// Starts the heartbeat thread.
+fn heartbeat_thread(socket: Socket) -> Result<(), Error> {
+    let heartbeat = Heartbeat::new(socket);
+    heartbeat.listen();
+    Ok(())
+}
+
+/// Starts the stdin thread.
+fn stdin_thread(
+    inbound_rx: Receiver<crate::Result<Message>>,
+    outbound_tx: Sender<OutboundMessage>,
+    stdin_request_rx: Receiver<StdInRequest>,
+    stdin_reply_tx: Sender<crate::Result<InputReply>>,
+    interrupt_rx: Receiver<bool>,
+    session: Session,
+) -> Result<(), Error> {
+    let stdin = Stdin::new(inbound_rx, outbound_tx, session);
+    stdin.listen(stdin_request_rx, stdin_reply_tx, interrupt_rx);
+    Ok(())
+}
+
+/// Starts the thread that forwards 0MQ messages to Amalthea channels
+/// and vice versa.
+fn zmq_forwarding_thread(
+    outbound_notif_socket: Socket,
+    stdin_socket: Socket,
+    stdin_inbound_tx: Sender<crate::Result<Message>>,
+    outbound_rx: Receiver<OutboundMessage>,
+) {
+    // This function checks for notifications that an outgoing message
+    // is ready to be read on an Amalthea channel. It returns
+    // immediately whether a message is ready or not.
+    let has_outbound = || -> bool {
+        if let Ok(n) = outbound_notif_socket.socket.poll(zmq::POLLIN, 0) {
+            if n == 0 {
+                return false;
             }
+            // Consume notification
+            let _ = unwrap!(outbound_notif_socket.socket.recv_bytes(0), Err(err) => {
+                report_error!("Could not consume outbound notification socket: {}", err);
+                return false;
+            });
+
+            true
+        } else {
+            false
         }
-    }
+    };
 
-    /// Starts the thread that notifies the forwarding thread that new
-    /// outgoing messages have arrived from Amalthea.
-    fn zmq_notifier_thread(notif_socket: Socket, outbound_rx: Receiver<OutboundMessage>) {
-        let mut sel = Select::new();
-        sel.recv(&outbound_rx);
-
-        loop {
-            let _ = sel.ready();
-
-            unwrap!(
-                notif_socket.send(zmq::Message::new()),
-                Err(err) => {
-                    report_error!("Couldn't notify 0MQ thread: {}", err);
-                    continue;
-                }
-            );
-
-            // To keep things synchronised, wait to be notified that the
-            // channel message has been consumed before continuing the loop.
-            unwrap!(
-                {
-                    let mut msg = zmq::Message::new();
-                    notif_socket.recv(&mut msg)
-                },
-                Err(err) => {
-                    report_error!("Couldn't received acknowledgement from 0MQ thread: {}", err);
-                    continue;
-                }
-            );
+    // This function checks that a 0MQ message from the frontend is ready.
+    let has_inbound = || -> bool {
+        match stdin_socket.socket.poll(zmq::POLLIN, 0) {
+            Ok(n) if n > 0 => true,
+            _ => false,
         }
-    }
+    };
 
-    /// Starts the output capture thread.
-    fn output_capture_thread(iopub_tx: Sender<IOPubMessage>) -> Result<(), Error> {
-        let output_capture = StreamCapture::new(iopub_tx);
-        output_capture.listen();
+    // Forwards channel message from Amalthea to the frontend via the
+    // corresponding 0MQ socket. Should consume exactly 1 message and
+    // notify back the notifier thread to keep the mechanism synchronised.
+    let forward_outbound = || -> anyhow::Result<()> {
+        // Consume message and forward it
+        let outbound_msg = outbound_rx.recv()?;
+        match outbound_msg {
+            OutboundMessage::StdIn(msg) => msg.send(&stdin_socket)?,
+        };
+
+        // Notify back
+        outbound_notif_socket.send(zmq::Message::new())?;
+
         Ok(())
+    };
+
+    // Forwards 0MQ message from the frontend to the corresponding
+    // Amalthea channel.
+    let forward_inbound = || -> anyhow::Result<()> {
+        let msg = Message::read_from_socket(&stdin_socket);
+        stdin_inbound_tx.send(msg)?;
+        Ok(())
+    };
+
+    // Create poll items necessary to call `zmq_poll()`
+    let mut poll_items = {
+        let outbound_notif_poll_item = outbound_notif_socket.socket.as_poll_item(zmq::POLLIN);
+        let stdin_poll_item = stdin_socket.socket.as_poll_item(zmq::POLLIN);
+        vec![outbound_notif_poll_item, stdin_poll_item]
+    };
+
+    loop {
+        let n = unwrap!(
+            zmq::poll(&mut poll_items, -1),
+            Err(err) => {
+                report_error!("While polling 0MQ items: {}", err);
+                0
+            }
+        );
+
+        for _ in 0..n {
+            if has_outbound() {
+                unwrap!(
+                    forward_outbound(),
+                    Err(err) => report_error!("While forwarding outbound message: {}", err)
+                );
+                continue;
+            }
+
+            if has_inbound() {
+                unwrap!(
+                    forward_inbound(),
+                    Err(err) => report_error!("While forwarding inbound message: {}", err)
+                );
+                continue;
+            }
+
+            report_error!("Could not find readable message");
+        }
     }
+}
+
+/// Starts the thread that notifies the forwarding thread that new
+/// outgoing messages have arrived from Amalthea.
+fn zmq_notifier_thread(notif_socket: Socket, outbound_rx: Receiver<OutboundMessage>) {
+    let mut sel = Select::new();
+    sel.recv(&outbound_rx);
+
+    loop {
+        let _ = sel.ready();
+
+        unwrap!(
+            notif_socket.send(zmq::Message::new()),
+            Err(err) => {
+                report_error!("Couldn't notify 0MQ thread: {}", err);
+                continue;
+            }
+        );
+
+        // To keep things synchronised, wait to be notified that the
+        // channel message has been consumed before continuing the loop.
+        unwrap!(
+            {
+                let mut msg = zmq::Message::new();
+                notif_socket.recv(&mut msg)
+            },
+            Err(err) => {
+                report_error!("Couldn't received acknowledgement from 0MQ thread: {}", err);
+                continue;
+            }
+        );
+    }
+}
+
+/// Starts the output capture thread.
+fn output_capture_thread(iopub_tx: Sender<IOPubMessage>) -> Result<(), Error> {
+    let output_capture = StreamCapture::new(iopub_tx);
+    output_capture.listen();
+    Ok(())
+}
+
+fn handshake(
+    registration: RegistrationFile,
+    ctx: &zmq::Context,
+    session: &Session,
+    control_port: u16,
+    shell_port: u16,
+    stdin_port: u16,
+    iopub_port: u16,
+    hb_port: u16,
+) -> crate::Result<()> {
+    // Create the Shell ROUTER/DEALER socket and start a thread to listen
+    // for client messages.
+    let registration_socket = Socket::new(
+        session.clone(),
+        ctx.clone(),
+        String::from("Registration"),
+        zmq::REQ,
+        None,
+        registration.endpoint(),
+    )?;
+
+    let message = HandshakeRequest {
+        control_port,
+        shell_port,
+        stdin_port,
+        iopub_port,
+        hb_port,
+    };
+    let message = JupyterMessage::create(message, None, &session);
+
+    message.send(&registration_socket)?;
+
+    // Wait for the handshake reply with a 5 second timeout.
+    if !registration_socket
+        .poll_incoming(5)
+        .map_err(|err| Error::ZmqError(String::from("registration"), err))?
+    {
+        return Err(crate::anyhow!(
+            "Timeout while waiting for connection information from registration socket"
+        ));
+    }
+
+    let reply = Message::read_from_socket(&registration_socket).unwrap();
+    let status = if let Message::HandshakeReply(reply) = reply {
+        reply.content.status
+    } else {
+        return Err(crate::anyhow!(
+            "Unexpected message type received from registration socket: {reply:?}"
+        ));
+    };
+
+    match status {
+        Status::Ok => Ok(()),
+        Status::Error => Err(crate::anyhow!("Client failed to connect to ports.")),
+    }
+}
+
+fn port_finalize(socket: &Socket, port: u16) -> u16 {
+    if port != 0 {
+        // Client specified the port
+        return port;
+    }
+
+    // TODO:
+    let _endpoint = socket.socket.get_last_endpoint();
+    return port;
 }

--- a/crates/amalthea/src/lib.rs
+++ b/crates/amalthea/src/lib.rs
@@ -13,6 +13,7 @@ pub mod kernel;
 pub mod kernel_dirs;
 pub mod kernel_spec;
 pub mod language;
+pub mod registration_file;
 pub mod session;
 pub mod socket;
 pub mod stream_capture;

--- a/crates/amalthea/src/registration_file.rs
+++ b/crates/amalthea/src/registration_file.rs
@@ -16,22 +16,22 @@ use crate::connection_file::ConnectionFile;
 
 /// The contents of the Registration File as implied in JEP 66.
 #[derive(Deserialize, Debug)]
-pub(crate) struct RegistrationFile {
+pub struct RegistrationFile {
     /// The transport type to use for ZeroMQ; generally "tcp"
-    pub(crate) transport: String,
+    pub transport: String,
 
     /// The signature scheme to use for messages; generally "hmac-sha256"
-    pub(crate) signature_scheme: String,
+    pub signature_scheme: String,
 
     /// The IP address to bind to
-    pub(crate) ip: String,
+    pub ip: String,
 
     /// The HMAC-256 signing key, or an empty string for an unauthenticated
     /// connection
-    pub(crate) key: String,
+    pub key: String,
 
     /// ZeroMQ port: Registration messages (handshake)
-    pub(crate) registration_port: u16,
+    pub registration_port: u16,
 }
 
 impl RegistrationFile {

--- a/crates/amalthea/src/registration_file.rs
+++ b/crates/amalthea/src/registration_file.rs
@@ -1,0 +1,84 @@
+/*
+ * registration_file.rs
+ *
+ * Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+use std::error::Error;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::wire::jupyter_message::Status;
+
+/// The contents of the Registration File as implied in JEP 66.
+#[derive(Deserialize, Debug)]
+pub(crate) struct RegistrationFile {
+    /// The transport type to use for ZeroMQ; generally "tcp"
+    pub(crate) transport: String,
+
+    /// The signature scheme to use for messages; generally "hmac-sha256"
+    pub(crate) signature_scheme: String,
+
+    /// The IP address to bind to
+    pub(crate) ip: String,
+
+    /// The HMAC-256 signing key, or an empty string for an unauthenticated
+    /// connection
+    pub(crate) key: String,
+
+    /// ZeroMQ port: Registration messages (handshake)
+    pub(crate) registration_port: u16,
+}
+
+/// The handshake request
+#[derive(Deserialize, Debug)]
+pub(crate) struct HandshakeRequest {
+    /// ZeroMQ port: Control channel (kernel interrupts)
+    pub(crate) control_port: u16,
+
+    /// ZeroMQ port: Shell channel (execution, completion)
+    pub(crate) shell_port: u16,
+
+    /// ZeroMQ port: Standard input channel (prompts)
+    pub(crate) stdin_port: u16,
+
+    /// ZeroMQ port: IOPub channel (broadcasts input/output)
+    pub(crate) iopub_port: u16,
+
+    /// ZeroMQ port: Heartbeat messages (echo)
+    pub(crate) hb_port: u16,
+}
+
+/// The handshake reply
+#[derive(Deserialize, Debug)]
+pub(crate) struct HandshakeReply {
+    pub(crate) status: Status,
+}
+
+impl RegistrationFile {
+    /// Create a RegistrationFile by parsing the contents of a registration file.
+    pub fn from_file<P: AsRef<Path>>(
+        registration_file: P,
+    ) -> Result<RegistrationFile, Box<dyn Error>> {
+        let file = File::open(registration_file)?;
+        let reader = BufReader::new(file);
+        let control = serde_json::from_reader(reader)?;
+
+        Ok(control)
+    }
+
+    /// Given a port, return a URI-like string that can be used to connect to
+    /// the port, given the other parameters in the connection file.
+    ///
+    /// Example: `32` => `"tcp://127.0.0.1:32"`
+    pub fn endpoint(&self) -> String {
+        format!(
+            "{}://{}:{}",
+            self.transport, self.ip, self.registration_port
+        )
+    }
+}

--- a/crates/amalthea/src/session.rs
+++ b/crates/amalthea/src/session.rs
@@ -30,7 +30,7 @@ pub struct Session {
 
 impl Session {
     /// Create a new Session.
-    pub fn create(key: String) -> Result<Self, Error> {
+    pub fn create(key: &str) -> Result<Self, Error> {
         // Derive the signing key; an empty key indicates a session that doesn't
         // authenticate messages.
         let hmac_key = match key.len() {
@@ -38,7 +38,7 @@ impl Session {
             _ => {
                 let result = match Hmac::<Sha256>::new_from_slice(key.as_bytes()) {
                     Ok(hmac) => hmac,
-                    Err(err) => return Err(Error::HmacKeyInvalid(key, err)),
+                    Err(err) => return Err(Error::HmacKeyInvalid(String::from(key), err)),
                 };
                 Some(result)
             },

--- a/crates/amalthea/src/wire/handshake_reply.rs
+++ b/crates/amalthea/src/wire/handshake_reply.rs
@@ -1,0 +1,25 @@
+/*
+ * handshake_reply.rs
+ *
+ * Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::wire::jupyter_message::MessageType;
+use crate::wire::jupyter_message::Status;
+
+/// Represents a reply to a handshake_request
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HandshakeReply {
+    /// The execution status ("ok" or "error")
+    pub status: Status,
+}
+
+impl MessageType for HandshakeReply {
+    fn message_type() -> String {
+        String::from("handshake_reply")
+    }
+}

--- a/crates/amalthea/src/wire/handshake_request.rs
+++ b/crates/amalthea/src/wire/handshake_request.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 
 use crate::wire::jupyter_message::MessageType;
 
-/// Represents a reply to a handshake_request
+/// Represents a handshake_request
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HandshakeRequest {
     /// ZeroMQ port: Control channel (kernel interrupts)

--- a/crates/amalthea/src/wire/handshake_request.rs
+++ b/crates/amalthea/src/wire/handshake_request.rs
@@ -1,0 +1,36 @@
+/*
+ * handshake_request.rs
+ *
+ * Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::wire::jupyter_message::MessageType;
+
+/// Represents a reply to a handshake_request
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HandshakeRequest {
+    /// ZeroMQ port: Control channel (kernel interrupts)
+    pub control_port: u16,
+
+    /// ZeroMQ port: Shell channel (execution, completion)
+    pub shell_port: u16,
+
+    /// ZeroMQ port: Standard input channel (prompts)
+    pub stdin_port: u16,
+
+    /// ZeroMQ port: IOPub channel (broadcasts input/output)
+    pub iopub_port: u16,
+
+    /// ZeroMQ port: Heartbeat messages (echo)
+    pub hb_port: u16,
+}
+
+impl MessageType for HandshakeRequest {
+    fn message_type() -> String {
+        String::from("handshake_request")
+    }
+}

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -8,6 +8,8 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::handshake_reply::HandshakeReply;
+use super::handshake_request::HandshakeRequest;
 use super::stream::StreamOutput;
 use crate::comm::base_comm::JsonRpcReply;
 use crate::comm::ui_comm::UiFrontendRequest;
@@ -103,6 +105,8 @@ pub enum Message {
     CommReply(JupyterMessage<JsonRpcReply>),
     CommClose(JupyterMessage<CommClose>),
     StreamOutput(JupyterMessage<StreamOutput>),
+    HandshakeRequest(JupyterMessage<HandshakeRequest>),
+    HandshakeReply(JupyterMessage<HandshakeReply>),
 }
 
 /// Associates a `Message` to a 0MQ socket
@@ -153,6 +157,8 @@ impl TryFrom<&Message> for WireMessage {
             Message::CommRequest(msg) => WireMessage::try_from(msg),
             Message::CommReply(msg) => WireMessage::try_from(msg),
             Message::StreamOutput(msg) => WireMessage::try_from(msg),
+            Message::HandshakeReply(msg) => WireMessage::try_from(msg),
+            Message::HandshakeRequest(msg) => WireMessage::try_from(msg),
         }
     }
 }
@@ -255,6 +261,12 @@ impl TryFrom<&WireMessage> for Message {
         }
         if kind == JsonRpcReply::message_type() {
             return Ok(Message::CommReply(JupyterMessage::try_from(msg)?));
+        }
+        if kind == HandshakeRequest::message_type() {
+            return Ok(Message::HandshakeRequest(JupyterMessage::try_from(msg)?));
+        }
+        if kind == HandshakeReply::message_type() {
+            return Ok(Message::HandshakeReply(JupyterMessage::try_from(msg)?));
         }
         return Err(Error::UnknownMessageType(kind));
     }

--- a/crates/amalthea/src/wire/mod.rs
+++ b/crates/amalthea/src/wire/mod.rs
@@ -22,6 +22,8 @@ pub mod execute_reply_exception;
 pub mod execute_request;
 pub mod execute_response;
 pub mod execute_result;
+pub mod handshake_reply;
+pub mod handshake_request;
 pub mod header;
 pub mod help_link;
 pub mod input_reply;

--- a/crates/amalthea/tests/client.rs
+++ b/crates/amalthea/tests/client.rs
@@ -10,11 +10,13 @@ use std::sync::Mutex;
 
 use amalthea::comm::comm_channel::CommMsg;
 use amalthea::comm::event::CommManagerEvent;
+use amalthea::fixtures::dummy_frontend::DummyConnection;
 use amalthea::fixtures::dummy_frontend::DummyFrontend;
-use amalthea::kernel::Kernel;
+use amalthea::kernel;
 use amalthea::kernel::StreamBehavior;
 use amalthea::socket::comm::CommInitiator;
 use amalthea::socket::comm::CommSocket;
+use amalthea::socket::iopub::IOPubMessage;
 use amalthea::socket::stdin::StdInRequest;
 use amalthea::wire::comm_close::CommClose;
 use amalthea::wire::comm_info_reply::CommInfoTargetName;
@@ -48,18 +50,18 @@ fn test_kernel() {
     #[cfg(target_os = "windows")]
     return;
 
-    let frontend = DummyFrontend::new();
-    let connection_file = frontend.get_connection_file();
-    let mut kernel = Kernel::new("amalthea", connection_file).unwrap();
+    let connection = DummyConnection::new();
+    let (connection_file, registration_file) = connection.get_connection_files();
 
-    let iopub_tx = kernel.create_iopub_tx();
-    let comm_manager_tx = kernel.create_comm_manager_tx();
+    let (iopub_tx, iopub_rx) = bounded::<IOPubMessage>(10);
+
+    let (comm_manager_tx, comm_manager_rx) = bounded::<CommManagerEvent>(10);
 
     let (stdin_request_tx, stdin_request_rx) = bounded::<StdInRequest>(1);
     let (stdin_reply_tx, stdin_reply_rx) = unbounded();
 
     let shell = Arc::new(Mutex::new(shell::Shell::new(
-        iopub_tx,
+        iopub_tx.clone(),
         stdin_request_tx,
         stdin_reply_rx,
     )));
@@ -69,12 +71,19 @@ fn test_kernel() {
     env_logger::init();
     info!("Starting test kernel");
 
-    if let Err(err) = kernel.connect(
+    if let Err(err) = kernel::connect(
+        "amalthea",
+        connection_file,
+        Some(registration_file),
         shell,
         control,
         None,
         None,
         StreamBehavior::None,
+        iopub_tx,
+        iopub_rx,
+        comm_manager_tx.clone(),
+        comm_manager_rx,
         stdin_request_rx,
         stdin_reply_tx,
     ) {
@@ -86,8 +95,8 @@ fn test_kernel() {
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     // Complete client initialization
-    info!("Completing frontend initialization");
-    frontend.complete_initialization();
+    info!("Creating frontend");
+    let frontend = DummyFrontend::from_connection(connection);
 
     // Ask the kernel for the kernel info. This should return an object with the
     // language "Test" defined in our shell handler.

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use std::sync::MutexGuard;
 use std::sync::OnceLock;
 
+use amalthea::fixtures::dummy_frontend::DummyConnection;
 use amalthea::fixtures::dummy_frontend::DummyFrontend;
 
 use crate::interface::RMain;
@@ -52,9 +53,6 @@ impl DummyArkFrontend {
             panic!("Can't spawn Ark more than once");
         }
 
-        let frontend = DummyFrontend::new();
-        let connection_file = frontend.get_connection_file();
-
         // We don't want cli to try and restore the cursor, it breaks our tests
         // by adding unecessary ANSI escapes. We don't need this in Positron because
         // cli also checks `isatty(stdout())`, which is false in Positron because
@@ -62,9 +60,13 @@ impl DummyArkFrontend {
         // https://github.com/r-lib/cli/blob/1220ed092c03e167ff0062e9839c81d7258a4600/R/onload.R#L33-L40
         unsafe { std::env::set_var("R_CLI_HIDE_CURSOR", "false") };
 
+        let connection = DummyConnection::new();
+        let (connection_file, registration_file) = connection.get_connection_files();
+
         // Start the kernel in this thread so that panics are propagated
         crate::start::start_kernel(
             connection_file,
+            Some(registration_file),
             vec![
                 String::from("--interactive"),
                 String::from("--vanilla"),
@@ -81,7 +83,8 @@ impl DummyArkFrontend {
             RMain::start();
         });
 
-        frontend.complete_initialization();
+        let frontend = DummyFrontend::from_connection(connection);
+
         frontend
     }
 }

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -84,9 +84,7 @@ impl DummyArkFrontend {
             RMain::start();
         });
 
-        let frontend = DummyFrontend::from_connection(connection);
-
-        frontend
+        DummyFrontend::from_connection(connection)
     }
 }
 

--- a/crates/ark/src/start.rs
+++ b/crates/ark/src/start.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use amalthea::comm::event::CommManagerEvent;
+use amalthea::connection_file::ConnectionFile;
 use amalthea::kernel;
+use amalthea::registration_file::RegistrationFile;
 use amalthea::socket::iopub::IOPubMessage;
 use amalthea::socket::stdin::StdInRequest;
 use bus::Bus;
@@ -27,7 +29,8 @@ use crate::shell::Shell;
 /// Exported for unit tests.
 /// Call `RMain::start()` after this.
 pub fn start_kernel(
-    connection_file: &str,
+    connection_file: ConnectionFile,
+    registration_file: Option<RegistrationFile>,
     r_args: Vec<String>,
     startup_file: Option<String>,
     session_mode: SessionMode,
@@ -95,10 +98,10 @@ pub fn start_kernel(
 
     let (stdin_reply_tx, stdin_reply_rx) = unbounded();
 
-    // Connect the Amalthea kernel using the connection file
     let res = kernel::connect(
         "ark",
         connection_file,
+        registration_file,
         shell,
         control,
         Some(lsp),

--- a/crates/echo/src/main.rs
+++ b/crates/echo/src/main.rs
@@ -43,7 +43,7 @@ fn start_kernel(connection_file: ConnectionFile, registration_file: Option<Regis
     )));
     let control = Arc::new(Mutex::new(Control {}));
 
-    // TODO!: Is this working right? Probably not?
+    // TODO: Is this working right? Probably not?
     // If we run the echo CLI and provide a `connection_file` that
     // implements handshakes, then this definitely won't work right
     if let Err(err) = kernel::connect(

--- a/crates/echo/src/main.rs
+++ b/crates/echo/src/main.rs
@@ -43,6 +43,9 @@ fn start_kernel(connection_file: ConnectionFile, registration_file: Option<Regis
     )));
     let control = Arc::new(Mutex::new(Control {}));
 
+    // TODO!: Is this working right? Probably not?
+    // If we run the echo CLI and provide a `connection_file` that
+    // implements handshakes, then this definitely won't work right
     if let Err(err) = kernel::connect(
         "echo",
         connection_file,

--- a/crates/echo/src/main.rs
+++ b/crates/echo/src/main.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use amalthea::connection_file::ConnectionFile;
-use amalthea::kernel::Kernel;
 use amalthea::kernel::StreamBehavior;
 use amalthea::kernel_spec::KernelSpec;
 use amalthea::socket::stdin::StdInRequest;
@@ -25,7 +24,7 @@ use crate::control::Control;
 use crate::shell::Shell;
 
 fn start_kernel(connection_file: ConnectionFile) {
-    let mut kernel = match Kernel::new("echo", connection_file) {
+    let mut kernel = match kernel::new("echo", connection_file) {
         Ok(k) => k,
         Err(err) => {
             log::error!("Failed to create kernel: {err:?}");


### PR DESCRIPTION
Closes #563 
Joint work with @lionel- 

This PR implements the alternative `RegistrationFile` approach outlined in JEP 66 that allows for a "handshake" to occur between the client and server on startup. In particular, it allows the server to be in charge of picking the ports, and immediately binds to them as it picks them, avoiding any race conditions here.

If the `--connection_file` argument provided to ark can parse into this structure:

```rust
pub struct RegistrationFile {
    /// The transport type to use for ZeroMQ; generally "tcp"
    pub transport: String,

    /// The signature scheme to use for messages; generally "hmac-sha256"
    pub signature_scheme: String,

    /// The IP address to bind to
    pub ip: String,

    /// The HMAC-256 signing key, or an empty string for an unauthenticated
    /// connection
    pub key: String,

    /// ZeroMQ port: Registration messages (handshake)
    pub registration_port: u16,
}
```

Then we assume we are going to be using the handshake method of connecting. Otherwise we parse into the typical `ConnectionFile` structure and assume the Client picked the ports.

We expect that the Client _binds_ to a `zmq::REP` socket on `registration_port`. Ark, as the Server, will then _connect_ to this `registration_port` as a `zmq::REQ` socket.

Ark will pick ports, bind to them, and send this message over the registration socket:

```rust
pub struct HandshakeRequest {
    /// ZeroMQ port: Control channel (kernel interrupts)
    pub control_port: u16,

    /// ZeroMQ port: Shell channel (execution, completion)
    pub shell_port: u16,

    /// ZeroMQ port: Standard input channel (prompts)
    pub stdin_port: u16,

    /// ZeroMQ port: IOPub channel (broadcasts input/output)
    pub iopub_port: u16,

    /// ZeroMQ port: Heartbeat messages (echo)
    pub hb_port: u16,
}
```

Ark will then _immediately_ block, waiting for this `HandshakeReply`:

```rust
pub struct HandshakeReply {
    /// The execution status ("ok" or "error")
    pub status: Status,
}
```

This is just a receipt from the Client that confirms that it received the socket information.

If ark does not receive this reply after a few seconds, it will shut itself down.

Ark disconnects from the registration socket after receiving the `HandshakeReply`, and the kernel proceeds to start up.

Co-authored-by: Lionel Henry <lionel@posit.co>
Co-authored-by: Davis Vaughan <davis@posit.co>