### PR TITLE
Patch to avoid accessing R off the main thread in integration test

### DIFF
--- a/crates/ark/tests/rstudioapi.rs
+++ b/crates/ark/tests/rstudioapi.rs
@@ -11,7 +11,10 @@ fn test_get_version() {
     }
 
     let value = "1.0.0";
-    harp::envvar::set_var("POSITRON_VERSION", value);
+    // Can't directly talk to R, need an `r_task()` that can be used alongside
+    // the `frontend`. See https://github.com/posit-dev/ark/issues/609.
+    // harp::envvar::set_var("POSITRON_VERSION", value);
+    set_var("POSITRON_VERSION", value, &frontend);
 
     let code = "as.character(rstudioapi::getVersion())";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
@@ -39,7 +42,10 @@ fn test_get_mode() {
     }
 
     let value = "desktop";
-    harp::envvar::set_var("POSITRON_MODE", value);
+    // Can't directly talk to R, need an `r_task()` that can be used alongside
+    // the `frontend`. See https://github.com/posit-dev/ark/issues/609.
+    // harp::envvar::set_var("POSITRON_MODE", value);
+    set_var("POSITRON_MODE", value, &frontend);
 
     let code = "rstudioapi::getMode()";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
@@ -51,6 +57,19 @@ fn test_get_mode() {
         frontend.recv_iopub_execute_result(),
         format!("[1] \"{value}\"")
     );
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+}
+
+fn set_var(key: &str, value: &str, frontend: &DummyArkFrontend) {
+    let code = format!("Sys.setenv({key} = \"{value}\")");
+    frontend.send_execute_request(code.as_str(), ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, code);
 
     frontend.recv_iopub_idle();
 


### PR DESCRIPTION
Patch for https://github.com/posit-dev/ark/issues/609 which causes us some test instability. We'd like to be able to use `r_test()`s in the long term, but it requires some thinking. In the meantime we can just directly go through an execute request and use that to ensure code is executed on the main R thread.