### PR TITLE
Ensure R doesn't run the `.Rprofile` on Windows

### DIFF
--- a/crates/ark/src/sys/windows/interface.rs
+++ b/crates/ark/src/sys/windows/interface.rs
@@ -20,6 +20,7 @@ use libr::R_DefParamsEx;
 use libr::R_HomeDir;
 use libr::R_SetParams;
 use libr::R_SignalHandlers;
+use libr::Rboolean_FALSE;
 use stdext::cargs;
 
 use crate::interface::r_busy;
@@ -68,6 +69,12 @@ pub fn setup_r(mut _args: Vec<*mut c_char>) {
 
         (*params).R_Interactive = 1;
         (*params).CharacterMode = libr::UImode_RGui;
+
+        // Never load the user or site `.Rprofile`s during `setup_Rmainloop()`.
+        // We do it for the user once ark is ready. We faithfully reimplement
+        // R's behavior for finding these files in `startup.rs`.
+        (*params).LoadInitFile = Rboolean_FALSE;
+        (*params).LoadSiteFile = Rboolean_FALSE;
 
         (*params).WriteConsole = None;
         (*params).WriteConsoleEx = Some(r_write_console);

--- a/crates/ark/tests/r-profile-once.rs
+++ b/crates/ark/tests/r-profile-once.rs
@@ -1,0 +1,50 @@
+use std::io::Write;
+
+use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use ark::fixtures::DummyArkFrontendRprofile;
+
+// SAFETY:
+// Do not write any other tests related to `.Rprofile` in
+// this integration test file. We can only start R up once
+// per process, so we can only run one `.Rprofile`. Use a
+// separate integration test (i.e. separate process) if you
+// need to test more details related to `.Rprofile` usage.
+
+/// See https://github.com/posit-dev/positron/issues/4253
+#[test]
+fn test_r_profile_is_only_run_once() {
+    // The trailing `\n` is critical, otherwise R's `source()` silently fails
+    let contents = r#"
+if (exists("x")) {
+  x <- 2
+} else {
+  x <- 1
+}
+
+"#;
+
+    // Write `contents` to a tempfile that we declare to be
+    // the `.Rprofile` that R should use
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    write!(file, "{contents}").unwrap();
+
+    let path = file.path();
+    let path = path.to_str().unwrap();
+
+    unsafe { std::env::set_var("R_PROFILE_USER", path) };
+
+    // Ok, start R. If we've set everything correctly, R should not run
+    // the `.Rprofile`, but ark should - i.e. it should run exactly 1 time.
+    let frontend = DummyArkFrontendRprofile::lock();
+
+    frontend.send_execute_request("x", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, "x");
+    assert_eq!(frontend.recv_iopub_execute_result(), "[1] 1");
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4253

Have I mentioned how much I love being able to write these integration tests?

---

The first part of my analysis in https://github.com/posit-dev/positron/issues/4253#issuecomment-2271978659 is not quite right. We do call `cmdlineoptions()` but we _don't_ actually pass it the command line arguments like `--no-init-file`.

Here's what actually used to happen:
- `RMain::start()` is called
- `setup_r()` is called
    - `R_SetParams()` is called to set our hooks. Because we used `R_DefParamsEx()` to initialize the params object, this defaults `->LoadInitFile` and `->LoadSiteFile` to `TRUE`.
    - `setup_Rmainloop()` runs. This runs both the user and site level `.Rprofile` because of the above bullet.
-  Back in `RMain::start()`, we don't see `--no-init-file` in the command line args, so ark decides it should load the user `.Rprofile`. We do so, meaning we've now run it twice.

The simple solution is to set `LoadInitFile` and `LoadSiteFile` to `FALSE` alongside the other `param` hooks. This ensures that ark is the only one who can run the user's `.Rprofile`s.

---

Note that this doesn't occur on Mac or Linux because we actually _do_ pass on the user's command line arguments through to `Rf_initialize_R()` there, and that respects the `--no-init-file` that we always pass through. On Windows we are not passing through the user's command line arguments _at all_, and we will probably move away from this on Unix too soon (https://github.com/posit-dev/positron/issues/5001).