### PR TITLE
Make heartbeat quiet in debug builds

### DIFF
--- a/crates/amalthea/src/socket/heartbeat.rs
+++ b/crates/amalthea/src/socket/heartbeat.rs
@@ -20,7 +20,9 @@ impl Heartbeat {
 
     /// Listen for heartbeats; does not return
     pub fn listen(&self) {
-        // Should we make it quiet by default in debug builds?
+        #[cfg(debug_assertions)]
+        let quiet = true;
+        #[cfg(not(debug_assertions))]
         let quiet = std::env::var("ARK_HEARTBEAT_QUIET").is_ok();
 
         loop {


### PR DESCRIPTION
This should make logs much easier to read by default. AFAIK the heartbeat has never been helpful for debugging but it's quite verbose so it drowns other important information.