### PR TITLE
Add back correct S4 support to the variables pane

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1906,10 +1906,11 @@ mod tests {
             let vars = PositronVariable::inspect(env.clone(), &path).unwrap();
 
             assert_eq!(vars.len(), 1);
-            assert_eq!(
-                vars[0].display_value,
-                "<S4 class ‘Person’ [package “.GlobalEnv”] with 3 slots>"
-            );
+            // Matching equality is not nice because the default `format` method for S4 objects
+            // uses different quoting characters on Windows vs Unix.
+            // Unix: <S4 class ‘ddiMatrix’ [package “Matrix”] with 4 slots>
+            // Windows: <S4 class 'ddiMatrix' [package "Matrix"] with 4 slots>
+            assert!(vars[0].display_value.starts_with("<S4 class"));
 
             // Inspect the S4 object
             let path = vec![String::from("x")];
@@ -2070,10 +2071,7 @@ mod tests {
             let path = vec![];
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
-            assert_eq!(
-                vars[0].display_value,
-                "<S4 class ‘ddiMatrix’ [package “Matrix”] with 4 slots>"
-            );
+            assert!(vars[0].display_value.starts_with("<S4 class"),);
         })
     }
 }

--- a/crates/harp/src/modules/format.R
+++ b/crates/harp/src/modules/format.R
@@ -86,3 +86,34 @@ init_test_format <- function() {
 
     environment()
 }
+
+harp_format_s4 <- function(x, ...) {
+    # For S4 values we assume that the formatted value is a character vector of length 1,
+    # even if the value has length > 1. This is because the formatted value is typically
+    # the class of the object, which is a single string.
+    # If for some reason the formatted value is not a character vector of length 1, we
+    # check if the result is a character vector the same length as `value`.
+    out <- base::format(x, ...)
+
+    if (length(out) != 1 && length(out) != length(x)) {
+        log_trace(sprintf(
+            "`format()` method for <%s> should return a character vector of length 1 or the same length as the object.",
+            class_collapsed(x)
+        ))
+        return(format_fallback_s4(x))
+    }
+
+    if (!is.character(out)) {
+        log_trace(sprintf(
+            "`format()` method for <%s> should return a character vector.",
+            class_collapsed(x)
+        ))
+        return(format_fallback_s4(x))
+    }
+
+    out
+}
+
+format_fallback_s4 <- function(x) {
+    paste0("<S4 class '", class_collapsed(x), "'>")
+}

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -735,6 +735,17 @@ pub fn r_format_vec(x: SEXP) -> Result<SEXP> {
     }
 }
 
+pub fn r_format_s4(x: SEXP) -> Result<SEXP> {
+    if !r_is_s4(x) {
+        return Err(Error::UnexpectedType(r_typeof(x), vec![S4SXP]));
+    }
+
+    let out = RFunction::new("", "harp_format_s4")
+        .add(x)
+        .call_in(unsafe { HARP_ENV.unwrap() })?;
+    Ok(out.sexp)
+}
+
 pub fn r_subset_vec(x: SEXP, indices: Vec<i64>) -> Result<SEXP> {
     let env = unsafe { HARP_ENV.unwrap() };
     let indices: Vec<i64> = indices.into_iter().map(|i| i + 1).collect();


### PR DESCRIPTION
The change in [this PR](https://github.com/posit-dev/ark/pull/630#discussion_r1853928076) broke S4 support. This PR restores it, but replaces the previous FormattedVector approach with a custom method, as the former seemed incorrect.

Adresses https://github.com/posit-dev/positron/issues/5685