### PR TITLE
Add a command-line argument to specify default repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "winsafe",
+ "xdg",
  "yaml-rust",
 ]
 
@@ -3811,6 +3812,12 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yaml-rust"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -62,7 +62,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-appender = "0.2.3"
 rustc-hash = "1.2.0"
 tracing-error = "0.2.0"
-xdg = "2.5.2"
 
 [dev-dependencies]
 insta = { version = "1.39.0" }
@@ -78,3 +77,6 @@ assets = [
     { source = "target/release/ark", dest = "/usr/bin/ark", mode = "755" },
 ]
 license = "TODO"
+
+[target.'cfg(unix)'.dependencies]
+xdg = "2.5.2"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -62,6 +62,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-appender = "0.2.3"
 rustc-hash = "1.2.0"
 tracing-error = "0.2.0"
+xdg = "2.5.2"
 
 [dev-dependencies]
 insta = { version = "1.39.0" }

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -9,6 +9,7 @@ use amalthea::fixtures::dummy_frontend::DummyConnection;
 use amalthea::fixtures::dummy_frontend::DummyFrontend;
 
 use crate::interface::SessionMode;
+use crate::repos::DefaultRepos;
 
 // There can be only one frontend per process. Needs to be in a mutex because
 // the frontend wraps zmq sockets which are unsafe to send across threads.
@@ -105,6 +106,7 @@ impl DummyArkFrontend {
                 None,
                 options.session_mode,
                 false,
+                DefaultRepos::None,
             );
         });
 

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -106,6 +106,8 @@ use crate::r_task::BoxFuture;
 use crate::r_task::RTask;
 use crate::r_task::RTaskStartInfo;
 use crate::r_task::RTaskStatus;
+use crate::repos::apply_default_repos;
+use crate::repos::DefaultRepos;
 use crate::request::debug_request_command;
 use crate::request::KernelRequest;
 use crate::request::RRequest;
@@ -300,6 +302,7 @@ impl RMain {
         kernel_request_rx: Receiver<KernelRequest>,
         dap: Arc<Mutex<Dap>>,
         session_mode: SessionMode,
+        default_repos: DefaultRepos,
     ) {
         // Set the main thread ID.
         // Must happen before doing anything that checks `RMain::on_main_thread()`,
@@ -426,6 +429,11 @@ impl RMain {
 
             // Set up the global error handler (after support function initialization)
             errors::initialize();
+
+            // Set default repositories
+            if let Err(err) = apply_default_repos(default_repos) {
+                log::error!("Error setting default repositories: {err:?}");
+            }
 
             // Now that R has started (emitting any startup messages), and now that we have set
             // up all hooks and handlers, officially finish the R initialization process to

--- a/crates/ark/src/lib.rs
+++ b/crates/ark/src/lib.rs
@@ -26,6 +26,7 @@ pub mod modules;
 pub mod modules_utils;
 pub mod plots;
 pub mod r_task;
+pub mod repos;
 pub mod request;
 pub mod reticulate;
 pub mod shell;

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -42,11 +42,11 @@ Available options:
 --startup-file FILE      An R file to run on session startup
 --session-mode MODE      The mode in which the session is running (console, notebook, background)
 --no-capture-streams     Do not capture stdout/stderr from R
---default-repos          Set the default repositories:
-                         "rstudio" ('cran.rstudio.com'), or
-                         "posit-ppm" ('packagemanager.posit.co' repository if available for this OS), or
+--default-repos          Set the default repositories to use:
+                         "rstudio" ('cran.rstudio.com', the default), or
+                         "posit-ppm" ('packagemanager.posit.co', subject to availability), or
                          a path to a .conf file containing a list of repositories, or
-                         "none" (do not alter the default repositories)
+                         "none" (do not alter the 'repos' option in any way)
 --version                Print the version of Ark
 --log FILE               Log to the given file (if not specified, stdout/stderr
                          will be used)
@@ -141,6 +141,8 @@ fn main() -> anyhow::Result<()> {
                         "posit-ppm" => DefaultRepos::PositPPM,
                         "none" => DefaultRepos::None,
                         _ => {
+                            // If the string is not one of the predefined options, assume it's a
+                            // file path
                             let path = std::path::PathBuf::from(repos.clone());
 
                             // Check to see if the file exists
@@ -154,7 +156,7 @@ fn main() -> anyhow::Result<()> {
                     }
                 } else {
                     return Err(anyhow::anyhow!(
-                        "A default repository must follow the --default-repos option."
+                        "A default repository must follow the --default-repos option; valid values are 'rstudio', 'posit-ppm', 'none', or a path to a .conf file."
                     ));
                 }
             },

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -45,7 +45,7 @@ Available options:
 --default-repos          Set the default repositories to use:
                          "rstudio" ('cran.rstudio.com', the default), or
                          "posit-ppm" ('packagemanager.posit.co', subject to availability), or
-                         a path to a .conf file containing a list of repositories, or
+                         a path to a .conf file containing a list of named repositories (`name = url`), or
                          "none" (do not alter the 'repos' option in any way)
 --version                Print the version of Ark
 --log FILE               Log to the given file (if not specified, stdout/stderr

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -341,6 +341,7 @@ fn main() -> anyhow::Result<()> {
         startup_file,
         session_mode,
         capture_streams,
+        default_repos,
     );
 
     // Just to please Rust

--- a/crates/ark/src/modules/positron/options.R
+++ b/crates/ark/src/modules/positron/options.R
@@ -26,23 +26,6 @@ options(device = function() {
     .ps.Call("ps_graphics_device")
 })
 
-# Set cran mirror
-repos <- getOption("repos")
-rstudio_cran <- "https://cran.rstudio.com/"
-if (is.null(repos) || !is.character(repos)) {
-    repos <- c(CRAN = rstudio_cran)
-} else {
-    if ("CRAN" %in% names(repos)) {
-        if (identical(repos[["CRAN"]], "@CRAN@")) {
-            repos[["CRAN"]] <- rstudio_cran
-            attr(repos, "IDE") <- TRUE
-        }
-    } else {
-        repos <- c(CRAN = rstudio_cran, repos)
-    }
-}
-options(repos = repos)
-
 # Show Plumber apps in the viewer
 options(plumber.docs.callback = function(url) {
     .ps.ui.showUrl(url)

--- a/crates/ark/src/modules/positron/repos.R
+++ b/crates/ark/src/modules/positron/repos.R
@@ -5,12 +5,12 @@
 #
 #
 
-# Applies CRAN defaults to the repos option. Does not override any existing
+# Applies defaults to the repos option. Does not override any existing
 # repositories set in the option.
 #
 # Arguments:
 #   defaults: A named character vector of default CRAN repositories.
-apply_cran_defaults <- function(defaults = c(CRAN = "https://cran.rstudio.com/")) {
+apply_repo_defaults <- function(defaults = c(CRAN = "https://cran.rstudio.com/")) {
     repos <- getOption("repos")
     if (is.null(repos) || !is.character(repos)) {
         # There are no repositories set, so apply the defaults directly
@@ -21,10 +21,10 @@ apply_cran_defaults <- function(defaults = c(CRAN = "https://cran.rstudio.com/")
             # specific URL, override it. This is the only instance in which we
             # replace an already-set repository option with a default.
             if (identical(repos[["CRAN"]], "@CRAN@")) {
-                repos[["CRAN"]] <- rstudio_cran
+                repos[["CRAN"]] <- defaults[["CRAN"]]
 
-                # Flag this CRAN repository as being set by the IDE. This flag
-                # is used by renv.
+                # Flag this CRAN repository as being set by the IDE. This flag is
+                # used by renv.
                 attr(repos, "IDE") <- TRUE
             }
         }

--- a/crates/ark/src/modules/positron/repos.R
+++ b/crates/ark/src/modules/positron/repos.R
@@ -1,0 +1,39 @@
+#
+# repos.R
+#
+# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+#
+#
+
+# Applies CRAN defaults to the repos option. Does not override any existing
+# repositories set in the option.
+#
+# Arguments:
+#   defaults: A named character vector of default CRAN repositories.
+apply_cran_defaults <- function(defaults = c(CRAN = "https://cran.rstudio.com/")) {
+    repos <- getOption("repos")
+    if (is.null(repos) || !is.character(repos)) {
+        # There are no repositories set, so apply the defaults directly
+        repos <- defaults
+    } else {
+        if ("CRAN" %in% names(repos) && "CRAN" %in% names(defaults)) {
+            # If a CRAN repository is set to @CRAN@, and a default provides a
+            # specific URL, override it. This is the only instance in which we
+            # replace an already-set repository option with a default.
+            if (identical(repos[["CRAN"]], "@CRAN@")) {
+                repos[["CRAN"]] <- rstudio_cran
+
+                # Flag this CRAN repository as being set by the IDE. This flag
+                # is used by renv.
+                attr(repos, "IDE") <- TRUE
+            }
+        }
+        # Set all the names in the defaults that are not already set
+        for (name in names(defaults)) {
+            if (!(name %in% names(repos))) {
+                repos[[name]] <- defaults[[name]]
+            }
+        }
+    }
+    options(repos = repos)
+}

--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -112,7 +112,7 @@ fn apply_default_repos_auto() -> anyhow::Result<()> {
 
 /// On Windows, we just use the RStudio CRAN mirror as the default.
 #[cfg(windows)]
-fn apply_default_repos_auto() {
+fn apply_default_repos_auto() -> anyhow::Result<()> {
     apply_default_repos(DefaultRepos::RStudio)
 }
 

--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -5,6 +5,8 @@
 //
 //
 
+use std::collections::HashMap;
+use std::io::BufRead;
 use std::path::PathBuf;
 
 #[derive(Debug)]
@@ -12,18 +14,134 @@ pub enum DefaultRepos {
     /// Do not set the repository automatically
     None,
 
-    /// Set the repository automatically. This checks for `/etc/rstudio/repos.conf` on
-    /// Unix-alikes); if found, it is used (as if were set as the `ConfFile`). If not, sets
-    /// `cran.rstudio.com` as the CRAN repository
+    /// Set the repository automatically. This checks for `repos.conf` in XDG locations; if found,
+    /// it is used (as if were set as the `ConfFile`). If not, sets `cran.rstudio.com` as the CRAN
+    /// repository
     Auto,
 
     /// Set the repository to the default CRAN repository, `cran.rstudio.com`
     RStudio,
 
-    /// Use Posit's Public Package Manager; this is a Posit-hosted service hosts built binaries for
-    /// many operating systems.
+    /// Use Posit's Public Package Manager; this is a Posit-hosted service that hosts built
+    /// binaries for many operating systems.
     PositPPM,
 
     /// Use the repositories specified in the given configuration file.
     ConfFile(PathBuf),
+}
+
+pub fn apply_default_repos(repos: DefaultRepos) -> anyhow::Result<()> {
+    match repos {
+        DefaultRepos::None => {
+            // This isn't the default, but it's a valid option
+            log::debug!("Not applying any default repositories (none were set)");
+            Ok(())
+        },
+        DefaultRepos::RStudio => {
+            log::info!("Setting default repositories to RStudio CRAN");
+            let mut repos = HashMap::new();
+            repos.insert("CRAN".to_string(), "https://cran.rstudio.com/".to_string());
+            apply_repos(repos)
+        },
+        DefaultRepos::Auto => {
+            // See if there's a repos file in the XDG directories
+            if let Some(path) = find_repos_conf() {
+                if let Err(e) = apply_repos_conf(path) {
+                    // We failed to apply the repos file; log the error and use the
+                    // RStudio defaults
+                    log::error!("Error applying repos file: {}; using defaults", e);
+                    apply_default_repos(DefaultRepos::RStudio)
+                } else {
+                    Ok(())
+                }
+            } else {
+                // No repos file found; use the RStudio defaults
+                apply_default_repos(DefaultRepos::RStudio)
+            }
+        },
+        DefaultRepos::ConfFile(path) => {
+            if path.exists() {
+                if let Err(e) = apply_repos_conf(path) {
+                    // We failed to apply the repos file; log the error and use defaults
+                    log::error!("Error applying repos file: {}; using defaults", e);
+                    apply_default_repos(DefaultRepos::Auto)
+                } else {
+                    Ok(())
+                }
+            } else {
+                log::warn!(
+                    "Specified repos file {:?} does not exist; using defaults",
+                    path
+                );
+                apply_default_repos(DefaultRepos::Auto)
+            }
+        },
+        DefaultRepos::PositPPM => {
+            log::info!("Setting default repositories to Posit's Public Package Manager");
+            Ok(())
+        },
+    }
+}
+
+fn find_repos_conf_xdg(prefix: String) -> Option<PathBuf> {
+    let xdg_dirs = match xdg::BaseDirectories::with_prefix(prefix.clone()) {
+        Ok(xdg_dirs) => xdg_dirs,
+        Err(e) => {
+            log::error!("Error finding {prefix:?} XDG directories: {}", e);
+            return None;
+        },
+    };
+    xdg_dirs.find_config_file("repos.conf")
+}
+
+fn find_repos_conf() -> Option<PathBuf> {
+    if let Some(path) = find_repos_conf_xdg("rstudio".to_string()) {
+        return Some(path);
+    }
+    if let Some(path) = find_repos_conf_xdg("positron".to_string()) {
+        return Some(path);
+    }
+    None
+}
+
+fn apply_repos(repos: HashMap<String, String>) -> anyhow::Result<()> {
+    log::debug!("Applying default repositories: {:?}", repos);
+    Ok(())
+}
+
+/// Apply the repos configuration file at the given path.
+///
+/// The repos configuration file is a simple INI-style configuration file styled after RStudio's
+/// /etc/rstudio/repos.conf. It is expected to consist of repository names and URLs, one per line,
+/// in the format `name=url`. Empty lines or lines beginning with `#` (comments) are ignored.
+///
+/// Arguments:
+/// - `path`: The path to the repos configuration file.
+///
+/// Returns:
+///
+/// `Ok(())` if the file was successfully read and applied, or an error if there was a
+/// problem.
+pub fn apply_repos_conf(path: PathBuf) -> anyhow::Result<()> {
+    log::info!("Using repos file at {:?}", path);
+    // Read the repos file
+    let file = std::fs::File::open(&path)?;
+    let reader = std::io::BufReader::new(file);
+    let mut repos = std::collections::HashMap::<String, String>::new();
+    for line in reader.lines() {
+        let line = line?;
+        // Ignore the line if it's only whitespace or starts with a comment
+        if line.trim().is_empty() || line.trim().starts_with('#') {
+            continue;
+        }
+        let parts: Vec<&str> = line.split('=').collect();
+        if parts.len() != 2 {
+            log::debug!("Skipping invalid line in repos file: {}", line);
+            continue;
+        }
+        let repo_name = parts[0].trim();
+        let repo_url = parts[1].trim();
+        repos.insert(repo_name.to_string(), repo_url.to_string());
+    }
+    apply_repos(repos)
 }

--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -1,0 +1,29 @@
+//
+// repos.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum DefaultRepos {
+    /// Do not set the repository automatically
+    None,
+
+    /// Set the repository automatically. This checks for `/etc/rstudio/repos.conf` on
+    /// Unix-alikes); if found, it is used (as if were set as the `ConfFile`). If not, sets
+    /// `cran.rstudio.com` as the CRAN repository
+    Auto,
+
+    /// Set the repository to the default CRAN repository, `cran.rstudio.com`
+    RStudio,
+
+    /// Use Posit's Public Package Manager; this is a Posit-hosted service hosts built binaries for
+    /// many operating systems.
+    PositPPM,
+
+    /// Use the repositories specified in the given configuration file.
+    ConfFile(PathBuf),
+}

--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -22,7 +22,7 @@ use crate::modules::ARK_ENVS;
 // Constants for repository URLs
 const GENERIC_P3M_REPO: &str = "https://packagemanager.posit.co/cran/latest";
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum DefaultRepos {
     /// Do not set the repository at all (don't touch the `repos` option)
     None,

--- a/crates/ark/src/start.rs
+++ b/crates/ark/src/start.rs
@@ -22,6 +22,7 @@ use crate::control::Control;
 use crate::dap;
 use crate::interface::SessionMode;
 use crate::lsp;
+use crate::repos::DefaultRepos;
 use crate::request::KernelRequest;
 use crate::request::RRequest;
 use crate::shell::Shell;
@@ -34,6 +35,7 @@ pub fn start_kernel(
     startup_file: Option<String>,
     session_mode: SessionMode,
     capture_streams: bool,
+    default_repos: DefaultRepos,
 ) {
     // Create the channels used for communication. These are created here
     // as they need to be shared across different components / threads.
@@ -122,5 +124,6 @@ pub fn start_kernel(
         kernel_request_rx,
         dap,
         session_mode,
+        default_repos,
     )
 }

--- a/crates/ark/tests/repos-auto.rs
+++ b/crates/ark/tests/repos-auto.rs
@@ -1,0 +1,31 @@
+//
+// repos-auto.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use ark::fixtures::DummyArkFrontendDefaultRepos;
+
+/// Using the automatic repos setting, the default CRAN repo should be set to the global RStudio
+/// CRAN mirror.
+#[test]
+fn test_auto_repos() {
+    let frontend = DummyArkFrontendDefaultRepos::lock(ark::repos::DefaultRepos::Auto);
+
+    let code = r#"getOption("repos")[["CRAN"]]"#;
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, code);
+    assert_eq!(
+        frontend.recv_iopub_execute_result(),
+        r#"[1] "https://cran.rstudio.com/""#
+    );
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+}

--- a/crates/ark/tests/repos-conf-file.rs
+++ b/crates/ark/tests/repos-conf-file.rs
@@ -1,0 +1,41 @@
+// repos-conf-file.rs
+//
+// Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::io::Write;
+
+use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use ark::fixtures::DummyArkFrontendDefaultRepos;
+
+/// Using a configuration file, set the default CRAN repo to a custom value.
+#[test]
+fn test_conf_file_repos() {
+    let contents = r#"# Custom CRAN repo configuration file
+
+CRAN=https://my.cran.mirror/
+Internal=https://internal.cran.mirror/
+"#;
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    write!(file, "{contents}").unwrap();
+
+    let path = file.path();
+    let frontend =
+        DummyArkFrontendDefaultRepos::lock(ark::repos::DefaultRepos::ConfFile(path.to_path_buf()));
+
+    let code = r#"getOption("repos")[["CRAN"]]"#;
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+
+    let input = frontend.recv_iopub_execute_input();
+    assert_eq!(input.code, code);
+    assert_eq!(
+        frontend.recv_iopub_execute_result(),
+        r#"[1] "https://my.cran.mirror/""#
+    );
+
+    frontend.recv_iopub_idle();
+
+    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+}


### PR DESCRIPTION
This change makes the kernel's behavior around setting default repositories configurable. Before the change, we always set the CRAN repository to `cran.rstudio.com` if it was set to `@CRAN@`. After it, there's a new `--default-repos` command line option which provides additional options for setting repositories:

- **none**, for telling Ark to just leave the option alone
- **rstudio**, for the previous behavior (auto set to `cran.rstudio.com`)
- **posit-ppm**, for setting to Posit's Public Package Manager ("P3M"), which provides convenient pre-built binaries
- a path to a conf file, which can be used to configure multiple repositories at once

If the option is not set, we set the `cran.rstudio.com` repository as we did before, unless there is a `repos.conf` file available in either RStudio or Ark configuration directories, in which case it is read and applied. This behavior lets you share global CRAN repository settings between Positron and RStudio, if desired.

Part of https://github.com/posit-dev/positron/issues/5509 (but doesn't fully address on its own since currently Positron does not pass this command line option; that's coming in a follow-up PR on the Positron side)
