### PR TITLE
Set `R_MAIN_THREAD_ID` at the very beginning of setup again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "stdext",
  "struct-field-names-as-array",
  "strum 0.26.2",
+ "tempfile",
  "tokio",
  "tower-lsp",
  "tracing",
@@ -893,6 +894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "filetime"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,7 +1455,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
 
@@ -1529,9 +1536,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -1564,6 +1571,12 @@ name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "local-channel"
@@ -2386,8 +2399,21 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.7",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2809,6 +2835,19 @@ name = "target-lexicon"
 version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+
+[[package]]
+name = "tempfile"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix 0.38.37",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "tendril"
@@ -3528,6 +3567,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -65,6 +65,7 @@ tracing-error = "0.2.0"
 [dev-dependencies]
 insta = { version = "1.39.0" }
 stdext = { path = "../stdext", features = ["testing"]}
+tempfile = "3.13.0"
 
 [build-dependencies]
 chrono = "0.4.23"

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -187,10 +187,11 @@ impl DummyArkFrontendRprofile {
     /// Lock a frontend that supports `.Rprofile`s.
     ///
     /// NOTE: This variant can only be called exactly once per process,
-    /// because you can only load an `.Rprofile` one time.
-    ///
-    /// NOTE: Only one `DummyArkFrontend` variant should call `lock()` within
-    /// a given process.
+    /// because you can only load an `.Rprofile` one time. Additionally,
+    /// only one `DummyArkFrontend` variant should call `lock()` within
+    /// a given process. Practically, this ends up meaning you can only
+    /// have 1 test block per integration test that uses a
+    /// `DummyArkFrontendRprofile`.
     pub fn lock() -> Self {
         Self::init();
 

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -8,7 +8,6 @@ use std::sync::OnceLock;
 use amalthea::fixtures::dummy_frontend::DummyConnection;
 use amalthea::fixtures::dummy_frontend::DummyFrontend;
 
-use crate::interface::RMain;
 use crate::interface::SessionMode;
 
 // There can be only one frontend per process. Needs to be in a mutex because
@@ -80,8 +79,6 @@ impl DummyArkFrontend {
                 session_mode,
                 false,
             );
-
-            RMain::start();
         });
 
         DummyFrontend::from_connection(connection)

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -56,14 +56,7 @@ impl DummyArkFrontend {
     fn get_frontend() -> &'static Arc<Mutex<DummyFrontend>> {
         // These are the hard-coded defaults. Call `init()` explicitly to
         // override.
-        let options = DummyArkFrontendOptions {
-            interactive: true,
-            site_r_profile: false,
-            user_r_profile: false,
-            r_environ: false,
-            session_mode: SessionMode::Console,
-        };
-
+        let options = DummyArkFrontendOptions::default();
         FRONTEND.get_or_init(|| Arc::new(Mutex::new(DummyArkFrontend::init(options))))
     }
 
@@ -156,14 +149,8 @@ impl DummyArkFrontendNotebook {
 
     /// Initialize with Notebook session mode
     fn init() {
-        let options = DummyArkFrontendOptions {
-            interactive: true,
-            site_r_profile: false,
-            user_r_profile: false,
-            r_environ: false,
-            session_mode: SessionMode::Notebook,
-        };
-
+        let mut options = DummyArkFrontendOptions::default();
+        options.session_mode = SessionMode::Notebook;
         FRONTEND.get_or_init(|| Arc::new(Mutex::new(DummyArkFrontend::init(options))));
     }
 }
@@ -202,14 +189,8 @@ impl DummyArkFrontendRprofile {
 
     /// Initialize with user level `.Rprofile` enabled
     fn init() {
-        let options = DummyArkFrontendOptions {
-            interactive: true,
-            site_r_profile: false,
-            user_r_profile: true,
-            r_environ: false,
-            session_mode: SessionMode::Console,
-        };
-
+        let mut options = DummyArkFrontendOptions::default();
+        options.user_r_profile = true;
         let status = FRONTEND.set(Arc::new(Mutex::new(DummyArkFrontend::init(options))));
 
         if status.is_err() {
@@ -232,5 +213,17 @@ impl Deref for DummyArkFrontendRprofile {
 impl DerefMut for DummyArkFrontendRprofile {
     fn deref_mut(&mut self) -> &mut Self::Target {
         DerefMut::deref_mut(&mut self.inner)
+    }
+}
+
+impl Default for DummyArkFrontendOptions {
+    fn default() -> Self {
+        Self {
+            interactive: true,
+            site_r_profile: false,
+            user_r_profile: false,
+            r_environ: false,
+            session_mode: SessionMode::Console,
+        }
     }
 }

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -12,7 +12,6 @@ use std::env;
 
 use amalthea::kernel;
 use amalthea::kernel_spec::KernelSpec;
-use ark::interface::RMain;
 use ark::interface::SessionMode;
 use ark::logger;
 use ark::signals::initialize_signal_block;
@@ -302,7 +301,8 @@ fn main() -> anyhow::Result<()> {
     // Parse the connection file
     let (connection_file, registration_file) = kernel::read_connection(connection_file.as_str());
 
-    // Set up R and start the Jupyter kernel
+    // Connect the Jupyter kernel and start R.
+    // Does not return!
     start_kernel(
         connection_file,
         registration_file,
@@ -311,9 +311,6 @@ fn main() -> anyhow::Result<()> {
         session_mode,
         capture_streams,
     );
-
-    // Start the REPL, does not return
-    RMain::start();
 
     // Just to please Rust
     Ok(())

--- a/crates/ark/src/start.rs
+++ b/crates/ark/src/start.rs
@@ -27,7 +27,6 @@ use crate::request::RRequest;
 use crate::shell::Shell;
 
 /// Exported for unit tests.
-/// Call `RMain::start()` after this.
 pub fn start_kernel(
     connection_file: ConnectionFile,
     registration_file: Option<RegistrationFile>,
@@ -118,8 +117,8 @@ pub fn start_kernel(
         panic!("Couldn't connect to frontend: {err:?}");
     }
 
-    // Setup the channels and R
-    crate::interface::RMain::setup(
+    // Start R
+    crate::interface::RMain::start(
         r_args,
         startup_file,
         kernel_clone,

--- a/crates/ark/tests/r-profile-cat.rs
+++ b/crates/ark/tests/r-profile-cat.rs
@@ -1,0 +1,34 @@
+use std::io::Write;
+
+use ark::fixtures::DummyArkFrontendRprofile;
+
+// SAFETY:
+// Do not write any other tests related to `.Rprofile` in
+// this integration test file. We can only start R up once
+// per process, so we can only run one `.Rprofile`. Use a
+// separate integration test (i.e. separate process) if you
+// need to test more details related to `.Rprofile` usage.
+
+/// See https://github.com/posit-dev/positron/issues/4973
+#[test]
+fn test_r_profile_can_cat() {
+    let message = "hi from rprofile";
+
+    // The `\n` is critical, otherwise R's `source()` silently fails
+    let contents = format!("cat('{message}')\n");
+
+    // Write `contents` to a tempfile that we declare to be
+    // the `.Rprofile` that R should use
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    write!(file, "{contents}").unwrap();
+
+    let path = file.path();
+    let path = path.to_str().unwrap();
+
+    unsafe { std::env::set_var("R_PROFILE_USER", path) };
+
+    // Ok, load up R now. It should `cat()` the `message` over iopub.
+    let frontend = DummyArkFrontendRprofile::lock();
+
+    frontend.recv_iopub_stream_stdout(message)
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4973

Also creates a new frontend variant called `DummyArkFrontendRprofile` - a `Console` ark that supports loading `.Rprofile`. This allows us to test that we can load `.Rprofile`s correctly on startup. Notably you can only call `DummyArkFrontendRprofile::lock()` once per process, because you can only load an `.Rprofile` once! This is enforced with a panic if you call `lock()` twice in a single integration test.