### PR TITLE
Export `.rs.api.getVersion()` and `.rs.api.getMode()`

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           packages:
             data.table
+            rstudioapi
             tibble
 
       - name: Setup SSH access

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           packages:
             data.table
+            rstudioapi
             tibble
 
       - name: Build

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           packages:
             data.table
+            rstudioapi
             tibble
 
       - name: Build

--- a/crates/ark/src/modules/rstudio/rstudioapi.R
+++ b/crates/ark/src/modules/rstudio/rstudioapi.R
@@ -26,9 +26,21 @@
 
     list(
         citation = positron_citation,
-        mode = Sys.getenv("POSITRON_MODE"),
-        version = package_version(Sys.getenv("POSITRON_VERSION")),
+        mode = .rs.api.getMode(),
+        version = .rs.api.getVersion(),
         long_version = Sys.getenv("POSITRON_LONG_VERSION"),
         ark_version = .ps.ark.version()
     )
+}
+
+# Since rstudioapi 0.17.0
+#' @export
+.rs.api.getVersion <- function() {
+    package_version(Sys.getenv("POSITRON_VERSION"))
+}
+
+# Since rstudioapi 0.17.0
+#' @export
+.rs.api.getMode <- function() {
+    Sys.getenv("POSITRON_MODE")
 }

--- a/crates/ark/tests/rstudioapi.rs
+++ b/crates/ark/tests/rstudioapi.rs
@@ -1,0 +1,87 @@
+use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use ark::fixtures::DummyArkFrontend;
+
+#[test]
+fn test_get_version() {
+    let frontend = DummyArkFrontend::lock();
+
+    if !has_rstudioapi(&frontend) {
+        report_skipped("test_get_version");
+        return;
+    }
+
+    let value = "1.0.0";
+    std::env::set_var("POSITRON_VERSION", value);
+
+    let code = "as.character(rstudioapi::getVersion())";
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, code);
+    assert_eq!(
+        frontend.recv_iopub_execute_result(),
+        format!("[1] \"{value}\"")
+    );
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+}
+
+#[test]
+fn test_get_mode() {
+    let frontend = DummyArkFrontend::lock();
+
+    if !has_rstudioapi(&frontend) {
+        report_skipped("test_get_mode");
+        return;
+    }
+
+    let value = "desktop";
+    std::env::set_var("POSITRON_MODE", value);
+
+    let code = "rstudioapi::getMode()";
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, code);
+    assert_eq!(
+        frontend.recv_iopub_execute_result(),
+        format!("[1] \"{value}\"")
+    );
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+}
+
+fn has_rstudioapi(frontend: &DummyArkFrontend) -> bool {
+    let code = ".ps.is_installed('rstudioapi')";
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, code);
+
+    let result = frontend.recv_iopub_execute_result();
+
+    let out = if result == "[1] TRUE" {
+        true
+    } else if result == "[1] FALSE" {
+        false
+    } else {
+        panic!("Expected `TRUE` or `FALSE`, got '{result}'.");
+    };
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+
+    out
+}
+
+fn report_skipped(f: &str) {
+    println!("Skipping `{f}()`. rstudioapi is not installed.");
+}

--- a/crates/ark/tests/rstudioapi.rs
+++ b/crates/ark/tests/rstudioapi.rs
@@ -11,7 +11,7 @@ fn test_get_version() {
     }
 
     let value = "1.0.0";
-    std::env::set_var("POSITRON_VERSION", value);
+    harp::envvar::set_var("POSITRON_VERSION", value);
 
     let code = "as.character(rstudioapi::getVersion())";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
@@ -39,7 +39,7 @@ fn test_get_mode() {
     }
 
     let value = "desktop";
-    std::env::set_var("POSITRON_MODE", value);
+    harp::envvar::set_var("POSITRON_MODE", value);
 
     let code = "rstudioapi::getMode()";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());

--- a/crates/harp/src/envvar.rs
+++ b/crates/harp/src/envvar.rs
@@ -1,0 +1,109 @@
+//
+// envvar.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use crate::protect::RProtect;
+use crate::r_lang;
+use crate::r_string;
+use crate::r_symbol;
+use crate::RObject;
+
+/// Set an environment variable through `Sys.setenv()`
+///
+/// This is a safe alternative to [std::env::set_var()]. On Windows in particular,
+/// using [std::env::set_var()] after R has started up (i.e. after Ark opens the
+/// R DLL and calls `setup_Rmainloop()`) has no effect. We believe this is because
+/// [std::env::set_var()] ends up calling `SetEnvironmentVariableW()` to set the
+/// environment variable, which only affects the Windows API environment space and
+/// not the C environment space that R seems to have access to after it has started
+/// up. This matters because R's `Sys.getenv()` uses the C level `getenv()` to
+/// access environment variables, which only looks at C environment space.
+///
+/// To affect the C environment space, [std::env::set_var()] would have had to call
+/// [libc::putenv()], but that has issues with thread safety, and we have seen this
+/// crash R before, so we'd like to stay away from using that ourselves.
+///
+/// The easiest solution to this problem is to just go through R's `Sys.setenv()`
+/// to ensure that R picks up the environment variable update.
+///
+/// If R has not started up yet, you should be safe to call [std::env::set_var()].
+/// For example, we do this for `R_HOME` during the startup process and for
+/// `R_PROFILE_USER` in some tests.
+pub fn set_var(key: &str, value: &str) {
+    unsafe {
+        let mut protect = RProtect::new();
+
+        let key = r_symbol!(key);
+        protect.add(key);
+
+        let value = r_string!(value, &mut protect);
+
+        let call = r_lang!(r_symbol!("Sys.setenv"), !!key = value);
+        protect.add(call);
+
+        libr::Rf_eval(call, libr::R_BaseEnv);
+    }
+}
+
+/// Fetch an environment variable using `Sys.getenv()`
+pub fn var(key: &str) -> Option<String> {
+    unsafe {
+        let mut protect = RProtect::new();
+
+        let key = r_string!(key, &mut protect);
+        protect.add(key);
+
+        let call = r_lang!(r_symbol!("Sys.getenv"), key);
+        protect.add(call);
+
+        let out = RObject::new(libr::Rf_eval(call, libr::R_BaseEnv));
+
+        // SAFETY: Input is length 1 string, so output must be a length 1 string.
+        let out = String::try_from(out).unwrap();
+
+        // If the output is `""`, then the environment variable was unset.
+        if out.is_empty() {
+            None
+        } else {
+            Some(out)
+        }
+    }
+}
+
+/// Remove an environment variable using `Sys.unsetenv()`
+pub fn remove_var(key: &str) {
+    unsafe {
+        let mut protect = RProtect::new();
+
+        let key = r_string!(key, &mut protect);
+        protect.add(key);
+
+        let call = r_lang!(r_symbol!("Sys.unsetenv"), key);
+        protect.add(call);
+
+        libr::Rf_eval(call, libr::R_BaseEnv);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::envvar::remove_var;
+    use crate::envvar::set_var;
+    use crate::envvar::var;
+
+    #[test]
+    fn test_env() {
+        crate::r_task(|| {
+            assert_eq!(var("TEST_VAR"), None);
+
+            set_var("TEST_VAR", "VALUE");
+            assert_eq!(var("TEST_VAR"), Some(String::from("VALUE")));
+
+            remove_var("TEST_VAR");
+            assert_eq!(var("TEST_VAR"), None);
+        })
+    }
+}

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -10,6 +10,7 @@ pub mod command;
 pub mod data_frame;
 pub mod environment;
 pub mod environment_iter;
+pub mod envvar;
 pub mod error;
 pub mod eval;
 pub mod exec;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5094

`rstudioapi::getMode()` is new as of rstudioapi 0.17.0

For `rstudioapi::getVersion()`, this function did exist but it used to be this:

```
> rstudioapi::getVersion
function () 
{
    verifyAvailable()
    callFun("versionInfo")$version
}
```

Note the `getVersion()` function calls `callFun("versionInfo")` to indirectly get at `$version`.

We do provide `.rs.api.versionInfo()`, so this was working before.

Now it more directly calls:

```
> rstudioapi::getVersion
function () 
{
    if (hasFun("getVersion")) 
        return(callFun("getVersion"))
    verifyAvailable()
    base <- .BaseNamespaceEnv
    version <- base$.Call("rs_rstudioVersion", PACKAGE = "(embedding)")
    package_version(version)
}
```

So we need to provide the more direct accessor of `callFun("getVersion")` / `.rs.api.getVersion()`, which this PR does.

---

I have tested that `getMode()` and `getVersion()` work with CRAN rstudioapi, and that `getVersion()` continues to work with older versions of rstudioapi too.