### PR TITLE
Expose package version info

### DIFF
--- a/crates/ark/src/modules/positron/package.R
+++ b/crates/ark/src/modules/positron/package.R
@@ -21,6 +21,32 @@
 #' @export
 .ps.rpc.is_installed <- .ps.is_installed
 
+# Returns a list containing:
+#   * the version string if the package is installed and NULL otherwise
+#   * a minimum version to check for, with '0.0.0' as a dummy default
+#   * a logical indicating if package is installed at or above the minimum version
+#  This may seem weird, but it's impractical for positron-r to do version
+#  comparisons.
+#' @export
+.ps.rpc.packageVersion <- function(pkg, checkAgainst = "0.0.0") {
+    installed <- system.file(package = pkg) != ""
+
+    if (installed) {
+        version <- utils::packageVersion(pkg)
+        list(
+          version = as.character(version),
+          checkAgainst = as.character(checkAgainst),
+          checkResult = version >= checkAgainst
+        )
+    } else {
+        list(
+          version = NULL,
+          checkAgainst = as.character(checkAgainst),
+          checkResult = FALSE
+        )
+    }
+}
+
 #' @export
 .ps.rpc.install_packages <- function(packages) {
     for (pkg in packages) {


### PR DESCRIPTION
Related to an incoming Positron PR to address https://github.com/posit-dev/positron/issues/1957

There are times when positron-r needs multiple pieces of related info about a package installation. I know it looks funny to get the package version _and_ to pass back info about whether that version satisfies a minimum version requirement, but it's impractical to do that comparison in positron-r (i.e. R package versions don't mesh with semver).

And to message about a package that is installed, but at insufficient version, you need all 3 of these pieces of info: installed version, required version, if that requirement is met.