### PR TITLE
Clean up state when plot is closed on the frontend

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,5 +1,8 @@
 {
     "languages": {
+        "Rust": {
+            "format_on_save": "on"
+        },
         "R": {
             "hard_tabs": false,
             "tab_size": 4,

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -29,10 +29,10 @@ add_recording <- function(id, recording) {
     RECORDINGS[[id]] <<- recording
 }
 
-# TODO: Use this when we get notified that we can remove a recording
-# remove_recording <- function(id) {
-#     RECORDINGS[[id]] <<- NULL
-# }
+# Called when a plot comm is closed by the frontend
+remove_recording <- function(id) {
+    RECORDINGS[[id]] <<- NULL
+}
 
 render_directory <- function() {
     directory <- file.path(tempdir(), "positron-plot-renderings")

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -301,7 +301,11 @@ impl DeviceContext {
                     log::error!("{error:?}");
                     // Refcell Safety: Short borrows in the file.
                     self.sockets.borrow_mut().remove(id);
-                    return;
+
+                    // Process remaining messages. Safe to do because we have
+                    // removed the `DeviceContext`'s copy off the sockets but we
+                    // are working through our own copy of them.
+                    continue;
                 },
             };
 

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -305,14 +305,19 @@ impl DeviceContext {
                 },
             };
 
-            // The user closed the plot. Clean up associated resources.
-            if let CommMsg::Close = message {
-                self.close_plot(id);
-                return;
+            match message {
+                CommMsg::Rpc(_, _) => {
+                    log::trace!("Handling `RPC` for plot `id` {id}");
+                    socket.handle_request(message, |req| self.handle_rpc(req, id));
+                },
+                CommMsg::Close => {
+                    log::trace!("Handling `Close` for plot `id` {id}");
+                    self.close_plot(id)
+                },
+                message => {
+                    log::error!("Received unexpected comm message for plot `id` {id}: {message:?}")
+                },
             }
-
-            log::trace!("Handling RPC for plot `id` {id}");
-            socket.handle_request(message, |req| self.handle_rpc(req, id));
         }
     }
 

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -147,6 +147,15 @@ impl DeviceContext {
         }
     }
 
+    // Reset state with defaults when the current plot is closed
+    fn reset(&self) {
+        self.has_changes.replace(false);
+        self.is_new_page.replace(true);
+        self.is_drawing.replace(false);
+        self.should_render.replace(true);
+        *self.id.borrow_mut() = Self::new_id();
+    }
+
     /// Should plot events be sent over [CommSocket]s to the frontend?
     ///
     /// This allows plots to be dynamically resized by their `id`. Only possible if the UI
@@ -360,6 +369,12 @@ impl DeviceContext {
             .call_in(ARK_ENVS.positron_ns)
         {
             log::error!("Can't clean up plot (id: {id}): {err:?}");
+        }
+
+        // If the currently active plot is closed, reset the state.
+        // See https://github.com/posit-dev/positron/issues/6702.
+        if *self.id.borrow() == *id {
+            self.reset();
         }
     }
 

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -314,10 +314,19 @@ impl DeviceContext {
                     log::trace!("Handling `RPC` for plot `id` {id}");
                     socket.handle_request(message, |req| self.handle_rpc(req, id));
                 },
+
+                // Note that ideally this handler should be invoked before we
+                // check for `should_render`. I.e. we should acknowledge a plot
+                // has been closed on the frontend side even when `dev.hold()`
+                // is active. Doing so would require some more careful
+                // bookkeeping of the state though, and since this is a very
+                // unlikely sequence of action nothing really bad happens with
+                // the current approach, we decided to keep handling here.
                 CommMsg::Close => {
                     log::trace!("Handling `Close` for plot `id` {id}");
                     self.close_plot(id)
                 },
+
                 message => {
                     log::error!("Received unexpected comm message for plot `id` {id}: {message:?}")
                 },


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/6738
Addresses https://github.com/posit-dev/positron/issues/6702

This was easier than I thought. Since all plots are backed by a Jupyter comm, and since the frontend duly closes clients (the equivalent Positron abstraction corresponding to comms in Jupyter-backed languages), we just needed to handle the close messages that we currently ignore.

We now clean up:

- The list of sockets
- The plot state on the R side
- The currently active device context (for https://github.com/posit-dev/positron/issues/6702)