### PR TITLE
Detect assignments in calls to avoid false positive lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2024-11
 
+- LSP: Assignments in function calls (e.g. `list(x <- 1)`) are now detected by the missing symbol linter to avoid annoying false positive diagnostics (https://github.com/posit-dev/positron/issues/3048). The downside is that this causes false negatives when the assignment happens in a call with local scope, e.g. in `local()` or `test_that()`. We prefer to be overly permissive than overly cautious in these matters.
+
 - Jupyter: The following environment variables are now set in the same way that R does:
 
   - `R_SHARE_DIR`
@@ -11,7 +13,6 @@
   - `R_DOC_DIR`
 
   This solves a number of problems in situations that depend on these variables being defined (https://github.com/posit-dev/positron/issues/3637).
-
 
 ## 2024-10
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1333,7 +1333,6 @@ foo
 
     #[test]
     fn test_dotty_assignment_within_native_pipe_braced_expr() {
-        // TODO: `apple` should be defined in the global env and there should not be a diagnostic here
         r_task(|| {
             let code = "
                 mtcars |> list({ .[apple] <- 1; apple })
@@ -1406,6 +1405,18 @@ foo
             assert_eq!(
                 generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
                 0
+            );
+
+            // `in_call` state variable is reset
+            let code = "
+                list()
+                x
+            ";
+            let document = Document::new(code, None);
+
+            assert_eq!(
+                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                1
             );
         })
     }


### PR DESCRIPTION
Addresses posit-dev/positron#3048.

## Positron Notes

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Assignments in function calls (e.g. `list(x <- 1)`) are now detected by the missing symbol linter to avoid annoying false positive diagnostics (posit-dev/positron#3048). The downside is that this causes false negatives when the assignment happens in a call with local scope, e.g. in `local()` or `test_that()`. In these cases the nested assignments will incorrectly overlast the end of the call. We prefer to be overly permissive than overly cautious in these matters.

### QA Notes

Assignments in calls, e.g. `list(x <- 1)` should now be treated the same as at top-level. Any further references to `x` at top level should not be linted, e.g. `y` should cause a lint but not `x` in:

```r
list(x <- 1)
x; y
```

Note that calls can be nested `list(x <- 1, list(y, x, y <- 2), 1, y)`.

In that example, the first `y` should in principle be linted as it hasn't been defined yet but we don't support this sort of lints inside arguments yet.
