### PR TITLE
Send pre-renderings of new plots to the frontend

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -665,7 +665,7 @@ pub struct ColumnSelection {
 }
 
 /// Possible values for ColumnDisplayType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnDisplayType {
 	#[serde(rename = "number")]
 	#[strum(to_string = "number")]
@@ -725,7 +725,7 @@ pub enum RowFilterCondition {
 }
 
 /// Possible values for RowFilterType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum RowFilterType {
 	#[serde(rename = "between")]
 	#[strum(to_string = "between")]
@@ -801,7 +801,7 @@ pub enum FilterComparisonOp {
 }
 
 /// Possible values for TextSearchType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum TextSearchType {
 	#[serde(rename = "contains")]
 	#[strum(to_string = "contains")]
@@ -825,7 +825,7 @@ pub enum TextSearchType {
 }
 
 /// Possible values for ColumnFilterType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnFilterType {
 	#[serde(rename = "text_search")]
 	#[strum(to_string = "text_search")]
@@ -837,7 +837,7 @@ pub enum ColumnFilterType {
 }
 
 /// Possible values for ColumnProfileType
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnProfileType {
 	#[serde(rename = "null_count")]
 	#[strum(to_string = "null_count")]
@@ -913,7 +913,7 @@ pub enum TableSelectionKind {
 }
 
 /// Possible values for ExportFormat
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ExportFormat {
 	#[serde(rename = "csv")]
 	#[strum(to_string = "csv")]
@@ -929,7 +929,7 @@ pub enum ExportFormat {
 }
 
 /// Possible values for SupportStatus
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum SupportStatus {
 	#[serde(rename = "unsupported")]
 	#[strum(to_string = "unsupported")]

--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -37,14 +37,7 @@ pub struct PlotResult {
 	pub mime_type: String,
 
 	/// The policy used to render the plot
-	pub policy: RenderPolicy
-}
-
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct RenderPolicy {
-    pub size: PlotSize,
-    pub pixel_ratio: f64,
-    pub format: RenderFormat,
+	pub policy: Option<RenderPolicy>
 }
 
 /// The size of a plot
@@ -57,8 +50,21 @@ pub struct PlotSize {
 	pub width: i64
 }
 
-/// Possible values for Format in Render
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+/// The policy used to render the plot
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct RenderPolicy {
+	/// Plot size of the render policy
+	pub size: PlotSize,
+
+	/// The pixel ratio of the display device
+	pub pixel_ratio: f64,
+
+	/// Format of the render policy
+	pub format: RenderFormat
+}
+
+/// Possible values for RenderFormat
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum RenderFormat {
 	#[serde(rename = "png")]
 	#[strum(to_string = "png")]
@@ -82,7 +88,7 @@ pub enum RenderFormat {
 }
 
 /// Possible values for PlotUnit
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum PlotUnit {
 	#[serde(rename = "pixels")]
 	#[strum(to_string = "pixels")]
@@ -172,3 +178,4 @@ pub enum PlotFrontendEvent {
 	Show,
 
 }
+

--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -48,7 +48,7 @@ pub struct PlotSize {
 }
 
 /// Possible values for Format in Render
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum RenderFormat {
 	#[serde(rename = "png")]
 	#[strum(to_string = "png")]

--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -34,11 +34,22 @@ pub struct PlotResult {
 	pub data: String,
 
 	/// The MIME type of the plot data
-	pub mime_type: String
+	pub mime_type: String,
+
+	/// The policy used to render the plot
+	pub policy: RenderPolicy
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct RenderPolicy {
+    pub width: i64,
+    pub height: i64,
+    pub pixel_ratio: f64,
+    pub format: RenderFormat,
 }
 
 /// The size of a plot
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PlotSize {
 	/// The plot's height, in pixels
 	pub height: i64,
@@ -162,4 +173,3 @@ pub enum PlotFrontendEvent {
 	Show,
 
 }
-

--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -42,8 +42,7 @@ pub struct PlotResult {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RenderPolicy {
-    pub width: i64,
-    pub height: i64,
+    pub size: PlotSize,
     pub pixel_ratio: f64,
     pub format: RenderFormat,
 }

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -21,6 +21,7 @@ use amalthea::comm::plot_comm::PlotBackendRequest;
 use amalthea::comm::plot_comm::PlotFrontendEvent;
 use amalthea::comm::plot_comm::PlotResult;
 use amalthea::comm::plot_comm::RenderFormat;
+use amalthea::comm::plot_comm::RenderPolicy;
 use amalthea::socket::comm::CommInitiator;
 use amalthea::socket::comm::CommSocket;
 use amalthea::socket::iopub::IOPubMessage;
@@ -133,14 +134,6 @@ struct DeviceContext {
 
     // Current rendering policy
     current_rendering_policy: Cell<RenderPolicy>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct RenderPolicy {
-    width: i64,
-    height: i64,
-    pixel_ratio: f64,
-    format: RenderFormat,
 }
 
 impl DeviceContext {
@@ -386,6 +379,7 @@ impl DeviceContext {
                 Ok(PlotBackendReply::RenderReply(PlotResult {
                     data: data.to_string(),
                     mime_type: mime_type.to_string(),
+                    policy,
                 }))
             },
         }
@@ -482,6 +476,7 @@ impl DeviceContext {
                 let pre_render = PlotResult {
                     data: pre_render.to_string(),
                     mime_type: mime_type.to_string(),
+                    policy,
                 };
 
                 serde_json::json!({ "pre_render": pre_render })

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -388,7 +388,7 @@ impl DeviceContext {
                 Ok(PlotBackendReply::RenderReply(PlotResult {
                     data: data.to_string(),
                     mime_type: mime_type.to_string(),
-                    policy,
+                    policy: Some(policy),
                 }))
             },
         }
@@ -485,7 +485,7 @@ impl DeviceContext {
                 let pre_render = PlotResult {
                     data: pre_render.to_string(),
                     mime_type: mime_type.to_string(),
-                    policy,
+                    policy: Some(policy),
                 };
 
                 serde_json::json!({ "pre_render": pre_render })

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -20,6 +20,7 @@ use amalthea::comm::plot_comm::PlotBackendReply;
 use amalthea::comm::plot_comm::PlotBackendRequest;
 use amalthea::comm::plot_comm::PlotFrontendEvent;
 use amalthea::comm::plot_comm::PlotResult;
+use amalthea::comm::plot_comm::PlotSize;
 use amalthea::comm::plot_comm::RenderFormat;
 use amalthea::comm::plot_comm::RenderPolicy;
 use amalthea::socket::comm::CommInitiator;
@@ -149,8 +150,10 @@ impl DeviceContext {
             sockets: RefCell::new(HashMap::new()),
             wrapped_callbacks: WrappedDeviceCallbacks::default(),
             current_rendering_policy: Cell::new(RenderPolicy {
-                width: 640,
-                height: 400,
+                size: PlotSize {
+                    width: 640,
+                    height: 400,
+                },
                 pixel_ratio: 1.,
                 format: RenderFormat::Png,
             }),
@@ -363,8 +366,10 @@ impl DeviceContext {
                 });
 
                 let policy = RenderPolicy {
-                    width: size.width,
-                    height: size.height,
+                    size: PlotSize {
+                        width: size.width,
+                        height: size.height,
+                    },
                     pixel_ratio: plot_meta.pixel_ratio,
                     format: plot_meta.format,
                 };
@@ -590,8 +595,10 @@ impl DeviceContext {
     fn create_display_data_plot(&self, id: &PlotId) -> Result<serde_json::Value, anyhow::Error> {
         // TODO: Take these from R global options? Like `ark.plot.width`?
         let policy = RenderPolicy {
-            width: 800,
-            height: 600,
+            size: PlotSize {
+                width: 800,
+                height: 600,
+            },
             pixel_ratio: 1.0,
             format: RenderFormat::Png,
         };
@@ -613,8 +620,8 @@ impl DeviceContext {
         let image_path = r_task(|| unsafe {
             RFunction::from(".ps.graphics.render_plot_from_recording")
                 .param("id", id)
-                .param("width", RObject::try_from(policy.width)?)
-                .param("height", RObject::try_from(policy.height)?)
+                .param("width", RObject::try_from(policy.size.width)?)
+                .param("height", RObject::try_from(policy.size.height)?)
                 .param("pixel_ratio", policy.pixel_ratio)
                 .param("format", policy.format.to_string())
                 .call()?

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -375,7 +375,11 @@ impl DeviceContext {
                 };
 
                 // Update the current rendering policy so that pre-rendering is
-                // as accurate as possible
+                // as accurate as possible.
+                // TODO: Once we get render policy events we should use that instead.
+                // This way a one-off render request with special settings won't cause
+                // the next pre-render to be invalid and force the frontend to request
+                // a proper render.
                 self.current_render_policy.replace(policy);
 
                 let data = self.render_plot(&id, &policy)?;

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -134,7 +134,7 @@ struct DeviceContext {
     wrapped_callbacks: WrappedDeviceCallbacks,
 
     // Current rendering policy
-    current_rendering_policy: Cell<RenderPolicy>,
+    current_render_policy: Cell<RenderPolicy>,
 }
 
 impl DeviceContext {
@@ -149,7 +149,7 @@ impl DeviceContext {
             id: RefCell::new(Self::new_id()),
             sockets: RefCell::new(HashMap::new()),
             wrapped_callbacks: WrappedDeviceCallbacks::default(),
-            current_rendering_policy: Cell::new(RenderPolicy {
+            current_render_policy: Cell::new(RenderPolicy {
                 size: PlotSize {
                     width: 640,
                     height: 400,
@@ -376,7 +376,7 @@ impl DeviceContext {
 
                 // Update the current rendering policy so that pre-rendering is
                 // as accurate as possible
-                self.current_rendering_policy.replace(policy);
+                self.current_render_policy.replace(policy);
 
                 let data = self.render_plot(&id, &policy)?;
                 let mime_type = Self::get_mime_type(&plot_meta.format);
@@ -471,7 +471,7 @@ impl DeviceContext {
             POSITRON_PLOT_CHANNEL_ID.to_string(),
         );
 
-        let policy = self.current_rendering_policy.get();
+        let policy = self.current_render_policy.get();
 
         // Prepare a pre-rendering of the plot so Positron has something to display immediately
         let data = match self.render_plot(id, &policy) {

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -157,8 +157,8 @@ impl DeviceContext {
             sockets: RefCell::new(HashMap::new()),
             wrapped_callbacks: WrappedDeviceCallbacks::default(),
             current_rendering_policy: Cell::new(RenderPolicy {
-                width: 800,
-                height: 640,
+                width: 640,
+                height: 400,
                 pixel_ratio: 1.,
                 format: RenderFormat::Png,
             }),

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -133,7 +133,7 @@ struct DeviceContext {
     /// The callbacks of the wrapped device, initialized on graphics device creation
     wrapped_callbacks: WrappedDeviceCallbacks,
 
-    // Current rendering policy
+    /// The settings used for pre-renderings of new plots.
     current_render_policy: Cell<RenderPolicy>,
 }
 


### PR DESCRIPTION
Ark side of https://github.com/posit-dev/positron/pull/7247
Progress towards https://github.com/posit-dev/positron/issues/5184
Progress towards https://github.com/posit-dev/positron/issues/6736

We now generate pre-renderings of new plots and send them over to the frontend as part of `comm_open` messages.

The current settings for the pre-renders are stored in a `Cell`. This requires a `Copy` type which is generated on the Positron side (see linked PR).
