### PR TITLE
Remove static mut in `graphics_device.rs`

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -347,6 +347,9 @@ impl RMain {
             session_mode,
         )));
 
+        // Initialize the GD context on this thread
+        graphics_device::init_graphics_device();
+
         let main = RMain::get_mut();
 
         let mut r_args = r_args.clone();

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -64,7 +64,7 @@ use crate::r_task;
 
 thread_local! {
   // Safety: Set once by `RMain` on initialization
-  pub static DEVICE_CONTEXT: RefCell<DeviceContext> = panic!("Must access `DEVICE_CONTEXT` from the R thread");
+  pub(crate) static DEVICE_CONTEXT: RefCell<DeviceContext> = panic!("Must access `DEVICE_CONTEXT` from the R thread");
 }
 
 const POSITRON_PLOT_CHANNEL_ID: &str = "positron.plot";

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -64,7 +64,7 @@ use crate::r_task;
 
 thread_local! {
   // Safety: Set once by `RMain` on initialization
-  pub(crate) static DEVICE_CONTEXT: RefCell<DeviceContext> = panic!("Must access `DEVICE_CONTEXT` from the R thread");
+  static DEVICE_CONTEXT: RefCell<DeviceContext> = panic!("Must access `DEVICE_CONTEXT` from the R thread");
 }
 
 const POSITRON_PLOT_CHANNEL_ID: &str = "positron.plot";

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -118,8 +118,6 @@ impl DeviceContext {
     }
 
     pub fn mode(&self, mode: i32, _dev: pDevDesc) {
-        // Refcell safety: Only called on the R thread and we make sure not to
-        // recurse into `DeviceContext` methods.
         self._mode.replace(mode);
 
         let old = self._changes.get();


### PR DESCRIPTION
Progress towards #661.

- `DEVICE_CONTEXT` is now a thread-local variable to reflect the fact it should only be accessed from the R thread.

- It's wrapped in a `RefCell` that is initialized from `RMain` on startup. All subsequent accesses are read-only and never panic.

- The device context requires mutable state. Where possible we use `Cell` which never panics. In a couple of places we use `RefCell` with care not to double-borrow on mutation, mainly by only performing short borrows to prevent holding a reference while recusing into a device context method by accident. (I haven't examined whether that would be possible in principle to recurse into a method as I'm not familiar with the graphics device code and its R hooks. I just made sure the borrows were short or at least only invoked pure Rust code.)