### PR TITLE
Stop excluding base::return() and base::function from completions

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -53,7 +53,7 @@ fn completions_from_search_path(
     let mut completions = vec![];
 
     const R_CONTROL_FLOW_KEYWORDS: &[&str] = &[
-        "if", "else", "for", "in", "while", "repeat", "break", "next", "return", "function",
+        "if", "else", "for", "in", "while", "repeat", "break", "next", "function",
     ];
 
     unsafe {

--- a/crates/ark/src/lsp/completions/sources/composite/search_path.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/search_path.rs
@@ -53,7 +53,7 @@ fn completions_from_search_path(
     let mut completions = vec![];
 
     const R_CONTROL_FLOW_KEYWORDS: &[&str] = &[
-        "if", "else", "for", "in", "while", "repeat", "break", "next", "function",
+        "if", "else", "for", "in", "while", "repeat", "break", "next",
     ];
 
     unsafe {


### PR DESCRIPTION
I'm opening Completion Month with a real banger! Let's stop explicitly excluding `base::return()` and `base::function` from completions.

Relates to https://github.com/posit-dev/positron/issues/4842

I've

* Thought about this 🤔 
* Looked through relevant comments and `git blame` in ark
* Looked at what RStudio does

and I can't find any reason to _not_ just let `base::return()` and `base::function` show up in our completions. They will both be contributed by our search path completions, coming from `base`.

Both are represented by snippets, which I have some mixed feelings about. So I plan to discuss some additional improvements relating to the snippet treatment of `function` and `return()`. We could also discuss https://github.com/posit-dev/positron/issues/1850 at the same time. But perhaps this simple fix can happen first, especially for `return()`.