### PR TITLE
Refactor completions

### DIFF
--- a/crates/ark/src/lsp/completions.rs
+++ b/crates/ark/src/lsp/completions.rs
@@ -5,6 +5,7 @@
 //
 //
 
+mod builder;
 mod completion_item;
 mod parameter_hints;
 mod provide;

--- a/crates/ark/src/lsp/completions.rs
+++ b/crates/ark/src/lsp/completions.rs
@@ -5,7 +5,7 @@
 //
 //
 
-mod builder;
+mod completion_context;
 mod completion_item;
 mod parameter_hints;
 mod provide;

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -16,7 +16,7 @@ use crate::lsp::completions::sources::composite::pipe::completions_from_pipe;
 use crate::lsp::completions::sources::composite::search_path::SearchPathCompletionProvider;
 use crate::lsp::completions::sources::composite::snippets::completions_from_snippets;
 use crate::lsp::completions::sources::composite::subset::completions_from_subset;
-use crate::lsp::completions::sources::composite::workspace::completions_from_workspace;
+use crate::lsp::completions::sources::composite::workspace::WorkspaceCompletionProvider;
 use crate::lsp::completions::sources::unique::colon::completions_from_single_colon;
 use crate::lsp::completions::sources::unique::comment::completions_from_comment;
 use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
@@ -54,12 +54,6 @@ impl<'a> CompletionBuilder<'a> {
         // set of reasonable completions based on loaded packages, the open
         // document, the current workspace, and any call related arguments
         self.completions_from_composite_sources()
-    }
-
-    // Temporary move: wrapper methods for functions that use parameter_hints
-
-    fn get_workspace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_workspace(self.context, self.state, &self.parameter_hints)
     }
 
     pub fn completions_from_unique_sources(&self) -> Result<Option<Vec<CompletionItem>>> {

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -1,3 +1,10 @@
+//
+// builder.rs
+//
+// Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+//
+//
+
 use std::cell::OnceCell;
 use std::collections::HashSet;
 
@@ -24,8 +31,9 @@ use crate::lsp::completions::sources::unique::comment::completions_from_comment;
 use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
 use crate::lsp::completions::sources::unique::extractor::completions_from_at;
 use crate::lsp::completions::sources::unique::extractor::completions_from_dollar;
-use crate::lsp::completions::sources::unique::namespace::NamespaceCompletionProvider;
+use crate::lsp::completions::sources::unique::namespace::NamespaceSource;
 use crate::lsp::completions::sources::unique::string::completions_from_string;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
@@ -92,7 +100,7 @@ impl<'a> CompletionBuilder<'a> {
             return Ok(Some(completions));
         }
 
-        if let Some(completions) = self.get_namespace_completions()? {
+        if let Some(completions) = NamespaceSource::provide_completions(self)? {
             return Ok(Some(completions));
         }
 

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -1,9 +1,22 @@
+use std::collections::HashSet;
+
 use anyhow::Result;
+use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
+use tower_lsp::lsp_types::CompletionItemKind;
 
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
-use crate::lsp::completions::sources::composite::completions_from_composite_sources;
+use crate::lsp::completions::sources::composite::call::completions_from_call;
+use crate::lsp::completions::sources::composite::document::completions_from_document;
+use crate::lsp::completions::sources::composite::find_pipe_root;
+use crate::lsp::completions::sources::composite::is_identifier_like;
+use crate::lsp::completions::sources::composite::keyword::completions_from_keywords;
+use crate::lsp::completions::sources::composite::pipe::completions_from_pipe;
+use crate::lsp::completions::sources::composite::search_path::completions_from_search_path;
+use crate::lsp::completions::sources::composite::snippets::completions_from_snippets;
+use crate::lsp::completions::sources::composite::subset::completions_from_subset;
+use crate::lsp::completions::sources::composite::workspace::completions_from_workspace;
 use crate::lsp::completions::sources::unique::colon::completions_from_single_colon;
 use crate::lsp::completions::sources::unique::comment::completions_from_comment;
 use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
@@ -13,7 +26,6 @@ use crate::lsp::completions::sources::unique::namespace::completions_from_namesp
 use crate::lsp::completions::sources::unique::string::completions_from_string;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
-
 pub(crate) struct CompletionBuilder<'a> {
     context: &'a DocumentContext<'a>,
     state: &'a WorldState,
@@ -40,7 +52,7 @@ impl<'a> CompletionBuilder<'a> {
         // At this point we aren't in a "unique" completion case, so just return a
         // set of reasonable completions based on loaded packages, the open
         // document, the current workspace, and any call related arguments
-        completions_from_composite_sources(self.context, self.state, self.parameter_hints)
+        self.completions_from_composite_sources()
     }
 
     pub fn completions_from_unique_sources(&self) -> Result<Option<Vec<CompletionItem>>> {
@@ -76,5 +88,97 @@ impl<'a> CompletionBuilder<'a> {
 
         // No unique sources of completions, allow composite sources to run
         Ok(None)
+    }
+
+    fn completions_from_composite_sources(&self) -> Result<Vec<CompletionItem>> {
+        log::info!("completions_from_composite_sources()");
+
+        let mut completions: Vec<CompletionItem> = vec![];
+
+        let root = find_pipe_root(self.context)?;
+
+        // Try argument completions
+        if let Some(mut additional_completions) = completions_from_call(self.context, root.clone())?
+        {
+            completions.append(&mut additional_completions);
+        }
+
+        // Try pipe completions
+        if let Some(mut additional_completions) = completions_from_pipe(root.clone())? {
+            completions.append(&mut additional_completions);
+        }
+
+        // Try subset completions (`[` or `[[`)
+        if let Some(mut additional_completions) = completions_from_subset(self.context)? {
+            completions.append(&mut additional_completions);
+        }
+
+        // Call, pipe, and subset completions should show up no matter what when
+        // the user requests completions (this allows them to Tab their way through
+        // completions effectively without typing anything). For the rest of the
+        // general completions, we require an identifier to begin showing
+        // anything.
+        if is_identifier_like(self.context.node) {
+            completions.append(&mut completions_from_keywords());
+            completions.append(&mut completions_from_snippets());
+            completions.append(&mut completions_from_search_path(
+                self.context,
+                self.parameter_hints,
+            )?);
+
+            if let Some(mut additional_completions) = completions_from_document(self.context)? {
+                completions.append(&mut additional_completions);
+            }
+
+            if let Some(mut additional_completions) =
+                completions_from_workspace(self.context, self.state, self.parameter_hints)?
+            {
+                completions.append(&mut additional_completions);
+            }
+        }
+
+        // Remove duplicates
+        let mut uniques = HashSet::new();
+        completions.retain(|x| uniques.insert(x.label.clone()));
+
+        // Sort completions by providing custom 'sort' text to be used when
+        // ordering completion results. we use some placeholders at the front
+        // to 'bin' different completion types differently; e.g. we place parameter
+        // completions at the front, followed by variable completions (like pipe
+        // completions and subset completions), followed by anything else.
+        for item in &mut completions {
+            // Start with existing `sort_text` if one exists
+            let sort_text = item.sort_text.take();
+
+            let sort_text = match sort_text {
+                Some(sort_text) => sort_text,
+                None => item.label.clone(),
+            };
+
+            case! {
+                // Argument name
+                item.kind == Some(CompletionItemKind::FIELD) => {
+                    item.sort_text = Some(join!["1-", sort_text]);
+                }
+
+                // Something like pipe completions, or data frame column names
+                item.kind == Some(CompletionItemKind::VARIABLE) => {
+                    item.sort_text = Some(join!["2-", sort_text]);
+                }
+
+                // Package names generally have higher preference than function
+                // names. Particularly useful for `dev|` to get to `devtools::`,
+                // as that has a lot of base R functions with similar names.
+                item.kind == Some(CompletionItemKind::MODULE) => {
+                    item.sort_text = Some(join!["3-", sort_text]);
+                }
+
+                => {
+                    item.sort_text = Some(join!["4-", sort_text]);
+                }
+            }
+        }
+
+        Ok(completions)
     }
 }

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -3,8 +3,14 @@ use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
-use crate::lsp::completions::sources::completions_from_composite_sources;
-use crate::lsp::completions::sources::completions_from_unique_sources;
+use crate::lsp::completions::sources::composite::completions_from_composite_sources;
+use crate::lsp::completions::sources::unique::colon::completions_from_single_colon;
+use crate::lsp::completions::sources::unique::comment::completions_from_comment;
+use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
+use crate::lsp::completions::sources::unique::extractor::completions_from_at;
+use crate::lsp::completions::sources::unique::extractor::completions_from_dollar;
+use crate::lsp::completions::sources::unique::namespace::completions_from_namespace;
+use crate::lsp::completions::sources::unique::string::completions_from_string;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
@@ -26,10 +32,8 @@ impl<'a> CompletionBuilder<'a> {
     }
 
     pub fn build(self) -> Result<Vec<CompletionItem>> {
-        // Initially just delegate to existing functions
-        if let Some(completions) =
-            completions_from_unique_sources(self.context, self.parameter_hints)?
-        {
+        // Try unique sources first
+        if let Some(completions) = self.completions_from_unique_sources()? {
             return Ok(completions);
         }
 
@@ -37,5 +41,40 @@ impl<'a> CompletionBuilder<'a> {
         // set of reasonable completions based on loaded packages, the open
         // document, the current workspace, and any call related arguments
         completions_from_composite_sources(self.context, self.state, self.parameter_hints)
+    }
+
+    pub fn completions_from_unique_sources(&self) -> Result<Option<Vec<CompletionItem>>> {
+        // Try to detect a single colon first, which is a special case where we
+        // don't provide any completions
+        if let Some(completions) = completions_from_single_colon(self.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_comment(self.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_string(self.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_namespace(self.context, self.parameter_hints)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_custom_source(self.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_dollar(self.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_at(self.context)? {
+            return Ok(Some(completions));
+        }
+
+        // No unique sources of completions, allow composite sources to run
+        Ok(None)
     }
 }

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -6,33 +6,16 @@
 //
 
 use std::cell::OnceCell;
-use std::collections::HashSet;
 
 use anyhow::Result;
-use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
-use tower_lsp::lsp_types::CompletionItemKind;
 
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
-use crate::lsp::completions::sources::composite::call::CallCompletionProvider;
-use crate::lsp::completions::sources::composite::document::completions_from_document;
 use crate::lsp::completions::sources::composite::find_pipe_root;
-use crate::lsp::completions::sources::composite::is_identifier_like;
-use crate::lsp::completions::sources::composite::keyword::completions_from_keywords;
-use crate::lsp::completions::sources::composite::pipe::PipeCompletionProvider;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
-use crate::lsp::completions::sources::composite::search_path::SearchPathCompletionProvider;
-use crate::lsp::completions::sources::composite::snippets::completions_from_snippets;
-use crate::lsp::completions::sources::composite::subset::completions_from_subset;
-use crate::lsp::completions::sources::composite::workspace::WorkspaceCompletionProvider;
-use crate::lsp::completions::sources::unique::colon::completions_from_single_colon;
-use crate::lsp::completions::sources::unique::comment::completions_from_comment;
-use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
-use crate::lsp::completions::sources::unique::extractor::completions_from_at;
-use crate::lsp::completions::sources::unique::extractor::completions_from_dollar;
-use crate::lsp::completions::sources::unique::namespace::NamespaceSource;
-use crate::lsp::completions::sources::unique::string::completions_from_string;
+use crate::lsp::completions::sources::composite::CompositeCompletionsSource;
+use crate::lsp::completions::sources::unique::UniqueCompletionsSource;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
@@ -48,7 +31,6 @@ impl<'a> CompletionBuilder<'a> {
     pub fn new(context: &'a DocumentContext, state: &'a WorldState) -> Self {
         let parameter_hints =
             parameter_hints::parameter_hints(context.node, &context.document.contents);
-
         Self {
             context,
             state,
@@ -75,132 +57,15 @@ impl<'a> CompletionBuilder<'a> {
 
     pub fn build(self) -> Result<Vec<CompletionItem>> {
         // Try unique sources first
-        if let Some(completions) = self.completions_from_unique_sources()? {
+        if let Some(completions) = UniqueCompletionsSource::provide_completions(&self)? {
             return Ok(completions);
         }
 
         // At this point we aren't in a "unique" completion case, so just return a
-        // set of reasonable completions based on loaded packages, the open
-        // document, the current workspace, and any call related arguments
-        self.completions_from_composite_sources()
-    }
-
-    pub fn completions_from_unique_sources(&self) -> Result<Option<Vec<CompletionItem>>> {
-        // Try to detect a single colon first, which is a special case where we
-        // don't provide any completions
-        if let Some(completions) = completions_from_single_colon(self.context)? {
-            return Ok(Some(completions));
+        // set of reasonable completions from composite sources
+        match CompositeCompletionsSource::provide_completions(&self)? {
+            Some(completions) => Ok(completions),
+            None => Ok(Vec::new()), // This shouldn't happen, but just in case
         }
-
-        if let Some(completions) = completions_from_comment(self.context)? {
-            return Ok(Some(completions));
-        }
-
-        if let Some(completions) = completions_from_string(self.context)? {
-            return Ok(Some(completions));
-        }
-
-        if let Some(completions) = NamespaceSource::provide_completions(self)? {
-            return Ok(Some(completions));
-        }
-
-        if let Some(completions) = completions_from_custom_source(self.context)? {
-            return Ok(Some(completions));
-        }
-
-        if let Some(completions) = completions_from_dollar(self.context)? {
-            return Ok(Some(completions));
-        }
-
-        if let Some(completions) = completions_from_at(self.context)? {
-            return Ok(Some(completions));
-        }
-
-        // No unique sources of completions, allow composite sources to run
-        Ok(None)
-    }
-
-    fn completions_from_composite_sources(&self) -> Result<Vec<CompletionItem>> {
-        log::info!("completions_from_composite_sources()");
-
-        let mut completions: Vec<CompletionItem> = vec![];
-
-        // Try argument completions
-        if let Some(mut additional_completions) = self.get_call_completions()? {
-            completions.append(&mut additional_completions);
-        }
-
-        // Try pipe completions
-        if let Some(mut additional_completions) = self.get_pipe_completions()? {
-            completions.append(&mut additional_completions);
-        }
-
-        // Try subset completions (`[` or `[[`)
-        if let Some(mut additional_completions) = completions_from_subset(self.context)? {
-            completions.append(&mut additional_completions);
-        }
-
-        // Call, pipe, and subset completions should show up no matter what when
-        // the user requests completions (this allows them to Tab their way through
-        // completions effectively without typing anything). For the rest of the
-        // general completions, we require an identifier to begin showing
-        // anything.
-        if is_identifier_like(self.context.node) {
-            completions.append(&mut completions_from_keywords());
-            completions.append(&mut completions_from_snippets());
-            completions.append(&mut self.get_search_path_completions()?);
-
-            if let Some(mut additional_completions) = completions_from_document(self.context)? {
-                completions.append(&mut additional_completions);
-            }
-
-            if let Some(mut additional_completions) = self.get_workspace_completions()? {
-                completions.append(&mut additional_completions);
-            }
-        }
-
-        // Remove duplicates
-        let mut uniques = HashSet::new();
-        completions.retain(|x| uniques.insert(x.label.clone()));
-
-        // Sort completions by providing custom 'sort' text to be used when
-        // ordering completion results. we use some placeholders at the front
-        // to 'bin' different completion types differently; e.g. we place parameter
-        // completions at the front, followed by variable completions (like pipe
-        // completions and subset completions), followed by anything else.
-        for item in &mut completions {
-            // Start with existing `sort_text` if one exists
-            let sort_text = item.sort_text.take();
-
-            let sort_text = match sort_text {
-                Some(sort_text) => sort_text,
-                None => item.label.clone(),
-            };
-
-            case! {
-                // Argument name
-                item.kind == Some(CompletionItemKind::FIELD) => {
-                    item.sort_text = Some(join!["1-", sort_text]);
-                }
-
-                // Something like pipe completions, or data frame column names
-                item.kind == Some(CompletionItemKind::VARIABLE) => {
-                    item.sort_text = Some(join!["2-", sort_text]);
-                }
-
-                // Package names generally have higher preference than function
-                // names. Particularly useful for `dev|` to get to `devtools::`,
-                // as that has a lot of base R functions with similar names.
-                item.kind == Some(CompletionItemKind::MODULE) => {
-                    item.sort_text = Some(join!["3-", sort_text]);
-                }
-
-                => {
-                    item.sort_text = Some(join!["4-", sort_text]);
-                }
-            }
-        }
-
-        Ok(completions)
     }
 }

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+use tower_lsp::lsp_types::CompletionItem;
+
+use crate::lsp::completions::parameter_hints::ParameterHints;
+use crate::lsp::completions::parameter_hints::{self};
+use crate::lsp::completions::sources::completions_from_composite_sources;
+use crate::lsp::completions::sources::completions_from_unique_sources;
+use crate::lsp::document_context::DocumentContext;
+use crate::lsp::state::WorldState;
+
+pub(crate) struct CompletionBuilder<'a> {
+    context: &'a DocumentContext<'a>,
+    state: &'a WorldState,
+    parameter_hints: ParameterHints,
+}
+
+impl<'a> CompletionBuilder<'a> {
+    pub fn new(context: &'a DocumentContext, state: &'a WorldState) -> Self {
+        let parameter_hints =
+            parameter_hints::parameter_hints(context.node, &context.document.contents);
+        Self {
+            context,
+            state,
+            parameter_hints,
+        }
+    }
+
+    pub fn build(self) -> Result<Vec<CompletionItem>> {
+        // Initially just delegate to existing functions
+        if let Some(completions) =
+            completions_from_unique_sources(self.context, self.parameter_hints)?
+        {
+            return Ok(completions);
+        }
+
+        // At this point we aren't in a "unique" completion case, so just return a
+        // set of reasonable completions based on loaded packages, the open
+        // document, the current workspace, and any call related arguments
+        completions_from_composite_sources(self.context, self.state, self.parameter_hints)
+    }
+}

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -13,7 +13,7 @@ use crate::lsp::completions::sources::composite::find_pipe_root;
 use crate::lsp::completions::sources::composite::is_identifier_like;
 use crate::lsp::completions::sources::composite::keyword::completions_from_keywords;
 use crate::lsp::completions::sources::composite::pipe::completions_from_pipe;
-use crate::lsp::completions::sources::composite::search_path::completions_from_search_path;
+use crate::lsp::completions::sources::composite::search_path::SearchPathCompletionProvider;
 use crate::lsp::completions::sources::composite::snippets::completions_from_snippets;
 use crate::lsp::completions::sources::composite::subset::completions_from_subset;
 use crate::lsp::completions::sources::composite::workspace::completions_from_workspace;
@@ -57,10 +57,6 @@ impl<'a> CompletionBuilder<'a> {
     }
 
     // Temporary move: wrapper methods for functions that use parameter_hints
-
-    fn get_search_path_completions(&self) -> Result<Vec<CompletionItem>> {
-        completions_from_search_path(self.context, &self.parameter_hints)
-    }
 
     fn get_workspace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_workspace(self.context, self.state, &self.parameter_hints)

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -57,15 +57,16 @@ impl<'a> CompletionBuilder<'a> {
 
     pub fn build(self) -> Result<Vec<CompletionItem>> {
         // Try unique sources first
-        if let Some(completions) = UniqueCompletionsSource::provide_completions(&self)? {
+        let unique_sources = UniqueCompletionsSource;
+        if let Some(completions) = unique_sources.provide_completions(&self)? {
             return Ok(completions);
         }
 
         // At this point we aren't in a "unique" completion case, so just return a
         // set of reasonable completions from composite sources
-        match CompositeCompletionsSource::provide_completions(&self)? {
-            Some(completions) => Ok(completions),
-            None => Ok(Vec::new()), // This shouldn't happen, but just in case
-        }
+        let composite_sources = CompositeCompletionsSource;
+        Ok(composite_sources
+            .provide_completions(&self)?
+            .unwrap_or_default())
     }
 }

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -53,7 +53,6 @@ impl<'a> CompletionBuilder<'a> {
         // Cache it for future calls (ignore failure if race condition, which shouldn't happen)
         let _ = self.pipe_root_cell.set(root.clone());
 
-        // Return the result
         Ok(root)
     }
 

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -22,15 +22,15 @@ use crate::lsp::completions::sources::unique::comment::completions_from_comment;
 use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
 use crate::lsp::completions::sources::unique::extractor::completions_from_at;
 use crate::lsp::completions::sources::unique::extractor::completions_from_dollar;
-use crate::lsp::completions::sources::unique::namespace::completions_from_namespace;
+use crate::lsp::completions::sources::unique::namespace::NamespaceCompletionProvider;
 use crate::lsp::completions::sources::unique::string::completions_from_string;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
 pub(crate) struct CompletionBuilder<'a> {
-    context: &'a DocumentContext<'a>,
-    state: &'a WorldState,
-    parameter_hints: ParameterHints,
+    pub(crate) context: &'a DocumentContext<'a>,
+    pub(crate) state: &'a WorldState,
+    pub(crate) parameter_hints: ParameterHints,
 }
 
 impl<'a> CompletionBuilder<'a> {
@@ -57,10 +57,6 @@ impl<'a> CompletionBuilder<'a> {
     }
 
     // Temporary move: wrapper methods for functions that use parameter_hints
-
-    fn get_namespace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_namespace(self.context, &self.parameter_hints)
-    }
 
     fn get_search_path_completions(&self) -> Result<Vec<CompletionItem>> {
         completions_from_search_path(self.context, &self.parameter_hints)

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -8,12 +8,12 @@ use tower_lsp::lsp_types::CompletionItemKind;
 
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
-use crate::lsp::completions::sources::composite::call::completions_from_call;
+use crate::lsp::completions::sources::composite::call::CallCompletionProvider;
 use crate::lsp::completions::sources::composite::document::completions_from_document;
 use crate::lsp::completions::sources::composite::find_pipe_root;
 use crate::lsp::completions::sources::composite::is_identifier_like;
 use crate::lsp::completions::sources::composite::keyword::completions_from_keywords;
-use crate::lsp::completions::sources::composite::pipe::completions_from_pipe;
+use crate::lsp::completions::sources::composite::pipe::PipeCompletionProvider;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
 use crate::lsp::completions::sources::composite::search_path::SearchPathCompletionProvider;
 use crate::lsp::completions::sources::composite::snippets::completions_from_snippets;
@@ -117,16 +117,13 @@ impl<'a> CompletionBuilder<'a> {
 
         let mut completions: Vec<CompletionItem> = vec![];
 
-        let root = self.get_pipe_root()?;
-
         // Try argument completions
-        if let Some(mut additional_completions) = completions_from_call(self.context, root.clone())?
-        {
+        if let Some(mut additional_completions) = self.get_call_completions()? {
             completions.append(&mut additional_completions);
         }
 
         // Try pipe completions
-        if let Some(mut additional_completions) = completions_from_pipe(root.clone())? {
+        if let Some(mut additional_completions) = self.get_pipe_completions()? {
             completions.append(&mut additional_completions);
         }
 

--- a/crates/ark/src/lsp/completions/builder.rs
+++ b/crates/ark/src/lsp/completions/builder.rs
@@ -23,20 +23,24 @@ use crate::lsp::state::WorldState;
 pub(crate) struct CompletionBuilder<'a> {
     pub(crate) context: &'a DocumentContext<'a>,
     pub(crate) state: &'a WorldState,
-    pub(crate) parameter_hints: ParameterHints,
+    parameter_hints_cell: OnceCell<ParameterHints>,
     pipe_root: OnceCell<Option<PipeRoot>>,
 }
 
 impl<'a> CompletionBuilder<'a> {
     pub fn new(context: &'a DocumentContext, state: &'a WorldState) -> Self {
-        let parameter_hints =
-            parameter_hints::parameter_hints(context.node, &context.document.contents);
         Self {
             context,
             state,
-            parameter_hints,
+            parameter_hints_cell: OnceCell::new(),
             pipe_root: OnceCell::new(),
         }
+    }
+
+    pub fn parameter_hints(&self) -> &ParameterHints {
+        self.parameter_hints_cell.get_or_init(|| {
+            parameter_hints::parameter_hints(self.context.node, &self.context.document.contents)
+        })
     }
 
     pub fn get_pipe_root(&self) -> Result<Option<PipeRoot>> {

--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -9,7 +9,7 @@ use std::cell::OnceCell;
 
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
-use crate::lsp::completions::sources::composite::find_pipe_root;
+use crate::lsp::completions::sources::composite::pipe::find_pipe_root;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;

--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -7,7 +7,6 @@
 
 use std::cell::OnceCell;
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -46,7 +45,7 @@ impl<'a> CompletionContext<'a> {
         })
     }
 
-    pub fn pipe_root(&self) -> Result<Option<PipeRoot>> {
+    pub fn pipe_root(&self) -> anyhow::Result<Option<PipeRoot>> {
         if let Some(root) = self.pipe_root_cell.get() {
             return Ok(root.clone());
         }
@@ -59,7 +58,7 @@ impl<'a> CompletionContext<'a> {
         Ok(root)
     }
 
-    pub fn build(self) -> Result<Vec<CompletionItem>> {
+    pub fn build(self) -> anyhow::Result<Vec<CompletionItem>> {
         // Try unique sources first
         let unique_sources = UniqueCompletionsSource;
         if let Some(completions) = unique_sources.provide_completions(&self)? {

--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -7,15 +7,10 @@
 
 use std::cell::OnceCell;
 
-use tower_lsp::lsp_types::CompletionItem;
-
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
 use crate::lsp::completions::sources::composite::find_pipe_root;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
-use crate::lsp::completions::sources::composite::CompositeCompletionsSource;
-use crate::lsp::completions::sources::unique::UniqueCompletionsSource;
-use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
@@ -56,20 +51,5 @@ impl<'a> CompletionContext<'a> {
         let _ = self.pipe_root_cell.set(root.clone());
 
         Ok(root)
-    }
-
-    pub fn build(self) -> anyhow::Result<Vec<CompletionItem>> {
-        // Try unique sources first
-        let unique_sources = UniqueCompletionsSource;
-        if let Some(completions) = unique_sources.provide_completions(&self)? {
-            return Ok(completions);
-        }
-
-        // At this point we aren't in a "unique" completion case, so just return a
-        // set of reasonable completions from composite sources
-        let composite_sources = CompositeCompletionsSource;
-        Ok(composite_sources
-            .provide_completions(&self)?
-            .unwrap_or_default())
     }
 }

--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -1,5 +1,5 @@
 //
-// builder.rs
+// completion_context.rs
 //
 // Copyright (C) 2025 Posit Software, PBC. All rights reserved.
 //
@@ -20,17 +20,17 @@ use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
-pub(crate) struct CompletionBuilder<'a> {
-    pub(crate) context: &'a DocumentContext<'a>,
+pub(crate) struct CompletionContext<'a> {
+    pub(crate) document_context: &'a DocumentContext<'a>,
     pub(crate) state: &'a WorldState,
     parameter_hints_cell: OnceCell<ParameterHints>,
     pipe_root_cell: OnceCell<Option<PipeRoot>>,
 }
 
-impl<'a> CompletionBuilder<'a> {
-    pub fn new(context: &'a DocumentContext, state: &'a WorldState) -> Self {
+impl<'a> CompletionContext<'a> {
+    pub fn new(document_context: &'a DocumentContext, state: &'a WorldState) -> Self {
         Self {
-            context,
+            document_context,
             state,
             parameter_hints_cell: OnceCell::new(),
             pipe_root_cell: OnceCell::new(),
@@ -39,7 +39,10 @@ impl<'a> CompletionBuilder<'a> {
 
     pub fn parameter_hints(&self) -> &ParameterHints {
         self.parameter_hints_cell.get_or_init(|| {
-            parameter_hints::parameter_hints(self.context.node, &self.context.document.contents)
+            parameter_hints::parameter_hints(
+                self.document_context.node,
+                &self.document_context.document.contents,
+            )
         })
     }
 
@@ -48,7 +51,7 @@ impl<'a> CompletionBuilder<'a> {
             return Ok(root.clone());
         }
 
-        let root = find_pipe_root(self.context)?;
+        let root = find_pipe_root(self.document_context)?;
 
         // Cache it for future calls (ignore failure if race condition, which shouldn't happen)
         let _ = self.pipe_root_cell.set(root.clone());

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -170,7 +170,7 @@ pub(super) unsafe fn completion_item_from_package(
 pub(super) fn completion_item_from_function(
     name: &str,
     package: Option<&str>,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<CompletionItem> {
     let label = format!("{}", name);
     let mut item = completion_item(label, CompletionData::Function {
@@ -253,7 +253,7 @@ pub(super) unsafe fn completion_item_from_object(
     envir: SEXP,
     package: Option<&str>,
     promise_strategy: PromiseStrategy,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<CompletionItem> {
     if r_typeof(object) == PROMSXP {
         return completion_item_from_promise(
@@ -303,7 +303,7 @@ pub(super) unsafe fn completion_item_from_promise(
     envir: SEXP,
     package: Option<&str>,
     promise_strategy: PromiseStrategy,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<CompletionItem> {
     if r_promise_is_forced(object) {
         // Promise has already been evaluated before.
@@ -373,7 +373,7 @@ pub(super) unsafe fn completion_item_from_namespace(
     name: &str,
     namespace: SEXP,
     package: &str,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<CompletionItem> {
     // First, look in the namespace itself.
     if let Some(item) = completion_item_from_symbol(
@@ -419,7 +419,8 @@ pub(super) unsafe fn completion_item_from_lazydata(
     // Lazydata objects are never functions, so this doesn't really matter
     let parameter_hints = ParameterHints::Enabled;
 
-    match completion_item_from_symbol(name, env, Some(package), promise_strategy, parameter_hints) {
+    match completion_item_from_symbol(name, env, Some(package), promise_strategy, &parameter_hints)
+    {
         Some(item) => item,
         None => {
             // Should be impossible, but we'll be extra safe
@@ -433,7 +434,7 @@ pub(super) unsafe fn completion_item_from_symbol(
     envir: SEXP,
     package: Option<&str>,
     promise_strategy: PromiseStrategy,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Option<Result<CompletionItem>> {
     let symbol = r_symbol!(name);
 

--- a/crates/ark/src/lsp/completions/parameter_hints.rs
+++ b/crates/ark/src/lsp/completions/parameter_hints.rs
@@ -1,3 +1,10 @@
+//
+// parameter_hints.rs
+//
+// Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+//
+//
+
 use ropey::Rope;
 use tree_sitter::Node;
 

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -8,9 +8,7 @@
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::parameter_hints::parameter_hints;
-use crate::lsp::completions::sources::completions_from_composite_sources;
-use crate::lsp::completions::sources::completions_from_unique_sources;
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
@@ -22,14 +20,5 @@ pub(crate) fn provide_completions(
 ) -> Result<Vec<CompletionItem>> {
     log::info!("provide_completions()");
 
-    let parameter_hints = parameter_hints(context.node, &context.document.contents);
-
-    if let Some(completions) = completions_from_unique_sources(context, parameter_hints)? {
-        return Ok(completions);
-    };
-
-    // At this point we aren't in a "unique" completion case, so just return a
-    // set of reasonable completions based on loaded packages, the open
-    // document, the current workspace, and any call related arguments
-    completions_from_composite_sources(context, state, parameter_hints)
+    CompletionBuilder::new(context, state).build()
 }

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
@@ -17,7 +16,7 @@ use crate::lsp::state::WorldState;
 pub(crate) fn provide_completions(
     document_context: &DocumentContext,
     state: &WorldState,
-) -> Result<Vec<CompletionItem>> {
+) -> anyhow::Result<Vec<CompletionItem>> {
     log::info!("provide_completions()");
 
     CompletionContext::new(document_context, state).build()

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -8,17 +8,17 @@
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
 // Entry point for completions.
 // Must be within an `r_task()`.
 pub(crate) fn provide_completions(
-    context: &DocumentContext,
+    document_context: &DocumentContext,
     state: &WorldState,
 ) -> Result<Vec<CompletionItem>> {
     log::info!("provide_completions()");
 
-    CompletionBuilder::new(context, state).build()
+    CompletionContext::new(document_context, state).build()
 }

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -8,6 +8,8 @@
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
+use crate::lsp::completions::sources::composite;
+use crate::lsp::completions::sources::unique;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
 
@@ -19,5 +21,14 @@ pub(crate) fn provide_completions(
 ) -> anyhow::Result<Vec<CompletionItem>> {
     log::info!("provide_completions()");
 
-    CompletionContext::new(document_context, state).build()
+    let completion_context = CompletionContext::new(document_context, state);
+
+    // Try unique sources first
+    if let Some(completions) = unique::get_completions(&completion_context)? {
+        return Ok(completions);
+    }
+
+    // At this point we aren't in a "unique" completion case, so just return a
+    // set of reasonable completions from composite sources
+    Ok(composite::get_completions(&completion_context)?.unwrap_or_default())
 }

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -1,7 +1,7 @@
 //
 // provide.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/resolve.rs
+++ b/crates/ark/src/lsp/completions/resolve.rs
@@ -6,7 +6,6 @@
 //
 
 use anyhow::bail;
-use anyhow::Result;
 use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::Documentation;
@@ -16,7 +15,7 @@ use tower_lsp::lsp_types::MarkupKind;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::help::RHtmlHelp;
 
-pub fn resolve_completion(item: &mut CompletionItem) -> Result<bool> {
+pub fn resolve_completion(item: &mut CompletionItem) -> anyhow::Result<bool> {
     let Some(data) = item.data.clone() else {
         bail!("Completion '{}' has no associated data", item.label);
     };
@@ -46,7 +45,10 @@ pub fn resolve_completion(item: &mut CompletionItem) -> Result<bool> {
     }
 }
 
-fn resolve_package_completion_item(item: &mut CompletionItem, package: &str) -> Result<bool> {
+fn resolve_package_completion_item(
+    item: &mut CompletionItem,
+    package: &str,
+) -> anyhow::Result<bool> {
     let topic = join!(package, "-package");
     let help = unwrap!(RHtmlHelp::from_topic(topic.as_str(), Some(package))?, None => {
         return Ok(false);
@@ -68,7 +70,7 @@ fn resolve_function_completion_item(
     item: &mut CompletionItem,
     name: &str,
     package: Option<&str>,
-) -> Result<bool> {
+) -> anyhow::Result<bool> {
     let help = unwrap!(RHtmlHelp::from_function(name, package)?, None => {
         return Ok(false);
     });
@@ -90,7 +92,7 @@ fn resolve_parameter_completion_item(
     item: &mut CompletionItem,
     name: &str,
     function: &str,
-) -> Result<bool> {
+) -> anyhow::Result<bool> {
     // Get help for this function.
     let help = unwrap!(RHtmlHelp::from_function(function, None)?, None => {
         return Ok(false);

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -7,7 +7,7 @@
 
 mod common;
 pub(crate) mod composite;
-pub mod unique;
+pub(crate) mod unique;
 mod utils;
 
 use anyhow::Result;

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -34,7 +34,7 @@ where
     S: CompletionSource,
 {
     let source_name = source.name();
-    log::debug!("Trying completions from source: {}", source_name);
+    log::trace!("Trying completions from source: {}", source_name);
 
     if let Some(completions) = source.provide_completions(completion_context)? {
         log::info!(

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -10,7 +10,6 @@ pub(crate) mod composite;
 pub(crate) mod unique;
 mod utils;
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
@@ -23,13 +22,13 @@ pub trait CompletionSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>>;
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>>;
 }
 
 pub fn collect_completions<S>(
     source: S,
     completion_context: &CompletionContext,
-) -> Result<Option<Vec<CompletionItem>>>
+) -> anyhow::Result<Option<Vec<CompletionItem>>>
 where
     S: CompletionSource,
 {
@@ -52,7 +51,7 @@ pub fn collect_and_append_completions<S>(
     source: S,
     completion_context: &CompletionContext,
     completions: &mut Vec<CompletionItem>,
-) -> Result<()>
+) -> anyhow::Result<()>
 where
     S: CompletionSource,
 {

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -18,8 +18,6 @@ use crate::lsp::completions::builder::CompletionBuilder;
 /// Interface for any source we consult for completions
 pub trait CompletionSource {
     /// Name of this source for logging/debugging
-    /// Not used (yet?) but seems like a good idea
-    #[allow(dead_code)]
     fn name(&self) -> &'static str;
 
     fn provide_completions(

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -22,5 +22,8 @@ pub trait CompletionSource {
     #[allow(dead_code)]
     fn name(&self) -> &'static str;
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>>;
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>>;
 }

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -25,3 +25,39 @@ pub trait CompletionSource {
         completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>>;
 }
+
+pub fn collect_completions<S>(
+    source: S,
+    completion_context: &CompletionContext,
+) -> Result<Option<Vec<CompletionItem>>>
+where
+    S: CompletionSource,
+{
+    let source_name = source.name();
+    log::debug!("Trying completions from source: {}", source_name);
+
+    if let Some(completions) = source.provide_completions(completion_context)? {
+        log::info!(
+            "Found {} completions from source: {}",
+            completions.len(),
+            source_name
+        );
+        Ok(Some(completions))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn collect_and_append_completions<S>(
+    source: S,
+    completion_context: &CompletionContext,
+    completions: &mut Vec<CompletionItem>,
+) -> Result<()>
+where
+    S: CompletionSource,
+{
+    if let Some(mut additional_completions) = collect_completions(source, completion_context)? {
+        completions.append(&mut additional_completions);
+    }
+    Ok(())
+}

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -13,7 +13,7 @@ mod utils;
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 
 /// Interface for any source we consult for completions
 pub trait CompletionSource {
@@ -22,6 +22,6 @@ pub trait CompletionSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>>;
 }

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -6,9 +6,6 @@
 //
 
 mod common;
-mod composite;
-mod unique;
+pub(crate) mod composite;
+pub mod unique;
 mod utils;
-
-pub use composite::completions_from_composite_sources;
-pub use unique::completions_from_unique_sources;

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -1,7 +1,7 @@
 //
 // sources.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -9,3 +9,18 @@ mod common;
 pub(crate) mod composite;
 pub mod unique;
 mod utils;
+
+use anyhow::Result;
+use tower_lsp::lsp_types::CompletionItem;
+
+use crate::lsp::completions::builder::CompletionBuilder;
+
+/// Interface for any source we consult for completions
+pub trait CompletionSource {
+    /// Name of this source for logging/debugging
+    /// Not used (yet?) but seems like a good idea
+    #[allow(dead_code)]
+    fn name(&self) -> &'static str;
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>>;
+}

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -47,7 +47,7 @@ where
     }
 }
 
-pub fn collect_and_append_completions<S>(
+pub fn push_completions<S>(
     source: S,
     completion_context: &CompletionContext,
     completions: &mut Vec<CompletionItem>,

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -45,8 +45,11 @@ impl CompletionSource for CompositeCompletionsSource {
         "composite_sources"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
-        log::info!("completions_from_composite_sources()");
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        log::info!("Getting completions from composite sources");
 
         let mut completions: Vec<CompletionItem> = vec![];
 

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -23,7 +23,7 @@ use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionItemKind;
 use tree_sitter::Node;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
@@ -39,7 +39,7 @@ impl CompletionSource for CompositeCompletionsSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
         log::info!("Getting completions from composite sources");
 
@@ -54,7 +54,9 @@ impl CompletionSource for CompositeCompletionsSource {
             let source_name = source.name();
             log::debug!("Trying completions from source: {}", source_name);
 
-            if let Some(mut additional_completions) = source.provide_completions(builder)? {
+            if let Some(mut additional_completions) =
+                source.provide_completions(completion_context)?
+            {
                 log::debug!(
                     "Found {} completions from source: {}",
                     additional_completions.len(),
@@ -69,7 +71,7 @@ impl CompletionSource for CompositeCompletionsSource {
         // completions effectively without typing anything). For the rest of the
         // general completions, we require an identifier to begin showing
         // anything.
-        if is_identifier_like(builder.context.node) {
+        if is_identifier_like(completion_context.document_context.node) {
             let identifier_only_sources: &[&dyn CompletionSource] = &[
                 &keyword::KeywordSource,
                 &snippets::SnippetSource,
@@ -82,7 +84,9 @@ impl CompletionSource for CompositeCompletionsSource {
                 let source_name = source.name();
                 log::debug!("Trying completions from source: {}", source_name);
 
-                if let Some(mut additional_completions) = source.provide_completions(builder)? {
+                if let Some(mut additional_completions) =
+                    source.provide_completions(completion_context)?
+                {
                     log::debug!(
                         "Found {} completions from source: {}",
                         additional_completions.len(),

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -23,7 +23,7 @@ use tower_lsp::lsp_types::CompletionItemKind;
 use tree_sitter::Node;
 
 use crate::lsp::completions::completion_context::CompletionContext;
-use crate::lsp::completions::sources::collect_and_append_completions;
+use crate::lsp::completions::sources::push_completions;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
@@ -40,43 +40,39 @@ pub(crate) fn get_completions(
     // through completions effectively without typing anything.
 
     // argument completions
-    collect_and_append_completions(call::CallSource, completion_context, &mut completions)?;
+    push_completions(call::CallSource, completion_context, &mut completions)?;
 
     // pipe completions, such as column names of a data frame
-    collect_and_append_completions(pipe::PipeSource, completion_context, &mut completions)?;
+    push_completions(pipe::PipeSource, completion_context, &mut completions)?;
 
     // subset completions (`[` or `[[`)
-    collect_and_append_completions(subset::SubsetSource, completion_context, &mut completions)?;
+    push_completions(subset::SubsetSource, completion_context, &mut completions)?;
 
     // For the rest of the general completions, we require an identifier to
     // begin showing anything.
     if is_identifier_like(completion_context.document_context.node) {
         // Consulted settings.json
-        collect_and_append_completions(
-            keyword::KeywordSource,
-            completion_context,
-            &mut completions,
-        )?;
+        push_completions(keyword::KeywordSource, completion_context, &mut completions)?;
 
-        collect_and_append_completions(
+        push_completions(
             snippets::SnippetSource,
             completion_context,
             &mut completions,
         )?;
 
-        collect_and_append_completions(
+        push_completions(
             search_path::SearchPathSource,
             completion_context,
             &mut completions,
         )?;
 
-        collect_and_append_completions(
+        push_completions(
             document::DocumentSource,
             completion_context,
             &mut completions,
         )?;
 
-        collect_and_append_completions(
+        push_completions(
             workspace::WorkspaceSource,
             completion_context,
             &mut completions,

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -135,7 +135,7 @@ impl CompletionSource for CompositeCompletionsSource {
     }
 }
 
-pub fn is_identifier_like(x: Node) -> bool {
+fn is_identifier_like(x: Node) -> bool {
     if x.is_identifier() {
         // Obvious case
         return true;

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -16,7 +16,6 @@ mod workspace;
 
 use std::collections::HashSet;
 
-pub use pipe::find_pipe_root;
 use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionItemKind;

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -45,8 +45,11 @@ impl CompletionSource for CompositeCompletionsSource {
 
         let mut completions: Vec<CompletionItem> = vec![];
 
-        let always_sources: &[&dyn CompletionSource] =
-            &[&call::CallSource, &pipe::PipeSource, &subset::SubsetSource];
+        let always_sources: &[&dyn CompletionSource] = &[
+            &call::CallSource,     // argument completions
+            &pipe::PipeSource,     // pipe completions, e.g. column names
+            &subset::SubsetSource, // subset completions (`[` or `[[`)
+        ];
         for source in always_sources {
             let source_name = source.name();
             log::debug!("Trying completions from source: {}", source_name);

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -16,7 +16,6 @@ mod workspace;
 
 use std::collections::HashSet;
 
-use anyhow::Result;
 pub use pipe::find_pipe_root;
 use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
@@ -41,7 +40,7 @@ impl CompletionSource for CompositeCompletionsSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         log::info!("Getting completions from composite sources");
 
         let mut completions: Vec<CompletionItem> = vec![];

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -5,131 +5,22 @@
 //
 //
 
-mod call;
-mod document;
-mod keyword;
-mod pipe;
-mod search_path;
-mod snippets;
-mod subset;
-mod workspace;
+pub(crate) mod call;
+pub(crate) mod document;
+pub(crate) mod keyword;
+pub(crate) mod pipe;
+pub(crate) mod search_path;
+pub(crate) mod snippets;
+pub(crate) mod subset;
+pub(crate) mod workspace;
 
-use std::collections::HashSet;
-
-use anyhow::Result;
-use call::completions_from_call;
-use document::completions_from_document;
-use keyword::completions_from_keywords;
-use pipe::completions_from_pipe;
-use pipe::find_pipe_root;
-use search_path::completions_from_search_path;
-use snippets::completions_from_snippets;
-use stdext::*;
-use subset::completions_from_subset;
-use tower_lsp::lsp_types::CompletionItem;
-use tower_lsp::lsp_types::CompletionItemKind;
+pub use pipe::find_pipe_root;
 use tree_sitter::Node;
-use workspace::completions_from_workspace;
 
-use crate::lsp::completions::parameter_hints::ParameterHints;
-use crate::lsp::document_context::DocumentContext;
-use crate::lsp::state::WorldState;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-pub fn completions_from_composite_sources(
-    context: &DocumentContext,
-    state: &WorldState,
-    parameter_hints: ParameterHints,
-) -> Result<Vec<CompletionItem>> {
-    log::info!("completions_from_composite_sources()");
-
-    let mut completions: Vec<CompletionItem> = vec![];
-
-    let root = find_pipe_root(context)?;
-
-    // Try argument completions
-    if let Some(mut additional_completions) = completions_from_call(context, root.clone())? {
-        completions.append(&mut additional_completions);
-    }
-
-    // Try pipe completions
-    if let Some(mut additional_completions) = completions_from_pipe(root.clone())? {
-        completions.append(&mut additional_completions);
-    }
-
-    // Try subset completions (`[` or `[[`)
-    if let Some(mut additional_completions) = completions_from_subset(context)? {
-        completions.append(&mut additional_completions);
-    }
-
-    // Call, pipe, and subset completions should show up no matter what when
-    // the user requests completions (this allows them to Tab their way through
-    // completions effectively without typing anything). For the rest of the
-    // general completions, we require an identifier to begin showing
-    // anything.
-    if is_identifier_like(context.node) {
-        completions.append(&mut completions_from_keywords());
-        completions.append(&mut completions_from_snippets());
-        completions.append(&mut completions_from_search_path(context, parameter_hints)?);
-
-        if let Some(mut additional_completions) = completions_from_document(context)? {
-            completions.append(&mut additional_completions);
-        }
-
-        if let Some(mut additional_completions) =
-            completions_from_workspace(context, state, parameter_hints)?
-        {
-            completions.append(&mut additional_completions);
-        }
-    }
-
-    // Remove duplicates
-    let mut uniques = HashSet::new();
-    completions.retain(|x| uniques.insert(x.label.clone()));
-
-    // Sort completions by providing custom 'sort' text to be used when
-    // ordering completion results. we use some placeholders at the front
-    // to 'bin' different completion types differently; e.g. we place parameter
-    // completions at the front, followed by variable completions (like pipe
-    // completions and subset completions), followed by anything else.
-    for item in &mut completions {
-        // Start with existing `sort_text` if one exists
-        let sort_text = item.sort_text.take();
-
-        let sort_text = match sort_text {
-            Some(sort_text) => sort_text,
-            None => item.label.clone(),
-        };
-
-        case! {
-            // Argument name
-            item.kind == Some(CompletionItemKind::FIELD) => {
-                item.sort_text = Some(join!["1-", sort_text]);
-            }
-
-            // Something like pipe completions, or data frame column names
-            item.kind == Some(CompletionItemKind::VARIABLE) => {
-                item.sort_text = Some(join!["2-", sort_text]);
-            }
-
-            // Package names generally have higher preference than function
-            // names. Particularly useful for `dev|` to get to `devtools::`,
-            // as that has a lot of base R functions with similar names.
-            item.kind == Some(CompletionItemKind::MODULE) => {
-                item.sort_text = Some(join!["3-", sort_text]);
-            }
-
-            => {
-                item.sort_text = Some(join!["4-", sort_text]);
-            }
-        }
-    }
-
-    Ok(completions)
-}
-
-fn is_identifier_like(x: Node) -> bool {
+pub fn is_identifier_like(x: Node) -> bool {
     if x.is_identifier() {
         // Obvious case
         return true;

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -47,8 +47,6 @@ fn completions_from_call(
     context: &DocumentContext,
     root: Option<PipeRoot>,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_call()");
-
     let mut node = context.node;
     let mut has_call = false;
 
@@ -168,7 +166,7 @@ fn get_first_argument(context: &DocumentContext, node: &Node) -> Result<Option<R
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return Ok(None),
             Error::TryCatchError { message, .. } => {
-                log::info!("Can't evaluate first argument: {message}");
+                log::debug!("Can't evaluate first argument: {message}");
                 return Ok(None);
             },
             _ => {
@@ -186,7 +184,7 @@ fn completions_from_arguments(
     callable: &str,
     object: RObject,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_arguments({callable:?})");
+    log::debug!("completions_from_arguments({callable:?})");
 
     // Try looking up session function first, as the "current state of the world"
     // will provide the most accurate completions
@@ -206,7 +204,7 @@ fn completions_from_session_arguments(
     callable: &str,
     object: RObject,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_session_arguments({callable:?})");
+    log::debug!("completions_from_session_arguments({callable:?})");
 
     let mut completions = vec![];
 
@@ -265,7 +263,7 @@ fn completions_from_workspace_arguments(
     context: &DocumentContext,
     callable: &str,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_workspace_arguments({callable:?})");
+    log::debug!("completions_from_workspace_arguments({callable:?})");
 
     // Try to find the `callable` in the workspace and use its arguments
     // if we can

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -25,7 +25,7 @@ use crate::lsp::indexer;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub(super) fn completions_from_call(
+pub fn completions_from_call(
     context: &DocumentContext,
     root: Option<PipeRoot>,
 ) -> Result<Option<Vec<CompletionItem>>> {

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -1,7 +1,7 @@
 //
 // call.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -168,7 +168,7 @@ fn get_first_argument(context: &DocumentContext, node: &Node) -> Result<Option<R
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return Ok(None),
             Error::TryCatchError { message, .. } => {
-                log::debug!("Can't evaluate first argument: {message}");
+                log::trace!("Can't evaluate first argument: {message}");
                 return Ok(None);
             },
             _ => {
@@ -186,7 +186,7 @@ fn completions_from_arguments(
     callable: &str,
     object: RObject,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::debug!("completions_from_arguments({callable:?})");
+    log::trace!("completions_from_arguments({callable:?})");
 
     // Try looking up session function first, as the "current state of the world"
     // will provide the most accurate completions
@@ -206,7 +206,7 @@ fn completions_from_session_arguments(
     callable: &str,
     object: RObject,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::debug!("completions_from_session_arguments({callable:?})");
+    log::trace!("completions_from_session_arguments({callable:?})");
 
     let mut completions = vec![];
 
@@ -265,7 +265,7 @@ fn completions_from_workspace_arguments(
     context: &DocumentContext,
     callable: &str,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::debug!("completions_from_workspace_arguments({callable:?})");
+    log::trace!("completions_from_workspace_arguments({callable:?})");
 
     // Try to find the `callable` in the workspace and use its arguments
     // if we can

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -39,7 +39,7 @@ impl CompletionSource for CallSource {
     ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_call(
             completion_context.document_context,
-            completion_context.pipe_root()?,
+            completion_context.pipe_root(),
         )
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::error::Error;
 use harp::eval::RParseEvalOptions;
 use harp::exec::RFunction;
@@ -37,7 +36,7 @@ impl CompletionSource for CallSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_call(
             completion_context.document_context,
             completion_context.pipe_root()?,
@@ -48,7 +47,7 @@ impl CompletionSource for CallSource {
 fn completions_from_call(
     context: &DocumentContext,
     root: Option<PipeRoot>,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let mut node = context.node;
     let mut has_call = false;
 
@@ -122,7 +121,7 @@ fn completions_from_call(
     completions_from_arguments(context, &callee, object)
 }
 
-fn get_first_argument(context: &DocumentContext, node: &Node) -> Result<Option<RObject>> {
+fn get_first_argument(context: &DocumentContext, node: &Node) -> anyhow::Result<Option<RObject>> {
     // Get the first argument, if any (object used for dispatch).
     // TODO: We should have some way of matching calls, so we can
     // take a function signature from R and see how the call matches
@@ -185,7 +184,7 @@ fn completions_from_arguments(
     context: &DocumentContext,
     callable: &str,
     object: RObject,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_arguments({callable:?})");
 
     // Try looking up session function first, as the "current state of the world"
@@ -205,7 +204,7 @@ fn completions_from_session_arguments(
     context: &DocumentContext,
     callable: &str,
     object: RObject,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_session_arguments({callable:?})");
 
     let mut completions = vec![];
@@ -264,7 +263,7 @@ fn completions_from_session_arguments(
 fn completions_from_workspace_arguments(
     context: &DocumentContext,
     callable: &str,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_workspace_arguments({callable:?})");
 
     // Try to find the `callable` in the workspace and use its arguments

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -38,7 +38,7 @@ impl CompletionSource for CallSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        let root = builder.get_pipe_root()?;
+        let root = builder.pipe_root()?;
         completions_from_call(builder.context, root)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -21,20 +21,25 @@ use crate::lsp::completions::completion_item::completion_item_from_parameter;
 use crate::lsp::completions::sources::utils::call_node_position_type;
 use crate::lsp::completions::sources::utils::set_sort_text_by_first_appearance;
 use crate::lsp::completions::sources::utils::CallNodePositionType;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::indexer;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub trait CallCompletionProvider {
-    fn get_call_completions(&self) -> Result<Option<Vec<CompletionItem>>>;
-}
+pub struct CallSource;
 
-impl<'a> CallCompletionProvider for CompletionBuilder<'a> {
-    fn get_call_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
-        // Use the cached pipe_root from self instead of passing it in
-        let root = self.get_pipe_root()?;
-        completions_from_call(self.context, root)
+impl CompletionSource for CallSource {
+    fn name(&self) -> &'static str {
+        "call"
+    }
+
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        let root = builder.get_pipe_root()?;
+        completions_from_call(builder.context, root)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -27,7 +27,7 @@ use crate::lsp::indexer;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub struct CallSource;
+pub(super) struct CallSource;
 
 impl CompletionSource for CallSource {
     fn name(&self) -> &'static str {
@@ -38,8 +38,7 @@ impl CompletionSource for CallSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        let root = builder.pipe_root()?;
-        completions_from_call(builder.context, root)
+        completions_from_call(builder.context, builder.pipe_root()?)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -16,7 +16,7 @@ use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
 use super::pipe::PipeRoot;
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_parameter;
 use crate::lsp::completions::sources::utils::call_node_position_type;
 use crate::lsp::completions::sources::utils::set_sort_text_by_first_appearance;
@@ -36,9 +36,12 @@ impl CompletionSource for CallSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_call(builder.context, builder.pipe_root()?)
+        completions_from_call(
+            completion_context.document_context,
+            completion_context.pipe_root()?,
+        )
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/document.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/document.rs
@@ -10,7 +10,7 @@ use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_assignment;
 use crate::lsp::completions::completion_item::completion_item_from_scope_parameter;
 use crate::lsp::completions::sources::utils::filter_out_dot_prefixes;
@@ -32,9 +32,9 @@ impl CompletionSource for DocumentSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_document(builder.context)
+        completions_from_document(completion_context.document_context)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/document.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/document.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
@@ -33,12 +32,14 @@ impl CompletionSource for DocumentSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_document(completion_context.document_context)
     }
 }
 
-pub fn completions_from_document(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+pub fn completions_from_document(
+    context: &DocumentContext,
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     // get reference to AST
     let mut node = context.node;
 
@@ -147,7 +148,7 @@ fn completions_from_document_variables(
 fn completions_from_document_function_arguments(
     node: &Node,
     context: &DocumentContext,
-) -> Result<Vec<CompletionItem>> {
+) -> anyhow::Result<Vec<CompletionItem>> {
     let mut completions = vec![];
 
     // get the parameters node
@@ -180,7 +181,7 @@ fn completions_from_document_function_arguments(
 }
 
 fn call_uses_nse(node: &Node, context: &DocumentContext) -> bool {
-    let result: Result<()> = local! {
+    let result: anyhow::Result<()> = local! {
 
         let lhs = node.child(0).into_result()?;
         lhs.is_identifier_or_string().into_result()?;

--- a/crates/ark/src/lsp/completions/sources/composite/document.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/document.rs
@@ -1,7 +1,7 @@
 //
 // document.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -10,9 +10,11 @@ use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item_from_assignment;
 use crate::lsp::completions::completion_item::completion_item_from_scope_parameter;
 use crate::lsp::completions::sources::utils::filter_out_dot_prefixes;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::cursor::TreeCursorExt;
 use crate::lsp::traits::point::PointExt;
@@ -20,6 +22,21 @@ use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
+
+pub struct DocumentSource;
+
+impl CompletionSource for DocumentSource {
+    fn name(&self) -> &'static str {
+        "document"
+    }
+
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_document(builder.context)
+    }
+}
 
 pub fn completions_from_document(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     // get reference to AST

--- a/crates/ark/src/lsp/completions/sources/composite/document.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/document.rs
@@ -23,7 +23,7 @@ use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-pub struct DocumentSource;
+pub(super) struct DocumentSource;
 
 impl CompletionSource for DocumentSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/document.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/document.rs
@@ -21,9 +21,7 @@ use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-pub(super) fn completions_from_document(
-    context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+pub fn completions_from_document(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     // get reference to AST
     let mut node = context.node;
 

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -33,8 +33,6 @@ impl CompletionSource for KeywordSource {
 pub fn completions_from_keywords(
     _builder: &CompletionBuilder,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_keywords()");
-
     let mut completions = vec![];
 
     // provide keyword completion results

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -10,7 +10,7 @@ use stdext::unwrap;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionItemKind;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
@@ -24,15 +24,13 @@ impl CompletionSource for KeywordSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        _completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_keywords(builder)
+        completions_from_keywords()
     }
 }
 
-pub fn completions_from_keywords(
-    _builder: &CompletionBuilder,
-) -> Result<Option<Vec<CompletionItem>>> {
+pub fn completions_from_keywords() -> Result<Option<Vec<CompletionItem>>> {
     let mut completions = vec![];
 
     // provide keyword completion results

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::CompletionItemKind;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::types::CompletionData;
 
-pub(super) fn completions_from_keywords() -> Vec<CompletionItem> {
+pub fn completions_from_keywords() -> Vec<CompletionItem> {
     log::info!("completions_from_keywords()");
 
     let mut completions = vec![];

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use stdext::unwrap;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionItemKind;
@@ -25,12 +24,12 @@ impl CompletionSource for KeywordSource {
     fn provide_completions(
         &self,
         _completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_keywords()
     }
 }
 
-pub fn completions_from_keywords() -> Result<Option<Vec<CompletionItem>>> {
+pub fn completions_from_keywords() -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let mut completions = vec![];
 
     // provide keyword completion results

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -1,16 +1,34 @@
 //
 // keyword.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
+use anyhow::Result;
 use stdext::unwrap;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionItemKind;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
+
+pub struct KeywordSource;
+
+impl CompletionSource for KeywordSource {
+    fn name(&self) -> &'static str {
+        "keyword"
+    }
+
+    fn provide_completions(
+        &self,
+        _builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        Ok(Some(completions_from_keywords()))
+    }
+}
 
 pub fn completions_from_keywords() -> Vec<CompletionItem> {
     log::info!("completions_from_keywords()");

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -15,7 +15,7 @@ use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
 
-pub struct KeywordSource;
+pub(super) struct KeywordSource;
 
 impl CompletionSource for KeywordSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/keyword.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/keyword.rs
@@ -24,13 +24,15 @@ impl CompletionSource for KeywordSource {
 
     fn provide_completions(
         &self,
-        _builder: &CompletionBuilder,
+        builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        Ok(Some(completions_from_keywords()))
+        completions_from_keywords(builder)
     }
 }
 
-pub fn completions_from_keywords() -> Vec<CompletionItem> {
+pub fn completions_from_keywords(
+    _builder: &CompletionBuilder,
+) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_keywords()");
 
     let mut completions = vec![];
@@ -72,5 +74,5 @@ pub fn completions_from_keywords() -> Vec<CompletionItem> {
         completions.push(item);
     }
 
-    completions
+    Ok(Some(completions))
 }

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -1,7 +1,7 @@
 //
 // pipe.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -29,8 +29,7 @@ impl CompletionSource for PipeSource {
         &self,
         completion_context: &CompletionContext,
     ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
-        let root = completion_context.pipe_root()?;
-        completions_from_pipe(root)
+        completions_from_pipe(completion_context.pipe_root())
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -17,7 +17,7 @@ use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
 #[derive(Clone)]
-pub(super) struct PipeRoot {
+pub struct PipeRoot {
     pub(super) name: String,
 
     /// If `None`, we found a pipe root and tried to evaluate it, but the
@@ -25,7 +25,7 @@ pub(super) struct PipeRoot {
     pub(super) object: Option<RObject>,
 }
 
-pub(super) fn completions_from_pipe(
+pub fn completions_from_pipe(
     root: Option<PipeRoot>,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let Some(root) = root else {
@@ -51,7 +51,7 @@ pub(super) fn completions_from_pipe(
 
 /// Loop should be kept in sync with `completions_from_call()` so they find
 /// the same call to detect the pipe root of
-pub(super) fn find_pipe_root(context: &DocumentContext) -> anyhow::Result<Option<PipeRoot>> {
+pub fn find_pipe_root(context: &DocumentContext) -> anyhow::Result<Option<PipeRoot>> {
     log::info!("find_pipe_root()");
 
     let mut node = context.node;

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -19,7 +19,7 @@ use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub struct PipeSource;
+pub(super) struct PipeSource;
 
 impl CompletionSource for PipeSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -12,7 +12,7 @@ use harp::object::RObject;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::utils::completions_from_object_names;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
@@ -28,9 +28,9 @@ impl CompletionSource for PipeSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        let root = builder.pipe_root()?;
+        let root = completion_context.pipe_root()?;
         completions_from_pipe(root)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -69,7 +69,7 @@ fn completions_from_pipe(root: Option<PipeRoot>) -> anyhow::Result<Option<Vec<Co
 /// Loop should be kept in sync with `completions_from_call()` so they find
 /// the same call to detect the pipe root of
 pub fn find_pipe_root(context: &DocumentContext) -> anyhow::Result<Option<PipeRoot>> {
-    log::debug!("find_pipe_root()");
+    log::trace!("find_pipe_root()");
 
     let mut node = context.node;
     let mut has_call = false;
@@ -125,7 +125,7 @@ fn eval_pipe_root(name: &str) -> Option<RObject> {
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return None,
             Error::TryCatchError { message, .. } => {
-                log::debug!("Can't evaluate pipe root: {message}");
+                log::trace!("Can't evaluate pipe root: {message}");
                 return None;
             },
             _ => {

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use anyhow::Result;
 use harp::error::Error;
 use harp::eval::RParseEvalOptions;
 use harp::object::RObject;
@@ -13,18 +14,23 @@ use tree_sitter::Node;
 
 use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::sources::utils::completions_from_object_names;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub trait PipeCompletionProvider {
-    fn get_pipe_completions(&self) -> Result<Option<Vec<CompletionItem>>, anyhow::Error>;
-}
+pub struct PipeSource;
 
-impl<'a> PipeCompletionProvider for CompletionBuilder<'a> {
-    fn get_pipe_completions(&self) -> Result<Option<Vec<CompletionItem>>, anyhow::Error> {
-        // Use the cached pipe_root from self
-        let root = self.get_pipe_root()?;
+impl CompletionSource for PipeSource {
+    fn name(&self) -> &'static str {
+        "pipe"
+    }
+
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        let root = builder.get_pipe_root()?;
         completions_from_pipe(root)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -30,7 +30,7 @@ impl CompletionSource for PipeSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        let root = builder.get_pipe_root()?;
+        let root = builder.pipe_root()?;
         completions_from_pipe(root)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::error::Error;
 use harp::eval::RParseEvalOptions;
 use harp::object::RObject;
@@ -29,7 +28,7 @@ impl CompletionSource for PipeSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         let root = completion_context.pipe_root()?;
         completions_from_pipe(root)
     }

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -69,7 +69,7 @@ fn completions_from_pipe(root: Option<PipeRoot>) -> anyhow::Result<Option<Vec<Co
 /// Loop should be kept in sync with `completions_from_call()` so they find
 /// the same call to detect the pipe root of
 pub fn find_pipe_root(context: &DocumentContext) -> anyhow::Result<Option<PipeRoot>> {
-    log::info!("find_pipe_root()");
+    log::debug!("find_pipe_root()");
 
     let mut node = context.node;
     let mut has_call = false;
@@ -125,7 +125,7 @@ fn eval_pipe_root(name: &str) -> Option<RObject> {
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return None,
             Error::TryCatchError { message, .. } => {
-                log::info!("Can't evaluate pipe root: {message}");
+                log::debug!("Can't evaluate pipe root: {message}");
                 return None;
             },
             _ => {

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -19,6 +19,7 @@ use libr::R_lsInternal;
 use libr::ENCLOS;
 use tower_lsp::lsp_types::CompletionItem;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item_from_package;
 use crate::lsp::completions::completion_item::completion_item_from_symbol;
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -27,7 +28,19 @@ use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
 use crate::lsp::completions::types::PromiseStrategy;
 use crate::lsp::document_context::DocumentContext;
 
-pub fn completions_from_search_path(
+/// Extension trait for providing search path completions
+pub trait SearchPathCompletionProvider {
+    /// Get completions from the R search path
+    fn get_search_path_completions(&self) -> Result<Vec<CompletionItem>>;
+}
+
+impl<'a> SearchPathCompletionProvider for CompletionBuilder<'a> {
+    fn get_search_path_completions(&self) -> Result<Vec<CompletionItem>> {
+        completions_from_search_path(self.context, &self.parameter_hints)
+    }
+}
+
+fn completions_from_search_path(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
 ) -> Result<Vec<CompletionItem>> {

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -29,7 +29,7 @@ use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::PromiseStrategy;
 use crate::lsp::document_context::DocumentContext;
 
-pub struct SearchPathSource;
+pub(super) struct SearchPathSource;
 
 impl CompletionSource for SearchPathSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -25,25 +25,29 @@ use crate::lsp::completions::completion_item::completion_item_from_symbol;
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::sources::utils::filter_out_dot_prefixes;
 use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::PromiseStrategy;
 use crate::lsp::document_context::DocumentContext;
 
-/// Extension trait for providing search path completions
-pub trait SearchPathCompletionProvider {
-    /// Get completions from the R search path
-    fn get_search_path_completions(&self) -> Result<Vec<CompletionItem>>;
-}
+pub struct SearchPathSource;
 
-impl<'a> SearchPathCompletionProvider for CompletionBuilder<'a> {
-    fn get_search_path_completions(&self) -> Result<Vec<CompletionItem>> {
-        completions_from_search_path(self.context, &self.parameter_hints)
+impl CompletionSource for SearchPathSource {
+    fn name(&self) -> &'static str {
+        "search_path"
+    }
+
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_search_path(builder.context, &builder.parameter_hints)
     }
 }
 
 fn completions_from_search_path(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
-) -> Result<Vec<CompletionItem>> {
+) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_search_path()");
 
     let mut completions = vec![];
@@ -137,5 +141,5 @@ fn completions_from_search_path(
     // bottom of the sort list (like those starting with `.`, or `%>%`)
     set_sort_text_by_words_first(&mut completions);
 
-    Ok(completions)
+    Ok(Some(completions))
 }

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -48,8 +48,6 @@ fn completions_from_search_path(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_search_path()");
-
     let mut completions = vec![];
 
     const R_CONTROL_FLOW_KEYWORDS: &[&str] = &[

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -19,7 +19,7 @@ use libr::R_lsInternal;
 use libr::ENCLOS;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_package;
 use crate::lsp::completions::completion_item::completion_item_from_symbol;
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -38,9 +38,12 @@ impl CompletionSource for SearchPathSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_search_path(builder.context, builder.parameter_hints())
+        completions_from_search_path(
+            completion_context.document_context,
+            completion_context.parameter_hints(),
+        )
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -29,7 +29,7 @@ use crate::lsp::document_context::DocumentContext;
 
 pub fn completions_from_search_path(
     context: &DocumentContext,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<Vec<CompletionItem>> {
     log::info!("completions_from_search_path()");
 

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::utils::r_env_is_pkg_env;
@@ -39,7 +38,7 @@ impl CompletionSource for SearchPathSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_search_path(
             completion_context.document_context,
             completion_context.parameter_hints(),
@@ -50,7 +49,7 @@ impl CompletionSource for SearchPathSource {
 fn completions_from_search_path(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let mut completions = vec![];
 
     const R_CONTROL_FLOW_KEYWORDS: &[&str] = &[

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -1,7 +1,7 @@
 //
 // search_path.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -27,7 +27,7 @@ use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
 use crate::lsp::completions::types::PromiseStrategy;
 use crate::lsp::document_context::DocumentContext;
 
-pub(super) fn completions_from_search_path(
+pub fn completions_from_search_path(
     context: &DocumentContext,
     parameter_hints: ParameterHints,
 ) -> Result<Vec<CompletionItem>> {

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -40,7 +40,7 @@ impl CompletionSource for SearchPathSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_search_path(builder.context, &builder.parameter_hints)
+        completions_from_search_path(builder.context, builder.parameter_hints())
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/snippets.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/snippets.rs
@@ -18,7 +18,7 @@ use tower_lsp::lsp_types::InsertTextFormat;
 use tower_lsp::lsp_types::MarkupContent;
 use tower_lsp::lsp_types::MarkupKind;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
@@ -50,7 +50,7 @@ impl CompletionSource for SnippetSource {
 
     fn provide_completions(
         &self,
-        _builder: &CompletionBuilder,
+        _completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_snippets()
     }

--- a/crates/ark/src/lsp/completions/sources/composite/snippets.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/snippets.rs
@@ -38,7 +38,7 @@ enum SnippetBody {
     Vector(Vec<String>),
 }
 
-pub(super) fn completions_from_snippets() -> Vec<CompletionItem> {
+pub fn completions_from_snippets() -> Vec<CompletionItem> {
     log::info!("completions_from_snippets()");
 
     // Return clone of cached snippet completion items

--- a/crates/ark/src/lsp/completions/sources/composite/snippets.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/snippets.rs
@@ -57,8 +57,6 @@ impl CompletionSource for SnippetSource {
 }
 
 pub(crate) fn completions_from_snippets() -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_snippets()");
-
     // Return clone of cached snippet completion items
     let completions = get_completions_from_snippets().clone();
 

--- a/crates/ark/src/lsp/completions/sources/composite/snippets.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/snippets.rs
@@ -41,7 +41,7 @@ enum SnippetBody {
     Vector(Vec<String>),
 }
 
-pub struct SnippetSource;
+pub(super) struct SnippetSource;
 
 impl CompletionSource for SnippetSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/snippets.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/snippets.rs
@@ -8,7 +8,6 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use anyhow::Result;
 use rust_embed::RustEmbed;
 use serde::Deserialize;
 use tower_lsp::lsp_types::CompletionItem;
@@ -51,12 +50,12 @@ impl CompletionSource for SnippetSource {
     fn provide_completions(
         &self,
         _completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_snippets()
     }
 }
 
-pub(crate) fn completions_from_snippets() -> Result<Option<Vec<CompletionItem>>> {
+pub(crate) fn completions_from_snippets() -> anyhow::Result<Option<Vec<CompletionItem>>> {
     // Return clone of cached snippet completion items
     let completions = get_completions_from_snippets().clone();
 

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -1,16 +1,34 @@
 //
 // subset.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
+use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::sources::CompletionSource;
+use crate::lsp::document_context::DocumentContext;
+
+pub struct SubsetSource;
+
+impl CompletionSource for SubsetSource {
+    fn name(&self) -> &'static str {
+        "subset"
+    }
+
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_subset(builder.context)
+    }
+}
+
 use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
 use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
-use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
@@ -19,7 +37,9 @@ use crate::treesitter::NodeTypeExt;
 ///
 /// `$` and `@` are handled elsewhere as they can't be composed with other
 /// completions.
-pub fn completions_from_subset(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+pub(crate) fn completions_from_subset(
+    context: &DocumentContext,
+) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_subset()");
 
     const ENQUOTE: bool = true;

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -39,8 +39,6 @@ impl CompletionSource for SubsetSource {
 pub(crate) fn completions_from_subset(
     context: &DocumentContext,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_subset()");
-
     const ENQUOTE: bool = true;
 
     let mut node = context.node;

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
@@ -27,7 +26,7 @@ impl CompletionSource for SubsetSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_subset(completion_context.document_context)
     }
 }
@@ -38,7 +37,7 @@ impl CompletionSource for SubsetSource {
 /// completions.
 pub(crate) fn completions_from_subset(
     context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     const ENQUOTE: bool = true;
 
     let mut node = context.node;

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -9,8 +9,13 @@ use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
+use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
+use crate::lsp::traits::rope::RopeExt;
+use crate::treesitter::NodeType;
+use crate::treesitter::NodeTypeExt;
 
 pub struct SubsetSource;
 
@@ -26,12 +31,6 @@ impl CompletionSource for SubsetSource {
         completions_from_subset(builder.context)
     }
 }
-
-use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
-use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
-use crate::lsp::traits::rope::RopeExt;
-use crate::treesitter::NodeType;
-use crate::treesitter::NodeTypeExt;
 
 /// Checks for `[` and `[[` completions
 ///

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -19,9 +19,7 @@ use crate::treesitter::NodeTypeExt;
 ///
 /// `$` and `@` are handled elsewhere as they can't be composed with other
 /// completions.
-pub(super) fn completions_from_subset(
-    context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+pub fn completions_from_subset(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_subset()");
 
     const ENQUOTE: bool = true;

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -8,7 +8,7 @@
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
 use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
 use crate::lsp::completions::sources::CompletionSource;
@@ -26,9 +26,9 @@ impl CompletionSource for SubsetSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_subset(builder.context)
+        completions_from_subset(completion_context.document_context)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -17,7 +17,7 @@ use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-pub struct SubsetSource;
+pub(super) struct SubsetSource;
 
 impl CompletionSource for SubsetSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -13,7 +13,7 @@ use tower_lsp::lsp_types::Documentation;
 use tower_lsp::lsp_types::MarkupContent;
 use tower_lsp::lsp_types::MarkupKind;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_function;
 use crate::lsp::completions::completion_item::completion_item_from_variable;
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -36,9 +36,13 @@ impl CompletionSource for WorkspaceSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_workspace(builder.context, builder.state, builder.parameter_hints())
+        completions_from_workspace(
+            completion_context.document_context,
+            completion_context.state,
+            completion_context.parameter_hints(),
+        )
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -25,7 +25,7 @@ use crate::lsp::traits::string::StringExt;
 use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
-pub(super) fn completions_from_workspace(
+pub fn completions_from_workspace(
     context: &DocumentContext,
     state: &WorldState,
     parameter_hints: ParameterHints,

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -18,6 +18,7 @@ use crate::lsp::completions::completion_item::completion_item_from_function;
 use crate::lsp::completions::completion_item::completion_item_from_variable;
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::sources::utils::filter_out_dot_prefixes;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
@@ -26,13 +27,18 @@ use crate::lsp::traits::string::StringExt;
 use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
-pub trait WorkspaceCompletionProvider {
-    fn get_workspace_completions(&self) -> Result<Option<Vec<CompletionItem>>>;
-}
+pub struct WorkspaceSource;
 
-impl<'a> WorkspaceCompletionProvider for CompletionBuilder<'a> {
-    fn get_workspace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_workspace(self.context, self.state, &self.parameter_hints)
+impl CompletionSource for WorkspaceSource {
+    fn name(&self) -> &'static str {
+        "workspace"
+    }
+
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_workspace(builder.context, builder.state, &builder.parameter_hints)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -47,8 +47,6 @@ fn completions_from_workspace(
     state: &WorldState,
     parameter_hints: &ParameterHints,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_workspace()");
-
     let node = context.node;
 
     if node.is_namespace_operator() {

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use log::*;
 use stdext::*;
 use tower_lsp::lsp_types::CompletionItem;
@@ -37,7 +36,7 @@ impl CompletionSource for WorkspaceSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_workspace(
             completion_context.document_context,
             completion_context.state,
@@ -50,7 +49,7 @@ fn completions_from_workspace(
     context: &DocumentContext,
     state: &WorldState,
     parameter_hints: &ParameterHints,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     if node.is_namespace_operator() {

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -27,7 +27,7 @@ use crate::lsp::traits::string::StringExt;
 use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
-pub struct WorkspaceSource;
+pub(super) struct WorkspaceSource;
 
 impl CompletionSource for WorkspaceSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -13,6 +13,7 @@ use tower_lsp::lsp_types::Documentation;
 use tower_lsp::lsp_types::MarkupContent;
 use tower_lsp::lsp_types::MarkupKind;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item_from_function;
 use crate::lsp::completions::completion_item::completion_item_from_variable;
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -25,7 +26,17 @@ use crate::lsp::traits::string::StringExt;
 use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
-pub fn completions_from_workspace(
+pub trait WorkspaceCompletionProvider {
+    fn get_workspace_completions(&self) -> Result<Option<Vec<CompletionItem>>>;
+}
+
+impl<'a> WorkspaceCompletionProvider for CompletionBuilder<'a> {
+    fn get_workspace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_workspace(self.context, self.state, &self.parameter_hints)
+    }
+}
+
+fn completions_from_workspace(
     context: &DocumentContext,
     state: &WorldState,
     parameter_hints: &ParameterHints,

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -38,7 +38,7 @@ impl CompletionSource for WorkspaceSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_workspace(builder.context, builder.state, &builder.parameter_hints)
+        completions_from_workspace(builder.context, builder.state, builder.parameter_hints())
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -28,7 +28,7 @@ use crate::treesitter::NodeTypeExt;
 pub fn completions_from_workspace(
     context: &DocumentContext,
     state: &WorldState,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_workspace()");
 

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -70,7 +70,7 @@ impl CompletionSource for UniqueCompletionsSource {
             }
         }
 
-        log::debug!("No unique sources provided completions");
+        log::debug!("No unique source provided completions");
         Ok(None)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -17,7 +17,7 @@ mod subset;
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::unique::colon::SingleColonSource;
 use crate::lsp::completions::sources::unique::comment::CommentSource;
 use crate::lsp::completions::sources::unique::custom::CustomSource;
@@ -40,7 +40,7 @@ impl CompletionSource for UniqueCompletionsSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
         log::info!("Getting completions from unique sources");
 
@@ -60,7 +60,7 @@ impl CompletionSource for UniqueCompletionsSource {
             let source_name = source.name();
             log::debug!("Trying completions from source: {}", source_name);
 
-            if let Some(completions) = source.provide_completions(builder)? {
+            if let Some(completions) = source.provide_completions(completion_context)? {
                 log::info!(
                     "Found {} completions from source: {}",
                     completions.len(),

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -42,6 +42,8 @@ impl CompletionSource for UniqueCompletionsSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
+        log::info!("Getting completions from unique sources");
+
         let sources: &[&dyn CompletionSource] = &[
             // Try to detect a single colon first, which is a special case where we
             // don't provide any completions
@@ -53,16 +55,18 @@ impl CompletionSource for UniqueCompletionsSource {
             &DollarSource,
             &AtSource,
         ];
-        log::debug!("Getting completions from unique source");
 
         for source in sources {
+            let source_name = source.name();
+            log::debug!("Trying completions from source: {}", source_name);
+
             if let Some(completions) = source.provide_completions(builder)? {
-                log::debug!("Getting completions from source: {}", source.name());
+                log::info!("Found completions from source: {}", source_name);
                 return Ok(Some(completions));
             }
         }
 
-        // No unique sources of completions, allow composite sources to run
+        log::debug!("No unique sources provided completions");
         Ok(None)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -48,12 +48,12 @@ impl CompletionSource for UniqueCompletionsSource {
             // Try to detect a single colon first, which is a special case where we
             // don't provide any completions
             &SingleColonSource,
-            &CommentSource,
-            &StringSource,
-            &NamespaceSource,
-            &CustomSource,
-            &DollarSource,
-            &AtSource,
+            &CommentSource,   // really about roxygen2 tags
+            &StringSource,    // could be a file path
+            &NamespaceSource, // pkg::xxx or pkg::::xxx
+            &CustomSource,    // custom completions for, eg, options or env vars
+            &DollarSource,    // as in foo$bar
+            &AtSource,        // as in foo@bar
         ];
 
         for source in sources {

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -5,71 +5,11 @@
 //
 //
 
-mod colon;
-mod comment;
-mod custom;
-mod extractor;
+pub mod colon;
+pub mod comment;
+pub mod custom;
+pub mod extractor;
 mod file_path;
-mod namespace;
-mod string;
+pub mod namespace;
+pub mod string;
 mod subset;
-
-use anyhow::Result;
-use colon::completions_from_single_colon;
-use comment::completions_from_comment;
-use custom::completions_from_custom_source;
-use extractor::completions_from_at;
-use extractor::completions_from_dollar;
-use namespace::completions_from_namespace;
-use string::completions_from_string;
-use tower_lsp::lsp_types::CompletionItem;
-
-use crate::lsp::completions::parameter_hints::ParameterHints;
-use crate::lsp::document_context::DocumentContext;
-
-pub fn completions_from_unique_sources(
-    context: &DocumentContext,
-    parameter_hints: ParameterHints,
-) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_unique_sources()");
-
-    // Try to detect a single colon first, which is a special case where we
-    // don't provide any completions
-    if let Some(completions) = completions_from_single_colon(context) {
-        return Ok(Some(completions));
-    }
-
-    // Try comment / roxygen2 completions
-    if let Some(completions) = completions_from_comment(context)? {
-        return Ok(Some(completions));
-    }
-
-    // Try string (like file path) completions
-    if let Some(completions) = completions_from_string(context)? {
-        return Ok(Some(completions));
-    }
-
-    // Try `package::prefix` (or `:::`) namespace completions
-    if let Some(completions) = completions_from_namespace(context, parameter_hints)? {
-        return Ok(Some(completions));
-    }
-
-    // Try specialized custom completions
-    // (Should be before more general ast / call completions)
-    if let Some(completions) = completions_from_custom_source(context)? {
-        return Ok(Some(completions));
-    }
-
-    // Try `$` completions
-    if let Some(completions) = completions_from_dollar(context)? {
-        return Ok(Some(completions));
-    }
-
-    // Try `@` completions
-    if let Some(completions) = completions_from_at(context)? {
-        return Ok(Some(completions));
-    }
-
-    // No unique sources of completions, allow composite sources to run
-    Ok(None)
-}

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -81,7 +81,7 @@ impl CompletionSource for UniqueCompletionsSource {
             return Ok(Some(completions));
         }
 
-        log::debug!("No unique source provided completions");
+        log::trace!("No unique source provided completions");
         Ok(None)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -61,7 +61,11 @@ impl CompletionSource for UniqueCompletionsSource {
             log::debug!("Trying completions from source: {}", source_name);
 
             if let Some(completions) = source.provide_completions(builder)? {
-                log::info!("Found completions from source: {}", source_name);
+                log::info!(
+                    "Found {} completions from source: {}",
+                    completions.len(),
+                    source_name
+                );
                 return Ok(Some(completions));
             }
         }

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -1,15 +1,74 @@
 //
 // unique.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
-pub mod colon;
-pub mod comment;
-pub mod custom;
-pub mod extractor;
+mod colon;
+mod comment;
+mod custom;
+mod extractor;
 mod file_path;
-pub mod namespace;
-pub mod string;
+mod namespace;
+mod string;
 mod subset;
+
+use anyhow::Result;
+use tower_lsp::lsp_types::CompletionItem;
+
+use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::sources::unique::colon::completions_from_single_colon;
+use crate::lsp::completions::sources::unique::comment::completions_from_comment;
+use crate::lsp::completions::sources::unique::custom::completions_from_custom_source;
+use crate::lsp::completions::sources::unique::extractor::completions_from_at;
+use crate::lsp::completions::sources::unique::extractor::completions_from_dollar;
+use crate::lsp::completions::sources::unique::namespace::NamespaceSource;
+use crate::lsp::completions::sources::unique::string::completions_from_string;
+use crate::lsp::completions::sources::CompletionSource;
+
+/// Aggregator for unique completion sources
+/// This source tries each unique source in order and returns the first set of
+/// completions that match.
+pub struct UniqueCompletionsSource;
+
+impl CompletionSource for UniqueCompletionsSource {
+    fn name(&self) -> &'static str {
+        "unique_sources"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        // Try to detect a single colon first, which is a special case where we
+        // don't provide any completions
+        if let Some(completions) = completions_from_single_colon(builder.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_comment(builder.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_string(builder.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = NamespaceSource::provide_completions(builder)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_custom_source(builder.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_dollar(builder.context)? {
+            return Ok(Some(completions));
+        }
+
+        if let Some(completions) = completions_from_at(builder.context)? {
+            return Ok(Some(completions));
+        }
+
+        // No unique sources of completions, allow composite sources to run
+        Ok(None)
+    }
+}

--- a/crates/ark/src/lsp/completions/sources/unique.rs
+++ b/crates/ark/src/lsp/completions/sources/unique.rs
@@ -14,7 +14,6 @@ mod namespace;
 mod string;
 mod subset;
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
@@ -42,7 +41,7 @@ impl CompletionSource for UniqueCompletionsSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         log::info!("Getting completions from unique sources");
 
         // Try to detect a single colon first, which is a special case where we

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -8,15 +8,27 @@
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
+use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
+
+pub struct SingleColonSource;
+
+impl CompletionSource for SingleColonSource {
+    fn name(&self) -> &'static str {
+        "single_colon"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_single_colon(builder.context)
+    }
+}
 
 // Don't provide completions if on a single `:`, which typically precedes
 // a `::` or `:::`. It means we don't provide completions for `1:` but we
 // accept that.
-pub fn completions_from_single_colon(
-    context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_single_colon(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     if is_single_colon(context) {
         // Return an empty vector to signal that we are done
         Ok(Some(vec![]))

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
@@ -23,7 +22,7 @@ impl CompletionSource for SingleColonSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_single_colon(completion_context.document_context)
     }
 }
@@ -31,7 +30,7 @@ impl CompletionSource for SingleColonSource {
 // Don't provide completions if on a single `:`, which typically precedes
 // a `::` or `:::`. It means we don't provide completions for `1:` but we
 // accept that.
-fn completions_from_single_colon(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_single_colon(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     if is_single_colon(context) {
         // Return an empty vector to signal that we are done
         Ok(Some(vec![]))

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -8,7 +8,7 @@
 use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
@@ -22,9 +22,9 @@ impl CompletionSource for SingleColonSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_single_colon(builder.context)
+        completions_from_single_colon(completion_context.document_context)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -20,7 +20,10 @@ impl CompletionSource for SingleColonSource {
         "single_colon"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_single_colon(builder.context)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -1,7 +1,7 @@
 //
 // colon.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::document_context::DocumentContext;
@@ -13,13 +14,15 @@ use crate::lsp::traits::rope::RopeExt;
 // Don't provide completions if on a single `:`, which typically precedes
 // a `::` or `:::`. It means we don't provide completions for `1:` but we
 // accept that.
-pub fn completions_from_single_colon(context: &DocumentContext) -> Option<Vec<CompletionItem>> {
+pub fn completions_from_single_colon(
+    context: &DocumentContext,
+) -> Result<Option<Vec<CompletionItem>>> {
     if is_single_colon(context) {
         // Return an empty vector to signal that we are done
-        Some(vec![])
+        Ok(Some(vec![]))
     } else {
         // Let other completions sources contribute
-        None
+        Ok(None)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -13,7 +13,7 @@ use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 
-pub struct SingleColonSource;
+pub(super) struct SingleColonSource;
 
 impl CompletionSource for SingleColonSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -33,7 +33,10 @@ impl CompletionSource for CommentSource {
         "comment"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_comment(builder.context)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -18,13 +18,27 @@ use tower_lsp::lsp_types::MarkupContent;
 use tower_lsp::lsp_types::MarkupKind;
 use yaml_rust::YamlLoader;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub fn completions_from_comment(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+pub struct CommentSource;
+
+impl CompletionSource for CommentSource {
+    fn name(&self) -> &'static str {
+        "comment"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_comment(builder.context)
+    }
+}
+
+fn completions_from_comment(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_comment()");
 
     let node = context.node;

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -26,7 +26,7 @@ use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NodeTypeExt;
 
-pub struct CommentSource;
+pub(super) struct CommentSource;
 
 impl CompletionSource for CommentSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -42,8 +42,6 @@ impl CompletionSource for CommentSource {
 }
 
 fn completions_from_comment(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_comment()");
-
     let node = context.node;
 
     if !node.is_comment() {

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -18,7 +18,7 @@ use tower_lsp::lsp_types::MarkupContent;
 use tower_lsp::lsp_types::MarkupKind;
 use yaml_rust::YamlLoader;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
@@ -35,9 +35,9 @@ impl CompletionSource for CommentSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_comment(builder.context)
+        completions_from_comment(completion_context.document_context)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -7,7 +7,6 @@
 
 use std::path::Path;
 
-use anyhow::Result;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use regex::Regex;
@@ -36,12 +35,12 @@ impl CompletionSource for CommentSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_comment(completion_context.document_context)
     }
 }
 
-fn completions_from_comment(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_comment(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     if !node.is_comment() {
@@ -108,7 +107,7 @@ fn completion_item_from_roxygen(
     name: &str,
     template: Option<&str>,
     description: Option<&str>,
-) -> Result<CompletionItem> {
+) -> anyhow::Result<CompletionItem> {
     let label = name.to_string();
 
     let mut item = completion_item(label.clone(), CompletionData::RoxygenTag {

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -1,7 +1,7 @@
 //
 // comment.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -1,7 +1,7 @@
 //
 // custom.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -40,7 +40,10 @@ impl CompletionSource for CustomSource {
         "custom"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_custom_source(builder.context)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -19,19 +19,33 @@ use stdext::IntoResult;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp;
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::completion_item::completion_item_from_dataset;
 use crate::lsp::completions::completion_item::completion_item_from_package;
 use crate::lsp::completions::sources::utils::call_node_position_type;
 use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
 use crate::lsp::completions::sources::utils::CallNodePositionType;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::signature_help::r_signature_help;
 use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
-pub fn completions_from_custom_source(
+pub struct CustomSource;
+
+impl CompletionSource for CustomSource {
+    fn name(&self) -> &'static str {
+        "custom"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_custom_source(builder.context)
+    }
+}
+
+fn completions_from_custom_source(
     context: &DocumentContext,
 ) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_custom_source()");

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::object::RObject;
@@ -43,14 +42,14 @@ impl CompletionSource for CustomSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_custom_source(completion_context.document_context)
     }
 }
 
 fn completions_from_custom_source(
     context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let mut node = context.node;
 
     let mut has_call = false;
@@ -85,7 +84,7 @@ fn completions_from_custom_source(
 
 pub fn completions_from_custom_source_impl(
     context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let point = context.point;
     let node = context.node;
 

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -51,8 +51,6 @@ impl CompletionSource for CustomSource {
 fn completions_from_custom_source(
     context: &DocumentContext,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_custom_source()");
-
     let mut node = context.node;
 
     let mut has_call = false;

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -19,7 +19,7 @@ use stdext::IntoResult;
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp;
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::completion_item::completion_item_from_dataset;
 use crate::lsp::completions::completion_item::completion_item_from_package;
@@ -42,9 +42,9 @@ impl CompletionSource for CustomSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_custom_source(builder.context)
+        completions_from_custom_source(completion_context.document_context)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -33,7 +33,7 @@ use crate::lsp::signature_help::r_signature_help;
 use crate::treesitter::node_in_string;
 use crate::treesitter::NodeTypeExt;
 
-pub struct CustomSource;
+pub(super) struct CustomSource;
 
 impl CompletionSource for CustomSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -133,7 +133,7 @@ fn locate_extractor_node(node: Node, node_type: NodeType) -> Option<Node> {
 }
 
 fn completions_from_extractor_object(text: &str, fun: &str) -> Result<Vec<CompletionItem>> {
-    log::info!("completions_from_extractor_object({text:?}, {fun:?})");
+    log::debug!("completions_from_extractor_object({text:?}, {fun:?})");
 
     const ENQUOTE: bool = false;
 

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -133,7 +133,7 @@ fn locate_extractor_node(node: Node, node_type: NodeType) -> Option<Node> {
 }
 
 fn completions_from_extractor_object(text: &str, fun: &str) -> Result<Vec<CompletionItem>> {
-    log::debug!("completions_from_extractor_object({text:?}, {fun:?})");
+    log::trace!("completions_from_extractor_object({text:?}, {fun:?})");
 
     const ENQUOTE: bool = false;
 

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -17,15 +17,41 @@ use libr::STRSXP;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item_from_data_variable;
 use crate::lsp::completions::sources::utils::set_sort_text_by_first_appearance;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::ExtractOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-pub fn completions_from_dollar(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+pub struct DollarSource;
+
+impl CompletionSource for DollarSource {
+    fn name(&self) -> &'static str {
+        "dollar"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_dollar(builder.context)
+    }
+}
+
+pub struct AtSource;
+
+impl CompletionSource for AtSource {
+    fn name(&self) -> &'static str {
+        "at"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_at(builder.context)
+    }
+}
+
+fn completions_from_dollar(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     completions_from_extractor(
         context,
         NodeType::ExtractOperator(ExtractOperatorType::Dollar),
@@ -33,7 +59,7 @@ pub fn completions_from_dollar(context: &DocumentContext) -> Result<Option<Vec<C
     )
 }
 
-pub fn completions_from_at(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_at(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     completions_from_extractor(
         context,
         NodeType::ExtractOperator(ExtractOperatorType::At),

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -17,7 +17,7 @@ use libr::STRSXP;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_data_variable;
 use crate::lsp::completions::sources::utils::set_sort_text_by_first_appearance;
 use crate::lsp::completions::sources::CompletionSource;
@@ -36,9 +36,9 @@ impl CompletionSource for DollarSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_dollar(builder.context)
+        completions_from_dollar(completion_context.document_context)
     }
 }
 
@@ -51,9 +51,9 @@ impl CompletionSource for AtSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        builder: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_at(builder.context)
+        completions_from_at(builder.document_context)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -78,8 +78,6 @@ fn completions_from_extractor(
     node_type: NodeType,
     fun: &str,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_extractor()");
-
     let node = context.node;
 
     let Some(node) = locate_extractor_node(node, node_type) else {

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::eval::RParseEvalOptions;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
@@ -37,7 +36,7 @@ impl CompletionSource for DollarSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_dollar(completion_context.document_context)
     }
 }
@@ -52,12 +51,14 @@ impl CompletionSource for AtSource {
     fn provide_completions(
         &self,
         builder: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_at(builder.document_context)
     }
 }
 
-fn completions_from_dollar(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_dollar(
+    context: &DocumentContext,
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     completions_from_extractor(
         context,
         NodeType::ExtractOperator(ExtractOperatorType::Dollar),
@@ -65,7 +66,7 @@ fn completions_from_dollar(context: &DocumentContext) -> Result<Option<Vec<Compl
     )
 }
 
-fn completions_from_at(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_at(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     completions_from_extractor(
         context,
         NodeType::ExtractOperator(ExtractOperatorType::At),
@@ -77,7 +78,7 @@ fn completions_from_extractor(
     context: &DocumentContext,
     node_type: NodeType,
     fun: &str,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     let Some(node) = locate_extractor_node(node, node_type) else {
@@ -132,7 +133,7 @@ fn locate_extractor_node(node: Node, node_type: NodeType) -> Option<Node> {
     }
 }
 
-fn completions_from_extractor_object(text: &str, fun: &str) -> Result<Vec<CompletionItem>> {
+fn completions_from_extractor_object(text: &str, fun: &str) -> anyhow::Result<Vec<CompletionItem>> {
     log::trace!("completions_from_extractor_object({text:?}, {fun:?})");
 
     const ENQUOTE: bool = false;

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -1,7 +1,7 @@
 //
 // extractor.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -34,7 +34,10 @@ impl CompletionSource for DollarSource {
         "dollar"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_dollar(builder.context)
     }
 }
@@ -46,7 +49,10 @@ impl CompletionSource for AtSource {
         "at"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_at(builder.context)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -27,7 +27,7 @@ use crate::treesitter::ExtractOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-pub struct DollarSource;
+pub(super) struct DollarSource;
 
 impl CompletionSource for DollarSource {
     fn name(&self) -> &'static str {
@@ -42,7 +42,7 @@ impl CompletionSource for DollarSource {
     }
 }
 
-pub struct AtSource;
+pub(super) struct AtSource;
 
 impl CompletionSource for AtSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/unique/file_path.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/file_path.rs
@@ -26,7 +26,7 @@ pub(super) fn completions_from_string_file_path(
     node: &Node,
     context: &DocumentContext,
 ) -> Result<Vec<CompletionItem>> {
-    log::debug!("completions_from_string_file_path()");
+    log::trace!("completions_from_string_file_path()");
 
     let mut completions: Vec<CompletionItem> = vec![];
 
@@ -37,14 +37,14 @@ pub(super) fn completions_from_string_file_path(
     // before searching the path entries.
     let token = context.document.contents.node_slice(&node)?.to_string();
     let contents = unsafe { r_string_decode(token.as_str()).into_result()? };
-    log::debug!("String value (decoded): {}", contents);
+    log::trace!("String value (decoded): {}", contents);
 
     // Use R to normalize the path.
     let path = r_normalize_path(RObject::from(contents))?;
 
     // parse the file path and get the directory component
     let mut path = PathBuf::from(path.as_str());
-    log::debug!("Normalized path: {}", path.display());
+    log::trace!("Normalized path: {}", path.display());
 
     // if this path doesn't have a root, add it on
     if !path.has_root() {
@@ -60,7 +60,7 @@ pub(super) fn completions_from_string_file_path(
     }
 
     // look for files in this directory
-    log::debug!("Reading directory: {}", path.display());
+    log::trace!("Reading directory: {}", path.display());
     let entries = std::fs::read_dir(path)?;
 
     for entry in entries.into_iter() {

--- a/crates/ark/src/lsp/completions/sources/unique/file_path.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/file_path.rs
@@ -26,7 +26,7 @@ pub(super) fn completions_from_string_file_path(
     node: &Node,
     context: &DocumentContext,
 ) -> Result<Vec<CompletionItem>> {
-    log::info!("completions_from_string_file_path()");
+    log::debug!("completions_from_string_file_path()");
 
     let mut completions: Vec<CompletionItem> = vec![];
 
@@ -37,14 +37,14 @@ pub(super) fn completions_from_string_file_path(
     // before searching the path entries.
     let token = context.document.contents.node_slice(&node)?.to_string();
     let contents = unsafe { r_string_decode(token.as_str()).into_result()? };
-    log::info!("String value (decoded): {}", contents);
+    log::debug!("String value (decoded): {}", contents);
 
     // Use R to normalize the path.
     let path = r_normalize_path(RObject::from(contents))?;
 
     // parse the file path and get the directory component
     let mut path = PathBuf::from(path.as_str());
-    log::info!("Normalized path: {}", path.display());
+    log::debug!("Normalized path: {}", path.display());
 
     // if this path doesn't have a root, add it on
     if !path.has_root() {
@@ -60,7 +60,7 @@ pub(super) fn completions_from_string_file_path(
     }
 
     // look for files in this directory
-    log::info!("Reading directory: {}", path.display());
+    log::debug!("Reading directory: {}", path.display());
     let entries = std::fs::read_dir(path)?;
 
     for entry in entries.into_iter() {

--- a/crates/ark/src/lsp/completions/sources/unique/file_path.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/file_path.rs
@@ -1,7 +1,7 @@
 //
 // file_path.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/unique/file_path.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/file_path.rs
@@ -8,7 +8,6 @@
 use std::env::current_dir;
 use std::path::PathBuf;
 
-use anyhow::Result;
 use harp::object::RObject;
 use harp::string::r_string_decode;
 use harp::utils::r_normalize_path;
@@ -25,7 +24,7 @@ use crate::lsp::traits::rope::RopeExt;
 pub(super) fn completions_from_string_file_path(
     node: &Node,
     context: &DocumentContext,
-) -> Result<Vec<CompletionItem>> {
+) -> anyhow::Result<Vec<CompletionItem>> {
     log::trace!("completions_from_string_file_path()");
 
     let mut completions: Vec<CompletionItem> = vec![];

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -43,7 +43,7 @@ impl CompletionSource for NamespaceSource {
         &self,
         builder: &CompletionBuilder,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_namespace(builder.context, &builder.parameter_hints)
+        completions_from_namespace(builder.context, builder.parameter_hints())
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -39,7 +39,10 @@ impl CompletionSource for NamespaceSource {
         "namespace"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_namespace(builder.context, &builder.parameter_hints)
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -53,8 +53,6 @@ fn completions_from_namespace(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_namespace()");
-
     let node = context.node;
 
     // We expect `DocumentContext` to have drilled down into the CST to the anonymous node,

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -31,8 +31,7 @@ use crate::treesitter::NamespaceOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
-/// Extension trait for providing namespace completions
-pub struct NamespaceSource;
+pub(super) struct NamespaceSource;
 
 impl CompletionSource for NamespaceSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -1,7 +1,7 @@
 //
 // namespace.rs
 //
-// Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 
@@ -19,6 +19,7 @@ use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 use tree_sitter::Point;
 
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::completion_item::completion_item_from_lazydata;
 use crate::lsp::completions::completion_item::completion_item_from_namespace;
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -29,9 +30,22 @@ use crate::treesitter::NamespaceOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
+/// Extension trait for providing namespace completions
+pub trait NamespaceCompletionProvider {
+    /// Get completions for namespace members (`::`/`:::` operator)
+    fn get_namespace_completions(&self) -> Result<Option<Vec<CompletionItem>>>;
+}
+
+impl<'a> NamespaceCompletionProvider for CompletionBuilder<'a> {
+    fn get_namespace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
+        // For now, just delegate to the existing function
+        completions_from_namespace(self.context, &self.parameter_hints)
+    }
+}
+
 // Handle the case with 'package::prefix', where the user has now
 // started typing the prefix of the symbol they would like completions for.
-pub fn completions_from_namespace(
+fn completions_from_namespace(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
 ) -> Result<Option<Vec<CompletionItem>>> {

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -19,7 +19,7 @@ use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 use tree_sitter::Point;
 
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_lazydata;
 use crate::lsp::completions::completion_item::completion_item_from_namespace;
 use crate::lsp::completions::parameter_hints::ParameterHints;
@@ -40,9 +40,12 @@ impl CompletionSource for NamespaceSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_namespace(builder.context, builder.parameter_hints())
+        completions_from_namespace(
+            completion_context.document_context,
+            completion_context.parameter_hints(),
+        )
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -33,7 +33,7 @@ use crate::treesitter::NodeTypeExt;
 // started typing the prefix of the symbol they would like completions for.
 pub fn completions_from_namespace(
     context: &DocumentContext,
-    parameter_hints: ParameterHints,
+    parameter_hints: &ParameterHints,
 ) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_namespace()");
 
@@ -238,7 +238,7 @@ mod tests {
             let point = Point { row: 0, column: 7 };
             let document = Document::new("utils::", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
 
@@ -255,7 +255,7 @@ mod tests {
             let point = Point { row: 0, column: 8 };
             let document = Document::new("utils:::", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
             let completion = completions
@@ -268,7 +268,7 @@ mod tests {
             let point = Point { row: 0, column: 11 };
             let document = Document::new("utils::blah", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
             let completion = completions.iter().find(|item| item.label == "adist");
@@ -283,7 +283,7 @@ mod tests {
             let document = Document::new("base::+", None);
             let context = DocumentContext::new(&document, point, None);
             let completions =
-                completions_from_namespace(&context, ParameterHints::Enabled).unwrap();
+                completions_from_namespace(&context, &ParameterHints::Enabled).unwrap();
             assert!(completions.is_none());
         })
     }
@@ -294,7 +294,7 @@ mod tests {
             let point = Point { row: 0, column: 2 };
             let document = Document::new("base::ab", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
             assert!(completions.is_empty());
@@ -307,7 +307,7 @@ mod tests {
             let point = Point { row: 0, column: 5 };
             let document = Document::new("base::ab", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
             assert!(completions.is_empty());
@@ -315,7 +315,7 @@ mod tests {
             let point = Point { row: 0, column: 5 };
             let document = Document::new("base:::ab", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
             assert!(completions.is_empty());
@@ -323,7 +323,7 @@ mod tests {
             let point = Point { row: 0, column: 6 };
             let document = Document::new("base:::ab", None);
             let context = DocumentContext::new(&document, point, None);
-            let completions = completions_from_namespace(&context, ParameterHints::Enabled)
+            let completions = completions_from_namespace(&context, &ParameterHints::Enabled)
                 .unwrap()
                 .unwrap();
             assert!(completions.is_empty());

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -24,6 +24,7 @@ use crate::lsp::completions::completion_item::completion_item_from_lazydata;
 use crate::lsp::completions::completion_item::completion_item_from_namespace;
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::sources::utils::set_sort_text_by_words_first;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::rope::RopeExt;
 use crate::treesitter::NamespaceOperatorType;
@@ -31,15 +32,15 @@ use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 
 /// Extension trait for providing namespace completions
-pub trait NamespaceCompletionProvider {
-    /// Get completions for namespace members (`::`/`:::` operator)
-    fn get_namespace_completions(&self) -> Result<Option<Vec<CompletionItem>>>;
-}
+pub struct NamespaceSource;
 
-impl<'a> NamespaceCompletionProvider for CompletionBuilder<'a> {
-    fn get_namespace_completions(&self) -> Result<Option<Vec<CompletionItem>>> {
-        // For now, just delegate to the existing function
-        completions_from_namespace(self.context, &self.parameter_hints)
+impl CompletionSource for NamespaceSource {
+    fn name(&self) -> &'static str {
+        "namespace"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_namespace(builder.context, &builder.parameter_hints)
     }
 }
 

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::object::RObject;
@@ -41,7 +40,7 @@ impl CompletionSource for NamespaceSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_namespace(
             completion_context.document_context,
             completion_context.parameter_hints(),
@@ -54,7 +53,7 @@ impl CompletionSource for NamespaceSource {
 fn completions_from_namespace(
     context: &DocumentContext,
     parameter_hints: &ParameterHints,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     // We expect `DocumentContext` to have drilled down into the CST to the anonymous node,
@@ -186,7 +185,7 @@ fn namespace_node_from_identifier(node: Node) -> NamespaceNodeKind {
 fn completions_from_namespace_lazydata(
     namespace: SEXP,
     package: &str,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_namespace_lazydata()");
 
     unsafe {

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -22,7 +22,10 @@ impl CompletionSource for StringSource {
         "string"
     }
 
-    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+    fn provide_completions(
+        &self,
+        builder: &CompletionBuilder,
+    ) -> Result<Option<Vec<CompletionItem>>> {
         completions_from_string(builder.context)
     }
 }
@@ -134,7 +137,8 @@ mod tests {
             let state = WorldState::default();
             let builder =
                 crate::lsp::completions::builder::CompletionBuilder::new(&context, &state);
-            let res = UniqueCompletionsSource::provide_completions(&builder).unwrap();
+            let unique_sources = UniqueCompletionsSource;
+            let res = unique_sources.provide_completions(&builder).unwrap();
 
             assert_match!(res, Some(items) => { assert!(items.len() == 0) });
         })

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -31,8 +31,6 @@ impl CompletionSource for StringSource {
 }
 
 fn completions_from_string(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_string()");
-
     let node = context.node;
 
     // Find actual `NodeType::String` node. Needed in case we are in its children.

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -29,7 +29,9 @@ impl CompletionSource for StringSource {
     }
 }
 
-fn completions_from_string(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
+fn completions_from_string(
+    context: &DocumentContext,
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     // Find actual `NodeType::String` node. Needed in case we are in its children.
@@ -72,9 +74,9 @@ mod tests {
     use stdext::assert_match;
 
     use crate::fixtures::point_from_cursor;
+    use crate::lsp::completions::completion_context::CompletionContext;
+    use crate::lsp::completions::sources::unique;
     use crate::lsp::completions::sources::unique::string::completions_from_string;
-    use crate::lsp::completions::sources::unique::UniqueCompletionsSource;
-    use crate::lsp::completions::sources::CompletionSource;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
     use crate::lsp::state::WorldState;
@@ -132,11 +134,8 @@ mod tests {
 
             // Check for same result when consulting (potentially all) unique sources
             let state = WorldState::default();
-            let builder = crate::lsp::completions::completion_context::CompletionContext::new(
-                &context, &state,
-            );
-            let unique_sources = UniqueCompletionsSource;
-            let res = unique_sources.provide_completions(&builder).unwrap();
+            let completion_context = CompletionContext::new(&context, &state);
+            let res = unique::get_completions(&completion_context).unwrap();
 
             assert_match!(res, Some(items) => { assert!(items.len() == 0) });
         })

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -59,6 +59,8 @@ mod tests {
 
     use crate::fixtures::point_from_cursor;
     use crate::lsp::completions::sources::unique::string::completions_from_string;
+    use crate::lsp::completions::sources::unique::UniqueCompletionsSource;
+    use crate::lsp::completions::sources::CompletionSource;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
     use crate::lsp::state::WorldState;
@@ -118,7 +120,8 @@ mod tests {
             let state = WorldState::default();
             let builder =
                 crate::lsp::completions::builder::CompletionBuilder::new(&context, &state);
-            let res = builder.completions_from_unique_sources().unwrap();
+            let res = UniqueCompletionsSource::provide_completions(&builder).unwrap();
+
             assert_match!(res, Some(items) => { assert!(items.len() == 0) });
         })
     }

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -58,11 +58,10 @@ mod tests {
     use stdext::assert_match;
 
     use crate::fixtures::point_from_cursor;
-    use crate::lsp::completions::parameter_hints::ParameterHints;
-    use crate::lsp::completions::sources::completions_from_unique_sources;
     use crate::lsp::completions::sources::unique::string::completions_from_string;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
+    use crate::lsp::state::WorldState;
     use crate::r_task;
     use crate::treesitter::node_find_string;
     use crate::treesitter::NodeTypeExt;
@@ -115,8 +114,11 @@ mod tests {
             let res = completions_from_string(&context).unwrap();
             assert_match!(res, Some(items) => { assert!(items.len() == 0) });
 
-            // Check one level up too
-            let res = completions_from_unique_sources(&context, ParameterHints::Enabled).unwrap();
+            // Check for same result when consulting (potentially all) unique sources
+            let state = WorldState::default();
+            let builder =
+                crate::lsp::completions::builder::CompletionBuilder::new(&context, &state);
+            let res = builder.completions_from_unique_sources().unwrap();
             assert_match!(res, Some(items) => { assert!(items.len() == 0) });
         })
     }

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -15,7 +15,7 @@ use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::treesitter::node_find_string;
 
-pub struct StringSource;
+pub(super) struct StringSource;
 
 impl CompletionSource for StringSource {
     fn name(&self) -> &'static str {

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use super::file_path::completions_from_string_file_path;
-use crate::lsp::completions::builder::CompletionBuilder;
+use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::unique::subset::completions_from_string_subset;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
@@ -24,9 +24,9 @@ impl CompletionSource for StringSource {
 
     fn provide_completions(
         &self,
-        builder: &CompletionBuilder,
+        completion_context: &CompletionContext,
     ) -> Result<Option<Vec<CompletionItem>>> {
-        completions_from_string(builder.context)
+        completions_from_string(completion_context.document_context)
     }
 }
 
@@ -133,8 +133,9 @@ mod tests {
 
             // Check for same result when consulting (potentially all) unique sources
             let state = WorldState::default();
-            let builder =
-                crate::lsp::completions::builder::CompletionBuilder::new(&context, &state);
+            let builder = crate::lsp::completions::completion_context::CompletionContext::new(
+                &context, &state,
+            );
             let unique_sources = UniqueCompletionsSource;
             let res = unique_sources.provide_completions(&builder).unwrap();
 

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -9,11 +9,25 @@ use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use super::file_path::completions_from_string_file_path;
+use crate::lsp::completions::builder::CompletionBuilder;
 use crate::lsp::completions::sources::unique::subset::completions_from_string_subset;
+use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
 use crate::treesitter::node_find_string;
 
-pub fn completions_from_string(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+pub struct StringSource;
+
+impl CompletionSource for StringSource {
+    fn name(&self) -> &'static str {
+        "string"
+    }
+
+    fn provide_completions(builder: &CompletionBuilder) -> Result<Option<Vec<CompletionItem>>> {
+        completions_from_string(builder.context)
+    }
+}
+
+fn completions_from_string(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
     log::info!("completions_from_string()");
 
     let node = context.node;

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -1,7 +1,7 @@
 //
 // string.rs
 //
-// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //
 //
 

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use tower_lsp::lsp_types::CompletionItem;
 
 use super::file_path::completions_from_string_file_path;
@@ -25,12 +24,12 @@ impl CompletionSource for StringSource {
     fn provide_completions(
         &self,
         completion_context: &CompletionContext,
-    ) -> Result<Option<Vec<CompletionItem>>> {
+    ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_string(completion_context.document_context)
     }
 }
 
-fn completions_from_string(context: &DocumentContext) -> Result<Option<Vec<CompletionItem>>> {
+fn completions_from_string(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     // Find actual `NodeType::String` node. Needed in case we are in its children.

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use ropey::Rope;
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
@@ -32,7 +31,7 @@ use crate::treesitter::NodeTypeExt;
 pub(super) fn completions_from_string_subset(
     node: &Node,
     context: &DocumentContext,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_string_subset()");
 
     // Already inside a string

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -33,7 +33,7 @@ pub(super) fn completions_from_string_subset(
     node: &Node,
     context: &DocumentContext,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::debug!("completions_from_string_subset()");
+    log::trace!("completions_from_string_subset()");
 
     // Already inside a string
     const ENQUOTE: bool = false;

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -33,7 +33,7 @@ pub(super) fn completions_from_string_subset(
     node: &Node,
     context: &DocumentContext,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_string_subset()");
+    log::debug!("completions_from_string_subset()");
 
     // Already inside a string
     const ENQUOTE: bool = false;

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -173,7 +173,7 @@ pub(super) fn completions_from_evaluated_object_names(
     enquote: bool,
     node_type: NodeType,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::debug!("completions_from_evaluated_object_names({name:?})");
+    log::trace!("completions_from_evaluated_object_names({name:?})");
 
     let options = RParseEvalOptions {
         forbid_function_calls: true,
@@ -193,7 +193,7 @@ pub(super) fn completions_from_evaluated_object_names(
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return Ok(None),
             Error::TryCatchError { message, .. } => {
-                log::debug!("Can't evaluate object: {message}");
+                log::trace!("Can't evaluate object: {message}");
                 return Ok(None);
             },
             _ => {
@@ -244,7 +244,7 @@ fn completions_from_object_names_impl(
     enquote: bool,
     function: &str,
 ) -> Result<Vec<CompletionItem>> {
-    log::debug!("completions_from_object_names_impl({object:?})");
+    log::trace!("completions_from_object_names_impl({object:?})");
 
     let mut completions = vec![];
 

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use anyhow::Result;
 use harp::error::Error;
 use harp::eval::RParseEvalOptions;
 use harp::exec::RFunction;
@@ -172,7 +171,7 @@ pub(super) fn completions_from_evaluated_object_names(
     name: &str,
     enquote: bool,
     node_type: NodeType,
-) -> Result<Option<Vec<CompletionItem>>> {
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_evaluated_object_names({name:?})");
 
     let options = RParseEvalOptions {
@@ -226,7 +225,7 @@ pub(super) fn completions_from_object_names(
     object: RObject,
     name: &str,
     enquote: bool,
-) -> Result<Vec<CompletionItem>> {
+) -> anyhow::Result<Vec<CompletionItem>> {
     completions_from_object_names_impl(object, name, enquote, "names")
 }
 
@@ -234,7 +233,7 @@ pub(super) fn completions_from_object_colnames(
     object: RObject,
     name: &str,
     enquote: bool,
-) -> Result<Vec<CompletionItem>> {
+) -> anyhow::Result<Vec<CompletionItem>> {
     completions_from_object_names_impl(object, name, enquote, "colnames")
 }
 
@@ -243,7 +242,7 @@ fn completions_from_object_names_impl(
     name: &str,
     enquote: bool,
     function: &str,
-) -> Result<Vec<CompletionItem>> {
+) -> anyhow::Result<Vec<CompletionItem>> {
     log::trace!("completions_from_object_names_impl({object:?})");
 
     let mut completions = vec![];

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -173,7 +173,7 @@ pub(super) fn completions_from_evaluated_object_names(
     enquote: bool,
     node_type: NodeType,
 ) -> Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_evaluated_object_names({name:?})");
+    log::debug!("completions_from_evaluated_object_names({name:?})");
 
     let options = RParseEvalOptions {
         forbid_function_calls: true,
@@ -193,7 +193,7 @@ pub(super) fn completions_from_evaluated_object_names(
         Err(err) => match err {
             Error::UnsafeEvaluationError(_) => return Ok(None),
             Error::TryCatchError { message, .. } => {
-                log::info!("Can't evaluate object: {message}");
+                log::debug!("Can't evaluate object: {message}");
                 return Ok(None);
             },
             _ => {
@@ -244,7 +244,7 @@ fn completions_from_object_names_impl(
     enquote: bool,
     function: &str,
 ) -> Result<Vec<CompletionItem>> {
-    log::info!("completions_from_object_names_impl({object:?})");
+    log::debug!("completions_from_object_names_impl({object:?})");
 
     let mut completions = vec![];
 


### PR DESCRIPTION
Relates to #681

The main goal is to introduce a new struct to serve as headquarters when generating completions. This gives us a home for features that we compute about the completion site, that can then be used downstream in one or multiple concrete completion sources. Two existing examples of this, each previously implemented in different ways, are:

* "parameter hints": Distinguishes whether we (think) we're completing a function invocation or a function value. See #680.
* "pipe root": If we're dealing with a pipe chain that starts with, e.g., a data frame, you might want to expose its column names as completions.

Qualities we wanted in this refactoring:

* Completion site features are lazy: computed upon first need and are not re-computed unnecessarily.
* Features and/or document don't need to be threaded through as arguments through all layers of completion sources and completion item helpers as "loose parts".
* Make the completion tooling easier to work on and debug, e.g. through more intentional logging.
* General effort to remove incidental inconsistencies across individual completion sources.

I'll make a few comments on the source as well.

(I've drafted a 2nd PR #755 that builds on this one, that proposes changes to how we manage completion items as they roll in from various sources. That's in draft form until the dust settles here.)