### PR TITLE
Folding Range LSP support

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -19,6 +19,7 @@ use tower_lsp::jsonrpc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::request::GotoImplementationParams;
 use tower_lsp::lsp_types::request::GotoImplementationResponse;
+use tower_lsp::lsp_types::FoldingRange;
 use tower_lsp::lsp_types::SelectionRange;
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;
@@ -90,6 +91,7 @@ pub(crate) enum LspRequest {
     GotoDefinition(GotoDefinitionParams),
     GotoImplementation(GotoImplementationParams),
     SelectionRange(SelectionRangeParams),
+    FoldingRange(FoldingRangeParams),
     References(ReferenceParams),
     StatementRange(StatementRangeParams),
     HelpTopic(HelpTopicParams),
@@ -113,6 +115,7 @@ pub(crate) enum LspResponse {
     GotoImplementation(Option<GotoImplementationResponse>),
     SelectionRange(Option<Vec<SelectionRange>>),
     References(Option<Vec<Location>>),
+    FoldingRange(Option<Vec<FoldingRange>>),
     StatementRange(Option<StatementRangeResponse>),
     HelpTopic(Option<HelpTopicResponse>),
     OnTypeFormatting(Option<Vec<TextEdit>>),
@@ -285,6 +288,13 @@ impl LanguageServer for Backend {
         cast_response!(
             self.request(LspRequest::SelectionRange(params)).await,
             LspResponse::SelectionRange
+        )
+    }
+
+    async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
+        cast_response!(
+            self.request(LspRequest::FoldingRange(params)).await,
+            LspResponse::FoldingRange
         )
     }
 

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -1,12 +1,10 @@
-use std::cell;
-
 use regex::Regex;
 use tower_lsp::lsp_types::FoldingRange;
 use tower_lsp::lsp_types::FoldingRangeKind;
 
 use crate::lsp::documents::Document;
 use crate::lsp::log_error;
-use crate::lsp::log_info;
+// use crate::lsp::log_info; // Uncomment to enable logging
 use crate::lsp::symbols::parse_comment_as_section;
 
 /// Detects and returns folding ranges for comment sections and curly-bracketed blocks
@@ -55,11 +53,11 @@ pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
     }
 
     // Log the final folding ranges and comment stacks
-    log_info!("folding_ranges: {:#?}", folding_ranges);
-    log_info!("comment_stack: {:#?}", comment_stack); // Should be empty
-    log_info!("bracket_stack: {:#?}", bracket_stack); // Should be empty
-    log_info!("region_marker: {:#?}", region_marker); // Should be None
-    log_info!("cell_marker: {:#?}", cell_marker); // Should be None
+    // log_info!("folding_ranges: {:#?}", folding_ranges); // Contains all folding ranges
+    // log_info!("comment_stack: {:#?}", comment_stack); // Should be empty
+    // log_info!("bracket_stack: {:#?}", bracket_stack); // Should be empty
+    // log_info!("region_marker: {:#?}", region_marker); // Should be None
+    // log_info!("cell_marker: {:#?}", cell_marker); // Should be None
 
     Ok(folding_ranges)
 }

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -1,0 +1,74 @@
+use tower_lsp::lsp_types::FoldingRange;
+use tower_lsp::lsp_types::FoldingRangeKind;
+
+use crate::lsp::documents::Document;
+use crate::lsp::log_info;
+use crate::lsp::symbols::parse_comment_as_section;
+
+/// Detects and returns folding ranges for comment sections and curly-bracketed blocks
+pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
+    let mut folding_ranges: Vec<FoldingRange> = Vec::new();
+    let text = &document.contents; // Assuming `contents()` gives the text of the document
+    let mut line_iter = text.lines().enumerate().peekable();
+
+    let mut comment_stack: Vec<(usize, usize)> = Vec::new(); // a stack of (level, start_line) tuples
+
+    while let Some((line_idx, line)) = line_iter.next() {
+        let line_text = line.to_string();
+        (folding_ranges, comment_stack) =
+            comment_processor(folding_ranges, comment_stack, line_idx, &line_text);
+        log_info!("line_idx: {:#?} line_text: {:#?}", line_idx, line_text);
+    }
+
+    // TODO: End line handling
+
+    Ok(folding_ranges)
+}
+
+fn comment_processor(
+    mut folding_ranges: Vec<FoldingRange>,
+    mut comment_stack: Vec<(usize, usize)>,
+    line_idx: usize,
+    line_text: &str,
+) -> (Vec<FoldingRange>, Vec<(usize, usize)>) {
+    let Some((level, _title)) = parse_comment_as_section(line_text) else {
+        return (folding_ranges, comment_stack); // return if the line is not a comment section
+    };
+
+    if comment_stack.is_empty() {
+        comment_stack.push((level, line_idx));
+        return (folding_ranges, comment_stack); // return if the stack is empty
+    }
+
+    while let Some((last_level, _)) = comment_stack.last() {
+        if *last_level < level {
+            comment_stack.push((level, line_idx));
+            break;
+        } else if *last_level == level {
+            folding_ranges.push(comment_range(comment_stack.last().unwrap().1, line_idx - 1));
+            comment_stack.pop();
+            comment_stack.push((level, line_idx));
+            break;
+        } else {
+            folding_ranges.push(comment_range(comment_stack.last().unwrap().1, line_idx - 1));
+            comment_stack.pop();
+        }
+    }
+
+    // log a copy of comment_stack
+    let comment_stack_copy = comment_stack.clone();
+    log_info!("comment_stack_copy: {:#?}", comment_stack_copy);
+
+    (folding_ranges, comment_stack)
+}
+
+fn comment_range(start_line: usize, end_line: usize) -> FoldingRange {
+    FoldingRange {
+        start_line: start_line.try_into().unwrap(),
+        start_character: None,
+        end_line: end_line.try_into().unwrap(),
+        end_character: None,
+        kind: Some(FoldingRangeKind::Region),
+        collapsed_text: None,
+    }
+}

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -13,12 +13,17 @@ pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
     let mut line_iter = text.lines().enumerate().peekable();
 
     let mut bracket_stack: Vec<(usize, usize)> = Vec::new(); // a stack of (start_line, start_character) tuples
-    let mut comment_stack: Vec<(usize, usize)> = Vec::new(); // a stack of (level, start_line) tuples
+    let mut comment_stack: Vec<Vec<(usize, usize)>> = vec![Vec::new()]; // a vector of stacks for each bracket level, within each stack is a vector of (level, start_line) tuples
 
     while let Some((line_idx, line)) = line_iter.next() {
         let line_text = line.to_string();
-        (folding_ranges, bracket_stack) =
-            bracket_processor(folding_ranges, bracket_stack, line_idx, &line_text);
+        (folding_ranges, bracket_stack, comment_stack) = bracket_processor(
+            folding_ranges,
+            bracket_stack,
+            comment_stack,
+            line_idx,
+            &line_text,
+        );
         (folding_ranges, comment_stack) =
             comment_processor(folding_ranges, comment_stack, line_idx, &line_text);
         // log_info!("line_idx: {:#?} line_text: {:#?}", line_idx, line_text);
@@ -35,9 +40,14 @@ pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
 fn bracket_processor(
     mut folding_ranges: Vec<FoldingRange>,
     mut bracket_stack: Vec<(usize, usize)>,
+    mut comment_stack: Vec<Vec<(usize, usize)>>,
     line_idx: usize,
     line_text: &str,
-) -> (Vec<FoldingRange>, Vec<(usize, usize)>) {
+) -> (
+    Vec<FoldingRange>,
+    Vec<(usize, usize)>,
+    Vec<Vec<(usize, usize)>>,
+) {
     // Remove any trailing comments (starting with #) and \n in line_text
     let line_text = line_text.split('#').next().unwrap_or("").trim_end();
     let mut whitespace_count = 0;
@@ -47,8 +57,11 @@ fn bracket_processor(
         match c {
             '{' => {
                 bracket_stack.push((line_idx, char_idx));
+                comment_stack.push(Vec::new());
             },
             '}' => {
+                (folding_ranges, comment_stack) =
+                    end_bracket_handler(folding_ranges, comment_stack, line_idx);
                 // If '}' is found, pop from the bracket_stack if it is not empty
                 if let Some((start_line, start_char)) = bracket_stack.pop() {
                     // Count the number of leading whitespace characters
@@ -75,7 +88,7 @@ fn bracket_processor(
         }
     }
 
-    (folding_ranges, bracket_stack)
+    (folding_ranges, bracket_stack, comment_stack)
 }
 
 fn bracket_range(
@@ -115,42 +128,68 @@ fn bracket_range(
     }
 }
 
+fn end_bracket_handler(
+    mut folding_ranges: Vec<FoldingRange>,
+    mut comment_stack: Vec<Vec<(usize, usize)>>,
+    line_idx: usize,
+) -> (Vec<FoldingRange>, Vec<Vec<(usize, usize)>>) {
+    // TODO: Iterate over the last elment of the comment stack and add it to the folding ranges by using the comment_range function
+    if let Some(last_section) = comment_stack.last() {
+        // Iterate over each (start level, start line) in the last section
+        for &(_level, start_line) in last_section.iter() {
+            // Add a new folding range for each range in the last section
+            folding_ranges.push(comment_range(start_line, line_idx - 1));
+        }
+    }
+
+    // Remove the last element from the comment stack after processing
+    comment_stack.pop();
+
+    (folding_ranges, comment_stack)
+}
+
 fn comment_processor(
     mut folding_ranges: Vec<FoldingRange>,
-    mut comment_stack: Vec<(usize, usize)>,
+    mut comment_stack: Vec<Vec<(usize, usize)>>,
     line_idx: usize,
     line_text: &str,
-) -> (Vec<FoldingRange>, Vec<(usize, usize)>) {
+) -> (Vec<FoldingRange>, Vec<Vec<(usize, usize)>>) {
     let Some((level, _title)) = parse_comment_as_section(line_text) else {
         return (folding_ranges, comment_stack); // return if the line is not a comment section
     };
 
+    if comment_stack.is_empty() {
+        log_error!("Folding Range: comment_stack should always contain at least one element here");
+        return (folding_ranges, comment_stack);
+    }
+
     loop {
-        if comment_stack.is_empty() {
-            comment_stack.push((level, line_idx));
+        if comment_stack.last().unwrap().is_empty() {
+            comment_stack.last_mut().unwrap().push((level, line_idx));
             return (folding_ranges, comment_stack); // return if the stack is empty
         }
 
-        let Some((last_level, _)) = comment_stack.last() else {
+        let Some((last_level, _)) = comment_stack.last().unwrap().last() else {
             log_error!("Folding Range: comment_stacks should not be empty here");
             return (folding_ranges, comment_stack);
         };
         if *last_level < level {
-            comment_stack.push((level, line_idx));
+            comment_stack.last_mut().unwrap().push((level, line_idx));
             break;
         } else if *last_level == level {
-            folding_ranges.push(comment_range(comment_stack.last().unwrap().1, line_idx - 1));
-
-            // Log a copy of folding_range
-            let folding_range_copy = folding_ranges.last().unwrap().clone();
-            log_info!("folding_range_copy: {:#?}", folding_range_copy);
-
-            comment_stack.pop();
-            comment_stack.push((level, line_idx));
+            folding_ranges.push(comment_range(
+                comment_stack.last().unwrap().last().unwrap().1,
+                line_idx - 1,
+            ));
+            comment_stack.last_mut().unwrap().pop();
+            comment_stack.last_mut().unwrap().push((level, line_idx));
             break;
         } else {
-            folding_ranges.push(comment_range(comment_stack.last().unwrap().1, line_idx - 1));
-            comment_stack.pop(); // TODO: Handle case where comment_stack is empty
+            folding_ranges.push(comment_range(
+                comment_stack.last().unwrap().last().unwrap().1,
+                line_idx - 1,
+            ));
+            comment_stack.last_mut().unwrap().pop(); // TODO: Handle case where comment_stack is empty
         }
     }
 

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -65,11 +65,11 @@ fn bracket_processor(
     // Iterate over each character in line_text to find the positions of `{` and `}`
     for (char_idx, c) in line_text.char_indices() {
         match c {
-            '{' => {
+            '{' | '(' | '[' => {
                 bracket_stack.push((line_idx, char_idx));
                 comment_stack.push(Vec::new());
             },
-            '}' => {
+            '}' | ')' | ']' => {
                 (folding_ranges, comment_stack) =
                     end_bracket_handler(folding_ranges, comment_stack, line_idx);
                 // If '}' is found, pop from the bracket_stack if it is not empty

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -2,6 +2,7 @@ use tower_lsp::lsp_types::FoldingRange;
 use tower_lsp::lsp_types::FoldingRangeKind;
 
 use crate::lsp::documents::Document;
+use crate::lsp::log_error;
 use crate::lsp::log_info;
 use crate::lsp::symbols::parse_comment_as_section;
 
@@ -11,18 +12,107 @@ pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
     let text = &document.contents; // Assuming `contents()` gives the text of the document
     let mut line_iter = text.lines().enumerate().peekable();
 
+    let mut bracket_stack: Vec<(usize, usize)> = Vec::new(); // a stack of (start_line, start_character) tuples
     let mut comment_stack: Vec<(usize, usize)> = Vec::new(); // a stack of (level, start_line) tuples
 
     while let Some((line_idx, line)) = line_iter.next() {
         let line_text = line.to_string();
+        (folding_ranges, bracket_stack) =
+            bracket_processor(folding_ranges, bracket_stack, line_idx, &line_text);
         (folding_ranges, comment_stack) =
             comment_processor(folding_ranges, comment_stack, line_idx, &line_text);
-        log_info!("line_idx: {:#?} line_text: {:#?}", line_idx, line_text);
+        // log_info!("line_idx: {:#?} line_text: {:#?}", line_idx, line_text);
     }
 
     // TODO: End line handling
 
+    // Log the final folding ranges
+    log_info!("folding_ranges: {:#?}", folding_ranges);
+
     Ok(folding_ranges)
+}
+
+fn bracket_processor(
+    mut folding_ranges: Vec<FoldingRange>,
+    mut bracket_stack: Vec<(usize, usize)>,
+    line_idx: usize,
+    line_text: &str,
+) -> (Vec<FoldingRange>, Vec<(usize, usize)>) {
+    // Remove any trailing comments (starting with #) and \n in line_text
+    let line_text = line_text.split('#').next().unwrap_or("").trim_end();
+    let mut whitespace_count = 0;
+
+    // Iterate over each character in line_text to find the positions of `{` and `}`
+    for (char_idx, c) in line_text.char_indices() {
+        match c {
+            '{' => {
+                bracket_stack.push((line_idx, char_idx));
+            },
+            '}' => {
+                // If '}' is found, pop from the bracket_stack if it is not empty
+                if let Some((start_line, start_char)) = bracket_stack.pop() {
+                    // Count the number of leading whitespace characters
+
+                    // Create a new FoldingRange from the start `{` to the current `}`
+                    let folding_range = bracket_range(
+                        start_line,
+                        start_char,
+                        line_idx,
+                        char_idx,
+                        &whitespace_count,
+                    );
+
+                    // Log a copy of the folding range
+                    // let folding_range_copy = folding_range.clone();
+                    // log_info!("folding_range_copy: {:#?}", folding_range_copy);
+
+                    // Add the folding range to the list
+                    folding_ranges.push(folding_range);
+                }
+            },
+            ' ' => whitespace_count += 1,
+            _ => {},
+        }
+    }
+
+    (folding_ranges, bracket_stack)
+}
+
+fn bracket_range(
+    start_line: usize,
+    start_char: usize,
+    end_line: usize,
+    end_char: usize,
+    white_space_count: &usize,
+) -> FoldingRange {
+    let mut end_line: u32 = end_line.try_into().unwrap();
+    let mut end_char: Option<u32> = Some(end_char.try_into().unwrap());
+
+    let adjusted_end_char = end_char.and_then(|val| val.checked_sub(*white_space_count as u32));
+
+    match adjusted_end_char {
+        Some(0) => {
+            end_line -= 1;
+            end_char = None;
+        },
+        Some(_) => {
+            if let Some(ref mut value) = end_char {
+                *value -= 1;
+            }
+        },
+        None => {
+            log_error!("Folding Range (bracket_range): adjusted_end_char should not be None here");
+        },
+    }
+
+    FoldingRange {
+        start_line: start_line.try_into().unwrap(),
+        start_character: Some(start_char as u32),
+        end_line,
+        end_character: end_char,
+        kind: Some(FoldingRangeKind::Region),
+        collapsed_text: None,
+    }
 }
 
 fn comment_processor(
@@ -35,23 +125,32 @@ fn comment_processor(
         return (folding_ranges, comment_stack); // return if the line is not a comment section
     };
 
-    if comment_stack.is_empty() {
-        comment_stack.push((level, line_idx));
-        return (folding_ranges, comment_stack); // return if the stack is empty
-    }
+    loop {
+        if comment_stack.is_empty() {
+            comment_stack.push((level, line_idx));
+            return (folding_ranges, comment_stack); // return if the stack is empty
+        }
 
-    while let Some((last_level, _)) = comment_stack.last() {
+        let Some((last_level, _)) = comment_stack.last() else {
+            log_error!("Folding Range: comment_stacks should not be empty here");
+            return (folding_ranges, comment_stack);
+        };
         if *last_level < level {
             comment_stack.push((level, line_idx));
             break;
         } else if *last_level == level {
             folding_ranges.push(comment_range(comment_stack.last().unwrap().1, line_idx - 1));
+
+            // Log a copy of folding_range
+            let folding_range_copy = folding_ranges.last().unwrap().clone();
+            log_info!("folding_range_copy: {:#?}", folding_range_copy);
+
             comment_stack.pop();
             comment_stack.push((level, line_idx));
             break;
         } else {
             folding_ranges.push(comment_range(comment_stack.last().unwrap().1, line_idx - 1));
-            comment_stack.pop();
+            comment_stack.pop(); // TODO: Handle case where comment_stack is empty
         }
     }
 

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -17,6 +17,8 @@ use tower_lsp::lsp_types::CompletionResponse;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingParams;
 use tower_lsp::lsp_types::DocumentSymbolParams;
 use tower_lsp::lsp_types::DocumentSymbolResponse;
+use tower_lsp::lsp_types::FoldingRange;
+use tower_lsp::lsp_types::FoldingRangeParams;
 use tower_lsp::lsp_types::GotoDefinitionParams;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::lsp_types::Hover;
@@ -47,6 +49,7 @@ use crate::lsp::config::VscDocumentConfig;
 use crate::lsp::definitions::goto_definition;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::encoding::convert_position_to_point;
+use crate::lsp::folding_range::folding_range;
 use crate::lsp::help_topic::help_topic;
 use crate::lsp::help_topic::HelpTopicParams;
 use crate::lsp::help_topic::HelpTopicResponse;
@@ -310,6 +313,22 @@ pub(crate) fn handle_selection_range(
         .collect();
 
     Ok(Some(selections))
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn handle_folding_range(
+    params: FoldingRangeParams,
+    state: &WorldState,
+) -> anyhow::Result<Option<Vec<FoldingRange>>> {
+    let uri = params.text_document.uri;
+    let document = state.get_document(&uri)?;
+    match folding_range(document) {
+        Ok(foldings) => Ok(Some(foldings)),
+        Err(err) => {
+            lsp::log_error!("{err:?}");
+            Ok(None)
+        },
+    }
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -287,6 +287,9 @@ impl GlobalState {
                         LspRequest::SelectionRange(params) => {
                             respond(tx, handlers::handle_selection_range(params, &self.world), LspResponse::SelectionRange)?;
                         },
+                        LspRequest::FoldingRange(params) => {
+                            respond(tx, handlers::handle_folding_range(params, &self.world), LspResponse::FoldingRange)?;
+                        }
                         LspRequest::References(params) => {
                             respond(tx, handlers::handle_references(params, &self.world), LspResponse::References)?;
                         },

--- a/crates/ark/src/lsp/mod.rs
+++ b/crates/ark/src/lsp/mod.rs
@@ -17,6 +17,7 @@ pub mod document_context;
 pub mod documents;
 pub mod encoding;
 pub mod events;
+pub mod folding_range;
 pub mod handler;
 pub mod handlers;
 pub mod help;

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -18,6 +18,7 @@ use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingOptions;
 use tower_lsp::lsp_types::ExecuteCommandOptions;
+use tower_lsp::lsp_types::FoldingRangeProviderCapability;
 use tower_lsp::lsp_types::FormattingOptions;
 use tower_lsp::lsp_types::HoverProviderCapability;
 use tower_lsp::lsp_types::ImplementationProviderCapability;
@@ -114,6 +115,7 @@ pub(crate) fn initialize(
                 TextDocumentSyncKind::INCREMENTAL,
             )),
             selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
+            folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
             hover_provider: Some(HoverProviderCapability::from(true)),
             completion_provider: Some(CompletionOptions {
                 resolve_provider: Some(true),

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -335,7 +335,7 @@ fn index_assignment_with_function(
 }
 
 // Function to parse a comment and return the section level and title
-fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
+pub fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
     // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
     // Ensure that there's actual content between the start and the trailing symbols.
     if let Some(caps) = indexer::RE_COMMENT_SECTION.captures(comment) {


### PR DESCRIPTION
It seems that the call for folding ranges has been quite a while: https://github.com/posit-dev/positron/issues/18, https://github.com/posit-dev/positron/issues/2924, https://github.com/posit-dev/positron/issues/3822.

I was initially only thinking about adding foldable comments, but it seems that doing this will disable the existing folding support for things like regions and brackets. Therefore, I rewrote these functionalities also.

The PR already supports the folding-range-handling of brackets, regions, code cells and *nested* comment sections:

![image](https://github.com/user-attachments/assets/51118e9a-6db5-424e-985f-350d84889118)

For the handling of regions and code cells, I'm currently implementing a simple lookup of regex, which respects the existing behaviour and disregards any nested structures. I note that this kinds of get messy when you are also using the nested comments. But maybe that's a separate issue?
