### PR TITLE
Bump tree-sitter-r

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 [[package]]
 name = "tree-sitter-r"
 version = "1.1.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=1dacc1035439421003e0940fe4b9ab0fd1c249a4#1dacc1035439421003e0940fe4b9ab0fd1c249a4"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=c094bd57652f8a08edc31d79a31222268fe798ee#c094bd57652f8a08edc31d79a31222268fe798ee"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 [[package]]
 name = "tree-sitter-r"
 version = "1.1.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=2097fa502efa21349d26af0ffee55d773015e481#2097fa502efa21349d26af0ffee55d773015e481"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=1dacc1035439421003e0940fe4b9ab0fd1c249a4#1dacc1035439421003e0940fe4b9ab0fd1c249a4"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -47,7 +47,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.23.0"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "1dacc1035439421003e0940fe4b9ab0fd1c249a4" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "c094bd57652f8a08edc31d79a31222268fe798ee" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -47,7 +47,7 @@ stdext = { path = "../stdext" }
 tokio = { version = "1.26.0", features = ["full"] }
 tower-lsp = "0.19.0"
 tree-sitter = "0.23.0"
-tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "2097fa502efa21349d26af0ffee55d773015e481" }
+tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "1dacc1035439421003e0940fe4b9ab0fd1c249a4" }
 uuid = "1.3.0"
 url = "2.4.1"
 walkdir = "2"

--- a/crates/ark/src/lsp/indent.rs
+++ b/crates/ark/src/lsp/indent.rs
@@ -239,6 +239,22 @@ mod tests {
     }
 
     #[test]
+    fn test_line_indent_leading_whitespace() {
+        // Indent should be unchanged regardless of how much leading whitespace
+        // there is before the first newline
+        // https://github.com/posit-dev/positron/issues/5258
+        let text = String::from("  \nx");
+        let doc = test_doc(&text);
+        let edit = indent_edit(&doc, 1).unwrap();
+        assert!(edit.is_none());
+
+        let text = String::from("\r\nx");
+        let doc = test_doc(&text);
+        let edit = indent_edit(&doc, 1).unwrap();
+        assert!(edit.is_none());
+    }
+
+    #[test]
     fn test_line_indent_chains() {
         let mut text = String::from("foo +\n  bar +\n    baz + qux |>\nfoofy()");
         let doc = test_doc(&text);


### PR DESCRIPTION
For https://github.com/r-lib/tree-sitter-r/pull/152
Addresses https://github.com/posit-dev/positron/issues/5258

### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- On Windows, indents of size 1 are no longer randomly added in R scripts (https://github.com/posit-dev/positron/issues/5258).