### PR TITLE
Limit the number of bins for histograms to avoid crashes

### DIFF
--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -519,5 +519,10 @@ histogram_num_bins <- function(x, method, fixed_num_bins) {
         }
     }
 
+    # Honor the maximum amount of bins requested by the front-end.
+    if (!is.null(fixed_num_bins) && num_bins > fixed_num_bins) {
+        num_bins <- fixed_num_bins
+    }
+
     as.integer(num_bins)
 }


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/5744 by limiting the maximum amount of bins that are returned to the front-end. This info was already provided by the front-end but we didn't respect it - instead using the result of `nClass` methods.