### PR TITLE
Add rpc to get loaded packages

### DIFF
--- a/crates/ark/src/modules/positron/package.R
+++ b/crates/ark/src/modules/positron/package.R
@@ -65,6 +65,6 @@
 }
 
 #' @export
-.ps.rpc.get_loaded_packages <- function(...) {
+.ps.rpc.get_attached_packages <- function(...) {
     .packages()
 }

--- a/crates/ark/src/modules/positron/package.R
+++ b/crates/ark/src/modules/positron/package.R
@@ -1,7 +1,7 @@
 #
 # package.R
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 #
 #
 

--- a/crates/ark/src/modules/positron/package.R
+++ b/crates/ark/src/modules/positron/package.R
@@ -51,7 +51,7 @@
             stop("Should not install a package if it's already attached.")
         }
     }
-    utils::install.packages(packages)
+    utils::install.packages(unlist(packages))
     TRUE
 }
 
@@ -62,4 +62,9 @@
     }
 
     pkg %in% .packages()
+}
+
+#' @export
+.ps.rpc.get_loaded_packages <- function(...) {
+    .packages()
 }


### PR DESCRIPTION
Ark side of https://github.com/posit-dev/positron/pull/6954; just adds an RPC to get the loaded packages, and calls `unlist` on the set of packages to install since those arrive in list form from the front end. 