### PR TITLE
Add option to show `.Last.value` in the Variables pane

### DIFF
--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -433,7 +433,7 @@ impl RVariables {
                 Err(err) => {
                     // This isn't a critical error but would also be very
                     // unexpected.
-                    log::debug!("Environment: Could not evaluate .Last.value ({err:?})");
+                    log::error!("Environment: Could not evaluate .Last.value ({err:?})");
                     None
                 },
             }

--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -1,7 +1,7 @@
 //
 // r_variables.rs
 //
-// Copyright (C) 2023-2024 by Posit Software, PBC
+// Copyright (C) 2023-2025 by Posit Software, PBC
 //
 //
 
@@ -364,6 +364,14 @@ impl RVariables {
 
         r_task(|| {
             let new_bindings = self.bindings();
+            let last_robj = harp::parse_eval_global(".Last.value").unwrap();
+
+            let last_value = PositronVariable::from(
+                String::from(".Last.value"),
+                String::from(".Last.value"),
+                last_robj.sexp,
+            );
+            assigned.push(last_value.var());
 
             let mut old_iter = self.current_bindings.get().iter();
             let mut old_next = old_iter.next();

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1,7 +1,7 @@
 //
 // variable.rs
 //
-// Copyright (C) 2023 by Posit Software, PBC
+// Copyright (C) 2023-2025 by Posit Software, PBC
 //
 //
 
@@ -1068,6 +1068,11 @@ impl PositronVariable {
     ) -> harp::Result<EnvironmentVariableNode> {
         // Concrete nodes are objects that are treated as is. Accessing an element from them
         // might result in special node types.
+
+        if *access_key == String::from(".Last.value") {
+            let last_robj = harp::parse_eval_global(".Last.value").unwrap();
+            return Ok(EnvironmentVariableNode::Concrete { object: last_robj });
+        }
 
         // First try to get child using a generic method
         // When building the children list of nodes that use a custom `get_children` method, the access_key is

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -651,7 +651,7 @@ impl PositronVariable {
     /**
      * Create a new Variable from an R object
      */
-    fn from(access_key: String, display_name: String, x: SEXP) -> Self {
+    pub fn from(access_key: String, display_name: String, x: SEXP) -> Self {
         let WorkspaceVariableDisplayValue {
             display_value,
             is_truncated,

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1071,8 +1071,8 @@ impl PositronVariable {
 
         // Check for the special access key `.Last.value`; we can only get the
         // value for this object by evaluating it in R
-        if *access_key == String::from(".Last.value") {
-            let last_robj = harp::parse_eval_global(".Last.value")?;
+        if access_key == ".Last.value" {
+            let last_robj = harp::environment::last_value()?;
             return Ok(EnvironmentVariableNode::Concrete { object: last_robj });
         }
 

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1069,8 +1069,10 @@ impl PositronVariable {
         // Concrete nodes are objects that are treated as is. Accessing an element from them
         // might result in special node types.
 
+        // Check for the special access key `.Last.value`; we can only get the
+        // value for this object by evaluating it in R
         if *access_key == String::from(".Last.value") {
-            let last_robj = harp::parse_eval_global(".Last.value").unwrap();
+            let last_robj = harp::parse_eval_global(".Last.value")?;
             return Ok(EnvironmentVariableNode::Concrete { object: last_robj });
         }
 

--- a/crates/ark/tests/environment.rs
+++ b/crates/ark/tests/environment.rs
@@ -330,7 +330,7 @@ fn test_environment_last_value_enabled() {
             test_env,
             comm.clone(),
             comm_manager_tx.clone(),
-            LastValue::Show,
+            LastValue::Always,
         );
     });
 

--- a/crates/harp/src/environment.rs
+++ b/crates/harp/src/environment.rs
@@ -131,6 +131,13 @@ impl Environment {
         }
     }
 
+    pub fn get(&self, name: impl Into<RSymbol>) -> harp::Result<RObject> {
+        let name = name.into();
+        let out = self.find(name)?;
+        let out = RObject::from(out);
+        Ok(out)
+    }
+
     pub fn is_empty(&self) -> bool {
         match self.filter {
             EnvironmentFilter::None => self.inner.length() == 0,
@@ -275,6 +282,12 @@ pub fn r_ns_env(name: &str) -> anyhow::Result<Environment> {
     let ns = registry.find(name)?;
 
     Ok(Environment::new(ns.into()))
+}
+
+/// Returns the value of the last evaluated expression in R
+/// (i.e. the value of `.Last.value`).
+pub fn last_value() -> harp::Result<RObject> {
+    Environment::view(R_ENVS.base).get(".Last.value")
 }
 
 #[cfg(test)]

--- a/crates/harp/src/environment_iter.rs
+++ b/crates/harp/src/environment_iter.rs
@@ -59,9 +59,7 @@ impl BindingValue {
 
 impl EnvironmentIter {
     pub fn new(env: Environment) -> Self {
-        let mut all_names = env.names();
-        all_names.push(String::from(".Last.value"));
-        let names = all_names.into_iter();
+        let names = env.names().into_iter();
         Self { env, names }
     }
 }

--- a/crates/harp/src/environment_iter.rs
+++ b/crates/harp/src/environment_iter.rs
@@ -59,7 +59,9 @@ impl BindingValue {
 
 impl EnvironmentIter {
     pub fn new(env: Environment) -> Self {
-        let names = env.names().into_iter();
+        let mut all_names = env.names();
+        all_names.push(String::from(".Last.value"));
+        let names = all_names.into_iter();
         Self { env, names }
     }
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -34,6 +34,12 @@ A boolean, with a default value of `TRUE`.
 
 If `TRUE`, virtual documents will be generated for packages without source references for usage during debugging.
 
+## positron.show_last_value
+
+A boolean, with a default value of `FALSE`.
+
+If `TRUE`, the special `.Last.value` will be shown in Positron's Variables pane.
+
 ## positron.error_entrace
 
 A boolean, with a default value of `TRUE`.


### PR DESCRIPTION
Quick airplane feature to optionally show `.Last.value` in Positron's Variables pane when the option `positron.show_last_value` is set.

Note that the option can be turned on during a session, but turning it off requires a restart. It's likely most users who want this will set it in their `.Rprofile`; we could also add a Positron setting for this.

Partially addresses https://github.com/posit-dev/positron/issues/3034.