### PR TITLE
Disable the LSP on crash

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -114,7 +114,6 @@ pub(crate) enum LspNotification {
 #[derive(Debug)]
 pub(crate) enum LspRequest {
     Initialize(InitializeParams),
-    Shutdown(),
     WorkspaceSymbol(WorkspaceSymbolParams),
     DocumentSymbol(DocumentSymbolParams),
     ExecuteCommand(ExecuteCommandParams),
@@ -136,7 +135,6 @@ pub(crate) enum LspRequest {
 #[derive(Debug)]
 pub(crate) enum LspResponse {
     Initialize(InitializeResult),
-    Shutdown(()),
     WorkspaceSymbol(Option<Vec<SymbolInformation>>),
     DocumentSymbol(Option<DocumentSymbolResponse>),
     ExecuteCommand(Option<Value>),
@@ -208,11 +206,9 @@ impl LanguageServer for Backend {
     }
 
     async fn shutdown(&self) -> Result<()> {
-        cast_response!(
-            self,
-            self.request(LspRequest::Shutdown()).await,
-            LspResponse::Shutdown
-        )
+        // Don't go through the main loop because we want this request to
+        // succeed even when the LSP has crashed and has been disabled.
+        Ok(())
     }
 
     async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -81,6 +81,9 @@ macro_rules! cast_response {
                         ),
                     )
                     .await;
+
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
                 // The backtrace is reported via `err` and eventually shows up
                 // in the LSP logs on the client side
                 let _ = $self.shutdown_tx.send(()).await;

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -334,7 +334,6 @@ pub(crate) fn handle_statement_range(
     params: StatementRangeParams,
     state: &WorldState,
 ) -> anyhow::Result<Option<StatementRangeResponse>> {
-    panic!("oh no");
     let uri = &params.text_document.uri;
     let document = state.get_document(uri)?;
 

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -334,6 +334,7 @@ pub(crate) fn handle_statement_range(
     params: StatementRangeParams,
     state: &WorldState,
 ) -> anyhow::Result<Option<StatementRangeResponse>> {
+    panic!("oh no");
     let uri = &params.text_document.uri;
     let document = state.get_document(uri)?;
 

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -279,10 +279,6 @@ impl GlobalState {
                         LspRequest::Initialize(params) => {
                             respond(tx, || state_handlers::initialize(params, &mut self.lsp_state, &mut self.world), LspResponse::Initialize)?;
                         },
-                        LspRequest::Shutdown() => {
-                            // TODO
-                            respond(tx, || Ok(()), LspResponse::Shutdown)?;
-                        },
                         LspRequest::WorkspaceSymbol(params) => {
                             respond(tx, || handlers::handle_symbol(params), LspResponse::WorkspaceSymbol)?;
                         },

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -396,7 +396,7 @@ impl GlobalState {
 /// # Arguments
 ///
 /// * - `response_tx`: A response channel for the tower-lsp request handler.
-/// * - `response`: The response wrapped in a `anyhow::Result`. Errors are logged.
+/// * - `response`: A closure producing a response wrapped in a `anyhow::Result`. Errors are logged.
 /// * - `into_lsp_response`: A constructor for the relevant `LspResponse` variant.
 fn respond<T>(
     response_tx: TokioUnboundedSender<RequestResponse>,

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -414,7 +414,19 @@ fn respond<T>(
             // Set global crash flag to disable the LSP
             LSP_HAS_CRASHED.store(true, Ordering::Release);
             crashed = true;
-            anyhow!("Panic occurred while handling request: {err:?}")
+
+            let msg: String = if let Some(msg) = err.downcast_ref::<&str>() {
+                msg.to_string()
+            } else if let Some(msg) = err.downcast_ref::<String>() {
+                msg.clone()
+            } else {
+                String::from("Couldn't retrieve the message.")
+            };
+
+            // This creates an uninformative backtrace that is reported in the
+            // LSP logs. Note that the relevant backtrace is the one created by
+            // our panic hook and reported via the _kernel_ logs.
+            anyhow!("Panic occurred while handling request: {msg}")
         })
         // Unwrap nested Result
         .and_then(|resp| resp);

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -8,6 +8,8 @@
 use std::collections::HashMap;
 use std::future;
 use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::RwLock;
 
 use anyhow::anyhow;
@@ -49,6 +51,8 @@ pub(crate) type TokioUnboundedReceiver<T> = tokio::sync::mpsc::UnboundedReceiver
 /// https://github.com/posit-dev/positron/issues/5321), it's possible for older
 /// LSPs to send log messages and tasks to the newer LSPs.
 static AUXILIARY_EVENT_TX: RwLock<Option<TokioUnboundedSender<AuxiliaryEvent>>> = RwLock::new(None);
+
+pub static LSP_HAS_CRASHED: AtomicBool = AtomicBool::new(false);
 
 // This is the syntax for trait aliases until an official one is stabilised.
 // This alias is for the future of a `JoinHandle<anyhow::Result<T>>`
@@ -272,61 +276,62 @@ impl GlobalState {
 
                     match request {
                         LspRequest::Initialize(params) => {
-                            respond(tx, state_handlers::initialize(params, &mut self.lsp_state, &mut self.world), LspResponse::Initialize)?;
+                            respond(tx, || state_handlers::initialize(params, &mut self.lsp_state, &mut self.world), LspResponse::Initialize)?;
                         },
                         LspRequest::Shutdown() => {
                             // TODO
-                            respond(tx, Ok(()), LspResponse::Shutdown)?;
+                            respond(tx, || Ok(()), LspResponse::Shutdown)?;
                         },
                         LspRequest::WorkspaceSymbol(params) => {
-                            respond(tx, handlers::handle_symbol(params), LspResponse::WorkspaceSymbol)?;
+                            respond(tx, || handlers::handle_symbol(params), LspResponse::WorkspaceSymbol)?;
                         },
                         LspRequest::DocumentSymbol(params) => {
-                            respond(tx, handlers::handle_document_symbol(params, &self.world), LspResponse::DocumentSymbol)?;
+                            respond(tx, || handlers::handle_document_symbol(params, &self.world), LspResponse::DocumentSymbol)?;
                         },
                         LspRequest::ExecuteCommand(_params) => {
-                            respond(tx, handlers::handle_execute_command(&self.client).await, LspResponse::ExecuteCommand)?;
+                            let response = handlers::handle_execute_command(&self.client).await;
+                            respond(tx, || response, LspResponse::ExecuteCommand)?;
                         },
                         LspRequest::Completion(params) => {
-                            respond(tx, handlers::handle_completion(params, &self.world), LspResponse::Completion)?;
+                            respond(tx, || handlers::handle_completion(params, &self.world), LspResponse::Completion)?;
                         },
                         LspRequest::CompletionResolve(params) => {
-                            respond(tx, handlers::handle_completion_resolve(params), LspResponse::CompletionResolve)?;
+                            respond(tx, || handlers::handle_completion_resolve(params), LspResponse::CompletionResolve)?;
                         },
                         LspRequest::Hover(params) => {
-                            respond(tx, handlers::handle_hover(params, &self.world), LspResponse::Hover)?;
+                            respond(tx, || handlers::handle_hover(params, &self.world), LspResponse::Hover)?;
                         },
                         LspRequest::SignatureHelp(params) => {
-                            respond(tx, handlers::handle_signature_help(params, &self.world), LspResponse::SignatureHelp)?;
+                            respond(tx, || handlers::handle_signature_help(params, &self.world), LspResponse::SignatureHelp)?;
                         },
                         LspRequest::GotoDefinition(params) => {
-                            respond(tx, handlers::handle_goto_definition(params, &self.world), LspResponse::GotoDefinition)?;
+                            respond(tx, || handlers::handle_goto_definition(params, &self.world), LspResponse::GotoDefinition)?;
                         },
                         LspRequest::GotoImplementation(_params) => {
                             // TODO
-                            respond(tx, Ok(None), LspResponse::GotoImplementation)?;
+                            respond(tx, || Ok(None), LspResponse::GotoImplementation)?;
                         },
                         LspRequest::SelectionRange(params) => {
-                            respond(tx, handlers::handle_selection_range(params, &self.world), LspResponse::SelectionRange)?;
+                            respond(tx, || handlers::handle_selection_range(params, &self.world), LspResponse::SelectionRange)?;
                         },
                         LspRequest::References(params) => {
-                            respond(tx, handlers::handle_references(params, &self.world), LspResponse::References)?;
+                            respond(tx, || handlers::handle_references(params, &self.world), LspResponse::References)?;
                         },
                         LspRequest::StatementRange(params) => {
-                            respond(tx, handlers::handle_statement_range(params, &self.world), LspResponse::StatementRange)?;
+                            respond(tx, || handlers::handle_statement_range(params, &self.world), LspResponse::StatementRange)?;
                         },
                         LspRequest::HelpTopic(params) => {
-                            respond(tx, handlers::handle_help_topic(params, &self.world), LspResponse::HelpTopic)?;
+                            respond(tx, || handlers::handle_help_topic(params, &self.world), LspResponse::HelpTopic)?;
                         },
                         LspRequest::OnTypeFormatting(params) => {
                             state_handlers::did_change_formatting_options(&params.text_document_position.text_document.uri, &params.options, &mut self.world);
-                            respond(tx, handlers::handle_indent(params, &self.world), LspResponse::OnTypeFormatting)?;
+                            respond(tx, || handlers::handle_indent(params, &self.world), LspResponse::OnTypeFormatting)?;
                         },
                         LspRequest::VirtualDocument(params) => {
-                            respond(tx, handlers::handle_virtual_document(params, &self.world), LspResponse::VirtualDocument)?;
+                            respond(tx, || handlers::handle_virtual_document(params, &self.world), LspResponse::VirtualDocument)?;
                         },
                         LspRequest::InputBoundaries(params) => {
-                            respond(tx, handlers::handle_input_boundaries(params), LspResponse::InputBoundaries)?;
+                            respond(tx, || handlers::handle_input_boundaries(params), LspResponse::InputBoundaries)?;
                         },
                     };
                 },
@@ -373,7 +378,7 @@ impl GlobalState {
         Handler: Send + 'static,
     {
         lsp::spawn_blocking(move || {
-            respond(response_tx, handler(), into_lsp_response).and(Ok(None))
+            respond(response_tx, || handler(), into_lsp_response).and(Ok(None))
         })
     }
 }
@@ -398,9 +403,18 @@ impl GlobalState {
 /// * - `into_lsp_response`: A constructor for the relevant `LspResponse` variant.
 fn respond<T>(
     response_tx: TokioUnboundedSender<anyhow::Result<LspResponse>>,
-    response: anyhow::Result<T>,
+    response: impl FnOnce() -> anyhow::Result<T>,
     into_lsp_response: impl FnOnce(T) -> LspResponse,
 ) -> anyhow::Result<()> {
+    let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(response))
+        .map_err(|err| {
+            // Set global crash flag to disable the LSP
+            LSP_HAS_CRASHED.store(true, Ordering::Release);
+            anyhow!("Panic occurred while handling request: {err:?}")
+        })
+        // Unwrap nested Result
+        .and_then(|resp| resp);
+
     let out = match response {
         Ok(_) => Ok(()),
         Err(ref err) => Err(anyhow!("Error while handling request:\n{err:?}")),

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -305,14 +305,6 @@ fn main() -> anyhow::Result<()> {
     // that we join all spawned threads up to the main thread.
     let old_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
-        // We don't want the threads managed by a Tokio runtime to `abort()` the
-        // process since their panics are caught and handled in other ways.
-        // This escape hatch is a hack that will also be activated by other
-        // Tokio contexts than just the LSP.
-        if tokio::runtime::Handle::try_current().is_ok() {
-            return;
-        }
-
         let info = panic_info.payload();
 
         let loc = if let Some(location) = panic_info.location() {
@@ -346,6 +338,14 @@ fn main() -> anyhow::Result<()> {
         } else {
             let trace = format!("Backtrace:\n{}", std::backtrace::Backtrace::force_capture());
             log::error!("Panic! {loc} No contextual information.\n{trace}");
+        }
+
+        // We don't want the threads managed by a Tokio runtime to `abort()` the
+        // process since their panics are caught and handled in other ways.
+        // This escape hatch is a hack that will also be activated by other
+        // Tokio contexts than just the LSP.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return;
         }
 
         // Give some time to flush log


### PR DESCRIPTION
Part of https://github.com/posit-dev/positron/issues/5507

The goal of this PR is to prevent the LSP from ever crashing the R session and lose the user state. I've moved all LSP request handlers behind a [`catch_unwind()`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html), basically a `try` for panics. When an LSP handler panics, we detect it, report it, and flip our state to crashed. Once crashed, all LSP handlers respond with an error. This causes some chatter in the LSP logs but I made sure these errors do not carry a backtrace to avoid flooding the logs.

Ideally we'd shut down the LSP entirely and forcefully disconnect from the client. Unfortunately that scenario of a server-initiated shutdown is not supported by the LSP protocol and tower-lsp does not give us the tools to do this.

Alternatively we could send a notification to the client that the LSP has crashed. The client could then initiate a shutdown. I chose not to go that route because to avoid having to deal with synchronisation issues and having to make changes to both the client and the server.

For context, this is a temporary workaround. Once the LSP lives in Air a crash will never be a big deal for the user. Most of the time they will not be aware of it since VS Code / Positron silently restarts crashed servers (unless they crash too many times in a short period, in which case the user is notified and the server is no longer restarted).

Here is a screencast of what happens when the LSP crashes:


https://github.com/user-attachments/assets/61737d86-4018-47f9-8a1d-5ed4ad566291


The user is notified of the crash and requested to send a report with the logs.

Note that the relevant backtrace is sent by our panic hook to the _kernel_ logs rather than the LSP logs. The backtrace in the LSP logs is unlikely to be helpful.
