### PR TITLE
Add a method to query a unique session id

### DIFF
--- a/crates/ark/src/modules/positron/reticulate.R
+++ b/crates/ark/src/modules/positron/reticulate.R
@@ -127,3 +127,8 @@
         }
     )
 }
+
+#' @export
+.ps.rpc.reticulate_id <- function() {
+    .ps.Call("ps_reticulate_id")
+}

--- a/crates/ark/src/reticulate.rs
+++ b/crates/ark/src/reticulate.rs
@@ -23,7 +23,7 @@ use crate::interface::RMain;
 static RETICULATE_OUTGOING_TX: LazyLock<Mutex<Option<Sender<CommMsg>>>> =
     LazyLock::new(|| Mutex::new(None));
 
-// Each ark session has it's unique session id which is used by Positron's front-end
+// Each ark session has a unique session id which is used by the Positron frontend
 // to associate a client id with a session.
 static RETICULATE_ID: Lazy<String> =
     Lazy::new(|| format!("reticulate-{}", Uuid::new_v4().to_string()));

--- a/crates/ark/src/reticulate.rs
+++ b/crates/ark/src/reticulate.rs
@@ -11,7 +11,6 @@ use harp::utils::r_is_null;
 use harp::RObject;
 use libr::R_NilValue;
 use libr::SEXP;
-use once_cell::sync::Lazy;
 use serde_json::json;
 use stdext::result::ResultOrLog;
 use stdext::spawn;
@@ -25,8 +24,8 @@ static RETICULATE_OUTGOING_TX: LazyLock<Mutex<Option<Sender<CommMsg>>>> =
 
 // Each ark session has a unique session id which is used by the Positron frontend
 // to associate a client id with a session.
-static RETICULATE_ID: Lazy<String> =
-    Lazy::new(|| format!("reticulate-{}", Uuid::new_v4().to_string()));
+static RETICULATE_ID: LazyLock<String> =
+    LazyLock::new(|| format!("reticulate-{}", Uuid::new_v4().to_string()));
 
 #[derive(Clone)]
 pub struct ReticulateService {


### PR DESCRIPTION
This is part of https://github.com/posit-dev/positron/pull/7024
Each R session can only ever host a single reticulate session. With this PR we add a `reticulate_id()` method that allows us to link a Positron `sessionId` to the ark session it's running. This is necessary specially when a session is opened from Positron directly, (not calling `reticulate::repl_python()` ) - which currently doesn't trigger the reticulate service to be started.