### PR TITLE
Bump required Rust version to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = [
     "crates/echo",
     "crates/harp",
     "crates/libr",
-    "crates/stdext"
+    "crates/stdext",
 ]
 
 [workspace.package]
-rust-version = "1.80"
+rust-version = "1.85"
 edition = "2021"
 license = "MIT"
 authors = ["Posit Software, PBC"]


### PR DESCRIPTION
This fixes some weird LSP issues I was seeing in Zed where it was using Rust 1.80 for diagnostics and was getting confused.

It also better matches our actual Rust version we build with.