### PR TITLE
Rerun ark's `build.rs` on changes to `src/` or `resources/`

### DIFF
--- a/crates/ark/build.rs
+++ b/crates/ark/build.rs
@@ -10,6 +10,13 @@ use std::process::Command;
 extern crate embed_resource;
 
 fn main() {
+    // Ensures that env vars are refreshed on any `src/` or `resources/` change, which is
+    // required for `.ps.ark.version()` to work as you'd expect. Notably this also ensures
+    // changes to `src/debug.c` force a refresh, which otherwise aren't considered by
+    // cargo's defaults as requiring a rebuild.
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=resources");
+
     // Attempt to use `git rev-parse HEAD` to get the current git hash. If this
     // fails, we'll just use the string "<unknown>" to indicate that the git hash
     // could not be determined..
@@ -60,6 +67,5 @@ fn main() {
         .join("ark-manifest.rc");
     embed_resource::compile_for_everything(resource, embed_resource::NONE);
 
-    println!("cargo:rerun-if-changed=src/debug.c");
     cc::Build::new().file("src/debug.c").compile("debug");
 }


### PR DESCRIPTION
cargo is conservative by default and generally will always rerun the build script if any file in the project changes.

But if you add your own `rerun-if-changed`, then it will start to get more specific and will only run in those specific cases you specified!

We recently added `println!("cargo:rerun-if-changed=src/debug.c");` which means that `build.rs` will now _only_ rerun when that one file is changed, making `.ps.ark.version()` basically useless.

Unfortunately `debug.c` is not recognized by cargo as being something that triggers a rebuild if we just remove this, so we need to include it. So instead we broaden the scope to anything in `src` or `resources`, which seems like itll work well.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#:~:text=in%20the%20FAQ.-,cargo%3A%3Arerun%2Dif%2Dchanged%3DPATH,if%20the%20file%20has%20changed