### PR TITLE
Fix segfault in variables tests

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1864,7 +1864,8 @@ mod tests {
 
     fn inspect_from_expr(code: &str) -> Vec<Variable> {
         let env = Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
-        env.bind("x".into(), harp::parse_eval_base(code).unwrap());
+        let value = harp::parse_eval_base(code).unwrap();
+        env.bind("x".into(), value.sexp);
         // Inspect the S4 object
         let path = vec![String::from("x")];
         PositronVariable::inspect(env.into(), &path).unwrap()
@@ -1971,10 +1972,8 @@ mod tests {
     fn test_truncation_on_matrices() {
         r_task(|| {
             let env = Environment::new_empty().unwrap();
-            env.bind(
-                "x".into(),
-                harp::parse_eval_base("matrix(0, nrow = 10000, ncol = 10000)").unwrap(),
-            );
+            let value = harp::parse_eval_base("matrix(0, nrow = 10000, ncol = 10000)").unwrap();
+            env.bind("x".into(), value.sexp);
 
             // Inspect the matrix, we should see the list of columns truncated
             let path = vec![String::from("x")];
@@ -1993,10 +1992,8 @@ mod tests {
     fn test_string_truncation() {
         r_task(|| {
             let env = Environment::new_empty().unwrap();
-            env.bind(
-                "x".into(),
-                harp::parse_eval_base("paste(1:5e6, collapse = ' - ')").unwrap(),
-            );
+            let value = harp::parse_eval_base("paste(1:5e6, collapse = ' - ')").unwrap();
+            env.bind("x".into(), value.sexp);
 
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
@@ -2006,7 +2003,8 @@ mod tests {
 
             // Test for the empty string
             let env = Environment::new_empty().unwrap();
-            env.bind("x".into(), harp::parse_eval_base("''").unwrap());
+            let value = harp::parse_eval_base("''").unwrap();
+            env.bind("x".into(), value.sexp);
 
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
@@ -2015,10 +2013,8 @@ mod tests {
 
             // Test for the single elment matrix, but with a large character
             let env = Environment::new_empty().unwrap();
-            env.bind(
-                "x".into(),
-                harp::parse_eval_base("matrix(paste(1:5e6, collapse = ' - '))").unwrap(),
-            );
+            let value = harp::parse_eval_base("matrix(paste(1:5e6, collapse = ' - '))").unwrap();
+            env.bind("x".into(), value.sexp);
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
@@ -2027,10 +2023,8 @@ mod tests {
 
             // Test for the empty matrix
             let env = Environment::new_empty().unwrap();
-            env.bind(
-                "x".into(),
-                harp::parse_eval_base("matrix(NA, ncol = 0, nrow = 0)").unwrap(),
-            );
+            let value = harp::parse_eval_base("matrix(NA, ncol = 0, nrow = 0)").unwrap();
+            env.bind("x".into(), value.sexp);
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1865,7 +1865,7 @@ mod tests {
     fn inspect_from_expr(code: &str) -> Vec<Variable> {
         let env = Environment::new(harp::parse_eval_base("new.env(parent = emptyenv())").unwrap());
         let value = harp::parse_eval_base(code).unwrap();
-        env.bind("x".into(), value.sexp);
+        env.bind("x".into(), &value);
         // Inspect the S4 object
         let path = vec![String::from("x")];
         PositronVariable::inspect(env.into(), &path).unwrap()
@@ -1973,7 +1973,7 @@ mod tests {
         r_task(|| {
             let env = Environment::new_empty().unwrap();
             let value = harp::parse_eval_base("matrix(0, nrow = 10000, ncol = 10000)").unwrap();
-            env.bind("x".into(), value.sexp);
+            env.bind("x".into(), &value);
 
             // Inspect the matrix, we should see the list of columns truncated
             let path = vec![String::from("x")];
@@ -1993,7 +1993,7 @@ mod tests {
         r_task(|| {
             let env = Environment::new_empty().unwrap();
             let value = harp::parse_eval_base("paste(1:5e6, collapse = ' - ')").unwrap();
-            env.bind("x".into(), value.sexp);
+            env.bind("x".into(), &value);
 
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
@@ -2004,7 +2004,7 @@ mod tests {
             // Test for the empty string
             let env = Environment::new_empty().unwrap();
             let value = harp::parse_eval_base("''").unwrap();
-            env.bind("x".into(), value.sexp);
+            env.bind("x".into(), &value);
 
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
@@ -2014,7 +2014,7 @@ mod tests {
             // Test for the single elment matrix, but with a large character
             let env = Environment::new_empty().unwrap();
             let value = harp::parse_eval_base("matrix(paste(1:5e6, collapse = ' - '))").unwrap();
-            env.bind("x".into(), value.sexp);
+            env.bind("x".into(), &value);
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
@@ -2024,7 +2024,7 @@ mod tests {
             // Test for the empty matrix
             let env = Environment::new_empty().unwrap();
             let value = harp::parse_eval_base("matrix(NA, ncol = 0, nrow = 0)").unwrap();
-            env.bind("x".into(), value.sexp);
+            env.bind("x".into(), &value);
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);

--- a/crates/harp/src/environment.rs
+++ b/crates/harp/src/environment.rs
@@ -91,13 +91,13 @@ impl Environment {
         std::iter::successors(Some(self.clone()), |p| p.parent())
     }
 
-    pub fn bind(&self, name: RSymbol, value: SEXP) {
+    pub fn bind(&self, name: RSymbol, value: &RObject) {
         unsafe {
-            Rf_defineVar(name.sexp, value.into(), self.inner.sexp);
+            Rf_defineVar(name.sexp, value.sexp, self.inner.sexp);
         }
     }
 
-    pub fn force_bind(&self, name: RSymbol, value: SEXP) {
+    pub fn force_bind(&self, name: RSymbol, value: &RObject) {
         let locked = self.is_locked_binding(name);
         if locked {
             self.unlock_binding(name);

--- a/crates/harp/src/environment.rs
+++ b/crates/harp/src/environment.rs
@@ -91,13 +91,13 @@ impl Environment {
         std::iter::successors(Some(self.clone()), |p| p.parent())
     }
 
-    pub fn bind(&self, name: RSymbol, value: impl Into<SEXP>) {
+    pub fn bind(&self, name: RSymbol, value: SEXP) {
         unsafe {
             Rf_defineVar(name.sexp, value.into(), self.inner.sexp);
         }
     }
 
-    pub fn force_bind(&self, name: RSymbol, value: impl Into<SEXP>) {
+    pub fn force_bind(&self, name: RSymbol, value: SEXP) {
         let locked = self.is_locked_binding(name);
         if locked {
             self.unlock_binding(name);

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -673,8 +673,9 @@ pub fn save_rds(x: SEXP, path: &str) {
     let path = RObject::from(path);
 
     let env = Environment::new(harp::parse_eval_base("new.env()").unwrap());
-    env.bind("x".into(), x);
-    env.bind("path".into(), path.sexp);
+    let x = RObject::from(x);
+    env.bind("x".into(), &x);
+    env.bind("path".into(), &path);
 
     let res = harp::parse_eval0("base::saveRDS(x, path)", env);
 
@@ -701,9 +702,10 @@ pub fn push_rds(x: SEXP, path: &str, context: &str) {
 
     let env = Environment::new(harp::parse_eval_base("new.env()").unwrap());
 
-    env.bind("x".into(), x);
-    env.bind("path".into(), path.sexp);
-    env.bind("context".into(), context.sexp);
+    let x = RObject::from(x);
+    env.bind("x".into(), &x);
+    env.bind("path".into(), &path);
+    env.bind("context".into(), &context);
 
     let res = harp::parse_eval0(".ps.internal(push_rds(x, path, context))", env);
 

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -674,7 +674,7 @@ pub fn save_rds(x: SEXP, path: &str) {
 
     let env = Environment::new(harp::parse_eval_base("new.env()").unwrap());
     env.bind("x".into(), x);
-    env.bind("path".into(), path);
+    env.bind("path".into(), path.sexp);
 
     let res = harp::parse_eval0("base::saveRDS(x, path)", env);
 
@@ -702,8 +702,8 @@ pub fn push_rds(x: SEXP, path: &str, context: &str) {
     let env = Environment::new(harp::parse_eval_base("new.env()").unwrap());
 
     env.bind("x".into(), x);
-    env.bind("path".into(), path);
-    env.bind("context".into(), context);
+    env.bind("path".into(), path.sexp);
+    env.bind("context".into(), context.sexp);
 
     let res = harp::parse_eval0(".ps.internal(push_rds(x, path, context))", env);
 


### PR DESCRIPTION
With current main, running:  

```
cargo test -p ark --lib variables::variable::tests::test_truncation
```

Will eventually fail with:

```
Error: VECTOR_ELT() can only be applied to a 'list', not a 'symbol'
Fatal error: unable to initialize the JIT
```

While I'm not entirely sure what's happenning, I believe this is a protection issue, and this PR seems to fix the problem.