### PR TITLE
Fix `static mut` issues with routines

### DIFF
--- a/crates/harp/src/routines.rs
+++ b/crates/harp/src/routines.rs
@@ -48,7 +48,7 @@ pub unsafe fn r_register_routines() {
     });
 
     // Now unwrap the definitions from our thread-safe type
-    let unwrapped: Vec<R_CallMethodDef> = R_ROUTINES
+    let routines: Vec<R_CallMethodDef> = R_ROUTINES
         .lock()
         .unwrap()
         .iter()
@@ -58,7 +58,7 @@ pub unsafe fn r_register_routines() {
     R_registerRoutines(
         info,
         std::ptr::null(),
-        unwrapped.as_ptr(),
+        routines.as_ptr(),
         std::ptr::null(),
         std::ptr::null(),
     );

--- a/crates/harp/src/routines.rs
+++ b/crates/harp/src/routines.rs
@@ -5,18 +5,32 @@
 //
 //
 
+use std::sync::Mutex;
+
 use libr::R_CallMethodDef;
 use libr::R_getEmbeddingDllInfo;
 use libr::R_registerRoutines;
 use log::error;
 
-static mut R_ROUTINES: Vec<R_CallMethodDef> = vec![];
+// Sync and Send wrapper that we can store in a global. Necessary because
+// `R_CallMethodDef` includes raw pointers.
+struct CallMethodDef {
+    inner: R_CallMethodDef,
+}
+
+unsafe impl Send for CallMethodDef {}
+unsafe impl Sync for CallMethodDef {}
+
+static R_ROUTINES: Mutex<Vec<CallMethodDef>> = Mutex::new(vec![]);
 
 // NOTE: This function is used via the #[harp::register] macro,
 // which ensures that routines are initialized and executed on
 // application startup.
 pub unsafe fn add(def: R_CallMethodDef) {
-    R_ROUTINES.push(def);
+    R_ROUTINES
+        .lock()
+        .unwrap()
+        .push(CallMethodDef { inner: def });
 }
 
 pub unsafe fn r_register_routines() {
@@ -27,16 +41,24 @@ pub unsafe fn r_register_routines() {
     }
 
     // Make sure we have an "empty" routine at the end.
-    R_ROUTINES.push(R_CallMethodDef {
+    add(R_CallMethodDef {
         name: std::ptr::null(),
         fun: None,
         numArgs: 0,
     });
 
+    // Now unwrap the definitions from our thread-safe type
+    let unwrapped: Vec<R_CallMethodDef> = R_ROUTINES
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|def| def.inner)
+        .collect();
+
     R_registerRoutines(
         info,
         std::ptr::null(),
-        R_ROUTINES.as_ptr(),
+        unwrapped.as_ptr(),
         std::ptr::null(),
         std::ptr::null(),
     );

--- a/crates/libr/src/functions.rs
+++ b/crates/libr/src/functions.rs
@@ -43,7 +43,7 @@ macro_rules! generate {
                     $(#[doc=$doc])*
                     $(#[cfg($cfg)])*
                     pub unsafe fn $name() -> bool {
-                        [<$name _opt>].is_some()
+                        matches!([<$name _opt>], Some(_))
                     }
                 }
             )+

--- a/crates/libr/src/functions_variadic.rs
+++ b/crates/libr/src/functions_variadic.rs
@@ -45,7 +45,7 @@ macro_rules! generate {
                     $(#[doc=$doc])*
                     $(#[cfg($cfg)])*
                     pub unsafe fn $name() -> bool {
-                        [<$name _opt>].is_some()
+                        matches!([<$name _opt>], Some(_))
                     }
                 }
             )+


### PR DESCRIPTION
Closes #661.

Ideally `R_ROUTINES` would be thread-local but that's currently inconvenient in unit tests.