### PR TITLE
`break` loop when truncating

### DIFF
--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -205,10 +205,14 @@ impl WorkspaceVariableDisplayValue {
 
             if display_value.len() > MAX_DISPLAY_VALUE_LENGTH || display_i.is_truncated {
                 is_truncated = true;
+                break;
             }
         }
 
-        display_value.push(']');
+        if !is_truncated {
+            display_value.push_str("]");
+        }
+
         Self::new(display_value, is_truncated)
     }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6220
Without the `break` we would format the entire list, even though we only display a maximum of 1000 characters.