### PR TITLE
Index all assigned variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2024-10
 
-- Assigned objects are now indexed, in addition to assigned functions. When a name is assigned multiple times, we now only index the first occurrence. This allows you to jump to the first "declaration" of the variable. In the future we'll improve this mechanism so that you can jump to the most recent assignment.
+- Objects assigned at top level are now indexed, in addition to assigned functions. When a name is assigned multiple times, we now only index the first occurrence. This allows you to jump to the first "declaration" of the variable. In the future we'll improve this mechanism so that you can jump to the most recent assignment.
 
   We also index `method(generic, class) <-` assignment to help with S7 development. This might be replaced by a "Find implementations" mechanism in the future.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 2024-10
 
+- Assigned objects are now indexed, in addition to assigned functions. When a name is assigned multiple times, we now only index the first occurrence. This allows you to jump to the first "declaration" of the variable. In the future we'll improve this mechanism so that you can jump to the most recent assignment.
+
+  We also index `method(generic, class) <-` assignment to help with S7 development. This might be replaced by a "Find implementations" mechanism in the future.
+
 - Results from completions have been improved with extra details.
   Package functions now display the package name (posit-dev/positron#5225)
   and namespace completions now display `::` to hint at what is being

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -273,6 +273,14 @@ pub(super) unsafe fn completion_item_from_object(
     Ok(item)
 }
 
+pub(super) fn completion_item_from_variable(name: &str) -> anyhow::Result<CompletionItem> {
+    let mut item = completion_item(String::from(name), CompletionData::Object {
+        name: String::from(name),
+    })?;
+    item.kind = Some(CompletionItemKind::VALUE);
+    Ok(item)
+}
+
 pub(super) unsafe fn completion_item_from_promise(
     name: &str,
     object: SEXP,

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -271,6 +271,7 @@ fn completions_from_workspace_arguments(
             // Not a function
             return Ok(None);
         },
+        indexer::IndexEntryData::Variable { .. } => return Ok(None),
     }
 
     // Only 1 call worth of arguments are added to the completion set.

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -14,6 +14,7 @@ use tower_lsp::lsp_types::MarkupContent;
 use tower_lsp::lsp_types::MarkupKind;
 
 use crate::lsp::completions::completion_item::completion_item_from_function;
+use crate::lsp::completions::completion_item::completion_item_from_variable;
 use crate::lsp::completions::sources::utils::filter_out_dot_prefixes;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::indexer;
@@ -97,6 +98,16 @@ pub(super) fn completions_from_workspace(
             },
 
             indexer::IndexEntryData::Section { level: _, title: _ } => {},
+            indexer::IndexEntryData::Variable { name } => {
+                let completion = match completion_item_from_variable(name) {
+                    Ok(item) => item,
+                    Err(err) => {
+                        log::error!("{err:?}");
+                        return;
+                    },
+                };
+                completions.push(completion);
+            },
         }
     });
 

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -120,6 +120,10 @@ fn insert(path: &Path, entry: IndexEntry) -> anyhow::Result<()> {
     let path = str_from_path(path)?;
 
     let index = index.entry(path.to_string()).or_default();
+
+    // Retain the first occurrence in the index. In the future we'll track every occurrences and
+    // their scopes but for now we only track the first definition of an object (in a way, its
+    // declaration).
     if !index.contains_key(&entry.key) {
         index.insert(entry.key.clone(), entry);
     }

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -120,7 +120,9 @@ fn insert(path: &Path, entry: IndexEntry) -> anyhow::Result<()> {
     let path = str_from_path(path)?;
 
     let index = index.entry(path.to_string()).or_default();
-    index.insert(entry.key.clone(), entry);
+    if !index.contains_key(&entry.key) {
+        index.insert(entry.key.clone(), entry);
+    }
 
     Ok(())
 }

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -288,18 +288,21 @@ fn index_variable(
     let Some(lhs) = node.child_by_field_name("lhs") else {
         return Ok(None);
     };
-    if !lhs.is_identifier_or_string() {
+
+    let lhs_text = contents.node_slice(&lhs)?.to_string();
+
+    // Super hacky but let's wait until the typed API to do better
+    if !lhs_text.starts_with("method(") && !lhs.is_identifier_or_string() {
         return Ok(None);
     }
-    let name = contents.node_slice(&lhs)?.to_string();
 
     let start = convert_point_to_position(contents, lhs.start_position());
     let end = convert_point_to_position(contents, lhs.end_position());
 
     Ok(Some(IndexEntry {
-        key: name.clone(),
+        key: lhs_text.clone(),
         range: Range { start, end },
-        data: IndexEntryData::Variable { name },
+        data: IndexEntryData::Variable { name: lhs_text },
     }))
 }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -95,6 +95,19 @@ pub fn symbols(params: &WorkspaceSymbolParams) -> anyhow::Result<Vec<SymbolInfor
                     container_name: None,
                 });
             },
+            IndexEntryData::Variable { name } => {
+                info.push(SymbolInformation {
+                    name: name.clone(),
+                    kind: SymbolKind::VARIABLE,
+                    location: Location {
+                        uri: Url::from_file_path(path).unwrap(),
+                        range: entry.range,
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: None,
+                });
+            },
         };
     });
 


### PR DESCRIPTION
Quick fix to improve S7 workflow.
Addresses https://github.com/posit-dev/positron/issues/5274

Also a nice improvement all around as you can jump to the definition of e.g. a data frame in a script.