### PR TITLE
Be willing to complete in the face of emptiness

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -210,9 +210,12 @@ fn is_identifier_like(x: Node) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::fixtures::point_from_cursor;
+    use crate::lsp::completions::completion_context::CompletionContext;
+    use crate::lsp::completions::sources::composite::get_completions;
     use crate::lsp::completions::sources::composite::is_identifier_like;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
+    use crate::lsp::state::WorldState;
     use crate::r_task;
     use crate::treesitter::NodeType;
     use crate::treesitter::NodeTypeExt;
@@ -235,5 +238,40 @@ mod tests {
                 );
             }
         })
+    }
+
+    #[test]
+    fn test_get_completions_on_empty_document() {
+        r_task(|| {
+            let (text, point) = point_from_cursor("@");
+            let document = Document::new(text.as_str(), None);
+            let document_context = DocumentContext::new(&document, point, None);
+            let state = WorldState::default();
+            let context = CompletionContext::new(&document_context, &state);
+
+            assert!(context.document_context.node.is_program());
+
+            let completions = get_completions(&context).unwrap();
+            assert!(completions.is_some());
+            assert!(!completions.unwrap().is_empty());
+        });
+    }
+
+    #[test]
+    fn test_get_completions_on_empty_line_in_non_empty_document() {
+        r_task(|| {
+            let code = "x <- 1:3\n@\nrnorm(3)";
+            let (text, point) = point_from_cursor(code);
+            let document = Document::new(text.as_str(), None);
+            let document_context = DocumentContext::new(&document, point, None);
+            let state = WorldState::default();
+            let context = CompletionContext::new(&document_context, &state);
+
+            assert!(context.document_context.node.is_program());
+
+            let completions = get_completions(&context).unwrap();
+            assert!(completions.is_some());
+            assert!(!completions.unwrap().is_empty());
+        });
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -209,8 +209,7 @@ fn is_identifier_like(x: Node) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use tree_sitter::Point;
-
+    use crate::fixtures::point_from_cursor;
     use crate::lsp::completions::sources::composite::is_identifier_like;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
@@ -225,9 +224,10 @@ mod tests {
             // anonymous nodes and keywords, so they need to look like
             // identifiers that we provide completions for
             for keyword in ["if", "for", "while"] {
-                let point = Point { row: 0, column: 0 };
-                let document = Document::new(keyword, None);
+                let (text, point) = point_from_cursor(&format!("{keyword}@"));
+                let document = Document::new(text.as_str(), None);
                 let context = DocumentContext::new(&document, point, None);
+
                 assert!(is_identifier_like(context.node));
                 assert_eq!(
                     context.node.node_type(),

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -201,6 +201,20 @@ fn is_identifier_like(x: Node) -> bool {
         return true;
     }
 
+    // Consider when the user asks for completions with no existing
+    // text-to-complete, such as at the R prompt in the Console, in an empty R
+    // file, or on an empty line of a non-empty R file.
+    //
+    // Gesture-wise, a Positron user could do this with Ctrl + Space, which
+    // invokes the command editor.action.triggerSuggest.
+    //
+    // The nominal completion node in these cases is just the root or 'Program'
+    // node of the AST. In this case, we should just provide "all" completions,
+    // for some reasonable definition of "all".
+    if x.node_type() == NodeType::Program {
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
Fixes #770

See the last "move" in https://github.com/posit-dev/ark/pull/805#discussion_r2089689821 for a concrete illustration of what this PR does. If the client asks for completions in any context where we aren't inside a node (i.e. we're just in the 'Program' node), we should basically send all composite completions, instead of no completions.

I've verified that the new tests fail on `main` and `bugfix/nearest-enclosing-node` for the reasons I expect.