### PR TITLE
Improve `data.table` column names autocomplete.

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -68,7 +68,7 @@ pub(super) fn completions_from_subset(
 
     let text = context.document.contents.node_slice(&child)?.to_string();
 
-    completions_from_evaluated_object_names(&text, ENQUOTE)
+    completions_from_evaluated_object_names(&text, ENQUOTE, node.node_type())
 }
 
 #[cfg(test)]
@@ -173,6 +173,18 @@ mod tests {
             // TODO: ideally we could assert that mpg doesn't appear again, or appears at the end
             assert_eq!(completion.label, "mpg".to_string());
             assert_eq!(completion.insert_text, None); // No enquote, means the label is used directly
+
+            // Works completing subset2
+            let point = Point { row: 0, column: 3 };
+            let document = Document::new("x[[]]", None);
+            let context = DocumentContext::new(&document, point, None);
+
+            let completions = completions_from_subset(&context).unwrap().unwrap();
+            assert_eq!(completions.len(), 11);
+
+            let completion = completions.get(0).unwrap();
+            assert_eq!(completion.label, "mpg".to_string());
+            assert_eq!(completion.insert_text, Some("\"mpg\"".to_string())); // Enquoted result
 
             harp::parse_eval_global("remove(x)").unwrap();
         })

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -50,7 +50,9 @@ pub(super) fn completions_from_string_subset(
 
     let text = context.document.contents.node_slice(&node)?.to_string();
 
-    if let Some(mut candidates) = completions_from_evaluated_object_names(&text, ENQUOTE)? {
+    if let Some(mut candidates) =
+        completions_from_evaluated_object_names(&text, ENQUOTE, node.node_type())?
+    {
         completions.append(&mut candidates);
     }
 

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -207,8 +207,8 @@ pub(super) fn completions_from_evaluated_object_names(
         // Special case just for 2D arrays
         completions_from_object_colnames(object, name, enquote)?
     } else if r_inherits(object.sexp, "data.table") {
-        // When completing names for data.table objects, we don't want to
-        // enquote the names.
+        // The `[` method for data.table uses NSE so we don't enquote the names
+        // https://github.com/posit-dev/positron/issues/3140
         let enquote = match node_type {
             NodeType::Subset => false,
             NodeType::Subset2 => true,


### PR DESCRIPTION
Makes `data.table` a special case when subseting column names.
Addresses https://github.com/posit-dev/positron/issues/3140