### PR TITLE
`row_labels.is_null()` actually refers to a method checking for a null pointer

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -63,7 +63,6 @@ use harp::exec::RFunctionExt;
 use harp::object::RObject;
 use harp::r_symbol;
 use harp::tbl_get_column;
-use harp::utils::r_is_null;
 use harp::TableInfo;
 use harp::TableKind;
 use itertools::Itertools;
@@ -898,7 +897,7 @@ impl RDataExplorer {
             row_filters: self.row_filters.clone(),
             column_filters: self.col_filters.clone(),
             sort_keys: self.sort_keys.clone(),
-            has_row_labels: !r_is_null(row_names.sexp),
+            has_row_labels: !row_names.is_null(),
             supported_features: SupportedFeatures {
                 get_column_profiles: GetColumnProfilesFeatures {
                     support_status: SupportStatus::Supported,

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -63,6 +63,7 @@ use harp::exec::RFunctionExt;
 use harp::object::RObject;
 use harp::r_symbol;
 use harp::tbl_get_column;
+use harp::utils::r_is_null;
 use harp::TableInfo;
 use harp::TableKind;
 use itertools::Itertools;
@@ -897,7 +898,7 @@ impl RDataExplorer {
             row_filters: self.row_filters.clone(),
             column_filters: self.col_filters.clone(),
             sort_keys: self.sort_keys.clone(),
-            has_row_labels: !row_names.is_null(),
+            has_row_labels: !r_is_null(row_names.sexp),
             supported_features: SupportedFeatures {
                 get_column_profiles: GetColumnProfilesFeatures {
                     support_status: SupportStatus::Supported,

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -1877,12 +1877,28 @@ fn test_row_names_matrix() {
         }),
         format_options: default_format_options(),
     });
+    assert_match!(socket_rpc(&socket, DataExplorerBackendRequest::GetState),
+        DataExplorerBackendReply::GetStateReply(state) => {
+            assert_eq!(state.has_row_labels, true)
+        }
+    );
+
     assert_match!(socket_rpc(&socket, req),
         DataExplorerBackendReply::GetRowLabelsReply(row_labels) => {
             let labels = row_labels.row_labels;
             assert_eq!(labels[0][0], "Valiant");
             assert_eq!(labels[0][1], "Duster 360");
             assert_eq!(labels[0][2], "Merc 240D");
+        }
+    );
+
+    // Convert mtcars to a matrix
+    let socket =
+        open_data_explorer_from_expression("matrix(0, ncol =10, nrow = 10)", Some("zero_matrix"))
+            .unwrap();
+    assert_match!(socket_rpc(&socket, DataExplorerBackendRequest::GetState),
+        DataExplorerBackendReply::GetStateReply(state) => {
+            assert_eq!(state.has_row_labels, false)
         }
     );
 }

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -352,6 +352,10 @@ impl RObject {
         r_is_object(self.sexp)
     }
 
+    pub fn is_null(&self) -> bool {
+        r_is_null(self.sexp)
+    }
+
     pub fn size(&self) -> harp::Result<usize> {
         r_size(self.sexp)
     }
@@ -1154,6 +1158,7 @@ mod tests {
     use stdext::assert_match;
 
     use super::*;
+    use crate::parse_eval_global;
     use crate::r_char;
 
     #[test]
@@ -1727,6 +1732,17 @@ mod tests {
             // Now convert back to a vector of RObjects.
             let items_out = Vec::<RObject>::try_from(list).unwrap();
             assert_eq!(items_in, items_out);
+        })
+    }
+
+    #[test]
+    fn test_is_null() {
+        crate::r_task(|| {
+            let x = parse_eval_global("NULL").unwrap();
+            assert!(x.is_null());
+
+            let x = parse_eval_global("1").unwrap();
+            assert!(!x.is_null());
         })
     }
 }


### PR DESCRIPTION
This fixes a regression caused by https://github.com/posit-dev/ark/pull/706. `is_null()` is actually checking for a NULL opinter. Now properly check using `r_is_null()`.