### PR TITLE
More completion refactoring around how completions are marshalled

### DIFF
--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -447,10 +447,6 @@ pub(super) unsafe fn completion_item_from_symbol(
             // are handled extremely specially.
             return Some(completion_item_from_active_binding(name));
         },
-        // TO THINK: we see this for any thing that is imported from another
-        // package, then re-exported
-        // so, for dplyr, for example, this generates a lot of noise in the log
-        // which isn't really helpful
         Err(err) => {
             log::error!("Can't determine if binding is active: {err:?}");
             return None;

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -447,6 +447,10 @@ pub(super) unsafe fn completion_item_from_symbol(
             // are handled extremely specially.
             return Some(completion_item_from_active_binding(name));
         },
+        // TO THINK: we see this for any thing that is imported from another
+        // package, then re-exported
+        // so, for dplyr, for example, this generates a lot of noise in the log
+        // which isn't really helpful
         Err(err) => {
             log::error!("Can't determine if binding is active: {err:?}");
             return None;

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -21,14 +21,11 @@ pub(crate) fn provide_completions(
     document_context: &DocumentContext,
     state: &WorldState,
 ) -> anyhow::Result<Vec<CompletionItem>> {
-    let node = document_context.node;
-    let node_text = node_text(&node, &document_context.document.contents).unwrap_or_default();
-    let node_type = format!("{:?}", node.node_type());
-
     log::info!(
-        "provide_completions() - Completion node text: '{}', Node type: '{}'",
-        node_text,
-        node_type
+        "provide_completions() - Completion node text: '{node_text}', Node type: '{node_type:?}'",
+        node_text = node_text(&document_context.node, &document_context.document.contents)
+            .unwrap_or_default(),
+        node_type = document_context.node.node_type()
     );
 
     let completion_context = CompletionContext::new(document_context, state);

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -12,6 +12,8 @@ use crate::lsp::completions::sources::composite;
 use crate::lsp::completions::sources::unique;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
+use crate::treesitter::node_text;
+use crate::treesitter::NodeTypeExt;
 
 // Entry point for completions.
 // Must be within an `r_task()`.
@@ -19,7 +21,15 @@ pub(crate) fn provide_completions(
     document_context: &DocumentContext,
     state: &WorldState,
 ) -> anyhow::Result<Vec<CompletionItem>> {
-    log::info!("provide_completions()");
+    let node = document_context.node;
+    let node_text = node_text(&node, &document_context.document.contents).unwrap_or_default();
+    let node_type = format!("{:?}", node.node_type());
+
+    log::info!(
+        "provide_completions() - Completion node text: '{}', Node type: '{}'",
+        node_text,
+        node_type
+    );
 
     let completion_context = CompletionContext::new(document_context, state);
 

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -46,17 +46,3 @@ where
         Ok(None)
     }
 }
-
-pub fn push_completions<S>(
-    source: S,
-    completion_context: &CompletionContext,
-    completions: &mut Vec<CompletionItem>,
-) -> anyhow::Result<()>
-where
-    S: CompletionSource,
-{
-    if let Some(mut additional_completions) = collect_completions(source, completion_context)? {
-        completions.append(&mut additional_completions);
-    }
-    Ok(())
-}

--- a/crates/ark/src/lsp/completions/sources.rs
+++ b/crates/ark/src/lsp/completions/sources.rs
@@ -33,7 +33,7 @@ where
     S: CompletionSource,
 {
     let source_name = source.name();
-    log::trace!("Trying completions from source: {}", source_name);
+    log::info!("Trying completions from source: {}", source_name);
 
     if let Some(completions) = source.provide_completions(completion_context)? {
         log::info!(

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -151,18 +151,6 @@ fn finalize_completions(
         .values()
         .map(|sourced_item| {
             let mut item = sourced_item.item.clone();
-
-            // Store source information in the `data` field as a simple string
-            if !sourced_item.sources.is_empty() {
-                let sources_string = sourced_item.sources.join(",");
-                item.data = Some(serde_json::Value::String(sources_string.clone()));
-                log::debug!(
-                    "Completion '{}' has sources: {}",
-                    item.label,
-                    sources_string
-                );
-            }
-
             item
         })
         .collect();

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -105,7 +105,7 @@ where
     if let Some(source_completions) = collect_completions(source, completion_context)? {
         for item in source_completions {
             if let Some(existing) = completions.get(&item.label) {
-                log::debug!(
+                log::trace!(
                     "Completion with label '{}' already exists (first contributed by source: {}, now also from: {})",
                     item.label,
                     existing.source,

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -40,7 +40,7 @@ pub(crate) fn get_completions(
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::info!("Getting completions from composite sources");
 
-    let mut completions: HashMap<String, CompletionItemWithSource> = HashMap::new();
+    let mut completions = HashMap::new();
 
     // Call, pipe, and subset completions should show up no matter what when
     // the user requests completions. This allows them to "tab" their way

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -58,7 +58,6 @@ pub(crate) fn get_completions(
     // For the rest of the general completions, we require an identifier to
     // begin showing anything.
     if is_identifier_like(completion_context.document_context.node) {
-        // Consulted settings.json
         push_completions(keyword::KeywordSource, completion_context, &mut completions)?;
 
         push_completions(

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -161,7 +161,11 @@ fn finalize_completions(
     items
 }
 
-/// Sort completions by providing custom 'sort' text
+// Sort completions by providing custom 'sort' text to be used when
+// ordering completion results. we use some placeholders at the front
+// to 'bin' different completion types differently; e.g. we place parameter
+// completions at the front, followed by variable completions (like pipe
+// completions and subset completions), followed by anything else.
 fn sort_completions(completions: &mut Vec<CompletionItem>) {
     for item in completions {
         // Start with existing `sort_text` if one exists


### PR DESCRIPTION
Builds on #754 and closes #681. The second and final of piece of that refactoring effort.

This is about managing the accumulation of completion items from composite sources.

Main ideas:

* Instead of adding CompletionItems onto an ever-growing collection, manage the accumulation in a map of completion items + their ~source(s)~. *Update: we've decided to record the first-encountered source. If a completion item shows up again, we log this event, so we have a thread to pull on, if we choose to investigate this.*
* Update the map as each new completion source is consulted. Novel items are added. Pre-existing items ~get an update (addition) to their completion source~ *that are re-contributed get logged.*
* No more need for explicit deduplication.
* Keep adding / modifying the logging for future debugging happiness