### PR TITLE
Improve bindings comparisons for the variables pane

### DIFF
--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -409,7 +409,7 @@ impl RVariables {
 
                     (Some(old), Some(new)) => {
                         if old.name == new.name {
-                            if old.value != new.value {
+                            if old.value.id() != new.value.id() {
                                 assigned.push(PositronVariable::new(&new).var());
                             }
                             old_next = old_iter.next();


### PR DESCRIPTION
This PR addresses: https://github.com/posit-dev/positron/issues/6618

The main issue is that when comparing two S4 connections objects (that include environments as attributes) we're using all the derived methods and ultimately resolving to `impl PartialEq for BindingNestedEnvironment` which always says `false` if objects have nested environments.

However, the variables pane is not trying to compare by value, but only for identity. 
This PR removes the `has_nested_environment` attribute that doesn't seem to be used anywhere and proposes that equality of Bindings are:

1. Their symbols are identical
2. Their values are identical (ie, they are pointing to the same `SEXP`)

We might want to use a different naming for this compariso, instead of overloading `eq`, let me know what you think.