### PR TITLE
Remove `ARK_VDOCS` by sending vdocs over a Kernel -> LSP event

### DIFF
--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -6,8 +6,6 @@
 //
 
 use anyhow::anyhow;
-use dashmap::DashMap;
-use once_cell::sync::Lazy;
 use serde_json::Value;
 use stdext::unwrap;
 use struct_field_names_as_array::FieldNamesAsArray;
@@ -384,14 +382,12 @@ pub(crate) fn handle_indent(
     })
 }
 
-// TODO: Should be in WorldState and updated via message passing
-pub static mut ARK_VDOCS: Lazy<DashMap<String, String>> = Lazy::new(|| DashMap::new());
-
 pub(crate) fn handle_virtual_document(
     params: VirtualDocumentParams,
+    state: &WorldState,
 ) -> anyhow::Result<VirtualDocumentResponse> {
-    if let Some(doc) = unsafe { ARK_VDOCS.get(&params.path) } {
-        Ok(doc.clone())
+    if let Some(contents) = state.virtual_documents.get(&params.path) {
+        Ok(contents.clone())
     } else {
         Err(anyhow!("Can't find virtual document {}", params.path))
     }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -73,6 +73,38 @@ pub(crate) enum Event {
 #[derive(Debug)]
 pub(crate) enum KernelNotification {
     DidChangeConsoleInputs(ConsoleInputs),
+    DidOpenVirtualDocument(DidOpenVirtualDocumentParams),
+}
+
+#[derive(Debug)]
+pub(crate) struct DidOpenVirtualDocumentParams {
+    pub(crate) uri: String,
+    pub(crate) contents: String,
+}
+
+impl KernelNotification {
+    pub(crate) fn trace(&self) -> TraceKernelNotification {
+        TraceKernelNotification { inner: self }
+    }
+}
+
+pub(crate) struct TraceKernelNotification<'a> {
+    inner: &'a KernelNotification,
+}
+
+impl std::fmt::Debug for TraceKernelNotification<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.inner {
+            KernelNotification::DidChangeConsoleInputs(_) => f.write_str("DidChangeConsoleInputs"),
+            KernelNotification::DidOpenVirtualDocument(params) => f
+                .debug_struct("DidOpenVirtualDocument")
+                .field("uri", &params.uri)
+                .field("contents", &"<snip>")
+                .finish(),
+            // NOTE: Uncomment if we have notifications we don't care to specially handle
+            //notification => std::fmt::Debug::fmt(notification, f),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -311,7 +343,7 @@ impl GlobalState {
                             respond(tx, handlers::handle_indent(params, &self.world), LspResponse::OnTypeFormatting)?;
                         },
                         LspRequest::VirtualDocument(params) => {
-                            respond(tx, handlers::handle_virtual_document(params), LspResponse::VirtualDocument)?;
+                            respond(tx, handlers::handle_virtual_document(params, &self.world), LspResponse::VirtualDocument)?;
                         },
                         LspRequest::InputBoundaries(params) => {
                             respond(tx, handlers::handle_input_boundaries(params), LspResponse::InputBoundaries)?;
@@ -320,10 +352,17 @@ impl GlobalState {
                 },
             },
 
-            Event::Kernel(notif) => match notif {
-                KernelNotification::DidChangeConsoleInputs(inputs) => {
-                    state_handlers::did_change_console_inputs(inputs, &mut self.world)?;
-                },
+            Event::Kernel(notif) => {
+                lsp::log_info!("{notif:#?}", notif = notif.trace());
+
+                match notif {
+                    KernelNotification::DidChangeConsoleInputs(inputs) => {
+                        state_handlers::did_change_console_inputs(inputs, &mut self.world)?;
+                    },
+                    KernelNotification::DidOpenVirtualDocument(params) => {
+                        state_handlers::did_open_virtual_document(params, &mut self.world)?;
+                    }
+                }
             },
         }
 

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -76,35 +76,15 @@ pub(crate) enum KernelNotification {
     DidOpenVirtualDocument(DidOpenVirtualDocumentParams),
 }
 
-#[derive(Debug)]
-pub(crate) struct DidOpenVirtualDocumentParams {
-    pub(crate) uri: String,
-    pub(crate) contents: String,
-}
-
-impl KernelNotification {
-    pub(crate) fn trace(&self) -> TraceKernelNotification {
-        TraceKernelNotification { inner: self }
-    }
-}
-
+/// A thin wrapper struct with a custom `Debug` method more appropriate for trace logs
 pub(crate) struct TraceKernelNotification<'a> {
     inner: &'a KernelNotification,
 }
 
-impl std::fmt::Debug for TraceKernelNotification<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.inner {
-            KernelNotification::DidChangeConsoleInputs(_) => f.write_str("DidChangeConsoleInputs"),
-            KernelNotification::DidOpenVirtualDocument(params) => f
-                .debug_struct("DidOpenVirtualDocument")
-                .field("uri", &params.uri)
-                .field("contents", &"<snip>")
-                .finish(),
-            // NOTE: Uncomment if we have notifications we don't care to specially handle
-            //notification => std::fmt::Debug::fmt(notification, f),
-        }
-    }
+#[derive(Debug)]
+pub(crate) struct DidOpenVirtualDocumentParams {
+    pub(crate) uri: String,
+    pub(crate) contents: String,
 }
 
 #[derive(Debug)]
@@ -627,4 +607,25 @@ pub(crate) fn publish_diagnostics(uri: Url, diagnostics: Vec<Diagnostic>, versio
         diagnostics,
         version,
     ));
+}
+
+impl KernelNotification {
+    pub(crate) fn trace(&self) -> TraceKernelNotification {
+        TraceKernelNotification { inner: self }
+    }
+}
+
+impl std::fmt::Debug for TraceKernelNotification<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.inner {
+            KernelNotification::DidChangeConsoleInputs(_) => f.write_str("DidChangeConsoleInputs"),
+            KernelNotification::DidOpenVirtualDocument(params) => f
+                .debug_struct("DidOpenVirtualDocument")
+                .field("uri", &params.uri)
+                .field("contents", &"<snip>")
+                .finish(),
+            // NOTE: Uncomment if we have notifications we don't care to specially handle
+            //notification => std::fmt::Debug::fmt(notification, f),
+        }
+    }
 }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -18,6 +18,10 @@ pub(crate) struct WorldState {
     /// Watched folders
     pub(crate) workspace: Workspace,
 
+    /// Virtual documents that the LSP serves as a text document content provider for
+    /// Maps a `String` uri to the contents of the document
+    pub(crate) virtual_documents: HashMap<String, String>,
+
     /// The scopes for the console. This currently contains a list (outer `Vec`)
     /// of names (inner `Vec`) within the environments on the search path, starting
     /// from the global environment and ending with the base package. Eventually

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -47,6 +47,7 @@ use crate::lsp::diagnostics::DiagnosticsConfig;
 use crate::lsp::documents::Document;
 use crate::lsp::encoding::get_position_encoding_kind;
 use crate::lsp::indexer;
+use crate::lsp::main_loop::DidOpenVirtualDocumentParams;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::state::workspace_uris;
 use crate::lsp::state::WorldState;
@@ -390,6 +391,16 @@ pub(crate) fn did_change_console_inputs(
     // to refresh from here.
     lsp::spawn_diagnostics_refresh_all(state.clone());
 
+    Ok(())
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn did_open_virtual_document(
+    params: DidOpenVirtualDocumentParams,
+    state: &mut WorldState,
+) -> anyhow::Result<()> {
+    // Insert new document, replacing any old one
+    state.virtual_documents.insert(params.uri, params.contents);
     Ok(())
 }
 

--- a/crates/ark/src/srcref.rs
+++ b/crates/ark/src/srcref.rs
@@ -9,7 +9,7 @@ use harp::r_symbol;
 use harp::utils::r_typeof;
 use libr::*;
 
-use crate::lsp::handlers::ARK_VDOCS;
+use crate::interface::RMain;
 use crate::modules::ARK_ENVS;
 use crate::r_task;
 use crate::variables::variable::is_binding_fancy;
@@ -96,11 +96,12 @@ pub(crate) async fn ns_populate_srcref(ns_name: String) -> anyhow::Result<()> {
         vdoc.len()
     );
 
-    // SAFETY: That's a DashMap so should be safe across threads
-    unsafe {
-        // Save virtual document containing the namespace source
-        ARK_VDOCS.insert(uri_path, vdoc.join("\n"));
-    }
+    let contents = vdoc.join("\n");
+
+    // Notify LSP of the opened virtual document so the LSP can function as a
+    // text document content provider of the virtual document contents, which is
+    // used by the debugger.
+    RMain::with_mut(|main| main.did_open_virtual_document(uri_path, contents));
 
     Ok(())
 }


### PR DESCRIPTION
Part of https://github.com/posit-dev/ark/issues/661

There was a TODO to do this anyways, and it seemed like a pretty reasonable alternative to the global.

Getting this right is a little tricky. It's common for the base R packages (and anything loaded in your `.Rprofile`) to have their namespace vdocs be generated _very quickly_ after startup before the LSP has even started up yet. This means we wouldn't have access to those namespace vdoc files, which means you would not be able to debug those packages.

We _could_ try and fix the timing so that we don't generate any vdocs until after the LSP starts up, but that is pretty brittle.

The alternative here is to maintain our own copy of the virtual documents on the kernel side. As soon as the LSP connects and we get `lsp_events_tx`, we send over any known virtual documents (anything we attempted to send over before this connection would have been dropped). This also has the benefit of being able to refresh the LSP if it restarts out from under us.

---

Side note: In the future I think it might be better if the kernel itself was the one registered as the `TextDocumentContentProvider` for these virtual documents. It's unlikely that the debugger will ever move out of ark, but the LSP probably will. It feels quite weird for Positron to be asking the LSP for the contents of one of these documents. I wonder if instead our `VirtualDocumentProvider` on the positron-r side can perform a Jupyter request to ark for the document contents?