### PR TITLE
Only force ALTREP compact row names (i.e. from duckplyr) if requested

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -570,7 +570,7 @@ impl RDataExplorer {
             };
 
             // `df_n_row()` will materialize duckplyr compact row names, but we are ok
-            // with that for the data explorer
+            // with that for the data explorer and don't provide a hook to opt out.
             let (n_row, n_col, column_names) = match kind {
                 TableKind::Dataframe => (
                     harp::df_n_row(table_sexp)?,

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -577,7 +577,7 @@ impl RDataExplorer {
                     ColumnNames::from_data_frame(table.sexp)?,
                 ),
                 TableKind::Matrix => {
-                    let (n_row, n_col) = harp::mat_dim(table.sexp)?;
+                    let (n_row, n_col) = harp::Matrix::dim(table.sexp)?;
                     (n_row, n_col, ColumnNames::from_matrix(table.sexp)?)
                 },
             };

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -563,9 +563,8 @@ impl RDataExplorer {
     fn r_get_shape(table: RObject) -> anyhow::Result<DataObjectShape> {
         unsafe {
             let table = table.clone();
-            let table_sexp = table.sexp;
 
-            let Some(kind) = table_kind(table_sexp) else {
+            let Some(kind) = table_kind(table.sexp) else {
                 return Err(anyhow!("Unsupported type for the data viewer"));
             };
 
@@ -573,13 +572,13 @@ impl RDataExplorer {
             // with that for the data explorer and don't provide a hook to opt out.
             let (n_row, n_col, column_names) = match kind {
                 TableKind::Dataframe => (
-                    harp::df_n_row(table_sexp)?,
-                    harp::df_n_col(table_sexp)?,
-                    ColumnNames::from_data_frame(table_sexp)?,
+                    harp::df_n_row(table.sexp)?,
+                    harp::df_n_col(table.sexp)?,
+                    ColumnNames::from_data_frame(table.sexp)?,
                 ),
                 TableKind::Matrix => {
-                    let (n_row, n_col) = harp::mat_dim(table_sexp)?;
-                    (n_row, n_col, ColumnNames::from_matrix(table_sexp)?)
+                    let (n_row, n_col) = harp::mat_dim(table.sexp)?;
+                    (n_row, n_col, ColumnNames::from_matrix(table.sexp)?)
                 },
             };
 
@@ -593,8 +592,8 @@ impl RDataExplorer {
                 // TODO: handling for nested data frame columns
 
                 let col = match kind {
-                    harp::TableKind::Dataframe => VECTOR_ELT(table_sexp, i),
-                    harp::TableKind::Matrix => table_sexp,
+                    harp::TableKind::Dataframe => VECTOR_ELT(table.sexp, i),
+                    harp::TableKind::Matrix => table.sexp,
                 };
 
                 let type_name = WorkspaceVariableDisplayType::from(col, false).display_type;

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -568,12 +568,12 @@ impl RDataExplorer {
                 return Err(anyhow!("Unsupported type for the data viewer"));
             };
 
-            // `df_n_row()` will materialize duckplyr compact row names, but we are ok
-            // with that for the data explorer and don't provide a hook to opt out.
+            // `DataFrame::n_row()` will materialize duckplyr compact row names, but we
+            // are ok with that for the data explorer and don't provide a hook to opt out.
             let (n_row, n_col, column_names) = match kind {
                 TableKind::Dataframe => (
-                    harp::df_n_row(table.sexp)?,
-                    harp::df_n_col(table.sexp)?,
+                    harp::DataFrame::n_row(table.sexp)?,
+                    harp::DataFrame::n_col(table.sexp)?,
                     ColumnNames::from_data_frame(table.sexp)?,
                 ),
                 TableKind::Matrix => {

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -62,8 +62,9 @@ use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::object::RObject;
 use harp::r_symbol;
+use harp::table_kind;
 use harp::tbl_get_column;
-use harp::TableInfo;
+use harp::ColumnNames;
 use harp::TableKind;
 use itertools::Itertools;
 use libr::*;
@@ -562,22 +563,28 @@ impl RDataExplorer {
     fn r_get_shape(table: RObject) -> anyhow::Result<DataObjectShape> {
         unsafe {
             let table = table.clone();
-            let object = *table;
+            let table_sexp = table.sexp;
 
-            let info = table_info_or_bail(object)?;
+            let Some(kind) = table_kind(table_sexp) else {
+                return Err(anyhow!("Unsupported type for the data viewer"));
+            };
 
-            let harp::TableInfo {
-                kind,
-                dims:
-                    harp::TableDim {
-                        num_rows,
-                        num_cols: total_num_columns,
-                    },
-                col_names: column_names,
-            } = info;
+            // `df_n_row()` will materialize duckplyr compact row names, but we are ok
+            // with that for the data explorer
+            let (n_row, n_col, column_names) = match kind {
+                TableKind::Dataframe => (
+                    harp::df_n_row(table_sexp)?,
+                    harp::df_n_col(table_sexp)?,
+                    ColumnNames::from_data_frame(table_sexp)?,
+                ),
+                TableKind::Matrix => {
+                    let (n_row, n_col) = harp::mat_dim(table_sexp)?;
+                    (n_row, n_col, ColumnNames::from_matrix(table_sexp)?)
+                },
+            };
 
             let mut column_schemas = Vec::<ColumnSchema>::new();
-            for i in 0..(total_num_columns as isize) {
+            for i in 0..(n_col as isize) {
                 let column_name = match column_names.get_unchecked(i) {
                     Some(name) => name,
                     None => String::from(""),
@@ -586,8 +593,8 @@ impl RDataExplorer {
                 // TODO: handling for nested data frame columns
 
                 let col = match kind {
-                    harp::TableKind::Dataframe => VECTOR_ELT(object, i),
-                    harp::TableKind::Matrix => object,
+                    harp::TableKind::Dataframe => VECTOR_ELT(table_sexp, i),
+                    harp::TableKind::Matrix => table_sexp,
                 };
 
                 let type_name = WorkspaceVariableDisplayType::from(col, false).display_type;
@@ -610,7 +617,7 @@ impl RDataExplorer {
             Ok(DataObjectShape {
                 columns: column_schemas,
                 kind,
-                num_rows,
+                num_rows: n_row,
             })
         }
     }
@@ -1071,10 +1078,6 @@ impl RDataExplorer {
             )
         })
     }
-}
-
-fn table_info_or_bail(x: SEXP) -> anyhow::Result<TableInfo> {
-    harp::table_info(x).ok_or(anyhow!("Unsupported type for data viewer"))
 }
 
 /// Open an R object in the data viewer.

--- a/crates/ark/src/modules/positron/methods.R
+++ b/crates/ark/src/modules/positron/methods.R
@@ -24,7 +24,7 @@ ark_methods_table$ark_positron_variable_get_children <- new.env(
 )
 lockEnvironment(ark_methods_table, TRUE)
 
-ark_methods_allowed_packages <- c("torch", "reticulate")
+ark_methods_allowed_packages <- c("torch", "reticulate", "duckplyr")
 
 # check if the calling package is allowed to touch the methods table
 check_caller_allowed <- function() {
@@ -77,7 +77,9 @@ check_register_args <- function(generic, class) {
     check_register_args(generic, class)
 
     for (cls in class) {
-        if (exists(cls, envir = ark_methods_table[[generic]], inherits = FALSE)) {
+        if (
+            exists(cls, envir = ark_methods_table[[generic]], inherits = FALSE)
+        ) {
             remove(list = cls, envir = ark_methods_table[[generic]])
         }
     }

--- a/crates/ark/src/srcref.rs
+++ b/crates/ark/src/srcref.rs
@@ -139,7 +139,7 @@ fn generate_source(
     }
 
     // Ignore functions that already have sources
-    if let Some(_) = old.attr("srcref") {
+    if let Some(_) = old.get_attribute("srcref") {
         return Ok(None);
     }
 

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -730,6 +730,9 @@ impl PositronVariable {
 
     fn variable_length(x: SEXP) -> usize {
         // Check for tabular data
+        // We don't currently provide an ark hook for variable length, so we are somewhat
+        // careful to only query n-col and never n-row for data frames, to avoid duckplyr
+        // query materialization.
         if let Some(kind) = harp::table_kind(x) {
             return match kind {
                 TableKind::Dataframe => match harp::df_n_col(x) {

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -300,7 +300,7 @@ impl WorkspaceVariableDisplayValue {
     }
 
     fn from_matrix(value: SEXP) -> anyhow::Result<Self> {
-        let (n_row, n_col) = harp::mat_dim(value)?;
+        let (n_row, n_col) = harp::Matrix::dim(value)?;
 
         let class = match r_classes(value) {
             None => String::from(" <matrix>"),
@@ -742,7 +742,7 @@ impl PositronVariable {
                         0
                     },
                 },
-                TableKind::Matrix => match harp::mat_dim(x) {
+                TableKind::Matrix => match harp::Matrix::dim(x) {
                     Ok((_n_row, n_col)) => n_col as usize,
                     Err(error) => {
                         log::error!("Can't compute matrix dimensions: {error}");
@@ -1218,7 +1218,7 @@ impl PositronVariable {
 
     fn inspect_matrix(matrix: SEXP) -> anyhow::Result<Vec<Variable>> {
         let matrix = RObject::new(matrix);
-        let (_n_row, n_col) = harp::mat_dim(matrix.sexp)?;
+        let (_n_row, n_col) = harp::Matrix::dim(matrix.sexp)?;
 
         let make_variable = |access_key, display_name, display_value, is_truncated| Variable {
             access_key,

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -25,7 +25,6 @@ use harp::object::RObject;
 use harp::r_null;
 use harp::r_symbol;
 use harp::symbol::RSymbol;
-use harp::table_info;
 use harp::utils::pairlist_size;
 use harp::utils::r_altrep_class;
 use harp::utils::r_assert_type;
@@ -51,7 +50,7 @@ use harp::vector::CharacterVector;
 use harp::vector::IntegerVector;
 use harp::vector::Vector;
 use harp::List;
-use harp::TableDim;
+use harp::TableKind;
 use itertools::Itertools;
 use libr::*;
 use stdext::local;
@@ -90,7 +89,7 @@ impl WorkspaceVariableDisplayValue {
 
         let out = match r_typeof(value) {
             NILSXP => Self::new(String::from("NULL"), false),
-            VECSXP if r_inherits(value, "data.frame") => Self::from_data_frame(value),
+            VECSXP if r_is_data_frame(value) => Self::from_data_frame(value)?,
             VECSXP if !r_inherits(value, "POSIXlt") => Self::from_list(value),
             LISTSXP => Self::empty(),
             SYMSXP if value == unsafe { R_MissingArg } => {
@@ -157,15 +156,16 @@ impl WorkspaceVariableDisplayValue {
         Ok(Self::new(display_value, truncated))
     }
 
-    fn from_data_frame(value: SEXP) -> Self {
-        let dim = match unsafe { harp::df_dim(value) } {
-            Ok(dim) => dim,
-            // FIXME: Needs more type safety
-            Err(_) => TableDim {
-                num_rows: -1,
-                num_cols: -1,
-            },
+    fn from_data_frame(value: SEXP) -> anyhow::Result<Self> {
+        // Avoid materializing ALTREP compact row names (duckplyr)
+        let n_row = harp::df_n_row_if_possible(value)?;
+        let (n_row, row_word) = match n_row {
+            Some(n_row) => (n_row.to_string(), plural("row", n_row)),
+            None => (String::from("?"), String::from("rows")),
         };
+
+        let n_col = harp::df_n_col(value)?;
+        let (n_col, col_word) = (n_col.to_string(), plural("column", n_col));
 
         let class = match r_classes(value) {
             None => String::from(""),
@@ -175,15 +175,9 @@ impl WorkspaceVariableDisplayValue {
             },
         };
 
-        let value = format!(
-            "[{} {} x {} {}]{}",
-            dim.num_rows,
-            plural("row", dim.num_rows),
-            dim.num_cols,
-            plural("column", dim.num_cols),
-            class
-        );
-        Self::new(value, false)
+        let value = format!("[{n_row} {row_word} x {n_col} {col_word}]{class}");
+
+        Ok(Self::new(value, false))
     }
 
     fn from_list(value: SEXP) -> Self {
@@ -305,13 +299,7 @@ impl WorkspaceVariableDisplayValue {
     }
 
     fn from_matrix(value: SEXP) -> anyhow::Result<Self> {
-        let (n_row, n_col) = match harp::table_info(value) {
-            Some(info) => (info.dims.num_rows, info.dims.num_cols),
-            None => {
-                log::error!("Failed to get matrix dimensions");
-                (-1, -1)
-            },
-        };
+        let (n_row, n_col) = harp::mat_dim(value)?;
 
         let class = match r_classes(value) {
             None => String::from(" <matrix>"),
@@ -496,13 +484,25 @@ impl WorkspaceVariableDisplayType {
                     let dfclass = classes.get_unchecked(0).unwrap();
                     match include_length {
                         true => {
-                            let dim = table_info(value);
-                            let shape = match dim {
-                                Some(info) => {
-                                    format!("{}, {}", info.dims.num_rows, info.dims.num_cols)
+                            // Avoid materializing ALTREP compact row names (duckplyr)
+                            let n_row = match harp::df_n_row_if_possible(value) {
+                                Ok(n_row) => match n_row {
+                                    Some(n_row) => n_row.to_string(),
+                                    None => String::from("?"),
                                 },
-                                None => String::from("?, ?"),
+                                Err(error) => {
+                                    log::error!("Can't compute number of rows: {error}");
+                                    String::from("?")
+                                },
                             };
+                            let n_col = match harp::df_n_col(value) {
+                                Ok(n_col) => n_col.to_string(),
+                                Err(error) => {
+                                    log::error!("Can't compute number of columns: {error}");
+                                    String::from("?")
+                                },
+                            };
+                            let shape = format!("{n_row}, {n_col}");
                             let display_type = format!("{} [{}]", dfclass, shape);
                             Self::simple(display_type)
                         },
@@ -731,8 +731,23 @@ impl PositronVariable {
 
     fn variable_length(x: SEXP) -> usize {
         // Check for tabular data
-        if let Some(info) = harp::table_info(x) {
-            return info.dims.num_cols as usize;
+        if let Some(kind) = harp::table_kind(x) {
+            return match kind {
+                TableKind::Dataframe => match harp::df_n_col(x) {
+                    Ok(n_col) => n_col as usize,
+                    Err(error) => {
+                        log::error!("Can't compute number of data frame columns: {error}");
+                        0
+                    },
+                },
+                TableKind::Matrix => match harp::mat_dim(x) {
+                    Ok((_n_row, n_col)) => n_col as usize,
+                    Err(error) => {
+                        log::error!("Can't compute matrix dimensions: {error}");
+                        0
+                    },
+                },
+            };
         }
 
         // Otherwise treat as vector
@@ -1201,14 +1216,7 @@ impl PositronVariable {
 
     fn inspect_matrix(matrix: SEXP) -> anyhow::Result<Vec<Variable>> {
         let matrix = RObject::new(matrix);
-
-        let n_col = match harp::table_info(matrix.sexp) {
-            Some(info) => info.dims.num_cols,
-            None => {
-                log::warn!("Unexpected matrix object. Couldn't get dimensions.");
-                return Ok(vec![]);
-            },
-        };
+        let (_n_row, n_col) = harp::mat_dim(matrix.sexp)?;
 
         let make_variable = |access_key, display_name, display_value, is_truncated| Variable {
             access_key,

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -159,8 +159,8 @@ impl WorkspaceVariableDisplayValue {
     fn from_data_frame(value: SEXP) -> anyhow::Result<Self> {
         // Classes should provide an `ark_positron_variable_display_value()` method
         // if they need to opt out of ALTREP materialization here.
-        let n_row = harp::df_n_row(value)?;
-        let n_col = harp::df_n_col(value)?;
+        let n_row = harp::DataFrame::n_row(value)?;
+        let n_col = harp::DataFrame::n_col(value)?;
 
         let row_word = plural("row", n_row);
         let col_word = plural("column", n_col);
@@ -487,14 +487,14 @@ impl WorkspaceVariableDisplayType {
                         true => {
                             // Classes should provide an `ark_positron_variable_display_type()` method
                             // if they need to opt out of ALTREP materialization here.
-                            let n_row: String = match harp::df_n_row(value) {
+                            let n_row: String = match harp::DataFrame::n_row(value) {
                                 Ok(n_row) => n_row.to_string(),
                                 Err(error) => {
                                     log::error!("Can't compute number of rows: {error}");
                                     String::from("?")
                                 },
                             };
-                            let n_col = match harp::df_n_col(value) {
+                            let n_col = match harp::DataFrame::n_col(value) {
                                 Ok(n_col) => n_col.to_string(),
                                 Err(error) => {
                                     log::error!("Can't compute number of columns: {error}");
@@ -735,7 +735,7 @@ impl PositronVariable {
         // query materialization.
         if let Some(kind) = harp::table_kind(x) {
             return match kind {
-                TableKind::Dataframe => match harp::df_n_col(x) {
+                TableKind::Dataframe => match harp::DataFrame::n_col(x) {
                     Ok(n_col) => n_col as usize,
                     Err(error) => {
                         log::error!("Can't compute number of data frame columns: {error}");

--- a/crates/harp/src/attrib.rs
+++ b/crates/harp/src/attrib.rs
@@ -20,7 +20,7 @@ fn zap_srcref_fn(x: SEXP) -> RObject {
     unsafe {
         let x = RObject::view(x).shallow_duplicate();
 
-        x.set_attr("srcref", r_null());
+        x.set_attribute("srcref", r_null());
         libr::SET_BODY(x.sexp, zap_srcref(libr::R_ClosureExpr(x.sexp)).sexp);
 
         x
@@ -64,7 +64,7 @@ fn zap_srcref_expr(x: SEXP) -> RObject {
 
 fn zap_srcref_attrib(x: SEXP) {
     let x = RObject::view(x);
-    x.set_attr("srcfile", r_null());
-    x.set_attr("srcref", r_null());
-    x.set_attr("wholeSrcref", r_null());
+    x.set_attribute("srcfile", r_null());
+    x.set_attribute("srcref", r_null());
+    x.set_attribute("wholeSrcref", r_null());
 }

--- a/crates/harp/src/column_names.rs
+++ b/crates/harp/src/column_names.rs
@@ -1,0 +1,55 @@
+use libr::*;
+
+use crate::exec::RFunction;
+use crate::exec::RFunctionExt;
+use crate::utils::*;
+use crate::vector::Vector;
+use crate::CharacterVector;
+
+/// Column names
+///
+/// Column names represent an optional character vector of names. This class is mostly
+/// useful for ergonomics, since [ColumnNames::get_unchecked()] will propagate [None]
+/// when used on a vector without column names.
+pub struct ColumnNames {
+    names: Option<CharacterVector>,
+}
+
+impl ColumnNames {
+    pub fn new(names: SEXP) -> Self {
+        unsafe {
+            let names = if r_typeof(names) == STRSXP {
+                Some(CharacterVector::new_unchecked(names))
+            } else {
+                None
+            };
+            Self { names }
+        }
+    }
+
+    pub fn from_data_frame(x: SEXP) -> crate::Result<Self> {
+        if !r_is_data_frame(x) {
+            return Err(crate::anyhow!("`x` must be a data frame."));
+        }
+        Ok(Self::new(r_names(x)))
+    }
+
+    pub fn from_matrix(x: SEXP) -> crate::Result<Self> {
+        if !r_is_matrix(x) {
+            return Err(crate::anyhow!("`x` must be a matrix."));
+        }
+        let column_names = RFunction::from("colnames").add(x).call()?;
+        Ok(Self::new(column_names.sexp))
+    }
+
+    pub fn get_unchecked(&self, index: isize) -> Option<String> {
+        if let Some(names) = &self.names {
+            if let Some(name) = names.get_unchecked(index) {
+                if name.len() > 0 {
+                    return Some(name);
+                }
+            }
+        }
+        None
+    }
+}

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -1,10 +1,5 @@
 use libr::*;
 
-use crate::environment::R_ENVS;
-use crate::exec::RFunction;
-use crate::exec::RFunctionExt;
-use crate::r_int_get;
-use crate::r_int_na;
 use crate::r_length;
 use crate::utils::*;
 use crate::vector::Vector;
@@ -32,7 +27,8 @@ impl DataFrame {
         let list = List::new(sexp)?;
         harp::assert_class(sexp, "data.frame")?;
 
-        // This materializes ALTREP compact row names (duckplyr)
+        // This materializes ALTREP compact row names (duckplyr) and we are okay with
+        // that even without providing a hook to opt out
         let nrow = df_n_row(list.obj.sexp)? as usize;
         let ncol = df_n_col(list.obj.sexp)? as usize;
 
@@ -83,8 +79,6 @@ impl DataFrame {
 }
 
 /// Compute the number of columns in a data frame
-///
-/// This is easy, it's the length of the VECSXP
 pub fn df_n_col(x: SEXP) -> crate::Result<i32> {
     if !r_is_data_frame(x) {
         return Err(crate::anyhow!("`x` must be a data frame"));
@@ -100,113 +94,36 @@ pub fn df_n_col(x: SEXP) -> crate::Result<i32> {
     }
 }
 
-/// Strategy used when encountering ALTREP compact rownames when determining the number of
-/// rows within a data frame
-///
-/// This is particularly needed for duckdb, where materializing the ALTREP compact
-/// rownames to determine the number of rows would materialize the whole query, which we
-/// want to avoid because that defeats the purpose of laziness. In the Variables pane we
-/// avoid materializing, but in the Data Explorer we have to materialize.
-#[derive(Debug, PartialEq)]
-enum AltrepCompactRownamesStrategy {
-    Materialize,
-    DontMaterialize,
-}
-
 /// Compute the number of rows in a data frame
-///
-/// # Safety
-///
-/// If `x` is a data frame with an ALTREP compact row names attribute (like in duckplyr),
-/// then this function will materialize those row names to be able to determine the size.
-/// See [df_n_row_if_known()] if you'd like to bail in that scenario instead.
 pub fn df_n_row(x: SEXP) -> crate::Result<i32> {
-    // Unwrap safety: The `Materialize` strategy ensures this is never `None`
-    Ok(df_n_row_impl(x, AltrepCompactRownamesStrategy::Materialize)?.unwrap())
-}
-
-/// Compute the number of rows in a data frame, returning [None] if this isn't possible
-/// without materializing ALTREP compact row names (like in duckplyr)
-pub fn df_n_row_if_possible(x: SEXP) -> crate::Result<Option<i32>> {
-    df_n_row_impl(x, AltrepCompactRownamesStrategy::DontMaterialize)
-}
-
-fn df_n_row_impl(
-    x: SEXP,
-    altrep_compact_rownames_strategy: AltrepCompactRownamesStrategy,
-) -> crate::Result<Option<i32>> {
     if !r_is_data_frame(x) {
         return Err(crate::anyhow!("`x` must be a data frame"));
     }
 
     r_assert_type(x, &[VECSXP])?;
 
-    // We can't go through `Rf_getAttrib()` directly, this materializes ALTREP compact row
-    // name objects like in duckplyr. Instead we use `.row_names_info(x, 0)` which goes
-    // through `getAttrib0()` and does not materialize.
-    let row_names = RFunction::new("base", ".row_names_info")
-        .param("x", x)
-        .param("type", 0)
-        .call_in(R_ENVS.global)?;
+    // Note that this turns compact row names of the form `c(NA, -5)` into ALTREP compact
+    // intrange objects. This is fine for our purposes because the row names are never
+    // fully expanded as we determine their length.
+    //
+    // There is a special case with duckplyr where the row names object can be an ALTREP
+    // integer vector that looks like an instance of compact row names like `c(NA, -5)`.
+    // Touching this with `INTEGER()` or `INTEGER_ELT()` to determine the number of rows
+    // will materialize the whole query (and run arbitrary R code). We've determined the
+    // only maintainable strategy for classes like this is to provide higher level ark
+    // hooks where packages like duckplyr can intercede before we even get here, providing
+    // their own custom methods (like for the variables pane). That keeps our hot path
+    // simpler, as we unconditionally materialize ALTREP vectors, while still providing a
+    // way to opt out.
+    let row_names = RObject::new(harp::r_row_names(x));
 
-    // If the row names object is ALTREP and looks like an instance of compact row names,
-    // we can't touch it if [AltrepCompactRownamesStrategy::DontMaterialize] is set.
-    if altrep_compact_rownames_strategy == AltrepCompactRownamesStrategy::DontMaterialize &&
-        is_likely_altrep_compact_row_names(row_names.sexp)
-    {
-        return Ok(None);
-    }
-
-    // If the row names object is just in compact form like `c(NA, -5)`, we extract the
-    // number of rows from that
-    if is_compact_row_names(row_names.sexp) {
-        return Ok(Some(compact_row_names_n_row(row_names.sexp)));
-    }
-
-    // Otherwise the row names object is typically an integer vector or character vector,
-    // and we just take the length of that to get the number of rows
+    // The row names object is typically an integer vector (possibly ALTREP compact
+    // intrange that knows its length) or character vector, and we just take the length of
+    // that to get the number of rows
     match i32::try_from(r_length(row_names.sexp)) {
-        Ok(n_row) => Ok(Some(n_row)),
+        Ok(n_row) => Ok(n_row),
         Err(_) => Err(crate::anyhow!("Number of rows of `x` must fit in a `i32`.")),
     }
-}
-
-/// Is `x` an instance of compact row names?
-///
-/// These take the form `c(NA, -5L)`, i.e.
-/// - INTSXP
-/// - Length 2
-/// - The first element is `NA`
-///
-/// The second element will be the row names, typically as a negative value.
-fn is_compact_row_names(x: SEXP) -> bool {
-    r_typeof(x) == INTSXP && r_length(x) == 2 && r_int_get(x, 0) == r_int_na()
-}
-
-/// Is `x` likely an instance of ALTREP compact row names?
-///
-/// In the case of duckdb, their compact row names object is actually an ALTREP object
-/// that knows it is an INTSXP and knows it is length 2, but you can't query any values
-/// in the vector, otherwise it will materialize the full duckdb query to be able to
-/// return the number of rows. You can't even call `INTEGER_ELT(x, 0)` on this currently,
-/// even though in theory only `INTEGER_ELT(x, 1)` should trigger the materialization.
-///
-/// This means we can't do the full check for compact row names, so we leave off the `NA`
-/// check and say that if the object meets the following criteria, it is probably an
-/// ALTREP compact row names object and we can't query the number of rows:
-/// - ALTREP
-/// - INTSXP
-/// - Length 2
-///
-/// TODO: We should ask duckdb to add `ALTREP_ELT` support so that we can query
-/// `INTEGER_ELT(x, 0)` without materializing the duckdb query, and then we can do
-/// the full [is_compact_row_names()] check!
-fn is_likely_altrep_compact_row_names(x: SEXP) -> bool {
-    r_is_altrep(x) && r_typeof(x) == INTSXP && r_length(x) == 2
-}
-
-fn compact_row_names_n_row(x: SEXP) -> i32 {
-    i32::abs(r_int_get(x, 1))
 }
 
 #[cfg(test)]
@@ -311,68 +228,4 @@ mod tests {
             });
         })
     }
-
-    // TODO: This is a very heavy test.
-    //
-    // - It requires `duckplyr` and `duckdb` as dependencies.
-    // - It greatly modifies the global state, as duckplyr shims dplyr verbs.
-    // - It relies on `duckdb` internals to check ALTREP materialization.
-    //
-    // When we switch to nextest with 1 R session per test, we should consider running
-    // this test in CI, but we should not feel too much pressure to run it if it gives us
-    // trouble.
-    //
-    //     #[test]
-    //     fn test_duckplyr_not_materialized() {
-    //         use crate::df_n_row;
-    //         use crate::df_n_row_if_known;
-    //         use crate::exec::RFunction;
-    //         use crate::exec::RFunctionExt;
-    //         use crate::fixtures::package::package_is_installed;
-    //
-    //         crate::r_task(|| {
-    //             if !package_is_installed("duckplyr") {
-    //                 return;
-    //             }
-    //
-    //             // Turn off autoupload startup message
-    //             harp::parse_eval_global("Sys.setenv(DUCKPLYR_FALLBACK_AUTOUPLOAD = 0)").unwrap();
-    //
-    //             let df = harp::parse_eval_global("duckplyr::duckdb_tibble(x = 1:100)").unwrap();
-    //
-    //             // Should not be able to compute `n_row` with `df_n_row_if_known()`
-    //             let n_row = df_n_row_if_known(df.sexp).expect("Can return `None` without `Error`");
-    //             assert!(n_row.is_none());
-    //
-    //             // And `df` should not be materialized
-    //             // This relies on duckdb internals
-    //             let is_materialized = unsafe {
-    //                 RFunction::new_internal("duckdb", "df_is_materialized")
-    //                     .param("df", df)
-    //                     .call()
-    //                     .unwrap()
-    //                     .to::<bool>()
-    //                     .unwrap()
-    //             };
-    //             assert!(!is_materialized);
-    //
-    //             let df = harp::parse_eval_global("duckplyr::duckdb_tibble(x = 1:100)").unwrap();
-    //
-    //             // Should be able to compute `n_row` with `df_n_row()`
-    //             let n_row = df_n_row(df.sexp).expect("Can compute `n_row`");
-    //             assert_eq!(n_row, 100);
-    //
-    //             // And `df` should be materialized
-    //             // This relies on duckdb internals
-    //             let is_materialized = unsafe {
-    //                 RFunction::new_internal("duckdb", "df_is_materialized")
-    //                     .param("df", df)
-    //                     .call()
-    //                     .unwrap()
-    //                     .to::<bool>()
-    //                     .unwrap()
-    //             };
-    //             assert!(is_materialized);
-    //         })
-    //     }
 }

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -1,3 +1,12 @@
+use libr::*;
+
+use crate::environment::R_ENVS;
+use crate::exec::RFunction;
+use crate::exec::RFunctionExt;
+use crate::r_int_get;
+use crate::r_int_na;
+use crate::r_length;
+use crate::utils::*;
 use crate::vector::Vector;
 use crate::List;
 use crate::RObject;
@@ -23,9 +32,9 @@ impl DataFrame {
         let list = List::new(sexp)?;
         harp::assert_class(sexp, "data.frame")?;
 
-        let dim = unsafe { harp::df_dim(list.obj.sexp) }?;
-        let nrow = dim.num_rows as usize;
-        let ncol = list.obj.length() as usize;
+        // This materializes ALTREP compact row names (duckplyr)
+        let nrow = df_n_row(list.obj.sexp)? as usize;
+        let ncol = df_n_col(list.obj.sexp)? as usize;
 
         let Some(names) = list.obj.names() else {
             return Err(harp::anyhow!("Data frame must have names"));
@@ -71,6 +80,133 @@ impl DataFrame {
             .get(idx as isize)?
             .ok_or_else(|| harp::unreachable!("missing column"))
     }
+}
+
+/// Compute the number of columns in a data frame
+///
+/// This is easy, it's the length of the VECSXP
+pub fn df_n_col(x: SEXP) -> crate::Result<i32> {
+    if !r_is_data_frame(x) {
+        return Err(crate::anyhow!("`x` must be a data frame"));
+    }
+
+    r_assert_type(x, &[VECSXP])?;
+
+    match i32::try_from(r_length(x)) {
+        Ok(n_col) => Ok(n_col),
+        Err(_) => Err(crate::anyhow!(
+            "Number of columns of `x` must fit in a `i32`."
+        )),
+    }
+}
+
+/// Strategy used when encountering ALTREP compact rownames when determining the number of
+/// rows within a data frame
+///
+/// This is particularly needed for duckdb, where materializing the ALTREP compact
+/// rownames to determine the number of rows would materialize the whole query, which we
+/// want to avoid because that defeats the purpose of laziness. In the Variables pane we
+/// avoid materializing, but in the Data Explorer we have to materialize.
+#[derive(Debug, PartialEq)]
+enum AltrepCompactRownamesStrategy {
+    Materialize,
+    DontMaterialize,
+}
+
+/// Compute the number of rows in a data frame
+///
+/// # Safety
+///
+/// If `x` is a data frame with an ALTREP compact row names attribute (like in duckplyr),
+/// then this function will materialize those row names to be able to determine the size.
+/// See [df_n_row_if_known()] if you'd like to bail in that scenario instead.
+pub fn df_n_row(x: SEXP) -> crate::Result<i32> {
+    // Unwrap safety: The `Materialize` strategy ensures this is never `None`
+    Ok(df_n_row_impl(x, AltrepCompactRownamesStrategy::Materialize)?.unwrap())
+}
+
+/// Compute the number of rows in a data frame, returning [None] if this isn't possible
+/// without materializing ALTREP compact row names (like in duckplyr)
+pub fn df_n_row_if_possible(x: SEXP) -> crate::Result<Option<i32>> {
+    df_n_row_impl(x, AltrepCompactRownamesStrategy::DontMaterialize)
+}
+
+fn df_n_row_impl(
+    x: SEXP,
+    altrep_compact_rownames_strategy: AltrepCompactRownamesStrategy,
+) -> crate::Result<Option<i32>> {
+    if !r_is_data_frame(x) {
+        return Err(crate::anyhow!("`x` must be a data frame"));
+    }
+
+    r_assert_type(x, &[VECSXP])?;
+
+    // We can't go through `Rf_getAttrib()` directly, this materializes ALTREP compact row
+    // name objects like in duckplyr. Instead we use `.row_names_info(x, 0)` which goes
+    // through `getAttrib0()` and does not materialize.
+    let row_names = RFunction::new("base", ".row_names_info")
+        .param("x", x)
+        .param("type", 0)
+        .call_in(R_ENVS.global)?;
+
+    // If the row names object is ALTREP and looks like an instance of compact row names,
+    // we can't touch it if [AltrepCompactRownamesStrategy::DontMaterialize] is set.
+    if altrep_compact_rownames_strategy == AltrepCompactRownamesStrategy::DontMaterialize &&
+        is_likely_altrep_compact_row_names(row_names.sexp)
+    {
+        return Ok(None);
+    }
+
+    // If the row names object is just in compact form like `c(NA, -5)`, we extract the
+    // number of rows from that
+    if is_compact_row_names(row_names.sexp) {
+        return Ok(Some(compact_row_names_n_row(row_names.sexp)));
+    }
+
+    // Otherwise the row names object is typically an integer vector or character vector,
+    // and we just take the length of that to get the number of rows
+    match i32::try_from(r_length(row_names.sexp)) {
+        Ok(n_row) => Ok(Some(n_row)),
+        Err(_) => Err(crate::anyhow!("Number of rows of `x` must fit in a `i32`.")),
+    }
+}
+
+/// Is `x` an instance of compact row names?
+///
+/// These take the form `c(NA, -5L)`, i.e.
+/// - INTSXP
+/// - Length 2
+/// - The first element is `NA`
+///
+/// The second element will be the row names, typically as a negative value.
+fn is_compact_row_names(x: SEXP) -> bool {
+    r_typeof(x) == INTSXP && r_length(x) == 2 && r_int_get(x, 0) == r_int_na()
+}
+
+/// Is `x` likely an instance of ALTREP compact row names?
+///
+/// In the case of duckdb, their compact row names object is actually an ALTREP object
+/// that knows it is an INTSXP and knows it is length 2, but you can't query any values
+/// in the vector, otherwise it will materialize the full duckdb query to be able to
+/// return the number of rows. You can't even call `INTEGER_ELT(x, 0)` on this currently,
+/// even though in theory only `INTEGER_ELT(x, 1)` should trigger the materialization.
+///
+/// This means we can't do the full check for compact row names, so we leave off the `NA`
+/// check and say that if the object meets the following criteria, it is probably an
+/// ALTREP compact row names object and we can't query the number of rows:
+/// - ALTREP
+/// - INTSXP
+/// - Length 2
+///
+/// TODO: We should ask duckdb to add `ALTREP_ELT` support so that we can query
+/// `INTEGER_ELT(x, 0)` without materializing the duckdb query, and then we can do
+/// the full [is_compact_row_names()] check!
+fn is_likely_altrep_compact_row_names(x: SEXP) -> bool {
+    r_is_altrep(x) && r_typeof(x) == INTSXP && r_length(x) == 2
+}
+
+fn compact_row_names_n_row(x: SEXP) -> i32 {
+    i32::abs(r_int_get(x, 1))
 }
 
 #[cfg(test)]
@@ -175,4 +311,68 @@ mod tests {
             });
         })
     }
+
+    // TODO: This is a very heavy test.
+    //
+    // - It requires `duckplyr` and `duckdb` as dependencies.
+    // - It greatly modifies the global state, as duckplyr shims dplyr verbs.
+    // - It relies on `duckdb` internals to check ALTREP materialization.
+    //
+    // When we switch to nextest with 1 R session per test, we should consider running
+    // this test in CI, but we should not feel too much pressure to run it if it gives us
+    // trouble.
+    //
+    //     #[test]
+    //     fn test_duckplyr_not_materialized() {
+    //         use crate::df_n_row;
+    //         use crate::df_n_row_if_known;
+    //         use crate::exec::RFunction;
+    //         use crate::exec::RFunctionExt;
+    //         use crate::fixtures::package::package_is_installed;
+    //
+    //         crate::r_task(|| {
+    //             if !package_is_installed("duckplyr") {
+    //                 return;
+    //             }
+    //
+    //             // Turn off autoupload startup message
+    //             harp::parse_eval_global("Sys.setenv(DUCKPLYR_FALLBACK_AUTOUPLOAD = 0)").unwrap();
+    //
+    //             let df = harp::parse_eval_global("duckplyr::duckdb_tibble(x = 1:100)").unwrap();
+    //
+    //             // Should not be able to compute `n_row` with `df_n_row_if_known()`
+    //             let n_row = df_n_row_if_known(df.sexp).expect("Can return `None` without `Error`");
+    //             assert!(n_row.is_none());
+    //
+    //             // And `df` should not be materialized
+    //             // This relies on duckdb internals
+    //             let is_materialized = unsafe {
+    //                 RFunction::new_internal("duckdb", "df_is_materialized")
+    //                     .param("df", df)
+    //                     .call()
+    //                     .unwrap()
+    //                     .to::<bool>()
+    //                     .unwrap()
+    //             };
+    //             assert!(!is_materialized);
+    //
+    //             let df = harp::parse_eval_global("duckplyr::duckdb_tibble(x = 1:100)").unwrap();
+    //
+    //             // Should be able to compute `n_row` with `df_n_row()`
+    //             let n_row = df_n_row(df.sexp).expect("Can compute `n_row`");
+    //             assert_eq!(n_row, 100);
+    //
+    //             // And `df` should be materialized
+    //             // This relies on duckdb internals
+    //             let is_materialized = unsafe {
+    //                 RFunction::new_internal("duckdb", "df_is_materialized")
+    //                     .param("df", df)
+    //                     .call()
+    //                     .unwrap()
+    //                     .to::<bool>()
+    //                     .unwrap()
+    //             };
+    //             assert!(is_materialized);
+    //         })
+    //     }
 }

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -28,9 +28,10 @@ impl DataFrame {
         harp::assert_class(sexp, "data.frame")?;
 
         // This materializes ALTREP compact row names (duckplyr) and we are okay with
-        // that even without providing a hook to opt out
-        let nrow = df_n_row(list.obj.sexp)? as usize;
-        let ncol = df_n_col(list.obj.sexp)? as usize;
+        // that. If you just need the number of columns without full validation, use
+        // the static method [DataFrame::n_col()].
+        let nrow = Self::n_row(list.obj.sexp)? as usize;
+        let ncol = Self::n_col(list.obj.sexp)? as usize;
 
         let Some(names) = list.obj.names() else {
             return Err(harp::anyhow!("Data frame must have names"));
@@ -76,49 +77,62 @@ impl DataFrame {
             .get(idx as isize)?
             .ok_or_else(|| harp::unreachable!("missing column"))
     }
-}
 
-/// Compute the number of columns in a data frame
-pub fn df_n_col(x: SEXP) -> crate::Result<i32> {
-    if !r_is_data_frame(x) {
-        return Err(crate::anyhow!("`x` must be a data frame"));
+    /// Compute the number of columns of a data frame
+    ///
+    /// # Notes
+    ///
+    /// In general, prefer [DataFrame::new()] followed by accessing the `ncol` field,
+    /// as that validates the data frame on the way in. Use this static method if you
+    /// need maximal performance, or if you only need the number of columns, and computing
+    /// the number of rows would materialize ALTREP objects unnecessarily.
+    pub fn n_col(x: libr::SEXP) -> crate::Result<i32> {
+        if !r_is_data_frame(x) {
+            return Err(crate::anyhow!("`x` must be a data frame"));
+        }
+
+        match i32::try_from(r_length(x)) {
+            Ok(n_col) => Ok(n_col),
+            Err(_) => Err(crate::anyhow!(
+                "Number of columns of `x` must fit in a `i32`."
+            )),
+        }
     }
 
-    match i32::try_from(r_length(x)) {
-        Ok(n_col) => Ok(n_col),
-        Err(_) => Err(crate::anyhow!(
-            "Number of columns of `x` must fit in a `i32`."
-        )),
-    }
-}
+    /// Compute the number of rows of a data frame
+    ///
+    /// # Notes
+    ///
+    /// In general, prefer [DataFrame::new()] followed by accessing the `nrow` field,
+    /// as that validates the data frame on the way in. Use this static method if you
+    /// need maximal performance.
+    pub fn n_row(x: SEXP) -> crate::Result<i32> {
+        if !r_is_data_frame(x) {
+            return Err(crate::anyhow!("`x` must be a data frame"));
+        }
 
-/// Compute the number of rows in a data frame
-pub fn df_n_row(x: SEXP) -> crate::Result<i32> {
-    if !r_is_data_frame(x) {
-        return Err(crate::anyhow!("`x` must be a data frame"));
-    }
+        // Note that this turns compact row names of the form `c(NA, -5)` into ALTREP compact
+        // intrange objects. This is fine for our purposes because the row names are never
+        // fully expanded as we determine their length.
+        //
+        // There is a special case with duckplyr where the row names object can be an ALTREP
+        // integer vector that looks like an instance of compact row names like `c(NA, -5)`.
+        // Touching this with `INTEGER()` or `INTEGER_ELT()` to determine the number of rows
+        // will materialize the whole query (and run arbitrary R code). We've determined the
+        // only maintainable strategy for classes like this is to provide higher level ark
+        // hooks where packages like duckplyr can intercede before we even get here, providing
+        // their own custom methods (like for the variables pane). That keeps our hot path
+        // simpler, as we unconditionally materialize ALTREP vectors, while still providing a
+        // way to opt out.
+        let row_names = RObject::new(harp::r_row_names(x));
 
-    // Note that this turns compact row names of the form `c(NA, -5)` into ALTREP compact
-    // intrange objects. This is fine for our purposes because the row names are never
-    // fully expanded as we determine their length.
-    //
-    // There is a special case with duckplyr where the row names object can be an ALTREP
-    // integer vector that looks like an instance of compact row names like `c(NA, -5)`.
-    // Touching this with `INTEGER()` or `INTEGER_ELT()` to determine the number of rows
-    // will materialize the whole query (and run arbitrary R code). We've determined the
-    // only maintainable strategy for classes like this is to provide higher level ark
-    // hooks where packages like duckplyr can intercede before we even get here, providing
-    // their own custom methods (like for the variables pane). That keeps our hot path
-    // simpler, as we unconditionally materialize ALTREP vectors, while still providing a
-    // way to opt out.
-    let row_names = RObject::new(harp::r_row_names(x));
-
-    // The row names object is typically an integer vector (possibly ALTREP compact
-    // intrange that knows its length) or character vector, and we just take the length of
-    // that to get the number of rows
-    match i32::try_from(r_length(row_names.sexp)) {
-        Ok(n_row) => Ok(n_row),
-        Err(_) => Err(crate::anyhow!("Number of rows of `x` must fit in a `i32`.")),
+        // The row names object is typically an integer vector (possibly ALTREP compact
+        // intrange that knows its length) or character vector, and we just take the length of
+        // that to get the number of rows
+        match i32::try_from(r_length(row_names.sexp)) {
+            Ok(n_row) => Ok(n_row),
+            Err(_) => Err(crate::anyhow!("Number of rows of `x` must fit in a `i32`.")),
+        }
     }
 }
 

--- a/crates/harp/src/data_frame.rs
+++ b/crates/harp/src/data_frame.rs
@@ -84,8 +84,6 @@ pub fn df_n_col(x: SEXP) -> crate::Result<i32> {
         return Err(crate::anyhow!("`x` must be a data frame"));
     }
 
-    r_assert_type(x, &[VECSXP])?;
-
     match i32::try_from(r_length(x)) {
         Ok(n_col) => Ok(n_col),
         Err(_) => Err(crate::anyhow!(
@@ -99,8 +97,6 @@ pub fn df_n_row(x: SEXP) -> crate::Result<i32> {
     if !r_is_data_frame(x) {
         return Err(crate::anyhow!("`x` must be a data frame"));
     }
-
-    r_assert_type(x, &[VECSXP])?;
 
     // Note that this turns compact row names of the form `c(NA, -5)` into ALTREP compact
     // intrange objects. This is fine for our purposes because the row names are never

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -6,6 +6,7 @@
 //
 pub mod attrib;
 pub mod call;
+mod column_names;
 pub mod command;
 pub mod data_frame;
 pub mod environment;
@@ -20,6 +21,7 @@ pub mod format;
 pub mod json;
 pub mod library;
 pub mod line_ending;
+mod matrix;
 pub mod modules;
 pub mod object;
 pub mod parse;
@@ -41,8 +43,10 @@ pub mod vec_format;
 pub mod vector;
 
 // Reexport API
+pub use column_names::*;
 pub use data_frame::*;
 pub use eval::*;
+pub use matrix::*;
 pub use object::*;
 pub use parse::*;
 pub use parser::*;

--- a/crates/harp/src/matrix.rs
+++ b/crates/harp/src/matrix.rs
@@ -1,0 +1,23 @@
+use libr::*;
+
+use crate::r_dim;
+use crate::r_int_get;
+use crate::r_length;
+use crate::utils::*;
+
+/// Compute the dimensions of a matrix
+pub fn mat_dim(x: SEXP) -> crate::Result<(i32, i32)> {
+    if !r_is_matrix(x) {
+        return Err(crate::anyhow!("`x` must be a matrix"));
+    }
+
+    let dim = r_dim(x);
+
+    if r_typeof(dim) != INTSXP || r_length(dim) != 2 {
+        return Err(crate::anyhow!(
+            "`dim` must be an integer vector of length 2"
+        ));
+    }
+
+    Ok((r_int_get(dim, 0), r_int_get(dim, 1)))
+}

--- a/crates/harp/src/matrix.rs
+++ b/crates/harp/src/matrix.rs
@@ -5,19 +5,30 @@ use crate::r_int_get;
 use crate::r_length;
 use crate::utils::*;
 
-/// Compute the dimensions of a matrix
-pub fn mat_dim(x: SEXP) -> crate::Result<(i32, i32)> {
-    if !r_is_matrix(x) {
-        return Err(crate::anyhow!("`x` must be a matrix"));
+/// Matrix support
+///
+/// # Notes
+///
+/// Currently we only utilize this for the static [Matrix::dim()] method,
+/// but we could actually wrap matrices here (with validation) and provide
+/// additional methods, like [harp::DataFrame].
+pub struct Matrix {}
+
+impl Matrix {
+    /// Compute the dimensions of a matrix
+    pub fn dim(x: SEXP) -> crate::Result<(i32, i32)> {
+        if !r_is_matrix(x) {
+            return Err(crate::anyhow!("`x` must be a matrix"));
+        }
+
+        let dim = r_dim(x);
+
+        if r_typeof(dim) != INTSXP || r_length(dim) != 2 {
+            return Err(crate::anyhow!(
+                "`dim` must be an integer vector of length 2"
+            ));
+        }
+
+        Ok((r_int_get(dim, 0), r_int_get(dim, 1)))
     }
-
-    let dim = r_dim(x);
-
-    if r_typeof(dim) != INTSXP || r_length(dim) != 2 {
-        return Err(crate::anyhow!(
-            "`dim` must be an integer vector of length 2"
-        ));
-    }
-
-    Ok((r_int_get(dim, 0), r_int_get(dim, 1)))
 }

--- a/crates/harp/src/parser/srcref.rs
+++ b/crates/harp/src/parser/srcref.rs
@@ -40,7 +40,7 @@ pub struct SrcFile {
 // attributes.
 impl RObject {
     pub fn srcrefs(&self) -> anyhow::Result<Vec<SrcRef>> {
-        let srcref = unwrap!(self.attr("srcref"), None => {
+        let srcref = unwrap!(self.get_attribute("srcref"), None => {
             return Err(anyhow!("Can't find `srcref` attribute"));
         });
 

--- a/crates/harp/src/table.rs
+++ b/crates/harp/src/table.rs
@@ -2,14 +2,9 @@ use libr::*;
 
 use crate::exec::RFunction;
 use crate::exec::RFunctionExt;
-use crate::object::r_length;
 use crate::object::RObject;
-use crate::r_assert_type;
 use crate::utils::r_is_data_frame;
 use crate::utils::r_is_matrix;
-use crate::utils::r_typeof;
-use crate::vector::CharacterVector;
-use crate::vector::Vector;
 
 #[derive(Clone, Copy)]
 pub enum TableKind {
@@ -17,25 +12,14 @@ pub enum TableKind {
     Matrix,
 }
 
-pub struct TableInfo {
-    pub kind: TableKind,
-    pub dims: TableDim,
-    pub col_names: ColumnNames,
-}
-
-// TODO: Might want to encode as types with methods so that we can make
-// assumptions about memory layout more safely. Also makes it possible
-// to compute properties more lazily.
-pub fn table_info(x: SEXP) -> Option<TableInfo> {
+pub fn table_kind(x: SEXP) -> Option<TableKind> {
     if r_is_data_frame(x) {
-        return df_info(x).ok();
+        Some(TableKind::Dataframe)
+    } else if r_is_matrix(x) {
+        Some(TableKind::Matrix)
+    } else {
+        None
     }
-
-    if r_is_matrix(x) {
-        return mat_info(x).ok();
-    }
-
-    None
 }
 
 /// Extracts a single column from a table.
@@ -62,111 +46,5 @@ pub fn tbl_get_column(x: SEXP, column_index: i32, kind: TableKind) -> anyhow::Re
                 .call()?;
             Ok(column)
         },
-    }
-}
-
-pub fn df_info(x: SEXP) -> anyhow::Result<TableInfo> {
-    unsafe {
-        let dims = df_dim(x)?;
-        let col_names = ColumnNames::new(Rf_getAttrib(x, R_NamesSymbol));
-
-        Ok(TableInfo {
-            kind: TableKind::Dataframe,
-            dims,
-            col_names,
-        })
-    }
-}
-
-pub fn mat_info(x: SEXP) -> anyhow::Result<TableInfo> {
-    let dims = mat_dim(x);
-
-    let col_names = RFunction::from("colnames").add(x).call()?;
-    let col_names = ColumnNames::new(col_names.sexp);
-
-    Ok(TableInfo {
-        kind: TableKind::Matrix,
-        dims,
-        col_names,
-    })
-}
-
-pub struct TableDim {
-    pub num_rows: i32,
-    pub num_cols: i32,
-}
-
-/// Safety: Assumes a data frame as input.
-/// TODO: Extract row info from attribute.
-pub unsafe fn df_dim(data: SEXP) -> harp::Result<TableDim> {
-    // FIXME: We shouldn't dispatch to methods here
-    let dims = RFunction::new("base", "dim.data.frame")
-        .add(data)
-        .call()
-        .unwrap();
-
-    let Ok(_) = r_assert_type(dims.sexp, &[libr::INTSXP]) else {
-        return Err(harp::anyhow!(
-            "Data frame dimensions must be an integer vector, instead it has type `{}`",
-            harp::r_type2char(dims.kind())
-        ));
-    };
-    if dims.length() != 2 {
-        return Err(harp::anyhow!(
-            "Data frame must have 2 dimensions, instead it has {}",
-            dims.length()
-        ));
-    }
-
-    Ok(TableDim {
-        num_rows: INTEGER_ELT(dims.sexp, 0),
-        num_cols: INTEGER_ELT(dims.sexp, 1),
-    })
-}
-
-pub fn mat_dim(x: SEXP) -> TableDim {
-    unsafe {
-        let dims = Rf_getAttrib(x, R_DimSymbol);
-
-        // Might want to return an error instead, or take a strongly typed input
-        if r_typeof(dims) != INTSXP || r_length(dims) != 2 {
-            return TableDim {
-                num_rows: r_length(x) as i32,
-                num_cols: 1,
-            };
-        }
-
-        TableDim {
-            num_rows: INTEGER_ELT(dims, 0),
-            num_cols: INTEGER_ELT(dims, 1),
-        }
-    }
-}
-
-pub struct ColumnNames {
-    pub names: Option<CharacterVector>,
-}
-
-impl ColumnNames {
-    pub fn new(names: SEXP) -> Self {
-        unsafe {
-            let names = if r_typeof(names) == STRSXP {
-                Some(CharacterVector::new_unchecked(names))
-            } else {
-                None
-            };
-            Self { names }
-        }
-    }
-
-    pub fn get_unchecked(&self, index: isize) -> Option<String> {
-        if let Some(names) = &self.names {
-            if let Some(name) = names.get_unchecked(index) {
-                if name.len() > 0 {
-                    return Some(name);
-                }
-            }
-        }
-        None
     }
 }

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -393,7 +393,21 @@ pub unsafe fn r_envir_remove(symbol: &str, envir: SEXP) {
     R_removeVarFromFrame(r_symbol!(symbol), envir);
 }
 
-/// Get the names attribute of a vector
+/// Get the row names attribute of an object
+///
+/// Raw access to the [R_RowNamesSymbol] attribute. Will return [R_NilValue] when no names
+/// are present.
+///
+/// Note that [Rf_getAttrib()] will turn compact row names of the form `c(NA, -5)` into
+/// ALTREP compact intrange objects. If you really need to avoid this, use
+/// `.row_names_info(x, 0L)` instead, which goes through `getAttrib0()`, but note that R
+/// core frowns on this.
+/// https://github.com/wch/r-source/blob/e11e04d1f9966551991569b43da2ba6ab2251f30/src/main/attrib.c#L177-L187
+pub fn r_row_names(x: SEXP) -> SEXP {
+    unsafe { Rf_getAttrib(x, R_RowNamesSymbol) }
+}
+
+/// Get the names attribute of an object
 ///
 /// Raw access to the [R_NamesSymbol] attribute. Will return [R_NilValue] when no names
 /// are present.

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -393,28 +393,6 @@ pub unsafe fn r_envir_remove(symbol: &str, envir: SEXP) {
     R_removeVarFromFrame(r_symbol!(symbol), envir);
 }
 
-/// Get the row names attribute of an object
-///
-/// Raw access to the [R_RowNamesSymbol] attribute. Will return [R_NilValue] when no names
-/// are present.
-///
-/// Note that [Rf_getAttrib()] will turn compact row names of the form `c(NA, -5)` into
-/// ALTREP compact intrange objects. If you really need to avoid this, use
-/// `.row_names_info(x, 0L)` instead, which goes through `getAttrib0()`, but note that R
-/// core frowns on this.
-/// https://github.com/wch/r-source/blob/e11e04d1f9966551991569b43da2ba6ab2251f30/src/main/attrib.c#L177-L187
-pub fn r_row_names(x: SEXP) -> SEXP {
-    unsafe { Rf_getAttrib(x, R_RowNamesSymbol) }
-}
-
-/// Get the names attribute of an object
-///
-/// Raw access to the [R_NamesSymbol] attribute. Will return [R_NilValue] when no names
-/// are present.
-pub fn r_names(x: SEXP) -> SEXP {
-    unsafe { Rf_getAttrib(x, R_NamesSymbol) }
-}
-
 /// Get names of a vector
 ///
 /// `r_names2()` always returns a character vector, even when the object does
@@ -427,7 +405,7 @@ pub fn r_names2(x: SEXP) -> SEXP {
 
     let size = r_length(x);
 
-    let names = r_names(x);
+    let names = unsafe { Rf_getAttrib(x, R_NamesSymbol) };
     unsafe { protect.add(names) };
 
     if r_is_null(names) {

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -393,6 +393,14 @@ pub unsafe fn r_envir_remove(symbol: &str, envir: SEXP) {
     R_removeVarFromFrame(r_symbol!(symbol), envir);
 }
 
+/// Get the names attribute of a vector
+///
+/// Raw access to the [R_NamesSymbol] attribute. Will return [R_NilValue] when no names
+/// are present.
+pub fn r_names(x: SEXP) -> SEXP {
+    unsafe { Rf_getAttrib(x, R_NamesSymbol) }
+}
+
 /// Get names of a vector
 ///
 /// `r_names2()` always returns a character vector, even when the object does
@@ -405,7 +413,7 @@ pub fn r_names2(x: SEXP) -> SEXP {
 
     let size = r_length(x);
 
-    let names = unsafe { Rf_getAttrib(x, R_NamesSymbol) };
+    let names = r_names(x);
     unsafe { protect.add(names) };
 
     if r_is_null(names) {

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -101,7 +101,7 @@ impl FormattedVector {
     }
 
     fn column_iter_indices(&self, column: isize) -> anyhow::Result<std::ops::Range<i64>> {
-        let (n_row, _n_col) = harp::mat_dim(self.vector.sexp)?;
+        let (n_row, _n_col) = harp::Matrix::dim(self.vector.sexp)?;
         let start = column as i64 * n_row as i64;
         let end = start + n_row as i64;
         Ok(start..end)

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -17,7 +17,6 @@ use crate::r_format_vec;
 use crate::r_is_object;
 use crate::r_length;
 use crate::r_subset_vec;
-use crate::table_info;
 use crate::utils::r_assert_type;
 use crate::utils::r_typeof;
 use crate::vector::CharacterVector;
@@ -102,12 +101,9 @@ impl FormattedVector {
     }
 
     fn column_iter_indices(&self, column: isize) -> anyhow::Result<std::ops::Range<i64>> {
-        let dim = table_info(self.vector.sexp)
-            .ok_or(anyhow!("Not a mtrix"))?
-            .dims;
-
-        let start = column as i64 * dim.num_rows as i64;
-        let end = start + dim.num_rows as i64;
+        let (n_row, n_col) = harp::mat_dim(self.vector.sexp)?;
+        let start = column as i64 * n_row as i64;
+        let end = start + n_col as i64;
         Ok(start..end)
     }
 }

--- a/crates/harp/src/vector/formatted_vector.rs
+++ b/crates/harp/src/vector/formatted_vector.rs
@@ -101,9 +101,9 @@ impl FormattedVector {
     }
 
     fn column_iter_indices(&self, column: isize) -> anyhow::Result<std::ops::Range<i64>> {
-        let (n_row, n_col) = harp::mat_dim(self.vector.sexp)?;
+        let (n_row, _n_col) = harp::mat_dim(self.vector.sexp)?;
         let start = column as i64 * n_row as i64;
-        let end = start + n_col as i64;
+        let end = start + n_row as i64;
         Ok(start..end)
     }
 }

--- a/crates/harp/src/vector/names.rs
+++ b/crates/harp/src/vector/names.rs
@@ -4,12 +4,11 @@
 // Copyright (C) 2022 Posit Software, PBC. All rights reserved.
 //
 //
-use libr::R_NamesSymbol;
-use libr::Rf_getAttrib;
 use libr::SEXP;
 
 use crate::object::RObject;
 use crate::utils::r_is_null;
+use crate::utils::r_names;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
 
@@ -21,7 +20,7 @@ pub struct Names {
 impl Names {
     pub fn new(x: SEXP, default: impl Fn(isize) -> String + 'static) -> Self {
         unsafe {
-            let names = RObject::new(Rf_getAttrib(x, R_NamesSymbol));
+            let names = RObject::new(r_names(x));
             let default = Box::new(default);
             if r_is_null(*names) {
                 Self {

--- a/crates/harp/src/vector/names.rs
+++ b/crates/harp/src/vector/names.rs
@@ -7,8 +7,6 @@
 use libr::SEXP;
 
 use crate::object::RObject;
-use crate::utils::r_is_null;
-use crate::utils::r_names;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
 
@@ -20,18 +18,17 @@ pub struct Names {
 impl Names {
     pub fn new(x: SEXP, default: impl Fn(isize) -> String + 'static) -> Self {
         unsafe {
-            let names = RObject::new(r_names(x));
+            let names = RObject::view(x).get_attribute_names();
             let default = Box::new(default);
-            if r_is_null(*names) {
-                Self {
+            match names {
+                Some(names) => Self {
+                    data: Some(CharacterVector::new_unchecked(names.sexp)),
+                    default,
+                },
+                None => Self {
                     data: None,
                     default,
-                }
-            } else {
-                Self {
-                    data: Some(CharacterVector::new_unchecked(names)),
-                    default,
-                }
+                },
             }
         }
     }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4158 at the request of @hadley (but not the part about errors during materialization crashing the kernel, that is a much deeper and harder to fix problem that requires us to adjust our assumptions about what a simple `INTEGER_ELT()` call can do - i.e. in an ALTREP world that can run arbitrary code that can error 😢)

Joint PR with https://github.com/tidyverse/duckplyr/pull/661

The problem is that duckplyr uses ALTREP compact row names as the `R_RowNamesSymbol` attribute. Calling `INTEGER_ELT()` or `INTEGER()` on this to get the number of rows will trigger the entire duckdb query to run, something we want to avoid. This is hard though, because that's how we determine the number of rows in the data frame. We've determined that rather than trying to carefully avoid ALTREP compact row names every time we look at the number of rows in a data frame, a better solution is to use @dfalbel's hooks for allowing S3 classes to provide custom Variables Pane implementations - avoiding these troublesome code paths entirely.

Most of the work that was _required_ for this is actually in https://github.com/tidyverse/duckplyr/pull/661. However, in `variable_length()` here on the Ark side we were calling `table_info()` which queried the number of rows (bad) and number of columns even though we only needed the number of columns. I've reworked some things to expose ways to compute _just_ the number of columns or _just_ the number of rows for a data frame. With that in place, https://github.com/tidyverse/duckplyr/pull/661 does the rest of the work.

This won't trigger the duckdb query:
- Creating a duckdb tibble and having it show up in the Variables pane

This will trigger the duckdb query, and we are ok with this, and this is similar to RStudio:
- "Expanding" the tibble in the Variables pane to look at the column values
- Viewing the tibble in the Data Explorer

Here are some videos of me toying around with this:

https://github.com/user-attachments/assets/2a82111b-5561-421e-b259-79c51fcfea11

https://github.com/user-attachments/assets/754a6ab4-8c94-4267-be4c-e46884da63bf

See also, RStudio's `rs_dim()` here:
https://github.com/rstudio/rstudio/blob/7a9ab7afe9ae006e60897596a189a904a716ec4f/src/cpp/session/modules/environment/SessionEnvironment.cpp#L536
https://github.com/rstudio/rstudio/blob/7a9ab7afe9ae006e60897596a189a904a716ec4f/src/cpp/session/modules/SessionEnvironment.R#L560
