### PR TITLE
WIP: Perform a two way handshake around `kernel_info_request`

### DIFF
--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -54,6 +54,7 @@ pub struct Shell {
     stdin_request_tx: Sender<StdInRequest>,
     kernel_request_tx: Sender<KernelRequest>,
     kernel_init_rx: BusReader<KernelInfo>,
+    kernel_info_request_tx: Sender<()>,
     kernel_info: Option<KernelInfo>,
 }
 
@@ -69,6 +70,7 @@ impl Shell {
         r_request_tx: Sender<RRequest>,
         stdin_request_tx: Sender<StdInRequest>,
         kernel_init_rx: BusReader<KernelInfo>,
+        kernel_info_request_tx: Sender<()>,
         kernel_request_tx: Sender<KernelRequest>,
     ) -> Self {
         Self {
@@ -77,6 +79,7 @@ impl Shell {
             stdin_request_tx,
             kernel_request_tx,
             kernel_init_rx,
+            kernel_info_request_tx,
             kernel_info: None,
         }
     }
@@ -120,6 +123,8 @@ impl ShellHandler for Shell {
         if self.kernel_info.is_none() {
             trace!("Got kernel info request; waiting for R to complete initialization");
             self.kernel_info = Some(self.kernel_init_rx.recv().unwrap());
+            trace!("R completed initialization; sending back kernel info request confirmation");
+            self.kernel_info_request_tx.send(()).unwrap();
         } else {
             trace!("R already started, using existing kernel information")
         }

--- a/crates/ark/src/start.rs
+++ b/crates/ark/src/start.rs
@@ -48,6 +48,7 @@ pub fn start_kernel(
     // A broadcast channel (bus) used to notify clients when the kernel
     // has finished initialization.
     let mut kernel_init_tx = Bus::new(1);
+    let (kernel_info_request_tx, kernel_info_request_rx) = bounded::<()>(1);
 
     // A channel pair used for kernel requests.
     // These events are used to manage the runtime state, and also to
@@ -75,6 +76,7 @@ pub fn start_kernel(
         r_request_tx.clone(),
         stdin_request_tx.clone(),
         kernel_init_rx,
+        kernel_info_request_tx,
         kernel_request_tx,
     ));
 
@@ -121,6 +123,7 @@ pub fn start_kernel(
         stdin_reply_rx,
         iopub_tx,
         kernel_init_tx,
+        kernel_info_request_rx,
         kernel_request_rx,
         dap,
         session_mode,


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6344 particularly by looking closely at the message order in https://github.com/posit-dev/positron/issues/6344#issuecomment-2675438161

This addresses the fact that we could run `.Rprofile` before receiving an IOPub subscription message from Kallichore. In this case both sides of the socket have technically connected, but the Kallichore side hasn't yet sent over its IOPub subscription message, so Ark's IOPub socket ends up _dropping_ messages on the way out because no one is subscribed yet.

We already block responding to a `kernel_info_request` until R is "started up enough". What I've added is a two-way handshake where we also block the final steps of R's startup procedure (running `.Rprofile` and then entering the main repl) until we've actually received the `kernel_info_request` at all. This has the side effect of being late enough that by this point we've received the IOPub subscription message. It is a little hand wavy though because  `kernel_info_request` comes in on Shell and technically we should be waiting to hear something on IOPub (maybe we can block until we get the IOPub subscription instead?).

I've still got a good amount of thinking and clean up to do here, but...


https://github.com/user-attachments/assets/f6812522-f986-409b-a5fd-9d3c79dab962

