### PR TITLE
Temporarily pin Rust to 1.83 on Windows

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -32,6 +32,12 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v4
 
+            - name: Install Rust temporarily pinned to 1.83 (https://github.com/posit-dev/ark/issues/678)
+              uses: dtolnay/rust-toolchain@1.83
+
+            - name: Report Rust version
+              run: rustc --version
+
             - name: Compile ARK
               env:
                   ARK_BUILD_TYPE: ${{ matrix.flavor }}


### PR DESCRIPTION
Related to #678 

The Windows ark binary built against Rust 1.84 doesn't work due to #678. @lionel- and I have spent a little time looking at it, and the solution isn't super obvious yet. We will have to pin to Rust 1.83 until we can figure it out.