### PR TITLE
Suppress confusing logging messages re: namespace completions

### DIFF
--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -429,7 +429,7 @@ pub(super) unsafe fn completion_item_from_lazydata(
 
     match completion_item_from_symbol(name, env, Some(package), promise_strategy, &parameter_hints)
     {
-        Ok(item) => return Ok(item),
+        Ok(item) => Ok(item),
         Err(err) => {
             // Should be impossible, but we'll be extra safe
             bail!("Object '{name}' not defined in lazydata environment for namespace {package}: {err}")

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -432,7 +432,7 @@ pub(super) unsafe fn completion_item_from_lazydata(
         Ok(item) => Ok(item),
         Err(err) => {
             // Should be impossible, but we'll be extra safe
-            bail!("Object '{name}' not defined in lazydata environment for namespace {package}: {err}")
+            Err(anyhow::anyhow!("Object '{name}' not defined in lazydata environment for namespace {package}: {err}"))
         },
     }
 }

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -458,14 +458,18 @@ pub(super) unsafe fn completion_item_from_symbol(
         Err(err) => {
             // The only error we anticipate is the case where `envir` doesn't
             // have a binding for `name`.
-            bail!("Failed to check if binding is active: {err}");
+            return Err(anyhow::anyhow!(
+                "Failed to check if binding is active: {err}"
+            ));
         },
     }
 
     let object = Rf_findVarInFrame(envir, symbol);
 
     if object == R_UnboundValue {
-        bail!("Symbol '{name}' should have been found but wasn't");
+        return Err(anyhow::anyhow!(
+            "Symbol '{name}' should have been found but wasn't"
+        ));
     }
 
     completion_item_from_object(

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -11,7 +11,6 @@ use anyhow::bail;
 use harp::r_symbol;
 use harp::utils::is_symbol_valid;
 use harp::utils::r_env_binding_is_active;
-use harp::utils::r_envir_name;
 use harp::utils::r_promise_force_with_rollback;
 use harp::utils::r_promise_is_forced;
 use harp::utils::r_promise_is_lazy_load_binding;
@@ -375,34 +374,44 @@ pub(super) unsafe fn completion_item_from_namespace(
     parameter_hints: &ParameterHints,
 ) -> anyhow::Result<CompletionItem> {
     // First, look in the namespace itself.
-    if let Some(item) = completion_item_from_symbol(
+    match completion_item_from_symbol(
         name,
         namespace,
         Some(package),
         PromiseStrategy::Force,
         parameter_hints,
     ) {
-        return item;
+        Ok(item) => return Ok(item),
+        Err(_) => {
+            // The only error we anticipate is the case where `namespace`
+            // doesn't have a binding for `name`, because the associated object
+            // has been imported and re-exported. For example, the way dplyr
+            // imports and re-exports `rlang::.data` or `tidyselect::all_of()`.
+            // In such a case, we'll succeed below, when we try again in the
+            // imports environment.
+        },
     }
 
     // Otherwise, try the imports environment.
     let imports = ENCLOS(namespace);
-    if let Some(item) = completion_item_from_symbol(
+    match completion_item_from_symbol(
         name,
         imports,
         Some(package),
         PromiseStrategy::Force,
         parameter_hints,
     ) {
-        return item;
+        Ok(item) => return Ok(item),
+        Err(err) => {
+            // This is really unexpected.
+            bail!(
+                "Failed to form completion item for '{}' in namespace '{}': {}",
+                name,
+                package,
+                err
+            );
+        },
     }
-
-    // If still not found, something is wrong.
-    bail!(
-        "Object '{}' not defined in namespace {:?}",
-        name,
-        r_envir_name(namespace)?
-    )
 }
 
 pub(super) unsafe fn completion_item_from_lazydata(
@@ -416,14 +425,14 @@ pub(super) unsafe fn completion_item_from_lazydata(
     let promise_strategy = PromiseStrategy::Simple;
 
     // Lazydata objects are never functions, so this doesn't really matter
-    let parameter_hints = ParameterHints::Enabled;
+    let parameter_hints = ParameterHints::Disabled;
 
     match completion_item_from_symbol(name, env, Some(package), promise_strategy, &parameter_hints)
     {
-        Some(item) => item,
-        None => {
+        Ok(item) => return Ok(item),
+        Err(err) => {
             // Should be impossible, but we'll be extra safe
-            bail!("Object '{name}' not defined in lazydata environment for namespace {package}")
+            bail!("Object '{name}' not defined in lazydata environment for namespace {package}: {err}")
         },
     }
 }
@@ -434,7 +443,7 @@ pub(super) unsafe fn completion_item_from_symbol(
     package: Option<&str>,
     promise_strategy: PromiseStrategy,
     parameter_hints: &ParameterHints,
-) -> Option<anyhow::Result<CompletionItem>> {
+) -> anyhow::Result<CompletionItem> {
     let symbol = r_symbol!(name);
 
     match r_env_binding_is_active(envir, symbol) {
@@ -445,29 +454,29 @@ pub(super) unsafe fn completion_item_from_symbol(
         Ok(true) => {
             // We can't even extract out the object for active bindings so they
             // are handled extremely specially.
-            return Some(completion_item_from_active_binding(name));
+            return completion_item_from_active_binding(name);
         },
         Err(err) => {
-            log::error!("Can't determine if binding is active: {err:?}");
-            return None;
+            // The only error we anticipate is the case where `envir` doesn't
+            // have a binding for `name`.
+            bail!("Failed to check if binding is active: {}", err);
         },
     }
 
     let object = Rf_findVarInFrame(envir, symbol);
 
     if object == R_UnboundValue {
-        log::error!("Symbol '{name}' should have been found.");
-        return None;
+        bail!("Symbol '{name}' should have been found but wasn't");
     }
 
-    Some(completion_item_from_object(
+    completion_item_from_object(
         name,
         object,
         envir,
         package,
         promise_strategy,
         parameter_hints,
-    ))
+    )
 }
 
 // This is used when providing completions for a parameter in a document

--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -459,7 +459,7 @@ pub(super) unsafe fn completion_item_from_symbol(
         Err(err) => {
             // The only error we anticipate is the case where `envir` doesn't
             // have a binding for `name`.
-            bail!("Failed to check if binding is active: {}", err);
+            bail!("Failed to check if binding is active: {err}");
         },
     }
 

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -111,11 +111,7 @@ fn completions_from_search_path(
                     Ok(item) => completions.push(item),
                     Err(err) => {
                         // Log the error but continue processing other symbols
-                        log::error!(
-                            "Failed to get completion item for symbol '{}': {}",
-                            symbol,
-                            err
-                        );
+                        log::error!("Failed to get completion item for symbol '{symbol}': {err}");
                         continue;
                     },
                 };

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -101,20 +101,23 @@ fn completions_from_search_path(
                 }
 
                 // Add the completion item.
-                let Some(item) = completion_item_from_symbol(
+                match completion_item_from_symbol(
                     symbol,
                     envir,
                     name,
                     promise_strategy.clone(),
                     parameter_hints,
-                ) else {
-                    log::error!("Completion symbol '{symbol}' was unexpectedly not found.");
-                    continue;
-                };
-
-                match item {
+                ) {
                     Ok(item) => completions.push(item),
-                    Err(error) => log::error!("{:?}", error),
+                    Err(err) => {
+                        // Log the error but continue processing other symbols
+                        log::error!(
+                            "Failed to get completion item for symbol '{}': {}",
+                            symbol,
+                            err
+                        );
+                        continue;
+                    },
                 };
             }
 

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -186,8 +186,6 @@ fn completions_from_namespace_lazydata(
     namespace: SEXP,
     package: &str,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
-    log::info!("completions_from_namespace_lazydata()");
-
     unsafe {
         let ns = Rf_findVarInFrame(namespace, r_symbol!(".__NAMESPACE__."));
         if ns == R_UnboundValue {


### PR DESCRIPTION
Fixes #764 

There were a few ways to fix this. I picked an approach based on the root cause being an unconventional return value from `completion_item_from_symbol()`. It was returning `Option<anyhow::Result<CompletionItem>>`, which seems like it might just be plain odd? More objectively, it was the _only_ `completion_item_from_*()` function that did so.

