### PR TITLE
Stop excluding `base::return()` from completions

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -53,7 +53,7 @@ fn completions_from_search_path(
     let mut completions = vec![];
 
     const R_CONTROL_FLOW_KEYWORDS: &[&str] = &[
-        "if", "else", "for", "in", "while", "repeat", "break", "next", "return", "function",
+        "if", "else", "for", "in", "while", "repeat", "break", "next", "function",
     ];
 
     unsafe {

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -53,7 +53,7 @@ fn completions_from_search_path(
     let mut completions = vec![];
 
     const R_CONTROL_FLOW_KEYWORDS: &[&str] = &[
-        "if", "else", "for", "in", "while", "repeat", "break", "next", "function",
+        "if", "else", "for", "in", "while", "repeat", "break", "next",
     ];
 
     unsafe {


### PR DESCRIPTION
I'm opening Completion Month with a real banger! Let's stop explicitly excluding `base::return()` from completions.

Relates to [#4842](https://github.com/posit-dev/positron/issues/4842) (the `function` part requires more thought -- will be separate PR)

I've

* Thought about this 🤔 
* Looked through relevant comments and `git blame` in ark
* Looked at what RStudio does

and I can't find any reason to _not_ just let `base::return()` show up in our search path completions.