### PR TITLE
Add ragg and svglite support

### DIFF
--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -193,7 +193,31 @@ with_graphics_device <- function(
     expr
 }
 
-use_ragg <- function() {
+use_ragg <- local({
+    USE_RAGG <- NULL
+
+    function() {
+        if (is.null(USE_RAGG)) {
+            USE_RAGG <<- init_use_ragg()
+        }
+
+        USE_RAGG
+    }
+})
+
+init_use_ragg <- function() {
+    option <- getOption("ark.use_ragg", default = TRUE)
+
+    if (!isTRUE(option)) {
+        # Bail on any non-`TRUE` option value
+        return(FALSE)
+    }
+
+    if (!.ps.is_installed("ragg", minimum_version = "1.3.3.9000")) {
+        # Need support for `agg_record()`
+        return(FALSE)
+    }
+
     TRUE
 }
 

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -214,7 +214,7 @@ init_use_ragg <- function() {
         return(FALSE)
     }
 
-    if (!.ps.is_installed("ragg", minimum_version = "1.3.3.9000")) {
+    if (!.ps.is_installed("ragg", minimum_version = "1.4.0")) {
         # Need support for `agg_record()`
         return(FALSE)
     }

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -40,9 +40,9 @@ render_directory <- function() {
     directory
 }
 
-render_path <- function(id) {
+render_path <- function(id, format) {
     directory <- render_directory()
-    file <- paste0("render-", id, ".png")
+    file <- paste0("render-", id, ".", format)
     file.path(directory, file)
 }
 
@@ -50,49 +50,25 @@ render_path <- function(id) {
 .ps.graphics.create_device <- function() {
     name <- "Ark Graphics Device"
 
-    # TODO: Remove the "shadow" device in favor of implementing our own
-    # minimal graphics device like {devoid}. That would allow us to remove
-    # all of the awkwardness here around:
-    # - A `filename` that we never look at
-    # - A `res` that isn't scaled by `pixel_ratio`
-    # - The fact that the `png` device is forcing double the work to happen,
-    #   as it is drawing graphics that we never look at.
-    # - The fact that `locator()` doesn't work b/c `png` doesn't support it.
-    directory <- render_directory()
-    filename <- file.path(directory, "current-plot.png")
-    type <- default_device_type()
-    res <- default_resolution_in_pixels_per_inch()
-
-    # Create the graphics device that we are going to shadow
-    withCallingHandlers(
-        grDevices::png(
-            filename = filename,
-            type = type,
-            res = res
-        ),
-        warning = function(w) {
-            stop("Error creating graphics device: ", conditionMessage(w))
-        }
-    )
+    # Create the graphics device that we are going to shadow.
+    # Creating a graphics device mutates global state, we don't need to capture
+    # the return value.
+    device_shadow()
 
     # Update the device name + description in the base environment.
     index <- grDevices::dev.cur()
-    oldDevice <- .Devices[[index]]
-    newDevice <- name
+    old_device <- .Devices[[index]]
+    new_device <- name
 
     # Copy device attributes. Usually, this is just the file path.
-    attributes(newDevice) <- attributes(oldDevice)
-
-    # Set other device properties.
-    attr(newDevice, "type") <- type
-    attr(newDevice, "res") <- res
+    attributes(new_device) <- attributes(old_device)
 
     # Update the devices list.
-    .Devices[[index]] <- newDevice
+    .Devices[[index]] <- new_device
 
     # Replace bindings.
     env_bind_force(baseenv(), ".Devices", .Devices)
-    env_bind_force(baseenv(), ".Device", newDevice)
+    env_bind_force(baseenv(), ".Device", new_device)
 
     # Also set ourselves as a known interactive device.
     # Used by `dev.interactive()`, which is used in `stats:::plot.lm()`
@@ -124,7 +100,7 @@ render_path <- function(id) {
     pixel_ratio,
     format
 ) {
-    path <- render_path(id)
+    path <- render_path(id, format)
     recording <- get_recording(id)
 
     if (is.null(recording)) {
@@ -169,42 +145,37 @@ with_graphics_device <- function(
     width <- args$width
     height <- args$height
     res <- args$res
-    type <- args$type
 
     # Create a new graphics device.
-    # TODO: Use 'ragg' if available?
     switch(
         format,
-        "png" = grDevices::png(
+        "png" = device_png(
             filename = path,
             width = width,
             height = height,
-            res = res,
-            type = type
+            res = res
         ),
-        "svg" = grDevices::svg(
+        "svg" = device_svg(
             filename = path,
             width = width,
             height = height,
         ),
-        "pdf" = grDevices::pdf(
-            file = path,
+        "pdf" = device_pdf(
+            filename = path,
             width = width,
             height = height
         ),
-        "jpeg" = grDevices::jpeg(
+        "jpeg" = device_jpeg(
             filename = path,
             width = width,
             height = height,
-            res = res,
-            type = type
+            res = res
         ),
-        "tiff" = grDevices::tiff(
+        "tiff" = device_tiff(
             filename = path,
             width = width,
             height = height,
-            res = res,
-            type = type
+            res = res
         ),
         stop("Internal error: Unknown plot `format`.")
     )
@@ -222,6 +193,110 @@ with_graphics_device <- function(
     expr
 }
 
+use_ragg <- function() {
+    TRUE
+}
+
+device_shadow <- function() {
+    if (use_ragg()) {
+        # For the shadow ragg device, we use a special device that only captures
+        # the display list, it doesn't actually do any rendering!
+        ragg::agg_record(
+            res = default_resolution_in_pixels_per_inch()
+        )
+    } else {
+        # For the shadow png device, we need a dummy file to write to,
+        # even though we never look at it. We only utilize the png device for
+        # the action of recording the display list.
+        directory <- render_directory()
+        filename <- file.path(directory, "dummy-plot.png")
+
+        withCallingHandlers(
+            grDevices::png(
+                filename = filename,
+                type = default_device_type(),
+                res = default_resolution_in_pixels_per_inch()
+            ),
+            warning = function(w) {
+                stop("Error creating graphics device: ", conditionMessage(w))
+            }
+        )
+    }
+}
+
+device_png <- function(filename, width, height, res) {
+    if (use_ragg()) {
+        ragg::agg_png(
+            filename = filename,
+            width = width,
+            height = height,
+            res = res
+        )
+    } else {
+        grDevices::png(
+            filename = filename,
+            width = width,
+            height = height,
+            res = res,
+            type = default_device_type()
+        )
+    }
+}
+
+device_svg <- function(filename, width, height) {
+    grDevices::svg(
+        filename = filename,
+        width = width,
+        height = height,
+    )
+}
+
+device_pdf <- function(filename, width, height) {
+    grDevices::pdf(
+        file = filename,
+        width = width,
+        height = height
+    )
+}
+
+device_jpeg <- function(filename, width, height, res) {
+    if (use_ragg()) {
+        ragg::agg_jpeg(
+            filename = filename,
+            width = width,
+            height = height,
+            res = res
+        )
+    } else {
+        grDevices::jpeg(
+            filename = filename,
+            width = width,
+            height = height,
+            res = res,
+            type = default_device_type()
+        )
+    }
+}
+
+device_tiff <- function(filename, width, height, res) {
+    if (use_ragg()) {
+        ragg::agg_tiff(
+            filename = filename,
+            width = width,
+            height = height,
+            res = res
+        )
+    } else {
+        grDevices::tiff(
+            filename = filename,
+            width = width,
+            height = height,
+            res = res,
+            type = default_device_type()
+        )
+    }
+}
+
 finalize_device_arguments <- function(format, width, height, pixel_ratio) {
     if (format == "png" || format == "jpeg" || format == "tiff") {
         # These devices require `width` and `height` in pixels, which is what
@@ -230,7 +305,6 @@ finalize_device_arguments <- function(format, width, height, pixel_ratio) {
         #
         # `res` is nominal resolution specified in pixels-per-inch (ppi).
         return(list(
-            type = default_device_type(),
             res = default_resolution_in_pixels_per_inch() * pixel_ratio,
             width = width * pixel_ratio,
             height = height * pixel_ratio
@@ -249,9 +323,8 @@ finalize_device_arguments <- function(format, width, height, pixel_ratio) {
         # `pixel_ratio` like we do above, which would have made it cancel out of
         # the equation below.
         #
-        # There is no `type` or `res` argument for these devices.
+        # There is no `res` argument for these devices.
         return(list(
-            type = NULL,
             res = NULL,
             width = width *
                 pixel_ratio /

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -194,6 +194,7 @@ with_graphics_device <- function(
 }
 
 use_ragg <- local({
+    # Only check global option once per session
     USE_RAGG <- NULL
 
     function() {

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -207,7 +207,7 @@ use_ragg <- local({
 })
 
 init_use_ragg <- function() {
-    option <- getOption("ark.use_ragg", default = TRUE)
+    option <- getOption("ark.ragg", default = TRUE)
 
     if (!isTRUE(option)) {
         # Bail on any non-`TRUE` option value

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -222,6 +222,13 @@ init_use_ragg <- function() {
     TRUE
 }
 
+#' Create a device to shadow
+#'
+#' For both ragg and png, we are hopeful that providing a `res` of the default
+#' resolution should not affect the render time results much (since we are just
+#' writing display list instructions), even if at render time we can actually
+#' support a `pixel_ratio` of 2x the default resolution. We simply don't know
+#' the pixel ratio at this point.
 device_shadow <- function() {
     if (use_ragg()) {
         # For the shadow ragg device, we use a special device that only captures

--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -195,15 +195,8 @@ with_graphics_device <- function(
 
 use_ragg <- local({
     # Only check global option once per session
-    USE_RAGG <- NULL
-
-    function() {
-        if (is.null(USE_RAGG)) {
-            USE_RAGG <<- init_use_ragg()
-        }
-
-        USE_RAGG
-    }
+    delayedAssign("use_ragg", init_use_ragg())
+    function() use_ragg
 })
 
 init_use_ragg <- function() {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,0 +1,21 @@
+# Introduction
+
+This guide details Ark's configuration.
+
+# R global variables
+
+## ark.ragg
+
+A boolean, with a default of `TRUE`.
+
+Should the ragg package be used for graphics generation?
+
+If `TRUE` and if ragg \>=1.4.0 is installed, then ragg will be used. In particular:
+
+-   ragg will be used for generating the display list of "plot instructions" regardless of the render type.
+
+-   ragg will be used for generating graphics for png, jpeg, and tiff formats.
+
+Otherwise, the corresponding device from grDevices will be used.
+
+This global variable is only checked once per session, we recommend that you place it in an `.Rprofile` if you need to modify it.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -18,6 +18,16 @@ Otherwise, the corresponding device from grDevices will be used.
 
 This global variable is only checked once per session, we recommend that you place it in an `.Rprofile` if you need to modify it.
 
+## ark.svglite
+
+A boolean, with a default value of `TRUE`.
+
+If `TRUE` and if svglite is installed, then svglite will be used for rendering SVG graphics.
+
+Otherwise, `grDevices::svg()` will be used.
+
+This global variable is only checked once per session, we recommend that you place it in an `.Rprofile` if you need to modify it.
+
 ## ark.resource_namespaces
 
 A boolean, with a default value of `TRUE`.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -8,9 +8,7 @@ This guide details Ark's configuration.
 
 A boolean, with a default of `TRUE`.
 
-Should the ragg package be used for graphics generation?
-
-If `TRUE` and if ragg \>=1.4.0 is installed, then ragg will be used. In particular:
+If `TRUE` and if ragg \>=1.4.0 is installed, then ragg will be used for graphics generation. In particular:
 
 -   ragg will be used for generating the display list of "plot instructions" regardless of the render type.
 
@@ -19,3 +17,15 @@ If `TRUE` and if ragg \>=1.4.0 is installed, then ragg will be used. In particul
 Otherwise, the corresponding device from grDevices will be used.
 
 This global variable is only checked once per session, we recommend that you place it in an `.Rprofile` if you need to modify it.
+
+## ark.resource_namespaces
+
+A boolean, with a default value of `TRUE`.
+
+If `TRUE`, virtual documents will be generated for packages without source references for usage during debugging.
+
+## positron.error_entrace
+
+A boolean, with a default value of `TRUE`.
+
+If `TRUE`, errors will be entraced by `rlang::entrace()` if rlang is installed. This often results in more informative backtraces.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6707
Addresses https://github.com/posit-dev/positron/discussions/7259
Partially addresses https://github.com/posit-dev/positron/issues/2919 (because if you have ragg, you won't be using Cairo!)

This PR adds opt-out ragg support to ark. We use:
- `ragg::agg_record()` to record the display list instructions (replayable by any device)
- `ragg::agg_png()`, `ragg::agg_jpeg()`, and `ragg::agg_tiff()` to render for those device types

It also adds opt-out svglite support for SVG rendering.
- `svglite::svglite()` is used to render for that device type

It adds `ark.ragg` as an R global variable:
- A boolean, with a `TRUE` default
- If ragg 1.4.0 is not installed, it is forced to `FALSE`, and grDevices is still used everywhere
- Only checked once per session (I think this keeps things simple)

It adds `ark.svglite` as an R global variable:
- A boolean, with a `TRUE` default
- If svglite is not installed, it is forced to `FALSE`, and grDevices is still used everywhere
- Only checked once per session (I think this keeps things simple)

I've also added a new `configuration.md` doc to at least track the Ark specific options somewhere. It can be promoted to some other official doc later if needed but we should try and keep this one updated.

In terms of testing, I've got a script of plot tests that I manually run from my previous work on plots, and it still looks good across the board

<details>

```r
# -------------------------
# Multiple plots at once

# Run the chunk all at once
plot(1:10)
plot(2:20)

# Run the chunk all at once
library(ggplot2)
g <- ggplot(mpg, aes(class))
# Number of cars in each class:
g + geom_bar()
# Total engine displacement of each class
g + geom_bar(aes(weight = displ))
# Map class to y instead to flip the orientation
ggplot(mpg) + geom_bar(aes(y = class))

# Inside a function
plt2 = function() {
  layout(matrix(1:2, 2))
  plot(1, 1)
  plot(1, 1)
}
plt2()

# Multiple ggplots
library(ggplot2)
library(purrr)
economics_list <- split(economics_long, economics_long$variable)
economics_list |>
  imap(\(df, nm) {
    df |>
      ggplot(aes(date, value)) +
      geom_line() +
      labs(title = nm)
  })

library(ggExtra)
library(ggplot2)
set.seed(30)
df <- data.frame(x = rnorm(500, 50, 10), y = runif(500, 0, 50))
p2 <- ggplot(df, aes(x, y)) + geom_point()
ggMarginal(p2, type = "boxplot")
ggMarginal(p2, type = "histogram")
par(mfrow = c(1, 1))

# -------------------------
# Plotting in a loop

# (Note it would be nice if we could process renders at interrupt time)

for (i in 1:5) {
  plot(i)
  Sys.sleep(1)
}

# -------------------------
# Par related examples

par(mfrow = c(2, 2))
hist(
  iris$Petal.Width[iris$Species == "virginica"],
  xlim = c(0, 3),
  breaks = 9,
  main = "Petal Width for Virginica",
  xlab = "",
  col = "green"
)
hist(
  iris$Petal.Width[iris$Species == "versicolor"],
  xlim = c(0, 3),
  breaks = 9,
  main = "Petal Width for Versicolor",
  xlab = "",
  col = "blue"
)
hist(
  iris$Petal.Width[iris$Species == "versicolor"],
  xlim = c(0, 3),
  breaks = 9,
  main = "Petal Width for Versicolor",
  xlab = "",
  col = "blue"
)
plot(1:10)
par(mfrow = c(1, 1))


par(mfrow = c(2, 1))
plot(rnorm(100))
plot(rnorm(1000))
par(mfrow = c(1, 1))

# Stars raster
library(stars)
library(terra)
r <- matrix(runif(9), nrow = 3) |>
  st_as_stars()
plot(r)
rast(r) |> plot()

# Performance models
library(performance)
data(mtcars)
m <- lm(mpg ~ gear + cyl + hp, data = mtcars)
check_model(m)

m <- lm(mpg ~ gear + cyl + hp, data = mtcars)
p <- plot(check_model(m), panel = FALSE)
p[[1]] # works
p[[2]] # works
# blank plot
patchwork::wrap_plots(p)

# rpart
library(rpart)
library(rpart.plot)
model <- rpart(Species ~ ., data = iris, method = "class")
rpart.plot(model)

# layout() related
# layout(matrix(
#   c(1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2),
#   nrow = 4,
#   byrow = TRUE
# ))
# layout.show(n = 2)

# sf
geo <- sf::st_make_grid(
  cellsize = c(1, 1),
  offset = c(0, 0),
  n = 10
)
x <- sample(c(0, 1), 100, prob = c(0.9, 0.1), replace = TRUE)
plot(sf::st_sf(x = x, geo))

# biplot
dat <- mtcars
pr <- princomp(dat)
biplot(pr)

# -------------------------
# dev.hold()-ing

# Run these one at a time!
# (RStudio can't actually do this)
dev.hold()
plot(1:10)
abline(1, 2)
dev.flush()

# -------------------------
# tinyplots

library(tinyplot)

plt(Sepal.Length ~ Petal.Length, data = iris)
plt(Sepal.Length ~ Petal.Length | Species, data = iris)
plt(Sepal.Length ~ Petal.Length | Species, data = iris, legend = "bottomright")

# generate data
lambda1 <- 1.8
lambda2 <- 0.7
x <- 0:10
p1 <- dpois(x, lambda1)
p2 <- dpois(x, lambda2)
dp <- data.frame(
  x = c(x, x),
  p = c(p1, p2),
  lambda = rep(c(lambda1, lambda2), each = length(x))
)
dp$lambda <- as.factor(dp$lambda)
# plot
plt(
  p ~ x,
  facet = ~lambda,
  data = dp,
  type = "h",
  lwd = 2,
  col = "skyblue",
  draw = c(
    axis(1, at = x, labels = x),
    points(p ~ x, data = dp, col = "black")
  )
)

# -------------------------
# The dreaded graphics device swap

# Run this all at once
library(ggplot2)
p <- ggplot(mtcars, aes(x = wt, y = mpg)) + geom_point()
p
ggsave("temp.png", p)

# Run this all at once
plot(1:10)
grDevices::png()
plot(1:20)
dev.off()

# -------------------------
# Something related to big plots was not working when you resize
# (I did some perf improvements)

library(qgraph)
data(big5)
data(big5groups)
# First plot
qgraph(
  cor(big5),
  minimum = 0.25,
  groups = big5groups,
  legend = TRUE,
  borders = FALSE,
  title = "Big 5 correlations"
)
# Second identical plot
qgraph(
  cor(big5),
  minimum = 0.25,
  groups = big5groups,
  legend = TRUE,
  borders = FALSE,
  title = "Big 5 correlations"
)

# -------------------------
# Doesn't work - stepping through plots one at a time
# Not precisely sure why, because in theory we are at idle time

fit_lm <- lm(
  mpg ~ cyl + wt,
  data = mtcars
)

# Renders only plot(fit_lm, which = 5)
# Not able to scroll through the which = 1, 2, 3 plots
# that are automatically called by plot.lm().
plot(fit_lm)

# -------------------------
# Doesn't work - we don't respond to render requests in the middle of R execution
# We respond at idle time right now in `process_events()`.
# So all the plots appear at once at the end

tourr::animate_xy(tourr::flea[, 1:6])

# Simpler example of the idea
{
  plot(1:10)
  plot(2:11)
  Sys.sleep(5)
}

```

</details>

---

One immediate benefit is how Chinese characters now render correctly

<img width="780" alt="Screenshot 2025-04-21 at 11 12 54 AM" src="https://github.com/user-attachments/assets/e8929df1-75af-4d9b-b235-b306d7cdfe99" />
