### PR TITLE
Fix crash when inspecting a `CHRSXP`

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -2092,6 +2092,14 @@ mod tests {
     #[test]
     fn test_charsxp() {
         r_task(|| {
+            // Skip test if rlang is not installed
+            if let Ok(false) = harp::parse_eval_global(r#".ps.is_installed("rlang")"#)
+                .unwrap()
+                .try_into()
+            {
+                return;
+            }
+
             let env = Environment::new_empty().unwrap();
             let value = harp::parse_eval_base(r#"rlang:::chr_get("foo", 0L)"#).unwrap();
             env.bind("x".into(), &value);

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -158,6 +158,11 @@ pub fn r_is_simple_vector(value: SEXP) -> bool {
 ///
 /// Notably returns `false` for 1D arrays and >=3D arrays.
 pub fn r_is_matrix(object: SEXP) -> bool {
+    // We can't check the `dim` attribute for CHARSXP's
+    if r_typeof(object) == CHARSXP {
+        return false;
+    }
+
     let dim = r_dim(object);
 
     if dim == r_null() {


### PR DESCRIPTION
Adresses https://github.com/posit-dev/ark/issues/692

You should be able to create a binding containing a `CHARSXP` using eg:

```
x <- rlang:::chr_get("foo", 0L)
```

We could access the value of the CHARSXP, but it would require using unsafe `libr` in the variables pane, which we try to avoid, or export a harp function for this. Seems like it's not worth given how rare this happens, but I could implement this further if you think that's important.

