### PR TITLE
Bump ark to 0.1.150

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.149"
+version = "0.1.150"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.149"
+version = "0.1.150"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/616 and https://github.com/posit-dev/ark/pull/620.

# Positron Release Notes

## New Features

- All top-level variables in R files are now indexed as workspace symbols. You can now find assigned objects in the "Go to symbol in Workspace feature" and use "Go to definition" to jump from a variable name to its assignment (posit-dev/positron#5274). Repeated assignments to the same name are not indexed yet but we plan to do so in the future.

- Completions for R functions and objects now display which package they are from (posit-dev/positron#5225). And completions for package namespaces are now indicated by a `::` suffix to make it clearer what is being completed.

## Bug Fixes

- N/A