### PR TITLE
Add nested outline to refactored code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - The document symbol kind for assigned variables is now `VARIABLE` (@kv9898, posit-dev/positron#5071). This produces a clearer icon in the outline.
 
-- Added partial support for outline headers in comments (@kv9898, posit-dev/positron#3822).
+- Added support for outline headers in comments (@kv9898, posit-dev/positron#3822).
 
 - Sending long inputs of more than 4096 bytes no longer fails (posit-dev/positron#4745).
 

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_assignment_function_nested_section.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_assignment_function_nested_section.snap
@@ -1,0 +1,221 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ----\n  ### title2 ----\n  ## title3 ----\n  # title4 ----\n}\n# title5 ----\")"
+---
+[
+    DocumentSymbol {
+        name: "title0",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 14,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 14,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "foo",
+                    detail: Some(
+                        "function()",
+                    ),
+                    kind: Function,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 7,
+                            character: 1,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 7,
+                            character: 1,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "title1",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 3,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 3,
+                                        character: 15,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 3,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 3,
+                                        character: 15,
+                                    },
+                                },
+                                children: Some(
+                                    [
+                                        DocumentSymbol {
+                                            name: "title2",
+                                            detail: None,
+                                            kind: String,
+                                            tags: None,
+                                            deprecated: None,
+                                            range: Range {
+                                                start: Position {
+                                                    line: 4,
+                                                    character: 2,
+                                                },
+                                                end: Position {
+                                                    line: 4,
+                                                    character: 17,
+                                                },
+                                            },
+                                            selection_range: Range {
+                                                start: Position {
+                                                    line: 4,
+                                                    character: 2,
+                                                },
+                                                end: Position {
+                                                    line: 4,
+                                                    character: 17,
+                                                },
+                                            },
+                                            children: Some(
+                                                [],
+                                            ),
+                                        },
+                                        DocumentSymbol {
+                                            name: "title3",
+                                            detail: None,
+                                            kind: String,
+                                            tags: None,
+                                            deprecated: None,
+                                            range: Range {
+                                                start: Position {
+                                                    line: 5,
+                                                    character: 2,
+                                                },
+                                                end: Position {
+                                                    line: 5,
+                                                    character: 16,
+                                                },
+                                            },
+                                            selection_range: Range {
+                                                start: Position {
+                                                    line: 5,
+                                                    character: 2,
+                                                },
+                                                end: Position {
+                                                    line: 5,
+                                                    character: 16,
+                                                },
+                                            },
+                                            children: Some(
+                                                [],
+                                            ),
+                                        },
+                                    ],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "title4",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 6,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 15,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 6,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 15,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            ],
+        ),
+    },
+    DocumentSymbol {
+        name: "title5",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 8,
+                character: 0,
+            },
+            end: Position {
+                line: 8,
+                character: 13,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 8,
+                character: 0,
+            },
+            end: Position {
+                line: 8,
+                character: 13,
+            },
+        },
+        children: Some(
+            [],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -224,21 +224,14 @@ fn index_comments(
     let symbol = new_symbol(title, SymbolKind::STRING, Range { start, end });
 
     // Find the appropriate number of layers to assemble `store_vec` to
-    let layer: usize;
-    {
-        let levels: Vec<usize> = store_vec.iter().map(|(level, _)| *level).collect();
-        let layer_index = levels
-            .iter()
-            .enumerate()
-            .rev() // Reverse the iterator to search from right to left
-            .find(|&(_, &l)| l < level) // Find the first element that is less than `level`
-            .map(|(index, _)| index);
-        layer = if let Some(value) = layer_index {
-            value + 1
-        } else {
-            1
-        }; // Turn option into usize
-    }
+    let levels: Vec<usize> = store_vec.iter().map(|(level, _)| *level).collect();
+    let layer = levels
+        .iter()
+        .enumerate()
+        .rev() // Reverse the iterator to search from right to left
+        .find(|&(_, &l)| l < level) // Find the first element that is less than `level`
+        .map(|(index, _)| index + 1)
+        .unwrap_or(1);
 
     store_vec = assemble_store(store_vec, layer);
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -470,6 +470,21 @@ mod tests {
     }
 
     #[test]
+    fn test_symbol_assignment_function_nested_section() {
+        insta::assert_debug_snapshot!(test_symbol(
+            "
+## title0 ----
+foo <- function() {
+  # title1 ----
+  ### title2 ----
+  ## title3 ----
+  # title4 ----
+}
+# title5 ----"
+        ));
+    }
+
+    #[test]
     fn test_symbol_braced_list() {
         let range = Range {
             start: Position {

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -189,8 +189,8 @@ fn index_expression_list(
     ))
 }
 
-// Pop store from the stack, recording its children adding it as child to its
-// parent (which becomes the last element in the stack).
+// Pop store from the stack, recording its children and adding it as child to
+// its parent (which becomes the last element in the stack).
 fn store_stack_pop(store_stack: &mut StoreStack) -> anyhow::Result<Option<Vec<DocumentSymbol>>> {
     let Some((_, symbol, last)) = store_stack.pop() else {
         return Ok(None);

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -166,7 +166,7 @@ fn index_expression_list(
     }
 
     // Iteratively add the children of the last element of `store_stack` until there is only one element
-    store_stack = store_stack_pop(store_stack, 1);
+    store_stack_pop(&mut store_stack, 1);
 
     // At the end, the remaining element in `store_stack` contains the updated store
     let (_, store) = store_stack.pop().unwrap();
@@ -175,10 +175,7 @@ fn index_expression_list(
 
 // Pop store from the stack, adding it as child to its parent (which becomes the
 // last element in the stack). Once popped, we no longer need to keep track of level.
-fn store_stack_pop(
-    mut store_stack: Vec<(usize, Vec<DocumentSymbol>)>,
-    layers: usize,
-) -> Vec<(usize, Vec<DocumentSymbol>)> {
+fn store_stack_pop(store_stack: &mut Vec<(usize, Vec<DocumentSymbol>)>, layers: usize) {
     while store_stack.len() > layers {
         // Pop the last element from `store_stack`
         let (last_level, mut last_symbols) = store_stack.pop().unwrap();
@@ -201,7 +198,6 @@ fn store_stack_pop(
             break;
         }
     }
-    return store_stack;
 }
 
 fn index_comments(
@@ -232,7 +228,7 @@ fn index_comments(
         .map(|(index, _)| index + 1)
         .unwrap_or(1);
 
-    store_stack = store_stack_pop(store_stack, layer);
+    store_stack_pop(&mut store_stack, layer);
 
     // Add the new symbol to the appropriate level in `store_stack`
     if let Some((last_level, symbols)) = store_stack.last_mut() {

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -183,25 +183,24 @@ fn index_expression_list(
 // Pop store from the stack, adding it as child to its parent (which becomes the
 // last element in the stack). Once popped, we no longer need to keep track of level.
 fn store_stack_pop(store_stack: &mut Vec<(usize, Vec<DocumentSymbol>)>) {
-    // Pop the last element from `store_stack`
     let (last_level, mut last_symbols) = store_stack.pop().unwrap();
 
     // Add the last_symbols as children to the previous level in `store_stack`
-    if let Some((_, parent_symbols)) = store_stack.last_mut() {
-        if let Some(parent_symbol) = parent_symbols.last_mut() {
-            parent_symbol
-                .children
-                .as_mut()
-                .unwrap()
-                .append(&mut last_symbols);
-        } else {
-            // If there's no last parent symbol, add the last symbols directly
-            parent_symbols.append(&mut last_symbols);
-        }
-    } else {
+    let Some((_, parent_symbols)) = store_stack.last_mut() else {
         // In case there's no parent, just push the `last_symbols` back
         store_stack.push((last_level, last_symbols));
         return;
+    };
+
+    if let Some(parent_symbol) = parent_symbols.last_mut() {
+        parent_symbol
+            .children
+            .as_mut()
+            .unwrap()
+            .append(&mut last_symbols);
+    } else {
+        // If there's no last parent symbol, add the last symbols directly
+        parent_symbols.append(&mut last_symbols);
     }
 }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -149,7 +149,7 @@ fn index_expression_list(
 ) -> anyhow::Result<Vec<DocumentSymbol>> {
     let mut cursor = node.walk();
 
-    // put level and store in a vector for nested structure handling
+    // Put level and store in a vector for nested structure handling
     let mut store_vec: Vec<(usize, Vec<DocumentSymbol>)> = vec![(usize::MAX, store.clone())];
     let mut current_store = store.clone();
 
@@ -168,10 +168,10 @@ fn index_expression_list(
         }
     }
 
-    // iteratively add the children of the last element of store_vec until there is only one element
+    // Iteratively add the children of the last element of `store_vec` until there is only one element
     store_vec = assemble_store(store_vec, 1);
 
-    // At the end, the remaining element in store_vec contains the updated store
+    // At the end, the remaining element in `store_vec` contains the updated store
     let (_, store) = store_vec.pop().unwrap();
     Ok(store)
 }
@@ -181,10 +181,10 @@ fn assemble_store(
     layers: usize,
 ) -> Vec<(usize, Vec<DocumentSymbol>)> {
     while store_vec.len() > layers {
-        // Pop the last element from store_vec
+        // Pop the last element from `store_vec`
         let (last_level, mut last_symbols) = store_vec.pop().unwrap();
 
-        // Add the last_symbols as children to the previous level in store_vec
+        // Add the last_symbols as children to the previous level in `store_vec`
         if let Some((_, parent_symbols)) = store_vec.last_mut() {
             if let Some(parent_symbol) = parent_symbols.last_mut() {
                 parent_symbol
@@ -197,7 +197,7 @@ fn assemble_store(
                 parent_symbols.append(&mut last_symbols);
             }
         } else {
-            // In case there's no parent, just push the last_symbols back
+            // In case there's no parent, just push the `last_symbols` back
             store_vec.push((last_level, last_symbols));
             break;
         }
@@ -223,7 +223,7 @@ fn index_comments(
 
     let symbol = new_symbol(title, SymbolKind::STRING, Range { start, end });
 
-    // find the appropriate number of layers to assmemble store_vec to
+    // Find the appropriate number of layers to assemble `store_vec` to
     let layer: usize;
     {
         let levels: Vec<usize> = store_vec.iter().map(|(level, _)| *level).collect();
@@ -237,30 +237,30 @@ fn index_comments(
             value + 1
         } else {
             1
-        }; // turn option into usize
+        }; // Turn option into usize
     }
 
     store_vec = assemble_store(store_vec, layer);
 
-    // Add the new symbol to the appropriate level in store_vec
+    // Add the new symbol to the appropriate level in `store_vec`
     if let Some((last_level, symbols)) = store_vec.last_mut() {
         if *last_level < level {
-            // If current level is greater, add a new level to store_vec
+            // If current level is greater, add a new level to `store_vec`
             store_vec.push((level, vec![symbol]));
         } else if *last_level == level {
             // If current level is equal, push the symbol as a child of the last element
             symbols.push(symbol);
         } else {
-            // for handling of the starting nodes, the level of which are set to maximum
+            // For handling of the starting nodes, the level of which are set to maximum
             symbols.push(symbol);
             *last_level = level;
         }
     } else {
-        // If store_vec is empty, add the new symbol at root
+        // If `store_vec` is empty, add the new symbol at root
         store_vec.push((level, vec![symbol]));
     }
 
-    // Add an empty vector to store_vec to subordinate other symbols
+    // Add an empty vector to `store_vec` to subordinate other symbols
     store_vec.push((usize::MAX, vec![])); // usize::MAX to make ensure it is never a parent
 
     Ok(store_vec)

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -150,20 +150,17 @@ fn index_expression_list(
     let mut cursor = node.walk();
 
     // Put level and store in a vector for nested structure handling
-    let mut store_stack: Vec<(usize, Vec<DocumentSymbol>)> = vec![(usize::MAX, store.clone())];
-    let mut current_store = store.clone();
+    let mut store_stack: Vec<(usize, Vec<DocumentSymbol>)> = vec![(usize::MAX, store)];
 
     for child in node.children(&mut cursor) {
         match child.node_type() {
             NodeType::Comment => {
                 store_stack = index_comments(&child, store_stack, contents)?;
-                (_, current_store) = store_stack.last().unwrap().clone();
             },
             _ => {
-                current_store = index_node(&child, current_store, contents)?;
-                if let Some((_, last)) = store_stack.last_mut() {
-                    *last = current_store.clone();
-                }
+                let (level, store) = store_stack.pop().expect("Stack has always one element");
+                let store = index_node(&child, store, contents)?;
+                store_stack.push((level, store));
             },
         }
     }

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -144,7 +144,7 @@ fn index_node(
 // Handles root node and braced lists
 fn index_expression_list(
     node: &Node,
-    mut store: Vec<DocumentSymbol>,
+    store: Vec<DocumentSymbol>,
     contents: &Rope,
 ) -> anyhow::Result<Vec<DocumentSymbol>> {
     let mut cursor = node.walk();
@@ -224,7 +224,7 @@ fn index_comments(
     let symbol = new_symbol(title, SymbolKind::STRING, Range { start, end });
 
     // find the appropriate number of layers to assmemble store_vec to
-    let mut layer: usize;
+    let layer: usize;
     {
         let levels: Vec<usize> = store_vec.iter().map(|(level, _)| *level).collect();
         let layer_index = levels

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -9,6 +9,7 @@
 
 use std::result::Result::Ok;
 
+use anyhow::anyhow;
 use ropey::Rope;
 use stdext::unwrap::IntoResult;
 use tower_lsp::lsp_types::DocumentSymbol;
@@ -158,7 +159,11 @@ fn index_expression_list(
                 store_stack = index_comments(&child, store_stack, contents)?;
             },
             _ => {
-                let (level, store) = store_stack.pop().expect("Stack has always one element");
+                let Some((level, store)) = store_stack.pop() else {
+                    return Err(anyhow!(
+                        "Internal error: Store stack must always have one element"
+                    ));
+                };
                 let store = index_node(&child, store, contents)?;
                 store_stack.push((level, store));
             },

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -166,14 +166,16 @@ fn index_expression_list(
     }
 
     // Iteratively add the children of the last element of `store_stack` until there is only one element
-    store_stack = assemble_store(store_stack, 1);
+    store_stack = store_stack_pop(store_stack, 1);
 
     // At the end, the remaining element in `store_stack` contains the updated store
     let (_, store) = store_stack.pop().unwrap();
     Ok(store)
 }
 
-fn assemble_store(
+// Pop store from the stack, adding it as child to its parent (which becomes the
+// last element in the stack). Once popped, we no longer need to keep track of level.
+fn store_stack_pop(
     mut store_stack: Vec<(usize, Vec<DocumentSymbol>)>,
     layers: usize,
 ) -> Vec<(usize, Vec<DocumentSymbol>)> {
@@ -220,7 +222,7 @@ fn index_comments(
 
     let symbol = new_symbol(title, SymbolKind::STRING, Range { start, end });
 
-    // Find the appropriate number of layers to assemble `store_stack` to
+    // Find the appropriate number of layers to pop from `store_stack`
     let levels: Vec<usize> = store_stack.iter().map(|(level, _)| *level).collect();
     let layer = levels
         .iter()
@@ -230,7 +232,7 @@ fn index_comments(
         .map(|(index, _)| index + 1)
         .unwrap_or(1);
 
-    store_stack = assemble_store(store_stack, layer);
+    store_stack = store_stack_pop(store_stack, layer);
 
     // Add the new symbol to the appropriate level in `store_stack`
     if let Some((last_level, symbols)) = store_stack.last_mut() {


### PR DESCRIPTION
Should solve the majority of https://github.com/posit-dev/positron/issues/3822 except for the foldable comment sections.

Also replace `OBJECT`s in tests with `VARIABLE`s.

With code:
```r
a <- 1 # important to make sure initial non-comment symbols are handled properly
b <- 2
#first level####
###########################
#==========================
#=#=#
## second level ####
#### jump to fourth level####
### Back to third level ####
## another second level ----
some_fucntion <- function(x){
  c <- 3
  # inside first level ####
  ## inside second level####
  #### inside fourth level####
  d <- 4
  ### inside third level ####
  e <- 5
}
```

The outline with the refactored code now looks like:
![image](https://github.com/user-attachments/assets/4b5b4a5a-83cd-43db-a68f-ccd0391d66ed)


