### PR TITLE
Implement JEP 65

### DIFF
--- a/crates/amalthea/src/comm/comm_manager.rs
+++ b/crates/amalthea/src/comm/comm_manager.rs
@@ -23,6 +23,7 @@ use crate::comm::event::CommManagerRequest;
 use crate::socket::comm::CommInitiator;
 use crate::socket::comm::CommSocket;
 use crate::socket::iopub::IOPubMessage;
+use crate::wire::comm_close::CommClose;
 use crate::wire::comm_msg::CommWireMsg;
 use crate::wire::comm_open::CommOpen;
 use crate::wire::header::JupyterHeader;
@@ -245,7 +246,9 @@ impl CommManager {
                     }
                 },
 
-                CommMsg::Close => IOPubMessage::CommClose(comm_socket.comm_id.clone()),
+                CommMsg::Close => IOPubMessage::CommClose(CommClose {
+                    comm_id: comm_socket.comm_id.clone(),
+                }),
             };
 
             // Deliver the message to the frontend

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -347,7 +347,7 @@ impl DummyFrontend {
             let msg = self.recv_iopub();
 
             // Assert its type
-            let piece = assert_matches!(msg, Message::StreamOutput(data) => {
+            let piece = assert_matches!(msg, Message::Stream(data) => {
                 assert_eq!(data.content.name, stream);
                 data.content.text
             });

--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -162,10 +162,6 @@ impl DummyFrontend {
         )
         .unwrap();
 
-        // Subscribe to IOPub! Server is the one that sent us this port,
-        // so its already connected on its end.
-        iopub_socket.subscribe().unwrap();
-
         let stdin_socket = Socket::new(
             connection.session.clone(),
             connection.ctx.clone(),
@@ -186,14 +182,19 @@ impl DummyFrontend {
         )
         .unwrap();
 
-        // TODO!: Without this sleep, `IOPub` `Busy` messages sporadically
-        // don't arrive when running integration tests. I believe this is a result
-        // of PUB sockets dropping messages while in a "mute" state (i.e. no subscriber
-        // connected yet). Even though we run `iopub_socket.subscribe()` to subscribe,
-        // it seems like we can return from this function even before our socket
-        // has fully subscribed, causing messages to get dropped.
-        // https://libzmq.readthedocs.io/en/latest/zmq_socket.html
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Subscribe to IOPub! Server's XPUB socket will receive a notification of
+        // our subscription with `subscription`, then will publish an IOPub `Welcome`
+        // message, sending back our `subscription`.
+        iopub_socket.subscribe(b"").unwrap();
+
+        // Immediately block until we've received the IOPub welcome message.
+        // This confirms that we've fully subscribed and avoids dropping any
+        // of the initial IOPub messages that a server may send if we start
+        // perform requests immediately.
+        // https://github.com/posit-dev/ark/pull/577
+        assert_matches!(Self::recv(&iopub_socket), Message::Welcome(data) => {
+            assert_eq!(data.content.subscription, String::from(""));
+        });
 
         Self {
             _control_socket,

--- a/crates/amalthea/src/socket/iopub.rs
+++ b/crates/amalthea/src/socket/iopub.rs
@@ -13,7 +13,6 @@ use crossbeam::channel::Sender;
 use crossbeam::select;
 use log::trace;
 use log::warn;
-use serde::de::DeserializeOwned;
 
 use crate::error::Error;
 use crate::session::Session;

--- a/crates/amalthea/src/socket/iopub.rs
+++ b/crates/amalthea/src/socket/iopub.rs
@@ -86,7 +86,6 @@ pub enum IOPubMessage {
     CommClose(CommClose),
     DisplayData(DisplayData),
     UpdateDisplayData(UpdateDisplayData),
-    Welcome(Welcome),
     Wait(Wait),
 }
 
@@ -244,7 +243,6 @@ impl IOPub {
                 ))
             },
             IOPubMessage::Wait(content) => self.process_wait_request(content),
-            IOPubMessage::Welcome(_content) => todo!(),
         }
     }
 

--- a/crates/amalthea/src/socket/iopub.rs
+++ b/crates/amalthea/src/socket/iopub.rs
@@ -76,7 +76,7 @@ pub enum IOPubContextChannel {
 /// via a channel to the IOPub thread.
 pub enum IOPubMessage {
     Status(JupyterHeader, IOPubContextChannel, KernelStatus),
-    ExecuteResult(ExecuteResult),
+    // ExecuteResult(ExecuteResult),
     ExecuteError(ExecuteError),
     ExecuteInput(ExecuteInput),
     Stream(StreamOutput),
@@ -168,7 +168,7 @@ impl IOPub {
     }
 
     /// Process an IOPub message from another thread.
-    fn process_outbound_message(&mut self, message: IOPubMessage) -> Result<(), Error> {
+    fn process_outbound_message(&mut self, message: IOPubMessage) -> crate::Result<()> {
         match message {
             IOPubMessage::Status(context, context_channel, content) => {
                 // When we enter the Busy state as a result of a message, we
@@ -253,7 +253,7 @@ impl IOPub {
     /// When we get a subscription notification, we forward along an IOPub
     /// `Welcome` message back to the SUB, in compliance with JEP 65. Clients
     /// that don't know how to process this `Welcome` message should just ignore it.
-    fn process_inbound_message(&self, message: SubscriptionMessage) -> Result<(), Error> {
+    fn process_inbound_message(&self, message: SubscriptionMessage) -> crate::Result<()> {
         let subscription = message.subscription;
 
         match message.kind {
@@ -314,7 +314,7 @@ impl IOPub {
     }
 
     /// Forward a message on to the actual IOPub socket through the outbound channel
-    fn forward(&self, message: Message) -> Result<(), Error> {
+    fn forward(&self, message: Message) -> crate::Result<()> {
         self.outbound_tx
             .send(OutboundMessage::IOPub(message))
             .map_err(|err| crate::Error::SendError(format!("{err:?}")))
@@ -354,7 +354,7 @@ impl IOPub {
     ///
     /// If this new message switches streams, then we flush the existing stream
     /// before switching.
-    fn process_stream_message(&mut self, message: StreamOutput) -> Result<(), Error> {
+    fn process_stream_message(&mut self, message: StreamOutput) -> crate::Result<()> {
         if message.name != self.buffer.name {
             // Swap streams, but flush the existing stream first
             self.flush_stream();
@@ -377,7 +377,7 @@ impl IOPub {
     /// waiting for the queue to empty, it is possible for a message on a
     /// different socket that is sent after waiting to still get processed by
     /// the frontend before the messages we cleared from the IOPub queue.
-    fn process_wait_request(&mut self, message: Wait) -> Result<(), Error> {
+    fn process_wait_request(&mut self, message: Wait) -> crate::Result<()> {
         message.wait_tx.send(()).unwrap();
         Ok(())
     }

--- a/crates/amalthea/src/socket/socket.rs
+++ b/crates/amalthea/src/socket/socket.rs
@@ -37,10 +37,13 @@ impl Socket {
 
         // For the server side of IOPub, there are a few options we need to tweak
         if name == "IOPub" && kind == zmq::SocketType::XPUB {
-            // Sets the XPUB socket behavior on new subscriptions and unsubscriptions.
-            // A value of `false` is the default and passes only new subscription messages
-            // to upstream. A value of `true` passes all subscription messages upstream.
-            // This is possibly important if a client temporarily disconnects? xeus also does this.
+            // Sets the XPUB socket to report subscription events even for
+            // topics that were already subscribed to.
+            //
+            // See notes in https://zguide.zeromq.org/docs/chapter5 and
+            // https://zguide.zeromq.org/docs/chapter6 and the discussion in
+            // https://lists.zeromq.org/pipermail/zeromq-dev/2012-October/018470.html
+            // that lead to the creation of this socket option.
             socket
                 .set_xpub_verbose(true)
                 .map_err(|err| Error::CreateSocketFailed(name.clone(), err))?;

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -120,7 +120,11 @@ pub enum Message {
     CommClose(JupyterMessage<CommClose>),
 }
 
-/// Associates a `Message` to a 0MQ socket
+/// Associates a `Message` to a 0MQ socket.
+///
+/// At a high level, outbound messages originate from kernel components on a
+/// crossbeam channel and are transfered to the client via a 0MQ socket owned by
+/// the forwarding thread.
 pub enum OutboundMessage {
     StdIn(Message),
     IOPub(Message),

--- a/crates/amalthea/src/wire/jupyter_message.rs
+++ b/crates/amalthea/src/wire/jupyter_message.rs
@@ -283,6 +283,9 @@ impl TryFrom<&WireMessage> for Message {
         if kind == HandshakeReply::message_type() {
             return Ok(Message::HandshakeReply(JupyterMessage::try_from(msg)?));
         }
+        if kind == Welcome::message_type() {
+            return Ok(Message::Welcome(JupyterMessage::try_from(msg)?));
+        }
         return Err(Error::UnknownMessageType(kind));
     }
 }

--- a/crates/amalthea/src/wire/mod.rs
+++ b/crates/amalthea/src/wire/mod.rs
@@ -44,4 +44,5 @@ pub mod shutdown_request;
 pub mod status;
 pub mod stream;
 pub mod update_display_data;
+pub mod welcome;
 pub mod wire_message;

--- a/crates/amalthea/src/wire/mod.rs
+++ b/crates/amalthea/src/wire/mod.rs
@@ -43,6 +43,7 @@ pub mod shutdown_reply;
 pub mod shutdown_request;
 pub mod status;
 pub mod stream;
+pub mod subscription_message;
 pub mod update_display_data;
 pub mod welcome;
 pub mod wire_message;

--- a/crates/amalthea/src/wire/subscription_message.rs
+++ b/crates/amalthea/src/wire/subscription_message.rs
@@ -27,7 +27,7 @@ pub enum SubscriptionKind {
 
 impl SubscriptionMessage {
     /// Read a SubscriptionMessage from a ZeroMQ socket.
-    pub fn read_from_socket(socket: &Socket) -> Result<SubscriptionMessage, Error> {
+    pub fn read_from_socket(socket: &Socket) -> crate::Result<SubscriptionMessage> {
         let bufs = socket.recv_multipart()?;
         Self::from_buffers(bufs)
     }
@@ -37,7 +37,7 @@ impl SubscriptionMessage {
     /// Always a single frame (i.e. `bufs` should be length 1).
     /// Either `1{subscription}` for subscription.
     /// Or `0{subscription}` for unsubscription.
-    fn from_buffers(bufs: Vec<Vec<u8>>) -> Result<SubscriptionMessage, Error> {
+    fn from_buffers(bufs: Vec<Vec<u8>>) -> crate::Result<SubscriptionMessage> {
         if bufs.len() != 1 {
             let n = bufs.len();
             return Err(crate::anyhow!(

--- a/crates/amalthea/src/wire/subscription_message.rs
+++ b/crates/amalthea/src/wire/subscription_message.rs
@@ -1,0 +1,81 @@
+/*
+ * subscription_message.rs
+ *
+ * Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::error::Error;
+use crate::socket::socket::Socket;
+
+/// Represents a special `SubscriptionMessage` sent from a SUB to an XPUB
+/// upon `socket.set_subscribe(subscription)` or `socket.set_unsubscribe(subscription)`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SubscriptionMessage {
+    pub kind: SubscriptionKind,
+    pub subscription: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum SubscriptionKind {
+    Subscribe,
+    Unsubscribe,
+}
+
+impl SubscriptionMessage {
+    /// Read a SubscriptionMessage from a ZeroMQ socket.
+    pub fn read_from_socket(socket: &Socket) -> Result<SubscriptionMessage, Error> {
+        let bufs = socket.recv_multipart()?;
+        Self::from_buffers(bufs)
+    }
+
+    /// Parse a SubscriptionMessage from an array of buffers (from a ZeroMQ message)
+    ///
+    /// Always a single frame (i.e. `bufs` should be length 1).
+    /// Either `1{subscription}` for subscription.
+    /// Or `0{subscription}` for unsubscription.
+    fn from_buffers(bufs: Vec<Vec<u8>>) -> Result<SubscriptionMessage, Error> {
+        if bufs.len() != 1 {
+            let n = bufs.len();
+            return Err(crate::anyhow!(
+                "Subscription message on XPUB must be a single frame. {n} frames were received."
+            ));
+        }
+
+        let buf = bufs.get(0).unwrap();
+
+        if buf.len() == 0 {
+            return Err(crate::anyhow!(
+                "Subscription message on XPUB must be at least length 1 to determine subscribe/unsubscribe."
+            ));
+        }
+
+        let kind = if buf[0] == 1 {
+            SubscriptionKind::Subscribe
+        } else {
+            SubscriptionKind::Unsubscribe
+        };
+
+        // Advance to access remaining buffer
+        let buf = &buf[1..];
+
+        // The rest of the message is the UTF-8 `subscription`
+        let subscription = match std::str::from_utf8(&buf) {
+            Ok(subscription) => subscription,
+            Err(err) => {
+                return Err(Error::Utf8Error(
+                    String::from("subscription"),
+                    buf.to_vec(),
+                    err,
+                ))
+            },
+        };
+
+        let subscription = subscription.to_string();
+
+        Ok(Self { kind, subscription })
+    }
+}

--- a/crates/amalthea/src/wire/welcome.rs
+++ b/crates/amalthea/src/wire/welcome.rs
@@ -17,8 +17,11 @@ pub struct Welcome {
     pub subscription: String,
 }
 
+// Message type comes from copying what xeus and jupyter_kernel_test use:
+// https://github.com/jupyter-xeus/xeus-zmq/pull/31
+// https://github.com/jupyter/jupyter_kernel_test/blob/5f2c65271b48dc95fc75a9585cb1d6db0bb55557/jupyter_kernel_test/__init__.py#L449-L450
 impl MessageType for Welcome {
     fn message_type() -> String {
-        String::from("welcome")
+        String::from("iopub_welcome")
     }
 }

--- a/crates/amalthea/src/wire/welcome.rs
+++ b/crates/amalthea/src/wire/welcome.rs
@@ -1,0 +1,24 @@
+/*
+ * welcome.rs
+ *
+ * Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::wire::jupyter_message::MessageType;
+
+/// An IOPub message used for handshaking by modern clients.
+/// See JEP 65: https://github.com/jupyter/enhancement-proposals/pull/65
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Welcome {
+    pub subscription: String,
+}
+
+impl MessageType for Welcome {
+    fn message_type() -> String {
+        String::from("welcome")
+    }
+}

--- a/crates/amalthea/src/wire/welcome.rs
+++ b/crates/amalthea/src/wire/welcome.rs
@@ -15,7 +15,7 @@ use crate::wire::jupyter_message::MessageType;
 ///
 /// Note that this IOPub `Welcome` message is the same basic idea as
 /// `ZMQ_XPUB_WELCOME_MSG`, set through `socket.set_xpub_welcome_msg()`,
-/// but the JEP committee decided not to use that for some reason.
+/// but the JEP committee decided not to use that.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Welcome {
     /// The `subscription` sent to the XPUB socket by the SUB's call

--- a/crates/amalthea/src/wire/welcome.rs
+++ b/crates/amalthea/src/wire/welcome.rs
@@ -12,8 +12,16 @@ use crate::wire::jupyter_message::MessageType;
 
 /// An IOPub message used for handshaking by modern clients.
 /// See JEP 65: https://github.com/jupyter/enhancement-proposals/pull/65
+///
+/// Note that this IOPub `Welcome` message is the same basic idea as
+/// `ZMQ_XPUB_WELCOME_MSG`, set through `socket.set_xpub_welcome_msg()`,
+/// but the JEP committee decided not to use that for some reason.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Welcome {
+    /// The `subscription` sent to the XPUB socket by the SUB's call
+    /// to `socket.set_subscribe(subscription)`. The IOPub XPUB socket
+    /// passes this `subscription` back to the IOPub SUB in the `Welcome`
+    /// message.
     pub subscription: String,
 }
 


### PR DESCRIPTION
Closes https://github.com/posit-dev/ark/issues/569

This PR fixes a race condition regarding subscriptions to IOPub that causes clients to miss IOPub messages:

- On startup a client connects to the server sockets of a kernel.
- The client sends a request on Shell.
- The kernel starts processing the request and emits busy on IOPub.

If the client hasn't been able to fully subscribe to IOPub, messages can be lost, in particular the Busy message that encloses the request output.

On the Positron side we fixed it by sending kernel-info requests in a loop until we get a Ready message on IOPub. This signals Positron that the kernel is fully connected and in the Ready state: https://github.com/posit-dev/positron/pull/2207. We haven't implemented a similar fix in our dummy clients for integration tests and we believe this is what is causing the race condition described in #569.

As noted in https://github.com/posit-dev/positron/pull/2207, there is an accepted JEP proposal (JEP 65) that aims at solving this problem by switching to XPUB.

https://jupyter.org/enhancement-proposals/65-jupyter-xpub/jupyter-xpub.html
https://github.com/jupyter/enhancement-proposals/pull/65

The XPUB socket allows the server to get notified of all new subscriptions. A message of type `iopub_welcome` is sent to all connected clients. They should generally ignore it but clients that have just started up can use it as a cue that IOPub is correctly connected and that they won't miss any output from that point on.

Approach:

The subscription notification comes in as a message on the IOPub socket. This is problematic because the IOPub thread now needs to listens to its crossbeam channel and to the 0MQ socket at the same time, which isn't possible without resorting to timeout polling. So we use the same approach and infrastructure that we implemented in https://github.com/posit-dev/ark/pull/58 for listeing to both input replies on the StdIn socket and interrupt notifications on a crossbeam channel. The forwarding thread now owns the IOPub socket and listens for subscription notifications and fowrards IOPub messages coming from the kernel components.


Co-authored-by: Davis Vaughan <davis@posit.co>
Co-authored-by: Lionel Henry <lionel@posit.co>