### PR TITLE
Use tree-sitter approach to expand across semicolons

### DIFF
--- a/crates/ark/src/lsp/encoding.rs
+++ b/crates/ark/src/lsp/encoding.rs
@@ -136,7 +136,7 @@ fn convert_character_from_utf16_to_utf8(x: &str, character: usize) -> usize {
 }
 
 /// Converts a character offset into a particular line from UTF-8 to UTF-16
-pub(crate) fn convert_character_from_utf8_to_utf16(x: &str, character: usize) -> usize {
+fn convert_character_from_utf8_to_utf16(x: &str, character: usize) -> usize {
     if x.is_ascii() {
         // Fast pass
         return character;


### PR DESCRIPTION
Alternative approach using tree-sitter rather than the R parser, so it will eventually be fairly easy to move to a standalone LSP

Joint work with @lionel- 