### PR TITLE
Add `r_command()` for executing commands over `R` and `R.bat`

### DIFF
--- a/crates/harp/src/command.rs
+++ b/crates/harp/src/command.rs
@@ -1,0 +1,47 @@
+//
+// command.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::io;
+use std::process::Command;
+use std::process::Output;
+
+use crate::sys::command::COMMAND_R_LOCATIONS;
+
+/// Execute a `Command` for R, trying multiple locations where R might exist
+///
+/// - For unix, this look at `R`
+/// - For Windows, this looks at `R` (`R.exe`) and `R.bat` (for rig compatibility)
+///
+/// Returns the `Ok()` value of the first success, or the `Err()` value of the
+/// last failure if all locations fail.
+pub fn r_command<F>(build: F) -> io::Result<Output>
+where
+    F: Fn(&mut Command),
+{
+    let n = COMMAND_R_LOCATIONS.len();
+    assert!(n > 0);
+
+    for (i, program) in COMMAND_R_LOCATIONS.iter().enumerate() {
+        // Build the `Command` from the user's function
+        let mut command = Command::new(program);
+        build(&mut command);
+
+        // Run it, waiting on it to finish
+        let out = command.output();
+
+        if out.is_ok() {
+            // Found R, executed command successfully
+            return out;
+        }
+        if i == n - 1 {
+            // On last location, but still couldn't find R, return error
+            return out;
+        }
+    }
+
+    unreachable!("`assert!` ensures at least 1 program location is provided.");
+}

--- a/crates/harp/src/fixtures/mod.rs
+++ b/crates/harp/src/fixtures/mod.rs
@@ -10,7 +10,6 @@
 
 use std::os::raw::c_char;
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::Once;
 
 use libr::setup_Rmainloop;
@@ -18,6 +17,7 @@ use libr::R_CStackLimit;
 use libr::Rf_initialize_R;
 use stdext::cargs;
 
+use crate::command::r_command;
 use crate::library::RLibraries;
 use crate::R_MAIN_THREAD_ID;
 
@@ -53,7 +53,10 @@ pub fn r_test_init() {
         let r_home = match std::env::var("R_HOME") {
             Ok(r_home) => PathBuf::from(r_home),
             Err(_) => {
-                let result = Command::new("R").arg("RHOME").output().unwrap();
+                let result = r_command(|command| {
+                    command.arg("RHOME");
+                })
+                .expect("Can't locate R to determine `R_HOME`.");
                 let r_home = String::from_utf8(result.stdout).unwrap();
                 let r_home = r_home.trim();
                 unsafe { std::env::set_var("R_HOME", r_home) };

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -6,6 +6,7 @@
 //
 pub mod attrib;
 pub mod call;
+pub mod command;
 pub mod data_frame;
 pub mod environment;
 pub mod environment_iter;

--- a/crates/harp/src/sys/unix.rs
+++ b/crates/harp/src/sys/unix.rs
@@ -5,6 +5,7 @@
  *
  */
 
+pub mod command;
 pub mod library;
 pub mod line_ending;
 pub mod polled_events;

--- a/crates/harp/src/sys/unix/command.rs
+++ b/crates/harp/src/sys/unix/command.rs
@@ -1,0 +1,9 @@
+/*
+ * command.rs
+ *
+ * Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+/// Locations on the `PATH` to look for R when using `Command::new()`
+pub(crate) const COMMAND_R_LOCATIONS: [&str; 1] = ["R"];

--- a/crates/harp/src/sys/windows.rs
+++ b/crates/harp/src/sys/windows.rs
@@ -5,6 +5,7 @@
  *
  */
 
+pub mod command;
 pub mod library;
 pub mod line_ending;
 mod locale;

--- a/crates/harp/src/sys/windows/command.rs
+++ b/crates/harp/src/sys/windows/command.rs
@@ -1,0 +1,9 @@
+/*
+ * command.rs
+ *
+ * Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *
+ */
+
+/// Locations on the `PATH` to look for R when using `Command::new()`
+pub(crate) const COMMAND_R_LOCATIONS: [&str; 2] = ["R", "R.bat"];


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4831

We now iterate over both `Command::new("R")` and `Command::new("R.bat")` and either:
- Exit on the first success
- Or return the error of the last failure if all fail

The main win here is being able to run `cargo test` out of the box on Windows when you have a Rig version of R installed, which puts R on the PATH as `R.bat` rather than `R.exe`