### PR TITLE
Add repo-specific guidance for co-pilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+Do not use `bail!`. Instead use an explicit `return Err(anyhow!(...))`.
+
+When a `match` expression is the last expression in a function, omit `return` keywords in match arms. Let the expression evaluate to the function's return value.
+
+For error messages and logging, prefer direct formatting syntax: `Err(anyhow!("Message: {err}"))` instead of `Err(anyhow!("Message: {}", err))`.
+
+Use `log::trace!` instead of `log::debug!` when `log::info!` is not appropriate.
+
+Use fully qualified result types (`anyhow::Result`) instead of importing them.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,6 @@ When a `match` expression is the last expression in a function, omit `return` ke
 
 For error messages and logging, prefer direct formatting syntax: `Err(anyhow!("Message: {err}"))` instead of `Err(anyhow!("Message: {}", err))`.
 
-Use `log::trace!` instead of `log::debug!` when `log::info!` is not appropriate.
+Use `log::trace!` instead of `log::debug!`.
 
 Use fully qualified result types (`anyhow::Result`) instead of importing them.


### PR DESCRIPTION
This adds custom instructions that should improve the quality of the code produced when chatting with copilot.

General documentation on custom instructions:

https://code.visualstudio.com/docs/copilot/copilot-customization

The repo-specific file that is consulted by default (which is what I'm doing in this PR):

https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file

I've seeded this with the little blunders I've been making recently as I develop my ark mojo.