### PR TITLE
Fix parameter documentation on R >=4.3.1

### DIFF
--- a/crates/ark/src/lsp/help.rs
+++ b/crates/ark/src/lsp/help.rs
@@ -411,7 +411,7 @@ mod tests {
 
             let markdown = help.parameter("x").unwrap().unwrap();
             assert_eq!(markdown.kind, MarkupKind::Markdown);
-            markdown.value.contains("vector or `NULL`");
+            assert!(markdown.value.contains("vector or `NULL`"));
 
             assert!(help.parameter("not_a_parameter").unwrap().is_none());
         });

--- a/crates/ark/src/lsp/help.rs
+++ b/crates/ark/src/lsp/help.rs
@@ -170,7 +170,7 @@ impl RHtmlHelp {
     /// <h3>Arguments</h3>
     ///
     /// <table>
-    /// <tr style="vertical-align: top;"><td><code>parameter</code></td>
+    /// <tr><td><code>parameter</code></td>
     /// <td>
     /// Parameter documentation.
     /// </td></tr>
@@ -212,7 +212,7 @@ impl RHtmlHelp {
 
             // Get the cells in this table.
             // I really wish R included classes on these table elements...
-            let selector = Selector::parse(r#"tr[style="vertical-align: top;"] > td"#).unwrap();
+            let selector = Selector::parse(r#"tr > td"#).unwrap();
             let mut cells = elt.select(&selector);
 
             // Start iterating through pairs of cells.
@@ -371,6 +371,8 @@ fn for_each_section(doc: &Html, mut callback: impl FnMut(ElementRef, Vec<Element
 
 #[cfg(test)]
 mod tests {
+    use tower_lsp::lsp_types::MarkupKind;
+
     use crate::lsp::help::RHtmlHelp;
     use crate::lsp::help::Status;
     use crate::r_task;
@@ -406,6 +408,12 @@ mod tests {
 
             let markdown = help.markdown().unwrap();
             markdown.contains("### Usage");
+
+            let markdown = help.parameter("x").unwrap().unwrap();
+            assert_eq!(markdown.kind, MarkupKind::Markdown);
+            markdown.value.contains("vector or `NULL`");
+
+            assert!(help.parameter("not_a_parameter").unwrap().is_none());
         });
     }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5302

Ah, welcome back to our old friend `R.css`!

I've explained the problem well here so I won't rehash it:
https://github.com/posit-dev/positron/issues/5302#issuecomment-2512657264

The solution is to just not "select" on `[style="vertical-align: top;"]` at all, since it no longer exists in R >=4.3.1, and to instead just select on `tr > td` while inside a `<table>` nested inside the `<h3>Arguments</h3>` header. Hopefully that is precise enough to not come up with false positives, and even if it does hit false positives it is unlikely that they work with the rest of the code that works on the selection itself. This has the benefit of also working in R < 4.3.1 when the extra styling was still there.

---

Here it is on R 4.2.1 (when `<tr style="vertical-align: top;"><td>` was still there, this works on `main`)

<img width="610" alt="Screenshot 2025-04-10 at 2 06 05 PM" src="https://github.com/user-attachments/assets/705ae369-1674-404e-a83b-f0cdd887de53" />

Here it is on R 4.4.3 (this only works with this PR)

<img width="609" alt="Screenshot 2025-04-10 at 2 06 23 PM" src="https://github.com/user-attachments/assets/ab657465-5a84-4518-bb6a-0b75d5aec2eb" />

---

One thing of note is that it looks like a monospaced font is being used for the help documentation now. That must be a fairly new VS Code change, because this image linked in the original issue did not use a monospaced font!

![image](https://github.com/user-attachments/assets/4f2aa423-37c9-4297-b05d-bcc0a5c63db2)
