### PR TITLE
Add CI caching of Rust dependency crates

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -29,8 +29,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Update Build Environment
+        run: |
+          sudo apt-get update
+
+      - name: Install Nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
         if: matrix.config.rust == 'nightly'
+
+      - name: Report Rust Toolchain
+        run: rustup show
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        # Cache isn't useful on nightly, it would be thrown away every day
+        if: matrix.config.rust != 'nightly'
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -44,10 +57,6 @@ jobs:
           packages:
             data.table
             tibble
-
-      - name: Setup Build Environment
-        run: |
-          sudo apt-get update
 
       - name: Setup SSH access
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Report Rust Toolchain
+        run: rustup show
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Report Rust Toolchain
+        run: rustup show
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install R
         uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Inspired by https://github.com/astral-sh/ruff/blob/main/.github/workflows/ci.yaml#L559

It seems pretty smart https://github.com/Swatinem/rust-cache