### PR TITLE
Avoid panics due to LSP connectivity issues

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -1735,7 +1735,9 @@ impl RMain {
 
     fn send_lsp_notification(&self, event: KernelNotification) {
         if let Some(ref tx) = self.lsp_events_tx {
-            tx.send(Event::Kernel(event)).unwrap();
+            if let Err(err) = tx.send(Event::Kernel(event)) {
+                log::error!("Failed to send LSP notification: {err:?}");
+            }
         }
     }
 


### PR DESCRIPTION
This change addresses an issue in ark when reading LSP events and sending notifications. If these operations fail, the kernel crashes and all user data is lost. 

The change minimally avoids these crashes as follows:

- If a notification can't be sent, we log instead of panicking.
- If the event loops don't receive events, we end the loops instead of panicking. 

Addresses https://github.com/posit-dev/positron/issues/4959.

