### PR TITLE
Switch from `extern "C"` to `extern "C-unwind"`

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -32,12 +32,6 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v4
 
-            - name: Install Rust temporarily pinned to 1.83 (https://github.com/posit-dev/ark/issues/678)
-              uses: dtolnay/rust-toolchain@1.83
-
-            - name: Report Rust version
-              run: rustc --version
-
             - name: Compile ARK
               env:
                   ARK_BUILD_TYPE: ${{ matrix.flavor }}

--- a/crates/ark/src/browser.rs
+++ b/crates/ark/src/browser.rs
@@ -16,7 +16,7 @@ use crate::help::message::ShowHelpUrlParams;
 use crate::interface::RMain;
 
 #[harp::register]
-pub unsafe extern "C" fn ps_browse_url(url: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_browse_url(url: SEXP) -> anyhow::Result<SEXP> {
     ps_browse_url_impl(url).or_else(|err| {
         log::error!("Failed to browse url due to: {err}");
         Ok(Rf_ScalarLogical(0))

--- a/crates/ark/src/connections/r_connection.rs
+++ b/crates/ark/src/connections/r_connection.rs
@@ -297,7 +297,7 @@ impl RConnection {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_connection_opened(
+pub unsafe extern "C-unwind" fn ps_connection_opened(
     name: SEXP,
     host: SEXP,
     r#type: SEXP,
@@ -333,7 +333,7 @@ pub unsafe extern "C" fn ps_connection_opened(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_connection_closed(id: SEXP) -> Result<SEXP, anyhow::Error> {
+pub unsafe extern "C-unwind" fn ps_connection_closed(id: SEXP) -> Result<SEXP, anyhow::Error> {
     let main = RMain::get();
     let id_ = RObject::view(id).to::<String>()?;
 
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn ps_connection_closed(id: SEXP) -> Result<SEXP, anyhow::
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_connection_updated(id: SEXP) -> Result<SEXP, anyhow::Error> {
+pub unsafe extern "C-unwind" fn ps_connection_updated(id: SEXP) -> Result<SEXP, anyhow::Error> {
     let main = RMain::get();
     let comm_id: String = RObject::view(id).to::<String>()?;
 

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -1088,7 +1088,7 @@ fn table_info_or_bail(x: SEXP) -> anyhow::Result<TableInfo> {
 ///   environment; optional.
 /// - `env`: The environment containing the R object; optional.
 #[harp::register]
-pub unsafe extern "C" fn ps_view_data_frame(
+pub unsafe extern "C-unwind" fn ps_view_data_frame(
     x: SEXP,
     title: SEXP,
     var: SEXP,

--- a/crates/ark/src/errors.rs
+++ b/crates/ark/src/errors.rs
@@ -20,7 +20,7 @@ use stdext::unwrap;
 use crate::interface::RMain;
 
 #[harp::register]
-unsafe extern "C" fn ps_record_error(evalue: SEXP, traceback: SEXP) -> anyhow::Result<SEXP> {
+unsafe extern "C-unwind" fn ps_record_error(evalue: SEXP, traceback: SEXP) -> anyhow::Result<SEXP> {
     let main = RMain::get_mut();
 
     // Convert to `RObject` for access to `try_from()` / `try_into()` methods.
@@ -45,7 +45,7 @@ unsafe extern "C" fn ps_record_error(evalue: SEXP, traceback: SEXP) -> anyhow::R
 }
 
 #[harp::register]
-unsafe extern "C" fn ps_format_traceback(calls: SEXP) -> anyhow::Result<SEXP> {
+unsafe extern "C-unwind" fn ps_format_traceback(calls: SEXP) -> anyhow::Result<SEXP> {
     Ok(r_format_traceback(calls.into())?.sexp)
 }
 
@@ -62,7 +62,7 @@ pub unsafe fn initialize() {
 }
 
 #[harp::register]
-unsafe extern "C" fn ps_rust_backtrace() -> anyhow::Result<SEXP> {
+unsafe extern "C-unwind" fn ps_rust_backtrace() -> anyhow::Result<SEXP> {
     let trace = std::backtrace::Backtrace::force_capture();
     let trace = format!("{trace}");
     Ok(*RObject::from(trace))

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -1973,7 +1973,7 @@ pub(crate) fn console_inputs() -> anyhow::Result<ConsoleInputs> {
 // global `RMain` singleton.
 
 #[no_mangle]
-pub extern "C" fn r_read_console(
+pub extern "C-unwind" fn r_read_console(
     prompt: *const c_char,
     buf: *mut c_uchar,
     buflen: c_int,

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -2018,30 +2018,30 @@ fn new_cstring(x: String) -> CString {
 }
 
 #[no_mangle]
-pub extern "C" fn r_write_console(buf: *const c_char, buflen: i32, otype: i32) {
+pub extern "C-unwind" fn r_write_console(buf: *const c_char, buflen: i32, otype: i32) {
     RMain::write_console(buf, buflen, otype);
 }
 
 #[no_mangle]
-pub extern "C" fn r_show_message(buf: *const c_char) {
+pub extern "C-unwind" fn r_show_message(buf: *const c_char) {
     let main = RMain::get();
     main.show_message(buf);
 }
 
 #[no_mangle]
-pub extern "C" fn r_busy(which: i32) {
+pub extern "C-unwind" fn r_busy(which: i32) {
     let main = RMain::get_mut();
     main.busy(which);
 }
 
 #[no_mangle]
-pub extern "C" fn r_suicide(buf: *const c_char) {
+pub extern "C-unwind" fn r_suicide(buf: *const c_char) {
     let msg = unsafe { CStr::from_ptr(buf) };
     panic!("Suicide: {}", msg.to_str().unwrap());
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn r_polled_events() {
+pub unsafe extern "C-unwind" fn r_polled_events() {
     let main = RMain::get_mut();
     main.polled_events();
 }
@@ -2049,7 +2049,7 @@ pub unsafe extern "C" fn r_polled_events() {
 // This hook is called like a user onLoad hook but for every package to be
 // loaded in the session
 #[harp::register]
-unsafe extern "C" fn ps_onload_hook(pkg: SEXP, _path: SEXP) -> anyhow::Result<SEXP> {
+unsafe extern "C-unwind" fn ps_onload_hook(pkg: SEXP, _path: SEXP) -> anyhow::Result<SEXP> {
     // NOTE: `_path` might be NULL for a compat reason, see comments on the R side
 
     let pkg: String = RObject::view(pkg).try_into()?;

--- a/crates/ark/src/json.rs
+++ b/crates/ark/src/json.rs
@@ -10,7 +10,7 @@ use libr::SEXP;
 
 /// Convenience method to convert a JSON object to a string
 #[harp::register]
-pub unsafe extern "C" fn ps_to_json(obj: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_to_json(obj: SEXP) -> anyhow::Result<SEXP> {
     let obj = RObject::view(obj);
 
     // Convert the object to a JSON value; this is the core serialization step

--- a/crates/ark/src/lsp/util.rs
+++ b/crates/ark/src/lsp/util.rs
@@ -14,7 +14,7 @@ use libr::SEXP;
 
 /// Shows a message in the Positron frontend
 #[harp::register]
-pub unsafe extern "C" fn ps_log_error(message: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_log_error(message: SEXP) -> anyhow::Result<SEXP> {
     let message = RObject::view(message).to::<String>();
     if let Ok(message) = message {
         log::error!("{}", message);
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn ps_log_error(message: SEXP) -> anyhow::Result<SEXP> {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_object_id(object: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_object_id(object: SEXP) -> anyhow::Result<SEXP> {
     let value = format!("{:p}", object);
     return Ok(Rf_mkString(value.as_ptr() as *const c_char));
 }

--- a/crates/ark/src/modules_utils.rs
+++ b/crates/ark/src/modules_utils.rs
@@ -1,13 +1,13 @@
 use libr::SEXP;
 
 #[harp::register]
-pub unsafe extern "C" fn ark_node_poke_cdr(node: SEXP, cdr: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ark_node_poke_cdr(node: SEXP, cdr: SEXP) -> anyhow::Result<SEXP> {
     libr::SETCDR(node, cdr);
     return Ok(harp::r_null());
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_deep_sleep(secs: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_deep_sleep(secs: SEXP) -> anyhow::Result<SEXP> {
     let secs = libr::Rf_asInteger(secs);
     let secs = std::time::Duration::from_secs(secs as u64);
     std::thread::sleep(secs);

--- a/crates/ark/src/reticulate.rs
+++ b/crates/ark/src/reticulate.rs
@@ -85,7 +85,7 @@ impl ReticulateService {
 // Further actions that reticulate can ask the front-end can be requested through
 // the comm_id that is returned by this function.
 #[harp::register]
-pub unsafe extern "C" fn ps_reticulate_open(input: SEXP) -> Result<SEXP, anyhow::Error> {
+pub unsafe extern "C-unwind" fn ps_reticulate_open(input: SEXP) -> Result<SEXP, anyhow::Error> {
     let main = RMain::get();
 
     let input: RObject = input.try_into()?;

--- a/crates/ark/src/srcref.rs
+++ b/crates/ark/src/srcref.rs
@@ -32,7 +32,7 @@ pub(crate) fn resource_loaded_namespaces() -> anyhow::Result<()> {
 }
 
 #[harp::register]
-unsafe extern "C" fn ps_ns_populate_srcref(ns_name: SEXP) -> anyhow::Result<SEXP> {
+unsafe extern "C-unwind" fn ps_ns_populate_srcref(ns_name: SEXP) -> anyhow::Result<SEXP> {
     let ns_name: String = RObject::view(ns_name).try_into()?;
     futures::executor::block_on(ns_populate_srcref(ns_name))?;
     Ok(harp::r_null())
@@ -183,6 +183,6 @@ fn generate_source(
 }
 
 #[harp::register]
-pub extern "C" fn ark_zap_srcref(x: SEXP) -> anyhow::Result<SEXP> {
+pub extern "C-unwind" fn ark_zap_srcref(x: SEXP) -> anyhow::Result<SEXP> {
     Ok(harp::attrib::zap_srcref(x).sexp)
 }

--- a/crates/ark/src/sys/unix/signals.rs
+++ b/crates/ark/src/sys/unix/signals.rs
@@ -64,6 +64,13 @@ pub fn set_interrupts_pending(pending: bool) {
     }
 }
 
+/// Unix interrupt handler
+///
+/// # Safety
+///
+/// Note that this can't be `"C-unwind"` because [SigHandler::Handler] takes a `"C"`
+/// function, so make absolute sure that the contents of this function can't Rust panic or
+/// C longjmp.
 pub extern "C" fn handle_interrupt(_signal: libc::c_int) {
     set_interrupts_pending(true);
 }

--- a/crates/ark/src/sys/windows/interface.rs
+++ b/crates/ark/src/sys/windows/interface.rs
@@ -180,12 +180,12 @@ fn get_user_home() -> String {
 }
 
 #[no_mangle]
-extern "C" fn r_callback() {
+extern "C-unwind" fn r_callback() {
     // Do nothing!
 }
 
 #[no_mangle]
-extern "C" fn r_yes_no_cancel(question: *const c_char) -> c_int {
+extern "C-unwind" fn r_yes_no_cancel(question: *const c_char) -> c_int {
     // This seems to only be used on Windows during R's default `CleanUp` when
     // `SA_SAVEASK` is used. We should replace `Cleanup` with our own version
     // that resolves `SA_SAVEASK`, changes `saveact` to the resolved value,

--- a/crates/ark/src/traps.rs
+++ b/crates/ark/src/traps.rs
@@ -22,7 +22,7 @@
 // and set this up now.
 pub use crate::sys::traps::register_trap_handlers;
 
-pub extern "C" fn backtrace_handler(signum: libc::c_int) {
+pub extern "C-unwind" fn backtrace_handler(signum: libc::c_int) {
     // Prevent infloop into the handler
     unsafe {
         libc::signal(signum, libc::SIG_DFL);

--- a/crates/ark/src/ui/events.rs
+++ b/crates/ark/src/ui/events.rs
@@ -20,7 +20,7 @@ use libr::SEXP;
 use crate::interface::RMain;
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_show_message(message: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_show_message(message: SEXP) -> anyhow::Result<SEXP> {
     let params = ShowMessageParams {
         message: RObject::view(message).try_into()?,
     };
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn ps_ui_show_message(message: SEXP) -> anyhow::Result<SEX
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_open_workspace(
+pub unsafe extern "C-unwind" fn ps_ui_open_workspace(
     path: SEXP,
     new_window: SEXP,
 ) -> anyhow::Result<SEXP> {
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn ps_ui_open_workspace(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_navigate_to_file(
+pub unsafe extern "C-unwind" fn ps_ui_navigate_to_file(
     file: SEXP,
     _line: SEXP,
     _column: SEXP,
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn ps_ui_navigate_to_file(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_set_selection_ranges(ranges: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_set_selection_ranges(ranges: SEXP) -> anyhow::Result<SEXP> {
     let selections = ps_ui_robj_as_ranges(ranges)?;
     let params = SetEditorSelectionsParams { selections };
 
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn ps_ui_set_selection_ranges(ranges: SEXP) -> anyhow::Res
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_show_url(url: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_show_url(url: SEXP) -> anyhow::Result<SEXP> {
     let params = ShowUrlParams {
         url: RObject::view(url).try_into()?,
     };

--- a/crates/ark/src/ui/methods.rs
+++ b/crates/ark/src/ui/methods.rs
@@ -22,14 +22,14 @@ use crate::interface::RMain;
 use crate::ui::events::ps_ui_robj_as_ranges;
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_last_active_editor_context() -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_last_active_editor_context() -> anyhow::Result<SEXP> {
     let main = RMain::get();
     let out = main.call_frontend_method(UiFrontendRequest::LastActiveEditorContext)?;
     Ok(out.sexp)
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_modify_editor_selections(
+pub unsafe extern "C-unwind" fn ps_ui_modify_editor_selections(
     ranges: SEXP,
     values: SEXP,
 ) -> anyhow::Result<SEXP> {
@@ -48,14 +48,17 @@ pub unsafe extern "C" fn ps_ui_modify_editor_selections(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_workspace_folder() -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_workspace_folder() -> anyhow::Result<SEXP> {
     let main = RMain::get();
     let out = main.call_frontend_method(UiFrontendRequest::WorkspaceFolder)?;
     Ok(out.sexp)
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_show_dialog(title: SEXP, message: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_show_dialog(
+    title: SEXP,
+    message: SEXP,
+) -> anyhow::Result<SEXP> {
     let params = ShowDialogParams {
         title: RObject::view(title).try_into()?,
         message: RObject::view(message).try_into()?,
@@ -67,7 +70,7 @@ pub unsafe extern "C" fn ps_ui_show_dialog(title: SEXP, message: SEXP) -> anyhow
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_show_question(
+pub unsafe extern "C-unwind" fn ps_ui_show_question(
     title: SEXP,
     message: SEXP,
     ok_button_title: SEXP,
@@ -94,7 +97,7 @@ pub unsafe extern "C" fn ps_ui_show_question(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_new_document(
+pub unsafe extern "C-unwind" fn ps_ui_new_document(
     contents: SEXP,
     language_id: SEXP,
 ) -> anyhow::Result<SEXP> {
@@ -109,7 +112,7 @@ pub unsafe extern "C" fn ps_ui_new_document(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_execute_command(command: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_execute_command(command: SEXP) -> anyhow::Result<SEXP> {
     let params = ExecuteCommandParams {
         command: RObject::view(command).try_into()?,
     };
@@ -120,7 +123,10 @@ pub unsafe extern "C" fn ps_ui_execute_command(command: SEXP) -> anyhow::Result<
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_execute_code(code: SEXP, focus: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_execute_code(
+    code: SEXP,
+    focus: SEXP,
+) -> anyhow::Result<SEXP> {
     let params = ExecuteCodeParams {
         language_id: String::from("r"),
         code: RObject::view(code).try_into()?,
@@ -134,7 +140,9 @@ pub unsafe extern "C" fn ps_ui_execute_code(code: SEXP, focus: SEXP) -> anyhow::
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_evaluate_when_clause(when_clause: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_evaluate_when_clause(
+    when_clause: SEXP,
+) -> anyhow::Result<SEXP> {
     let params = EvaluateWhenClauseParams {
         when_clause: RObject::view(when_clause).try_into()?,
     };
@@ -145,7 +153,7 @@ pub unsafe extern "C" fn ps_ui_evaluate_when_clause(when_clause: SEXP) -> anyhow
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ui_debug_sleep(ms: SEXP) -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ui_debug_sleep(ms: SEXP) -> anyhow::Result<SEXP> {
     let params = DebugSleepParams {
         ms: RObject::view(ms).try_into()?,
     };

--- a/crates/ark/src/version.rs
+++ b/crates/ark/src/version.rs
@@ -71,7 +71,7 @@ pub fn detect_r() -> anyhow::Result<RVersion> {
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_ark_version() -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_ark_version() -> anyhow::Result<SEXP> {
     let mut info = HashMap::<String, String>::new();
     // Set the version info in the map
     info.insert(

--- a/crates/ark/src/viewer.rs
+++ b/crates/ark/src/viewer.rs
@@ -49,7 +49,7 @@ fn emit_html_output_jupyter(
 }
 
 #[harp::register]
-pub unsafe extern "C" fn ps_html_viewer(
+pub unsafe extern "C-unwind" fn ps_html_viewer(
     url: SEXP,
     label: SEXP,
     height: SEXP,

--- a/crates/harp/harp-macros/src/lib.rs
+++ b/crates/harp/harp-macros/src/lib.rs
@@ -106,7 +106,7 @@ pub fn register(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Get metadata about the function being registered.
     let mut function: syn::ItemFn = syn::parse(item).unwrap();
 
-    // Make sure the function is 'extern "C"'.
+    // Make sure the function is 'extern "C-unwind"'.
     let abi = match function.sig.abi {
         Some(ref abi) => abi,
         None => invalid_extern(function.sig),
@@ -118,7 +118,7 @@ pub fn register(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let name = name.to_token_stream().to_string();
-    if name != "\"C\"" {
+    if name != "\"C-unwind\"" {
         invalid_extern(function.sig);
     }
 

--- a/crates/harp/src/environment.rs
+++ b/crates/harp/src/environment.rs
@@ -262,7 +262,7 @@ unsafe impl Send for REnvs {}
 unsafe impl Sync for REnvs {}
 
 #[harp::register]
-pub extern "C" fn ark_env_unlock(env: SEXP) -> crate::error::Result<SEXP> {
+pub extern "C-unwind" fn ark_env_unlock(env: SEXP) -> crate::error::Result<SEXP> {
     unsafe {
         crate::check_env(env)?;
         Environment::view(env).unlock();

--- a/crates/harp/src/exec.rs
+++ b/crates/harp/src/exec.rs
@@ -186,7 +186,7 @@ where
     };
     let payload = &mut callback_data as *mut _ as *mut c_void;
 
-    extern "C" fn callback<'env, F, T>(payload: *mut c_void) -> SEXP
+    extern "C-unwind" fn callback<'env, F, T>(payload: *mut c_void) -> SEXP
     where
         F: FnOnce() -> T,
         F: 'env,
@@ -202,7 +202,7 @@ where
         harp::r_null()
     }
 
-    extern "C" fn handler<'env, F, T>(err: SEXP, payload: *mut c_void) -> SEXP
+    extern "C-unwind" fn handler<'env, F, T>(err: SEXP, payload: *mut c_void) -> SEXP
     where
         F: FnOnce() -> T,
         F: 'env,
@@ -328,7 +328,7 @@ where
     };
     let payload = &mut callback_data as *mut _ as *mut c_void;
 
-    extern "C" fn callback<'env, F, T>(args: *mut c_void)
+    extern "C-unwind" fn callback<'env, F, T>(args: *mut c_void)
     where
         F: FnOnce() -> T,
         F: 'env,

--- a/crates/harp/src/sys/unix/polled_events.rs
+++ b/crates/harp/src/sys/unix/polled_events.rs
@@ -6,16 +6,16 @@
 //
 
 pub struct RLocalPolledEventsSuspended {
-    _raii: crate::raii::RLocal<Option<unsafe extern "C" fn()>>,
+    _raii: crate::raii::RLocal<Option<unsafe extern "C-unwind" fn()>>,
 }
 
 #[no_mangle]
-extern "C" fn r_polled_events_disabled() {}
+extern "C-unwind" fn r_polled_events_disabled() {}
 
 impl RLocalPolledEventsSuspended {
     pub fn new(value: bool) -> Self {
         let new_value = if value {
-            Some(r_polled_events_disabled as unsafe extern "C" fn())
+            Some(r_polled_events_disabled as unsafe extern "C-unwind" fn())
         } else {
             None
         };

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -50,7 +50,7 @@ static RE_SYNTACTIC_IDENTIFIER: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[\p{L}\p{Nl}.][\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}.]*$").unwrap());
 
 #[harp::register]
-pub extern "C" fn harp_log_trace(msg: SEXP) -> crate::error::Result<SEXP> {
+pub extern "C-unwind" fn harp_log_trace(msg: SEXP) -> crate::error::Result<SEXP> {
     let msg = String::try_from(RObject::view(msg))?;
     log::trace!("{msg}");
 
@@ -58,7 +58,7 @@ pub extern "C" fn harp_log_trace(msg: SEXP) -> crate::error::Result<SEXP> {
 }
 
 #[harp::register]
-pub extern "C" fn harp_log_warning(msg: SEXP) -> crate::error::Result<SEXP> {
+pub extern "C-unwind" fn harp_log_warning(msg: SEXP) -> crate::error::Result<SEXP> {
     let msg = String::try_from(RObject::view(msg))?;
     log::warn!("{msg}");
 
@@ -66,7 +66,7 @@ pub extern "C" fn harp_log_warning(msg: SEXP) -> crate::error::Result<SEXP> {
 }
 
 #[harp::register]
-pub extern "C" fn harp_log_error(msg: SEXP) -> crate::error::Result<SEXP> {
+pub extern "C-unwind" fn harp_log_error(msg: SEXP) -> crate::error::Result<SEXP> {
     let msg = String::try_from(RObject::view(msg))?;
     log::error!("{msg}");
 

--- a/crates/libr/src/functions.rs
+++ b/crates/libr/src/functions.rs
@@ -17,7 +17,7 @@ macro_rules! generate {
         $(
             paste::paste! {
                 $(#[cfg($cfg)])*
-                static mut [<$name _opt>]: Option<unsafe extern "C" fn ($($pty), *) $(-> $ret)*> = None;
+                static mut [<$name _opt>]: Option<unsafe extern "C-unwind" fn ($($pty), *) $(-> $ret)*> = None;
             }
         )+
 

--- a/crates/libr/src/functions_variadic.rs
+++ b/crates/libr/src/functions_variadic.rs
@@ -19,7 +19,7 @@ macro_rules! generate {
         $(
             paste::paste! {
                 $(#[cfg($cfg)])*
-                static mut [<$name _opt>]: Option<unsafe extern "C" fn ($($pty), *, ...) $(-> $ret)*> = None;
+                static mut [<$name _opt>]: Option<unsafe extern "C-unwind" fn ($($pty), *, ...) $(-> $ret)*> = None;
             }
         )+
 

--- a/crates/libr/src/graphics.rs
+++ b/crates/libr/src/graphics.rs
@@ -168,17 +168,26 @@ pub struct DevDescVersion13 {
     pub canGenKeybd: Rboolean,
     pub canGenIdle: Rboolean,
     pub gettingEvent: Rboolean,
-    pub activate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub circle: Option<unsafe extern "C" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
-    pub clip: Option<unsafe extern "C" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
-    pub close: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub deactivate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub locator: Option<unsafe extern "C" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
+    pub activate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub circle:
+        Option<unsafe extern "C-unwind" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
+    pub clip: Option<unsafe extern "C-unwind" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
+    pub close: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub deactivate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub locator:
+        Option<unsafe extern "C-unwind" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
     pub line: Option<
-        unsafe extern "C" fn(x1: f64, y1: f64, x2: f64, y2: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x1: f64,
+            y1: f64,
+            x2: f64,
+            y2: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub metricInfo: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             c: std::ffi::c_int,
             gc: pGEcontext,
             ascent: *mut f64,
@@ -187,10 +196,10 @@ pub struct DevDescVersion13 {
             dd: pDevDesc,
         ),
     >,
-    pub mode: Option<unsafe extern "C" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
-    pub newPage: Option<unsafe extern "C" fn(gc: pGEcontext, dd: pDevDesc)>,
+    pub mode: Option<unsafe extern "C-unwind" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
+    pub newPage: Option<unsafe extern "C-unwind" fn(gc: pGEcontext, dd: pDevDesc)>,
     pub polygon: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -199,7 +208,7 @@ pub struct DevDescVersion13 {
         ),
     >,
     pub polyline: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -208,10 +217,17 @@ pub struct DevDescVersion13 {
         ),
     >,
     pub rect: Option<
-        unsafe extern "C" fn(x0: f64, y0: f64, x1: f64, y1: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub path: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: *mut f64,
             y: *mut f64,
             npoly: std::ffi::c_int,
@@ -222,7 +238,7 @@ pub struct DevDescVersion13 {
         ),
     >,
     pub raster: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             raster: *mut std::ffi::c_uint,
             w: std::ffi::c_int,
             h: std::ffi::c_int,
@@ -236,9 +252,9 @@ pub struct DevDescVersion13 {
             dd: pDevDesc,
         ),
     >,
-    pub cap: Option<unsafe extern "C" fn(dd: pDevDesc) -> SEXP>,
+    pub cap: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> SEXP>,
     pub size: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             left: *mut f64,
             right: *mut f64,
             bottom: *mut f64,
@@ -247,10 +263,14 @@ pub struct DevDescVersion13 {
         ),
     >,
     pub strWidth: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub text: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -260,12 +280,13 @@ pub struct DevDescVersion13 {
             dd: pDevDesc,
         ),
     >,
-    pub onExit: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub getEvent: Option<unsafe extern "C" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
-    pub newFrameConfirm: Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    pub onExit: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub getEvent:
+        Option<unsafe extern "C-unwind" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
+    pub newFrameConfirm: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> Rboolean>,
     pub hasTextUTF8: Rboolean,
     pub textUTF8: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -276,14 +297,19 @@ pub struct DevDescVersion13 {
         ),
     >,
     pub strWidthUTF8: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
     pub useRotatedTextInContour: Rboolean,
     pub eventEnv: SEXP,
-    pub eventHelper: Option<unsafe extern "C" fn(dd: pDevDesc, code: std::ffi::c_int)>,
-    pub holdflush:
-        Option<unsafe extern "C" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int>,
+    pub eventHelper: Option<unsafe extern "C-unwind" fn(dd: pDevDesc, code: std::ffi::c_int)>,
+    pub holdflush: Option<
+        unsafe extern "C-unwind" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int,
+    >,
     pub haveTransparency: std::ffi::c_int,
     pub haveTransparentBg: std::ffi::c_int,
     pub haveRaster: std::ffi::c_int,
@@ -327,17 +353,26 @@ pub struct DevDescVersion14 {
     pub canGenKeybd: Rboolean,
     pub canGenIdle: Rboolean,
     pub gettingEvent: Rboolean,
-    pub activate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub circle: Option<unsafe extern "C" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
-    pub clip: Option<unsafe extern "C" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
-    pub close: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub deactivate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub locator: Option<unsafe extern "C" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
+    pub activate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub circle:
+        Option<unsafe extern "C-unwind" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
+    pub clip: Option<unsafe extern "C-unwind" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
+    pub close: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub deactivate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub locator:
+        Option<unsafe extern "C-unwind" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
     pub line: Option<
-        unsafe extern "C" fn(x1: f64, y1: f64, x2: f64, y2: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x1: f64,
+            y1: f64,
+            x2: f64,
+            y2: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub metricInfo: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             c: std::ffi::c_int,
             gc: pGEcontext,
             ascent: *mut f64,
@@ -346,10 +381,10 @@ pub struct DevDescVersion14 {
             dd: pDevDesc,
         ),
     >,
-    pub mode: Option<unsafe extern "C" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
-    pub newPage: Option<unsafe extern "C" fn(gc: pGEcontext, dd: pDevDesc)>,
+    pub mode: Option<unsafe extern "C-unwind" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
+    pub newPage: Option<unsafe extern "C-unwind" fn(gc: pGEcontext, dd: pDevDesc)>,
     pub polygon: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -358,7 +393,7 @@ pub struct DevDescVersion14 {
         ),
     >,
     pub polyline: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -367,10 +402,17 @@ pub struct DevDescVersion14 {
         ),
     >,
     pub rect: Option<
-        unsafe extern "C" fn(x0: f64, y0: f64, x1: f64, y1: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub path: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: *mut f64,
             y: *mut f64,
             npoly: std::ffi::c_int,
@@ -381,7 +423,7 @@ pub struct DevDescVersion14 {
         ),
     >,
     pub raster: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             raster: *mut std::ffi::c_uint,
             w: std::ffi::c_int,
             h: std::ffi::c_int,
@@ -395,9 +437,9 @@ pub struct DevDescVersion14 {
             dd: pDevDesc,
         ),
     >,
-    pub cap: Option<unsafe extern "C" fn(dd: pDevDesc) -> SEXP>,
+    pub cap: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> SEXP>,
     pub size: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             left: *mut f64,
             right: *mut f64,
             bottom: *mut f64,
@@ -406,10 +448,14 @@ pub struct DevDescVersion14 {
         ),
     >,
     pub strWidth: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub text: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -419,12 +465,13 @@ pub struct DevDescVersion14 {
             dd: pDevDesc,
         ),
     >,
-    pub onExit: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub getEvent: Option<unsafe extern "C" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
-    pub newFrameConfirm: Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    pub onExit: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub getEvent:
+        Option<unsafe extern "C-unwind" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
+    pub newFrameConfirm: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> Rboolean>,
     pub hasTextUTF8: Rboolean,
     pub textUTF8: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -435,25 +482,31 @@ pub struct DevDescVersion14 {
         ),
     >,
     pub strWidthUTF8: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
     pub useRotatedTextInContour: Rboolean,
     pub eventEnv: SEXP,
-    pub eventHelper: Option<unsafe extern "C" fn(dd: pDevDesc, code: std::ffi::c_int)>,
-    pub holdflush:
-        Option<unsafe extern "C" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int>,
+    pub eventHelper: Option<unsafe extern "C-unwind" fn(dd: pDevDesc, code: std::ffi::c_int)>,
+    pub holdflush: Option<
+        unsafe extern "C-unwind" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int,
+    >,
     pub haveTransparency: std::ffi::c_int,
     pub haveTransparentBg: std::ffi::c_int,
     pub haveRaster: std::ffi::c_int,
     pub haveCapture: std::ffi::c_int,
     pub haveLocator: std::ffi::c_int,
-    pub setPattern: Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releasePattern: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub setClipPath: Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releaseClipPath: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub setMask: Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releaseMask: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setPattern: Option<unsafe extern "C-unwind" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releasePattern: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setClipPath:
+        Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseClipPath: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setMask: Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseMask: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
     pub deviceVersion: std::ffi::c_int,
     pub deviceClip: Rboolean,
     pub reserved: [std::ffi::c_char; 64usize],
@@ -494,17 +547,26 @@ pub struct DevDescVersion15 {
     pub canGenKeybd: Rboolean,
     pub canGenIdle: Rboolean,
     pub gettingEvent: Rboolean,
-    pub activate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub circle: Option<unsafe extern "C" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
-    pub clip: Option<unsafe extern "C" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
-    pub close: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub deactivate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub locator: Option<unsafe extern "C" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
+    pub activate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub circle:
+        Option<unsafe extern "C-unwind" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
+    pub clip: Option<unsafe extern "C-unwind" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
+    pub close: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub deactivate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub locator:
+        Option<unsafe extern "C-unwind" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
     pub line: Option<
-        unsafe extern "C" fn(x1: f64, y1: f64, x2: f64, y2: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x1: f64,
+            y1: f64,
+            x2: f64,
+            y2: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub metricInfo: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             c: std::ffi::c_int,
             gc: pGEcontext,
             ascent: *mut f64,
@@ -513,10 +575,10 @@ pub struct DevDescVersion15 {
             dd: pDevDesc,
         ),
     >,
-    pub mode: Option<unsafe extern "C" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
-    pub newPage: Option<unsafe extern "C" fn(gc: pGEcontext, dd: pDevDesc)>,
+    pub mode: Option<unsafe extern "C-unwind" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
+    pub newPage: Option<unsafe extern "C-unwind" fn(gc: pGEcontext, dd: pDevDesc)>,
     pub polygon: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -525,7 +587,7 @@ pub struct DevDescVersion15 {
         ),
     >,
     pub polyline: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -534,10 +596,17 @@ pub struct DevDescVersion15 {
         ),
     >,
     pub rect: Option<
-        unsafe extern "C" fn(x0: f64, y0: f64, x1: f64, y1: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub path: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: *mut f64,
             y: *mut f64,
             npoly: std::ffi::c_int,
@@ -548,7 +617,7 @@ pub struct DevDescVersion15 {
         ),
     >,
     pub raster: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             raster: *mut std::ffi::c_uint,
             w: std::ffi::c_int,
             h: std::ffi::c_int,
@@ -562,9 +631,9 @@ pub struct DevDescVersion15 {
             dd: pDevDesc,
         ),
     >,
-    pub cap: Option<unsafe extern "C" fn(dd: pDevDesc) -> SEXP>,
+    pub cap: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> SEXP>,
     pub size: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             left: *mut f64,
             right: *mut f64,
             bottom: *mut f64,
@@ -573,10 +642,14 @@ pub struct DevDescVersion15 {
         ),
     >,
     pub strWidth: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub text: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -586,12 +659,13 @@ pub struct DevDescVersion15 {
             dd: pDevDesc,
         ),
     >,
-    pub onExit: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub getEvent: Option<unsafe extern "C" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
-    pub newFrameConfirm: Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    pub onExit: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub getEvent:
+        Option<unsafe extern "C-unwind" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
+    pub newFrameConfirm: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> Rboolean>,
     pub hasTextUTF8: Rboolean,
     pub textUTF8: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -602,45 +676,61 @@ pub struct DevDescVersion15 {
         ),
     >,
     pub strWidthUTF8: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
     pub useRotatedTextInContour: Rboolean,
     pub eventEnv: SEXP,
-    pub eventHelper: Option<unsafe extern "C" fn(dd: pDevDesc, code: std::ffi::c_int)>,
-    pub holdflush:
-        Option<unsafe extern "C" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int>,
+    pub eventHelper: Option<unsafe extern "C-unwind" fn(dd: pDevDesc, code: std::ffi::c_int)>,
+    pub holdflush: Option<
+        unsafe extern "C-unwind" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int,
+    >,
     pub haveTransparency: std::ffi::c_int,
     pub haveTransparentBg: std::ffi::c_int,
     pub haveRaster: std::ffi::c_int,
     pub haveCapture: std::ffi::c_int,
     pub haveLocator: std::ffi::c_int,
-    pub setPattern: Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releasePattern: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub setClipPath: Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releaseClipPath: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub setMask: Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releaseMask: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setPattern: Option<unsafe extern "C-unwind" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releasePattern: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setClipPath:
+        Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseClipPath: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setMask: Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseMask: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
     pub deviceVersion: std::ffi::c_int,
     pub deviceClip: Rboolean,
     pub defineGroup: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             source: SEXP,
             op: std::ffi::c_int,
             destination: SEXP,
             dd: pDevDesc,
         ) -> SEXP,
     >,
-    pub useGroup: Option<unsafe extern "C" fn(ref_: SEXP, trans: SEXP, dd: pDevDesc)>,
-    pub releaseGroup: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub stroke: Option<unsafe extern "C" fn(path: SEXP, gc: pGEcontext, dd: pDevDesc)>,
+    pub useGroup: Option<unsafe extern "C-unwind" fn(ref_: SEXP, trans: SEXP, dd: pDevDesc)>,
+    pub releaseGroup: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub stroke: Option<unsafe extern "C-unwind" fn(path: SEXP, gc: pGEcontext, dd: pDevDesc)>,
     pub fill: Option<
-        unsafe extern "C" fn(path: SEXP, rule: std::ffi::c_int, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            path: SEXP,
+            rule: std::ffi::c_int,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub fillStroke: Option<
-        unsafe extern "C" fn(path: SEXP, rule: std::ffi::c_int, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            path: SEXP,
+            rule: std::ffi::c_int,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
-    pub capabilities: Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    pub capabilities: Option<unsafe extern "C-unwind" fn(cap: SEXP) -> SEXP>,
     pub reserved: [std::ffi::c_char; 64usize],
 }
 pub type pDevDescVersion15 = *mut DevDescVersion15;
@@ -679,17 +769,26 @@ pub struct DevDescVersion16 {
     pub canGenKeybd: Rboolean,
     pub canGenIdle: Rboolean,
     pub gettingEvent: Rboolean,
-    pub activate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub circle: Option<unsafe extern "C" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
-    pub clip: Option<unsafe extern "C" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
-    pub close: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub deactivate: Option<unsafe extern "C" fn(arg1: pDevDesc)>,
-    pub locator: Option<unsafe extern "C" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
+    pub activate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub circle:
+        Option<unsafe extern "C-unwind" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
+    pub clip: Option<unsafe extern "C-unwind" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
+    pub close: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub deactivate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub locator:
+        Option<unsafe extern "C-unwind" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
     pub line: Option<
-        unsafe extern "C" fn(x1: f64, y1: f64, x2: f64, y2: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x1: f64,
+            y1: f64,
+            x2: f64,
+            y2: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub metricInfo: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             c: std::ffi::c_int,
             gc: pGEcontext,
             ascent: *mut f64,
@@ -698,10 +797,10 @@ pub struct DevDescVersion16 {
             dd: pDevDesc,
         ),
     >,
-    pub mode: Option<unsafe extern "C" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
-    pub newPage: Option<unsafe extern "C" fn(gc: pGEcontext, dd: pDevDesc)>,
+    pub mode: Option<unsafe extern "C-unwind" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
+    pub newPage: Option<unsafe extern "C-unwind" fn(gc: pGEcontext, dd: pDevDesc)>,
     pub polygon: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -710,7 +809,7 @@ pub struct DevDescVersion16 {
         ),
     >,
     pub polyline: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             x: *mut f64,
             y: *mut f64,
@@ -719,10 +818,17 @@ pub struct DevDescVersion16 {
         ),
     >,
     pub rect: Option<
-        unsafe extern "C" fn(x0: f64, y0: f64, x1: f64, y1: f64, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub path: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: *mut f64,
             y: *mut f64,
             npoly: std::ffi::c_int,
@@ -733,7 +839,7 @@ pub struct DevDescVersion16 {
         ),
     >,
     pub raster: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             raster: *mut std::ffi::c_uint,
             w: std::ffi::c_int,
             h: std::ffi::c_int,
@@ -747,9 +853,9 @@ pub struct DevDescVersion16 {
             dd: pDevDesc,
         ),
     >,
-    pub cap: Option<unsafe extern "C" fn(dd: pDevDesc) -> SEXP>,
+    pub cap: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> SEXP>,
     pub size: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             left: *mut f64,
             right: *mut f64,
             bottom: *mut f64,
@@ -758,10 +864,14 @@ pub struct DevDescVersion16 {
         ),
     >,
     pub strWidth: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub text: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -771,12 +881,13 @@ pub struct DevDescVersion16 {
             dd: pDevDesc,
         ),
     >,
-    pub onExit: Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    pub getEvent: Option<unsafe extern "C" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
-    pub newFrameConfirm: Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    pub onExit: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub getEvent:
+        Option<unsafe extern "C-unwind" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
+    pub newFrameConfirm: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> Rboolean>,
     pub hasTextUTF8: Rboolean,
     pub textUTF8: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             x: f64,
             y: f64,
             str: *const std::ffi::c_char,
@@ -787,47 +898,63 @@ pub struct DevDescVersion16 {
         ),
     >,
     pub strWidthUTF8: Option<
-        unsafe extern "C" fn(str: *const std::ffi::c_char, gc: pGEcontext, dd: pDevDesc) -> f64,
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
     pub useRotatedTextInContour: Rboolean,
     pub eventEnv: SEXP,
-    pub eventHelper: Option<unsafe extern "C" fn(dd: pDevDesc, code: std::ffi::c_int)>,
-    pub holdflush:
-        Option<unsafe extern "C" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int>,
+    pub eventHelper: Option<unsafe extern "C-unwind" fn(dd: pDevDesc, code: std::ffi::c_int)>,
+    pub holdflush: Option<
+        unsafe extern "C-unwind" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int,
+    >,
     pub haveTransparency: std::ffi::c_int,
     pub haveTransparentBg: std::ffi::c_int,
     pub haveRaster: std::ffi::c_int,
     pub haveCapture: std::ffi::c_int,
     pub haveLocator: std::ffi::c_int,
-    pub setPattern: Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releasePattern: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub setClipPath: Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releaseClipPath: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub setMask: Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
-    pub releaseMask: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setPattern: Option<unsafe extern "C-unwind" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releasePattern: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setClipPath:
+        Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseClipPath: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setMask: Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseMask: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
     pub deviceVersion: std::ffi::c_int,
     pub deviceClip: Rboolean,
     pub defineGroup: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             source: SEXP,
             op: std::ffi::c_int,
             destination: SEXP,
             dd: pDevDesc,
         ) -> SEXP,
     >,
-    pub useGroup: Option<unsafe extern "C" fn(ref_: SEXP, trans: SEXP, dd: pDevDesc)>,
-    pub releaseGroup: Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    pub stroke: Option<unsafe extern "C" fn(path: SEXP, gc: pGEcontext, dd: pDevDesc)>,
+    pub useGroup: Option<unsafe extern "C-unwind" fn(ref_: SEXP, trans: SEXP, dd: pDevDesc)>,
+    pub releaseGroup: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub stroke: Option<unsafe extern "C-unwind" fn(path: SEXP, gc: pGEcontext, dd: pDevDesc)>,
     pub fill: Option<
-        unsafe extern "C" fn(path: SEXP, rule: std::ffi::c_int, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            path: SEXP,
+            rule: std::ffi::c_int,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
     pub fillStroke: Option<
-        unsafe extern "C" fn(path: SEXP, rule: std::ffi::c_int, gc: pGEcontext, dd: pDevDesc),
+        unsafe extern "C-unwind" fn(
+            path: SEXP,
+            rule: std::ffi::c_int,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
     >,
-    pub capabilities: Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    pub capabilities: Option<unsafe extern "C-unwind" fn(cap: SEXP) -> SEXP>,
     pub glyph: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             n: std::ffi::c_int,
             glyphs: *mut std::ffi::c_int,
             x: *mut f64,

--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -694,16 +694,16 @@ mutable_globals::generate! {
     pub static mut R_wait_usec: i32;
 
     #[cfg(target_family = "unix")]
-    pub static mut R_PolledEvents: Option<unsafe extern "C" fn()>;
+    pub static mut R_PolledEvents: Option<unsafe extern "C-unwind" fn()>;
 
     #[cfg(target_family = "unix")]
     pub static mut ptr_R_WriteConsole: Option<
-        unsafe extern "C" fn(arg1: *const std::ffi::c_char, arg2: std::ffi::c_int),
+        unsafe extern "C-unwind" fn(arg1: *const std::ffi::c_char, arg2: std::ffi::c_int),
     >;
 
     #[cfg(target_family = "unix")]
     pub static mut ptr_R_WriteConsoleEx: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: *const std::ffi::c_char,
             arg2: std::ffi::c_int,
             arg3: std::ffi::c_int,
@@ -721,13 +721,13 @@ mutable_globals::generate! {
     >;
 
     #[cfg(target_family = "unix")]
-    pub static mut ptr_R_ShowMessage: Option<unsafe extern "C" fn(arg1: *const std::ffi::c_char)>;
+    pub static mut ptr_R_ShowMessage: Option<unsafe extern "C-unwind" fn(arg1: *const std::ffi::c_char)>;
 
     #[cfg(target_family = "unix")]
-    pub static mut ptr_R_Busy: Option<unsafe extern "C" fn(arg1: std::ffi::c_int)>;
+    pub static mut ptr_R_Busy: Option<unsafe extern "C-unwind" fn(arg1: std::ffi::c_int)>;
 
     #[cfg(target_family = "unix")]
-    pub static mut ptr_R_Suicide: Option<unsafe extern "C" fn(arg1: *const std::ffi::c_char)>;
+    pub static mut ptr_R_Suicide: Option<unsafe extern "C-unwind" fn(arg1: *const std::ffi::c_char)>;
 
     // -----------------------------------------------------------------------------------
     // Windows

--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -83,14 +83,14 @@ functions::generate! {
     pub fn R_RunPendingFinalizers();
 
     pub fn R_ToplevelExec(
-        fun: Option<unsafe extern "C" fn(arg1: *mut std::ffi::c_void)>,
+        fun: Option<unsafe extern "C-unwind" fn(arg1: *mut std::ffi::c_void)>,
         data: *mut std::ffi::c_void
     ) -> Rboolean;
 
     pub fn R_withCallingErrorHandler(
-        body: Option<unsafe extern "C" fn(args: *mut std::ffi::c_void) -> SEXP>,
+        body: Option<unsafe extern "C-unwind" fn(args: *mut std::ffi::c_void) -> SEXP>,
         bdata: *mut std::ffi::c_void,
-        handler: Option<unsafe extern "C" fn(err: SEXP, args: *mut std::ffi::c_void) -> SEXP>,
+        handler: Option<unsafe extern "C-unwind" fn(err: SEXP, args: *mut std::ffi::c_void) -> SEXP>,
         hdata: *mut std::ffi::c_void
     ) -> SEXP;
 

--- a/crates/libr/src/r.rs
+++ b/crates/libr/src/r.rs
@@ -712,7 +712,7 @@ mutable_globals::generate! {
 
     #[cfg(target_family = "unix")]
     pub static mut ptr_R_ReadConsole: Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: *const std::ffi::c_char,
             arg2: *mut std::ffi::c_uchar,
             arg3: std::ffi::c_int,

--- a/crates/libr/src/sys/windows/types.rs
+++ b/crates/libr/src/sys/windows/types.rs
@@ -147,7 +147,7 @@ pub struct structRstart {
     #[doc = "HOME"]
     pub home: *mut ::std::os::raw::c_char,
     pub ReadConsole: ::std::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: *const ::std::os::raw::c_char,
             arg2: *mut ::std::os::raw::c_uchar,
             arg3: ::std::os::raw::c_int,

--- a/crates/libr/src/sys/windows/types.rs
+++ b/crates/libr/src/sys/windows/types.rs
@@ -155,21 +155,24 @@ pub struct structRstart {
         ) -> ::std::os::raw::c_int,
     >,
     pub WriteConsole: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *const ::std::os::raw::c_char, arg2: ::std::os::raw::c_int),
+        unsafe extern "C-unwind" fn(
+            arg1: *const ::std::os::raw::c_char,
+            arg2: ::std::os::raw::c_int,
+        ),
     >,
     #[doc = "ProcessEvents under Unix"]
-    pub CallBack: ::std::option::Option<unsafe extern "C" fn()>,
+    pub CallBack: ::std::option::Option<unsafe extern "C-unwind" fn()>,
     pub ShowMessage:
-        ::std::option::Option<unsafe extern "C" fn(arg1: *const ::std::os::raw::c_char)>,
+        ::std::option::Option<unsafe extern "C-unwind" fn(arg1: *const ::std::os::raw::c_char)>,
     pub YesNoCancel: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int,
+        unsafe extern "C-unwind" fn(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int,
     >,
     #[doc = "Return value here is expected to be 1 for Yes, -1 for No and\n0 for Cancel: symbolic constants in graphapp.h"]
-    pub Busy: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
+    pub Busy: ::std::option::Option<unsafe extern "C-unwind" fn(arg1: ::std::os::raw::c_int)>,
     pub CharacterMode: UImode,
     #[doc = "The following field has been added in R 2.5.0"]
     pub WriteConsoleEx: ::std::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: *const ::std::os::raw::c_char,
             arg2: ::std::os::raw::c_int,
             arg3: ::std::os::raw::c_int,
@@ -179,16 +182,17 @@ pub struct structRstart {
     pub EmitEmbeddedUTF8: Rboolean,
     #[doc = "The following fields have been added in R 4.2.0 and are only\navailable with RstarVersion 1."]
     pub CleanUp: ::std::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: SA_TYPE,
             arg2: ::std::os::raw::c_int,
             arg3: ::std::os::raw::c_int,
         ),
     >,
-    pub ClearerrConsole: ::std::option::Option<unsafe extern "C" fn()>,
-    pub FlushConsole: ::std::option::Option<unsafe extern "C" fn()>,
-    pub ResetConsole: ::std::option::Option<unsafe extern "C" fn()>,
-    pub Suicide: ::std::option::Option<unsafe extern "C" fn(s: *const ::std::os::raw::c_char)>,
+    pub ClearerrConsole: ::std::option::Option<unsafe extern "C-unwind" fn()>,
+    pub FlushConsole: ::std::option::Option<unsafe extern "C-unwind" fn()>,
+    pub ResetConsole: ::std::option::Option<unsafe extern "C-unwind" fn()>,
+    pub Suicide:
+        ::std::option::Option<unsafe extern "C-unwind" fn(s: *const ::std::os::raw::c_char)>,
 }
 impl structRstart {
     #[inline]

--- a/crates/libr/src/types.rs
+++ b/crates/libr/src/types.rs
@@ -81,7 +81,7 @@ pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
 
-pub type DL_FUNC = Option<unsafe extern "C" fn() -> *mut std::ffi::c_void>;
+pub type DL_FUNC = Option<unsafe extern "C-unwind" fn() -> *mut std::ffi::c_void>;
 pub type R_NativePrimitiveArgType = std::ffi::c_uint;
 
 #[repr(C)]


### PR DESCRIPTION
Closes #678 
Reverts #683 

Joint work with @lionel- 

---

Consider the following

```rust
top_level_exec(|| {
     let msg = CString::new("ouch").unwrap();
     unsafe { Rf_error(msg.as_ptr()) };
})?;
```

This effectively gets called as something similar to this (but I'm oversimplifying a bit):

```rust
extern "C" fn callback(_args: *mut c_void)
{
     let msg = CString::new("ouch").unwrap();
     unsafe { Rf_error(msg.as_ptr()) };
}

unsafe { R_ToplevelExec(Some(callback), std::ptr::null_mut()) };
```

We can also write this in terms of frames

```
[ C: longjmp inside Rf_error ] --------------->
   |                                          |
[ Rust: Rf_error inside callback ]            | Jump over this middle `callback` frame
   |                                          |
[ C: callback inside R_ToplevelExec ]  <------|
   |
[ Rust: R_ToplevelExec inside top_level_exec ]
```

In other words, when a `Rf_error()` causes a `longjmp`, we are forced to jump over the rest of the Rust `callback()` frame. This is _undefined behavior_, even though we immediately catch that longjmp in `R_ToplevelExec()` in the next C frame. The fact that we have jumped over the rest of the Rust `callback()` is simplify undefined behavior, full stop.

The exact result of this undefined behavior seems to be platform dependent. It seems to mostly still work on Unix, as seen by our Mac and Linux builds still working. But on Windows it crashes ark hard with Rust 1.84, and we think it is due to this new `extern "C"` feature where `Drop` methods try to run now https://github.com/rust-lang/rust/pull/129582. In the above example, we think the `Drop` method for `msg` is expected to run, but we've longjmped past `callback()` so it can't properly run, and this blows something up.

---

The best description of this is this table:
https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html#abi-boundaries-and-unforced-unwinding.

<img width="827" alt="Screenshot 2025-02-24 at 10 59 26 AM" src="https://github.com/user-attachments/assets/da5f0ea7-4b6d-4e72-ae53-b6dcfdf665cf" />

We are currently in the combination of `panic=unwind`, `"C"-like`, causing `Unforced foreign unwind` to result in `UB`.

The goal of this PR is to move us to `"C-unwind"`, causing `Unforced foreign unwind` to result in `unwind`. This was introduced in Rust 1.71 https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html#c-unwind-abi

---

With `"C-unwind`, we still end up jumping over the rest of `callback()`, but Rust now expects that this is possible, so I'm guessing it allows for this internally. So now `msg` is simply "leaked" because its `Drop` method doesn't run (This `Drop` behavior is also platform dependent, notably the `Drop` does seem to still run on Windows, but not on Unix). Before this PR we knew it would be leaked, but now we think we have made the leak "defined behavior" to Rust.

So the moral of the story here is to still be extremely careful with the closure supplied to `try_catch()` and `top_level_exec()`. If the closure longjmps, then you cannot expect any destructors to run, so the closures should only create PODs if possible. But we now believe that jumping over the small `callback()` frame is now well defined.