### PR TITLE
Bump ark to 0.1.156

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.155"
+version = "0.1.156"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.155"
+version = "0.1.156"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
## Positron Notes

### Release Notes

#### New Features

- The variable pane now supports labels from the {haven} package (https://github.com/posit-dev/positron/issues/5327.

- The variable pane has improved support for formulas (https://github.com/posit-dev/positron/issues/4119).

#### Bug Fixes

- Assignments in function calls (e.g. `list(x <- 1)`) are now detected by the missing symbol linter to avoid annoying false positive diagnostics (posit-dev/positron#3048). The downside is that this causes false negatives when the assignment happens in a call with local scope, e.g. in `local()` or `test_that()`. In these cases the nested assignments will incorrectly overlast the end of the call. We prefer to be overly permissive than overly cautious in these matters.

- The following environment variables are now set in the same way that R does:

  - `R_SHARE_DIR`
  - `R_INCLUDE_DIR`
  - `R_DOC_DIR`

  This solves a number of problems in situations that depend on these variables being defined (https://github.com/posit-dev/positron/issues/3637).