### PR TITLE
Allow extensions to contribute to `F1` show help topic

### DIFF
--- a/crates/ark/src/browser.rs
+++ b/crates/ark/src/browser.rs
@@ -12,6 +12,7 @@ use libr::Rf_ScalarLogical;
 use libr::SEXP;
 
 use crate::help::message::HelpEvent;
+use crate::help::message::ShowHelpUrlKind;
 use crate::help::message::ShowHelpUrlParams;
 use crate::interface::RMain;
 
@@ -29,7 +30,10 @@ fn is_help_url(url: &str) -> bool {
 
 fn handle_help_url(url: String) -> anyhow::Result<()> {
     RMain::with(|main| {
-        let event = HelpEvent::ShowHelpUrl(ShowHelpUrlParams { url });
+        let event = HelpEvent::ShowHelpUrl(ShowHelpUrlParams {
+            url,
+            kind: ShowHelpUrlKind::HelpProxy,
+        });
         main.send_help_event(event)
     })
 }

--- a/crates/ark/src/help/message.rs
+++ b/crates/ark/src/help/message.rs
@@ -16,9 +16,16 @@ pub enum HelpEvent {
 }
 
 #[derive(Debug)]
+pub enum ShowHelpUrlKind {
+    HelpProxy,
+    External,
+}
+
+#[derive(Debug)]
 pub struct ShowHelpUrlParams {
     /// Url to attempt to show.
     pub url: String,
+    pub kind: ShowHelpUrlKind,
 }
 
 impl std::fmt::Display for HelpEvent {

--- a/crates/ark/src/lsp/help_topic.rs
+++ b/crates/ark/src/lsp/help_topic.rs
@@ -89,6 +89,7 @@ fn locate_help_node(tree: &Tree, point: Point) -> Option<Node> {
     // Even if they are at `p<>kg::fun`, we assume they really want docs for `fun`.
     let node = match node.parent() {
         Some(parent) if matches!(parent.node_type(), NodeType::NamespaceOperator(_)) => parent,
+        Some(parent) if matches!(parent.node_type(), NodeType::ExtractOperator(_)) => parent,
         Some(_) => node,
         None => node,
     };
@@ -138,5 +139,12 @@ mod tests {
         let node = locate_help_node(&tree, point).unwrap();
         let text = node.utf8_text(text.as_bytes()).unwrap();
         assert_eq!(text, "dplyr:::across");
+
+        // R6 methods, or reticulate accessors
+        let (text, point) = point_from_cursor("tf$a@bs(x)");
+        let tree = parser.parse(text.as_str(), None).unwrap();
+        let node = locate_help_node(&tree, point).unwrap();
+        let text = node.utf8_text(text.as_bytes()).unwrap();
+        assert_eq!(text, "tf$abs");
     }
 }

--- a/crates/ark/src/modules/positron/methods.R
+++ b/crates/ark/src/modules/positron/methods.R
@@ -25,6 +25,9 @@ ark_methods_table$ark_positron_variable_get_children <- new.env(
 ark_methods_table$ark_positron_variable_has_viewer <- new.env(
     parent = emptyenv()
 )
+ark_methods_table$ark_positron_help_get_handler <- new.env(
+    parent = emptyenv()
+)
 lockEnvironment(ark_methods_table, TRUE)
 
 ark_methods_allowed_packages <- c("torch", "reticulate", "duckplyr")


### PR DESCRIPTION
The goal of this PR is to allow extensions to add support for F1 show help topic for objects.
It's specifically targetting reticulate objects, but could be used by eg, R6 objects to go to their documentation.

There are 3 sets of changes:

- Include the extract operator in the topic node, so that if you have `object$fu@n()`, (`@` is marking the cursor position) and press `F1`, then we're calling showHelpTopic with topic = `"object$fun"`. I don't think this brings any downside because currently this would just send `foo`, and if `foo` is actually a function in the global namespace, it would actually show the wrong documentation page. eg `object$abs` shows the documentation for base `abs`.

- This is the core change. showHelpTopic now evaluates the `topic` string to figure out if there's an object accessible from the global environment with that name. If there is one, it tries to acquire a `help_handler` by calling a new ark method called `ark_help_get_handler`. If a helper is found, it's called for its side effects of showing the documentation in the help pane.

- The last change just adds an entrypoint to display a html file in the help pane. This is useful for showing help topipics that may be rendered by servers that are not the R Help server.

For instance, this how the method implementation looks like for reticulate:

```
.ark.register_method(
  "ark_positron_help_get_handler",
  "python.builtin.object",
  function(obj, ...) {
    if (is.null(.globals$pydoc_thread)) {
      .globals$pydoc_thread <- positron$pydoc$start_server(port = 64216L)
    }

    function(topic) {
      url <- paste0(
        .globals$pydoc_thread$url,
        "get?key=",
        positron$utils$get_qualname(obj)
      )

      .ps.help.browse_external_url(url)
      TRUE
    }
  }
)
```