### PR TITLE
Data Explorer: Return empty string in schema response instead of [, i] for empty column name

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -580,7 +580,7 @@ impl RDataExplorer {
             for i in 0..(total_num_columns as isize) {
                 let column_name = match column_names.get_unchecked(i) {
                     Some(name) => name,
-                    None => format!("[, {}]", i + 1),
+                    None => String::from(""),
                 };
 
                 // TODO: handling for nested data frame columns


### PR DESCRIPTION
Per discussion in https://github.com/posit-dev/positron/issues/3084, with code like

```
example <- data.frame(1:10, 1:10, 1:10)
names(example) <- c("", "age", "age ")
```

We have decided for now to return the column names as is, even if they are empty, and let the UI decide how to render them. With this change, we now see:

![image](https://github.com/user-attachments/assets/484a5841-9642-44f0-ad63-e1e34ad3d869)