### PR TITLE
Honor `MAX_DISPLAY_ENTRIES` when inspecting variables

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1906,21 +1906,21 @@ mod tests {
     #[test]
     fn test_truncation_on_matrices() {
         r_task(|| {
-            let env = harp::parse_eval_global("new.env()").unwrap();
-            harp::parse_eval0(
-                format!("x <- matrix(0, nrow = 10000, ncol = 10000)").as_str(),
-                env.clone(),
-            )
-            .unwrap();
+            let env =
+                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            env.bind(
+                "x".into(),
+                harp::parse_eval_base("matrix(0, nrow = 10000, ncol = 10000)").unwrap(),
+            );
 
             // Inspect the matrix, we should see the list of columns truncated
             let path = vec![String::from("x")];
-            let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
+            let vars = PositronVariable::inspect(env.clone().into(), &path).unwrap();
             assert_eq!(vars.len(), MAX_DISPLAY_VALUE_ENTRIES);
 
             // Now inspect the first column
             let path = vec![String::from("x"), vars[0].access_key.clone()];
-            let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
+            let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), MAX_DISPLAY_VALUE_ENTRIES);
             assert_eq!(vars[0].display_name, "[1, 1]");
         });
@@ -1929,50 +1929,51 @@ mod tests {
     #[test]
     fn test_string_truncation() {
         r_task(|| {
-            let env = harp::parse_eval_global("new.env()").unwrap();
-            harp::parse_eval0(
-                format!("x <- paste(1:5e6, collapse = ' - ')").as_str(),
-                env.clone(),
-            )
-            .unwrap();
+            let env =
+                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            env.bind(
+                "x".into(),
+                harp::parse_eval_base("paste(1:5e6, collapse = ' - ')").unwrap(),
+            );
 
             let path = vec![];
-            let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
+            let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
             assert_eq!(vars[0].display_value.len(), MAX_DISPLAY_VALUE_LENGTH);
             assert_eq!(vars[0].is_truncated, true);
 
             // Test for the empty string
-            let env = harp::parse_eval_global("new.env()").unwrap();
-            harp::parse_eval0(format!("x <- ''").as_str(), env.clone()).unwrap();
+            let env =
+                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            env.bind("x".into(), harp::parse_eval_base("''").unwrap());
 
             let path = vec![];
-            let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
+            let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
             assert_eq!(vars[0].display_value, "\"\"");
 
             // Test for the single elment matrix, but with a large character
-            let env = harp::parse_eval_global("new.env()").unwrap();
-            harp::parse_eval0(
-                format!("x <- matrix(paste(1:5e6, collapse = ' - '))").as_str(),
-                env.clone(),
-            )
-            .unwrap();
+            let env =
+                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            env.bind(
+                "x".into(),
+                harp::parse_eval_base("matrix(paste(1:5e6, collapse = ' - '))").unwrap(),
+            );
             let path = vec![];
-            let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
+            let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
             assert_eq!(vars[0].display_value.len(), MAX_DISPLAY_VALUE_LENGTH);
             assert_eq!(vars[0].is_truncated, true);
 
             // Test for the empty matrix
-            let env = harp::parse_eval_global("new.env()").unwrap();
-            harp::parse_eval0(
-                format!("x <- matrix(NA, ncol = 0, nrow = 0)").as_str(),
-                env.clone(),
-            )
-            .unwrap();
+            let env =
+                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            env.bind(
+                "x".into(),
+                harp::parse_eval_base("matrix(NA, ncol = 0, nrow = 0)").unwrap(),
+            );
             let path = vec![];
-            let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
+            let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
             assert_eq!(vars[0].display_value, "[]");
         });

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1906,8 +1906,7 @@ mod tests {
     #[test]
     fn test_truncation_on_matrices() {
         r_task(|| {
-            let env =
-                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            let env = Environment::new_empty().unwrap();
             env.bind(
                 "x".into(),
                 harp::parse_eval_base("matrix(0, nrow = 10000, ncol = 10000)").unwrap(),
@@ -1929,8 +1928,7 @@ mod tests {
     #[test]
     fn test_string_truncation() {
         r_task(|| {
-            let env =
-                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            let env = Environment::new_empty().unwrap();
             env.bind(
                 "x".into(),
                 harp::parse_eval_base("paste(1:5e6, collapse = ' - ')").unwrap(),
@@ -1943,8 +1941,7 @@ mod tests {
             assert_eq!(vars[0].is_truncated, true);
 
             // Test for the empty string
-            let env =
-                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            let env = Environment::new_empty().unwrap();
             env.bind("x".into(), harp::parse_eval_base("''").unwrap());
 
             let path = vec![];
@@ -1953,8 +1950,7 @@ mod tests {
             assert_eq!(vars[0].display_value, "\"\"");
 
             // Test for the single elment matrix, but with a large character
-            let env =
-                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            let env = Environment::new_empty().unwrap();
             env.bind(
                 "x".into(),
                 harp::parse_eval_base("matrix(paste(1:5e6, collapse = ' - '))").unwrap(),
@@ -1966,8 +1962,7 @@ mod tests {
             assert_eq!(vars[0].is_truncated, true);
 
             // Test for the empty matrix
-            let env =
-                Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+            let env = Environment::new_empty().unwrap();
             env.bind(
                 "x".into(),
                 harp::parse_eval_base("matrix(NA, ncol = 0, nrow = 0)").unwrap(),

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1819,11 +1819,11 @@ mod tests {
     }
 
     fn inspect_from_expr(code: &str) -> Vec<Variable> {
-        let env = harp::parse_eval_global("new.env()").unwrap();
-        harp::parse_eval0(format!("x <- {code}").as_str(), env.clone()).unwrap();
+        let env = Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
+        env.bind("x".into(), harp::parse_eval_base(code).unwrap());
         // Inspect the S4 object
         let path = vec![String::from("x")];
-        PositronVariable::inspect(env.clone(), &path).unwrap()
+        PositronVariable::inspect(env.into(), &path).unwrap()
     }
 
     #[test]

--- a/crates/harp/src/environment.rs
+++ b/crates/harp/src/environment.rs
@@ -56,6 +56,12 @@ impl Environment {
         Self::new_filtered(env, EnvironmentFilter::default())
     }
 
+    pub fn new_empty() -> anyhow::Result<Self> {
+        Ok(Self::new(harp::parse_eval_base(
+            "new.env(parent = emptyenv())",
+        )?))
+    }
+
     pub fn new_filtered(env: RObject, filter: EnvironmentFilter) -> Self {
         Self { inner: env, filter }
     }


### PR DESCRIPTION
This PR fixes some performance related issues that involve the variables pane.
Addressing: 
- https://github.com/posit-dev/positron/issues/4636 
- https://github.com/posit-dev/positron/issues/4573
- https://github.com/posit-dev/positron/issues/2223

The goal is to have the following scenarios working fine in positron:

```r
# create a single string that's very large
a <- paste0(rep(letters, length.out = 1e7), collapse="-")

# create a very large vector, and expand it in the variables pane
b <- 1:100000

# expand a data frame with many columns
d <- as.data.frame(lapply(1:10000, function(x) 1:100000))

# expand a data.frame with many rows
f <- as.data.frame(lapply(1:20, function(x) 1:5e6))

# visualizing large matrixes (many rows and columns)
g <- matrix(0, nrow = 100000, ncol = 10000)

# matrixes with large strings inside
h <- matrix(paste0(rep(letters, length.out = 1e7), collapse="-"), nrow = 10, ncol = 10)
```

Note: When testing it's important to use a Release version of ark. In my tests, with debug can be 20x slower in such cases - probably for the tail recursion optimizations important for the object size computation.

Not fixed in this PR: 

- https://github.com/posit-dev/positron/issues/2894
- If a package extends the variables pane and it's methods are slow
- R6 classes with many methods are not truncated yet
- S4 objects with many slots are not truncated
- Still expanding the `model` from https://github.com/posit-dev/positron/issues/4636 takes about 1s. I *think* a lot of this time is computing the objects size - because of the deeply nested object.
- https://github.com/posit-dev/positron/issues/3656 (This should be a quick fix as we are here)
