### PR TITLE
Support semi colons on single line in statement range detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 0.1.9000
 
+## 2024-12
+
+- LSP: The statement range provider now has better support for expressions separated by `;` on a single line (posit-dev/positron#4317).
+
 ## 2024-11
 
 - LSP: Assignments in function calls (e.g. `list(x <- 1)`) are now detected by the missing symbol linter to avoid annoying false positive diagnostics (https://github.com/posit-dev/positron/issues/3048). The downside is that this causes false negatives when the assignment happens in a call with local scope, e.g. in `local()` or `test_that()`. We prefer to be overly permissive than overly cautious in these matters.

--- a/crates/ark/src/lsp/encoding.rs
+++ b/crates/ark/src/lsp/encoding.rs
@@ -136,7 +136,7 @@ fn convert_character_from_utf16_to_utf8(x: &str, character: usize) -> usize {
 }
 
 /// Converts a character offset into a particular line from UTF-8 to UTF-16
-fn convert_character_from_utf8_to_utf16(x: &str, character: usize) -> usize {
+pub(crate) fn convert_character_from_utf8_to_utf16(x: &str, character: usize) -> usize {
     if x.is_ascii() {
         // Fast pass
         return character;

--- a/crates/ark/src/lsp/encoding.rs
+++ b/crates/ark/src/lsp/encoding.rs
@@ -136,7 +136,7 @@ fn convert_character_from_utf16_to_utf8(x: &str, character: usize) -> usize {
 }
 
 /// Converts a character offset into a particular line from UTF-8 to UTF-16
-pub(crate) fn convert_character_from_utf8_to_utf16(x: &str, character: usize) -> usize {
+fn convert_character_from_utf8_to_utf16(x: &str, character: usize) -> usize {
     if x.is_ascii() {
         // Fast pass
         return character;

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -7,6 +7,7 @@
 
 use anyhow::bail;
 use anyhow::Result;
+use harp::parse_exprs;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use ropey::Rope;
@@ -19,9 +20,11 @@ use tower_lsp::lsp_types::VersionedTextDocumentIdentifier;
 use tree_sitter::Node;
 use tree_sitter::Point;
 
+use super::encoding::convert_character_from_utf8_to_utf16;
 use crate::lsp::encoding::convert_point_to_position;
 use crate::lsp::traits::cursor::TreeCursorExt;
 use crate::lsp::traits::rope::RopeExt;
+use crate::r_task;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
@@ -64,6 +67,12 @@ pub(crate) fn statement_range(
         return Ok(Some(new_statement_range_response(&node, contents, code)));
     }
 
+    // First check with the R parser whether line at point is complete.
+    // In that case, send the whole line as range.
+    if let Some(range) = find_complete_line_at_point(contents, point)? {
+        return Ok(Some(StatementRangeResponse { range, code: None }));
+    }
+
     if let Some(node) = find_statement_range_node(&root, row) {
         return Ok(Some(new_statement_range_response(&node, contents, None)));
     };
@@ -87,6 +96,53 @@ fn new_statement_range_response(
     let range = Range { start, end };
 
     StatementRangeResponse { range, code }
+}
+
+fn find_complete_line_at_point(contents: &Rope, point: Point) -> anyhow::Result<Option<Range>> {
+    let mut row = point.row;
+    let line;
+
+    loop {
+        let Some(current_line) = contents.get_line(row) else {
+            // The document was empty and we've looped over all lines. Let
+            // regular handler deal with this.
+            return Ok(None);
+        };
+
+        let current_line = current_line.to_string();
+
+        let Ok(n_exprs) = r_task::r_task(|| -> anyhow::Result<isize> {
+            let exprs = parse_exprs(&current_line)?;
+            Ok(exprs.length())
+        }) else {
+            // If incomplete or doesn't parse, we don't have a complete line
+            return Ok(None);
+        };
+
+        // Eat empty lines
+        if n_exprs == 0 {
+            row = row + 1;
+            continue;
+        }
+
+        line = current_line;
+        break;
+    }
+
+    let end_column = line.chars().count();
+    let end_column = convert_character_from_utf8_to_utf16(&line, end_column) as u32;
+
+    let range = Range {
+        start: Position {
+            line: row as u32,
+            character: 0,
+        },
+        end: Position {
+            line: row as u32,
+            character: end_column,
+        },
+    };
+    Ok(Some(range))
 }
 
 fn find_roxygen_comment_at_point<'tree>(
@@ -497,10 +553,13 @@ fn contains_row_at_different_start_position(node: Node, row: usize) -> Option<No
 #[cfg(test)]
 mod tests {
     use ropey::Rope;
+    use tower_lsp::lsp_types;
     use tree_sitter::Node;
     use tree_sitter::Parser;
     use tree_sitter::Point;
 
+    use crate::lsp::documents::Document;
+    use crate::lsp::statement_range::find_complete_line_at_point;
     use crate::lsp::statement_range::find_roxygen_comment_at_point;
     use crate::lsp::statement_range::find_statement_range_node;
     use crate::lsp::traits::rope::RopeExt;
@@ -1371,6 +1430,68 @@ test_that('stuff', {
 }
 ",
         );
+    }
+
+    #[test]
+    fn test_multiple_expressions_on_one_line() {
+        // https://github.com/posit-dev/positron/issues/4317
+
+        // Can't use `statement_range_test()` because it revolves around finding nodes not ranges
+        let doc = Document::new(
+            "
+
+1; 2; 3
+",
+            None,
+        );
+        let expected_range = Some(lsp_types::Range {
+            start: lsp_types::Position {
+                line: 2,
+                character: 0,
+            },
+            end: lsp_types::Position {
+                line: 2,
+                character: 8,
+            },
+        });
+
+        let point = Point::new(2, 7);
+        let range = find_complete_line_at_point(&doc.contents, point).unwrap();
+        assert_eq!(range, expected_range);
+
+        // Empty lines don't prevent finding complete lines
+        let point = Point::new(0, 0);
+        let range = find_complete_line_at_point(&doc.contents, point).unwrap();
+        assert_eq!(range, expected_range);
+    }
+
+    #[test]
+    fn test_multiple_expressions_on_one_line_nested_case() {
+        // https://github.com/posit-dev/positron/issues/4317
+
+        // Can't use `statement_range_test()` because it revolves around finding nodes not ranges
+        let doc = Document::new(
+            "
+list({
+  1; 2; 3
+})
+",
+            None,
+        );
+        let expected_range = Some(lsp_types::Range {
+            start: lsp_types::Position {
+                line: 2,
+                character: 0,
+            },
+            end: lsp_types::Position {
+                line: 2,
+                character: 10,
+            },
+        });
+
+        let point = Point::new(2, 0);
+        let range = find_complete_line_at_point(&doc.contents, point).unwrap();
+        assert_eq!(range, expected_range);
     }
 
     #[test]


### PR DESCRIPTION
Branched from #636.
Addresses https://github.com/posit-dev/positron/issues/4317

~Adds a dependency of statement-range on the R parser. This is consistent with our plans to make evaluation of selections depend on the R parser as well (complete expressions detection).~

~When a statement range is requested, we simply check if the whole line completely parses. If that's the case we return the line range. This tactic doesn't work if multiline expressions are separated by semi-colons. We can find a better way when we switch to a Rowan implementation.~

No longer doing this, instead using https://github.com/posit-dev/ark/pull/644, which does not use the R parser.


### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- `Cmd/Ctrl + Enter` now works as expected with expressions separated by semi-colons on a single line.
   https://github.com/posit-dev/positron/issues/4317

### Positron QA Notes

Cmd/Ctrl + Enter on that line (or an empty preceding line) should run the entire line:

```r
1; 2; 3
```

A semi-colon following a multiline expression is not supported yet, so for instance this would evaluate only the braces:

```r
{
  1
}; 2
```
