### PR TITLE
Data Explorer: Display row names for matrix

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -875,6 +875,10 @@ impl RDataExplorer {
     }
 
     fn r_get_state(&self) -> anyhow::Result<DataExplorerBackendReply> {
+        let row_names = RFunction::new("base", "row.names")
+            .add(self.table.get()?)
+            .call_in(ARK_ENVS.positron_ns)?;
+
         let state = BackendState {
             display_name: self.title.clone(),
             connected: Some(true),
@@ -893,10 +897,7 @@ impl RDataExplorer {
             row_filters: self.row_filters.clone(),
             column_filters: self.col_filters.clone(),
             sort_keys: self.sort_keys.clone(),
-            has_row_labels: match self.table.get()?.attr("row.names") {
-                Some(_) => true,
-                None => false,
-            },
+            has_row_labels: !row_names.is_null(),
             supported_features: SupportedFeatures {
                 get_column_profiles: GetColumnProfilesFeatures {
                     support_status: SupportStatus::Supported,

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -1861,3 +1861,28 @@ fn test_frequency_table() {
         });
     });
 }
+
+#[test]
+fn test_row_names_matrix() {
+    let _lock = r_test_lock();
+
+    // Convert mtcars to a matrix
+    let socket =
+        open_data_explorer_from_expression("as.matrix(mtcars)", Some("mtcars_matrix")).unwrap();
+
+    // Check row names are present
+    let req = DataExplorerBackendRequest::GetRowLabels(GetRowLabelsParams {
+        selection: ArraySelection::SelectIndices(DataSelectionIndices {
+            indices: vec![5, 6, 7, 8, 9],
+        }),
+        format_options: default_format_options(),
+    });
+    assert_match!(socket_rpc(&socket, req),
+        DataExplorerBackendReply::GetRowLabelsReply(row_labels) => {
+            let labels = row_labels.row_labels;
+            assert_eq!(labels[0][0], "Valiant");
+            assert_eq!(labels[0][1], "Duster 360");
+            assert_eq!(labels[0][2], "Merc 240D");
+        }
+    );
+}


### PR DESCRIPTION
Checking for the `row.names` attribute is not enough to figure out if an object has `row.names`. Especially, matrices use the `dimnames` attributes to store this information. So we now call into `base::row.names()` to check for the existence of `row.names`.

Adresses https://github.com/posit-dev/positron/issues/6287