### PR TITLE
Increase test timeout from 1s -> 10s

### DIFF
--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -236,13 +236,16 @@ impl DummyFrontend {
     }
 
     pub fn recv(socket: &Socket) -> Message {
-        // It's important to wait with a timeout because the kernel thread might
-        // have panicked, preventing it from sending the expected message. The
-        // tests would then hang indefinitely.
+        // It's important to wait with a timeout because the kernel thread might have
+        // panicked, preventing it from sending the expected message. The tests would then
+        // hang indefinitely. We wait a decently long time (10s), as test processes are
+        // run in parallel and we think they seem to slow each other down occasionally
+        // (we've definitely seen false positive failures with a timeout of just 1s,
+        // particularly when running with nextest).
         //
-        // Note that the panic hook will still have run to record the panic, so
-        // we'll get expected panic information in the test output.
-        if socket.poll_incoming(1000).unwrap() {
+        // Note that the panic hook will still have run to record the panic, so we'll get
+        // expected panic information in the test output.
+        if socket.poll_incoming(10000).unwrap() {
             return Message::read_from_socket(socket).unwrap();
         }
 

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -90,7 +90,7 @@ fn open_data_explorer(dataset: String) -> socket::comm::CommSocket {
 
     // Wait for the new comm to show up.
     let msg = comm_manager_rx
-        .recv_timeout(std::time::Duration::from_secs(1))
+        .recv_timeout(std::time::Duration::from_secs(10))
         .unwrap();
     match msg {
         CommManagerEvent::Opened(socket, _value) => {
@@ -123,7 +123,7 @@ fn open_data_explorer_from_expression(
 
     // Release the R lock and wait for the new comm to show up.
     let msg = comm_manager_rx
-        .recv_timeout(std::time::Duration::from_secs(1))
+        .recv_timeout(std::time::Duration::from_secs(10))
         .unwrap();
 
     match msg {
@@ -198,7 +198,7 @@ fn expect_column_profile_results(
 
     let msg = socket
         .outgoing_rx
-        .recv_timeout(std::time::Duration::from_secs(1))
+        .recv_timeout(std::time::Duration::from_secs(10))
         .unwrap();
 
     // Because during tests, no threads are created with r_task::spawn_idle, the messages are in
@@ -219,7 +219,7 @@ fn expect_column_profile_results(
 
     let msg = socket
         .outgoing_rx
-        .recv_timeout(std::time::Duration::from_secs(1))
+        .recv_timeout(std::time::Duration::from_secs(10))
         .unwrap();
 
     let reply: DataExplorerBackendReply = match msg {
@@ -1081,7 +1081,7 @@ fn test_live_updates() {
     EVENTS.console_prompt.emit(());
 
     // Wait for an update event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1123,7 +1123,7 @@ DataExplorerBackendReply::SetSortColumnsReply() => {});
     EVENTS.console_prompt.emit(());
 
     // Wait for an update event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1153,7 +1153,7 @@ DataExplorerBackendReply::SetSortColumnsReply() => {});
     EVENTS.console_prompt.emit(());
 
     // This should trigger a schema update event.
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's schema update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1182,7 +1182,7 @@ DataExplorerBackendReply::SetSortColumnsReply() => {});
     EVENTS.console_prompt.emit(());
 
     // Wait for an close event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Close => {}
     );
 }
@@ -1369,7 +1369,7 @@ fn test_invalid_filters_preserved() {
     EVENTS.console_prompt.emit(());
 
     // Wait for an update event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1397,7 +1397,7 @@ fn test_invalid_filters_preserved() {
     EVENTS.console_prompt.emit(());
 
     // Wait for an update event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1425,7 +1425,7 @@ fn test_invalid_filters_preserved() {
     EVENTS.console_prompt.emit(());
 
     // Wait for an update event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1673,7 +1673,7 @@ fn test_update_data_filters_reapplied() {
 
     // Wait for an update event to arrive
     // Since only data changed, we expect a Data Update Event
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),
@@ -1769,7 +1769,7 @@ fn test_data_update_num_rows() {
     EVENTS.console_prompt.emit(());
 
     // Wait for an update event to arrive
-    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+    assert_match!(socket.outgoing_rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap(),
         CommMsg::Data(value) => {
             // Make sure it's a data update event.
             assert_match!(serde_json::from_value::<DataExplorerFrontendEvent>(value).unwrap(),


### PR DESCRIPTION
I've been exploring nextest a bit for ark, and I would get some consistent false positive timeouts with a 1s timeout. I think having multiple processes running at once causes some kind of contention, so we need a longer timeout. With this one change (and after #669) I can run `cargo nextest run` on my mac without any issues.

I don't think having a big timeout here is that big a deal, we aren't trying to ensure its _fast_, we just dont want it to get hung.

I would really like to look into nextest as I think it will help us simplify our test infra quite a bit (no management of locks or global state or needing to worry about not cross contaminating the test R session, because each test gets its own R session). It looks like we can just switch to it if we want to with little extra effort, then start simplifying