### PR TITLE
Refactor symbol search

### DIFF
--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -126,31 +126,6 @@ pub(crate) fn document_symbols(
     }
 }
 
-fn is_indexable(node: &Node) -> bool {
-    // don't index 'arguments' or 'parameters'
-    if matches!(node.node_type(), NodeType::Arguments | NodeType::Parameters) {
-        return false;
-    }
-
-    true
-}
-
-// Function to parse a comment and return the section level and title
-fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
-    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
-    // Ensure that there's actual content between the start and the trailing symbols.
-    if let Some(caps) = indexer::RE_COMMENT_SECTION.captures(comment) {
-        let hashes = caps.get(1)?.as_str().len(); // Count the number of '#'
-        let title = caps.get(2)?.as_str().trim().to_string(); // Extract the title text without trailing punctuations
-        if title.is_empty() {
-            return None; // Return None for lines with only hashtags
-        }
-        return Some((hashes, title)); // Return the level based on the number of '#' and the title
-    }
-
-    None
-}
-
 fn index_node(
     node: &Node,
     mut store: Vec<DocumentSymbol>,
@@ -265,6 +240,31 @@ fn index_assignment_with_function(
     store.push(symbol);
 
     Ok(store)
+}
+
+fn is_indexable(node: &Node) -> bool {
+    // Don't index 'arguments' or 'parameters'
+    if matches!(node.node_type(), NodeType::Arguments | NodeType::Parameters) {
+        return false;
+    }
+
+    true
+}
+
+// Function to parse a comment and return the section level and title
+fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
+    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
+    // Ensure that there's actual content between the start and the trailing symbols.
+    if let Some(caps) = indexer::RE_COMMENT_SECTION.captures(comment) {
+        let hashes = caps.get(1)?.as_str().len(); // Count the number of '#'
+        let title = caps.get(2)?.as_str().trim().to_string(); // Extract the title text without trailing punctuations
+        if title.is_empty() {
+            return None; // Return None for lines with only hashtags
+        }
+        return Some((hashes, title)); // Return the level based on the number of '#' and the title
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -9,7 +9,6 @@
 
 use std::result::Result::Ok;
 
-use log::*;
 use ropey::Rope;
 use stdext::unwrap::IntoResult;
 use tower_lsp::lsp_types::DocumentSymbol;
@@ -110,13 +109,20 @@ pub(crate) fn document_symbols(
 
     // Construct a root symbol, so we always have something to append to
     let range = Range { start, end };
-    let mut root = new_symbol("<root>".to_string(), SymbolKind::NULL, None, range);
+    let root = new_symbol("<root>".to_string(), SymbolKind::NULL, None, range);
 
     // Index from the root
-    index_node(&node, &contents, &mut root)?;
+    let root = match index_node(root, &node, &contents) {
+        Ok(root) => root,
+        Err(err) => {
+            log::error!("Error indexing node: {err:?}");
+            return Ok(Vec::new());
+        },
+    };
 
-    // Return the children we found
-    Ok(root.children.unwrap_or_default())
+    // Return the children we found. Safety: We always set the children to an
+    // empty vector.
+    Ok(root.children.unwrap())
 }
 
 fn is_indexable(node: &Node) -> bool {
@@ -150,7 +156,11 @@ fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
     None
 }
 
-fn index_node(node: &Node, contents: &Rope, parent: &mut DocumentSymbol) -> anyhow::Result<()> {
+fn index_node(
+    mut parent: DocumentSymbol,
+    node: &Node,
+    contents: &Rope,
+) -> anyhow::Result<DocumentSymbol> {
     // Check if the node is a comment and matches the markdown-style comment patterns
     if node.node_type() == NodeType::Comment {
         let comment_text = contents.node_slice(&node)?.to_string();
@@ -162,10 +172,10 @@ fn index_node(node: &Node, contents: &Rope, parent: &mut DocumentSymbol) -> anyh
             let end = convert_point_to_position(contents, node.end_position());
 
             let symbol = new_symbol(title, SymbolKind::STRING, None, Range { start, end });
-            push_child(parent, symbol);
+            push_child(&mut parent, symbol);
 
             // Return early to avoid further processing
-            return Ok(());
+            return Ok(parent);
         }
     }
 
@@ -174,33 +184,25 @@ fn index_node(node: &Node, contents: &Rope, parent: &mut DocumentSymbol) -> anyh
         NodeType::BinaryOperator(BinaryOperatorType::LeftAssignment) |
             NodeType::BinaryOperator(BinaryOperatorType::EqualsAssignment)
     ) {
-        match index_assignment(node, contents, parent) {
-            Ok(()) => {
-                return Ok(());
-            },
-            Err(err) => error!("{err:?}"),
-        }
+        parent = index_assignment(parent, node, contents)?;
     }
 
     // Recurse into children
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if is_indexable(&child) {
-            let result = index_node(&child, contents, parent);
-            if let Err(error) = result {
-                error!("{:?}", error);
-            }
+            parent = index_node(parent, &child, contents)?;
         }
     }
 
-    Ok(())
+    Ok(parent)
 }
 
 fn index_assignment(
+    mut parent: DocumentSymbol,
     node: &Node,
     contents: &Rope,
-    parent: &mut DocumentSymbol,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<DocumentSymbol> {
     // check for assignment
     matches!(
         node.node_type(),
@@ -217,7 +219,7 @@ fn index_assignment(
     let function = lhs.is_identifier_or_string() && rhs.is_function_definition();
 
     if function {
-        return index_assignment_with_function(node, contents, parent);
+        return index_assignment_with_function(parent, node, contents);
     }
 
     // otherwise, just index as generic object
@@ -227,16 +229,16 @@ fn index_assignment(
     let end = convert_point_to_position(contents, lhs.end_position());
 
     let symbol = new_symbol(name, SymbolKind::VARIABLE, None, Range { start, end });
-    push_child(parent, symbol);
+    push_child(&mut parent, symbol);
 
-    Ok(())
+    Ok(parent)
 }
 
 fn index_assignment_with_function(
+    mut parent: DocumentSymbol,
     node: &Node,
     contents: &Rope,
-    parent: &mut DocumentSymbol,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<DocumentSymbol> {
     // check for lhs, rhs
     let lhs = node.child_by_field_name("lhs").into_result()?;
     let rhs = node.child_by_field_name("rhs").into_result()?;
@@ -260,12 +262,13 @@ fn index_assignment_with_function(
         end: convert_point_to_position(contents, rhs.end_position()),
     };
     let symbol = new_symbol(name, SymbolKind::FUNCTION, Some(detail), range);
-    push_child(parent, symbol);
 
-    let parent = parent.children.as_mut().unwrap().last_mut().unwrap();
-    index_node(&rhs, contents, parent)?;
+    // Recurse into the function node
+    let symbol = index_node(symbol, &rhs, contents)?;
 
-    Ok(())
+    // Set as child after recursing, now that we own the symbol again
+    push_child(&mut parent, symbol);
+    Ok(parent)
 }
 
 #[cfg(test)]
@@ -282,7 +285,7 @@ mod tests {
         let start = convert_point_to_position(&doc.contents, node.start_position());
         let end = convert_point_to_position(&doc.contents, node.end_position());
 
-        let mut root = DocumentSymbol {
+        let root = DocumentSymbol {
             name: String::from("<root>"),
             kind: SymbolKind::NULL,
             children: Some(Vec::new()),
@@ -293,7 +296,7 @@ mod tests {
             selection_range: Range { start, end },
         };
 
-        index_node(&node, &doc.contents, &mut root).unwrap();
+        let root = index_node(root, &node, &doc.contents).unwrap();
         root.children.unwrap_or_default()
     }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -53,7 +53,6 @@ fn new_symbol(
         name,
         kind,
         detail,
-        // Safety: We assume `children` can't be `None`
         children: Some(Vec::new()),
         deprecated: None,
         tags: None,


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/positron/issues/3822.

- Errors are now consistently propagated as `Err` and only logged at the very top.

- We no longer recurse blindly into all node types except argument lists (this is the current restriction but note that we should recurse in arg lists in the future for e.g. `lapply` and `test_that`). Instead, we only recurse in handlers of specific node types. For instance, comment sections are only expected in expression lists, and thus only handled in the expression list handler.

- We no longer pass around a mut ref of the parent. Instead we pass a store of children by value and return it once done. If a handler inserts a note in the outline, it creates a new store, recurse into its children with this new store, and adds itself to the store of its caller.

  This simpler approach is easier to understand and should solve the lifetime issues encountered in https://github.com/posit-dev/ark/pull/593.

- Bunch of tests.
