### PR TITLE
Use smallest spanning node as the "starter" node in completions

### DIFF
--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -7,6 +7,8 @@
 
 use std::cell::OnceCell;
 
+use tree_sitter::Node;
+
 use crate::lsp::completions::parameter_hints::ParameterHints;
 use crate::lsp::completions::parameter_hints::{self};
 use crate::lsp::completions::sources::composite::pipe::find_pipe_root;
@@ -20,7 +22,7 @@ pub(crate) struct CompletionContext<'a> {
     pub(crate) state: &'a WorldState,
     parameter_hints_cell: OnceCell<ParameterHints>,
     pipe_root_cell: OnceCell<Option<PipeRoot>>,
-    is_in_call_cell: OnceCell<bool>,
+    containing_call_cell: OnceCell<Option<Node<'a>>>,
 }
 
 impl<'a> CompletionContext<'a> {
@@ -30,7 +32,7 @@ impl<'a> CompletionContext<'a> {
             state,
             parameter_hints_cell: OnceCell::new(),
             pipe_root_cell: OnceCell::new(),
-            is_in_call_cell: OnceCell::new(),
+            containing_call_cell: OnceCell::new(),
         }
     }
 
@@ -44,8 +46,10 @@ impl<'a> CompletionContext<'a> {
     }
 
     pub fn pipe_root(&self) -> Option<PipeRoot> {
+        let call_node = self.containing_call_node();
+
         self.pipe_root_cell
-            .get_or_init(|| match find_pipe_root(self.document_context) {
+            .get_or_init(|| match find_pipe_root(self.document_context, call_node) {
                 Ok(root) => root,
                 Err(e) => {
                     log::error!("Error trying to find pipe root: {e}");
@@ -55,8 +59,9 @@ impl<'a> CompletionContext<'a> {
             .clone()
     }
 
-    pub fn is_in_call(&self) -> &bool {
-        self.is_in_call_cell
-            .get_or_init(|| node_find_containing_call(self.document_context.node).is_some())
+    pub fn containing_call_node(&self) -> Option<Node<'a>> {
+        *self
+            .containing_call_cell
+            .get_or_init(|| node_find_containing_call(self.document_context.node))
     }
 }

--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -13,7 +13,7 @@ use crate::lsp::completions::sources::composite::pipe::find_pipe_root;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::state::WorldState;
-use crate::treesitter::NodeTypeExt;
+use crate::treesitter::node_find_containing_call;
 
 pub(crate) struct CompletionContext<'a> {
     pub(crate) document_context: &'a DocumentContext<'a>,
@@ -56,29 +56,7 @@ impl<'a> CompletionContext<'a> {
     }
 
     pub fn is_in_call(&self) -> &bool {
-        self.is_in_call_cell.get_or_init(|| {
-            let mut node = self.document_context.node;
-            let mut found_call = false;
-
-            loop {
-                if node.is_call() {
-                    found_call = true;
-                    break;
-                }
-
-                // If we reach a brace list, stop searching
-                if node.is_braced_expression() {
-                    break;
-                }
-
-                // Update the node
-                match node.parent() {
-                    Some(parent) => node = parent,
-                    None => break,
-                };
-            }
-
-            found_call
-        })
+        self.is_in_call_cell
+            .get_or_init(|| node_find_containing_call(self.document_context.node).is_some())
     }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -413,4 +413,39 @@ mod tests {
             harp::parse_eval("remove(my_fun)", options.clone()).unwrap();
         })
     }
+
+    #[test]
+    fn test_completions_multiline() {
+        r_task(|| {
+            // No arguments typed yet
+            let (text, point) = point_from_cursor("match(\n  @\n)");
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_call(&context, None).unwrap().unwrap();
+
+            assert_eq!(completions.len(), 4);
+            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.get(1).unwrap().label, "table = ");
+
+            // Partially typed argument
+            let (text, point) = point_from_cursor("match(\n  tab@\n)");
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_call(&context, None).unwrap().unwrap();
+
+            assert_eq!(completions.len(), 4);
+            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.get(1).unwrap().label, "table = ");
+
+            // Partially typed second argument
+            let (text, point) = point_from_cursor("match(\n  1,\n  tab@\n)");
+            let document = Document::new(text.as_str(), None);
+            let context = DocumentContext::new(&document, point, None);
+            let completions = completions_from_call(&context, None).unwrap().unwrap();
+
+            assert_eq!(completions.len(), 4);
+            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.get(1).unwrap().label, "table = ");
+        })
+    }
 }

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn test_completions_multiline() {
+    fn test_completions_multiline_call() {
         r_task(|| {
             // No arguments typed yet
             let (text, point) = point_from_cursor("match(\n  @\n)");

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -302,8 +302,8 @@ fn completions_from_workspace_arguments(
 #[cfg(test)]
 mod tests {
     use harp::eval::RParseEvalOptions;
-    use tree_sitter::Point;
 
+    use crate::fixtures::point_from_cursor;
     use crate::lsp::completions::sources::composite::call::completions_from_call;
     use crate::lsp::document_context::DocumentContext;
     use crate::lsp::documents::Document;
@@ -313,8 +313,8 @@ mod tests {
     fn test_completions_after_user_types_part_of_an_argument_name() {
         r_task(|| {
             // Right after `tab`
-            let point = Point { row: 0, column: 9 };
-            let document = Document::new("match(tab)", None);
+            let (text, point) = point_from_cursor("match(tab@)");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap().unwrap();
 
@@ -324,8 +324,8 @@ mod tests {
             assert_eq!(completions.get(1).unwrap().label, "table = ");
 
             // Right after `tab`
-            let point = Point { row: 0, column: 12 };
-            let document = Document::new("match(1, tab)", None);
+            let (text, point) = point_from_cursor("match(1, tab@)");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap().unwrap();
 
@@ -342,8 +342,8 @@ mod tests {
         // Can't find the function
         r_task(|| {
             // Place cursor between `()`
-            let point = Point { row: 0, column: 21 };
-            let document = Document::new("not_a_known_function()", None);
+            let (text, point) = point_from_cursor("not_a_known_function(@)");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap();
             assert!(completions.is_none());
@@ -360,8 +360,8 @@ mod tests {
             harp::parse_eval("my_fun <- function(y, x) x + y", options.clone()).unwrap();
 
             // Place cursor between `()`
-            let point = Point { row: 0, column: 7 };
-            let document = Document::new("my_fun()", None);
+            let (text, point) = point_from_cursor("my_fun(@)");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap().unwrap();
 
@@ -375,15 +375,15 @@ mod tests {
             assert_eq!(completion.label, "x = ");
 
             // Place just before the `()`
-            let point = Point { row: 0, column: 6 };
-            let document = Document::new("my_fun()", None);
+            let (text, point) = point_from_cursor("my_fun@()");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap();
             assert!(completions.is_none());
 
             // Place just after the `()`
-            let point = Point { row: 0, column: 8 };
-            let document = Document::new("my_fun()", None);
+            let (text, point) = point_from_cursor("my_fun()@");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap();
             assert!(completions.is_none());
@@ -403,8 +403,8 @@ mod tests {
             harp::parse_eval("my_fun <- 1", options.clone()).unwrap();
 
             // Place cursor between `()`
-            let point = Point { row: 0, column: 7 };
-            let document = Document::new("my_fun()", None);
+            let (text, point) = point_from_cursor("my_fun(@)");
+            let document = Document::new(text.as_str(), None);
             let context = DocumentContext::new(&document, point, None);
             let completions = completions_from_call(&context, None).unwrap().unwrap();
             assert_eq!(completions.len(), 0);

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -29,9 +29,6 @@ use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
 use crate::lsp::signature_help::r_signature_help;
 use crate::treesitter::node_in_string;
-use crate::treesitter::node_text;
-use crate::treesitter::NodeTypeExt;
-
 pub(super) struct CustomSource;
 
 impl CompletionSource for CustomSource {
@@ -50,7 +47,7 @@ impl CompletionSource for CustomSource {
 fn completions_from_custom_source(
     context: &CompletionContext,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
-    if !context.is_in_call() {
+    if context.containing_call_node().is_none() {
         // Didn't detect anything worth completing in this context,
         // let other sources add their own candidates instead
         return Ok(None);

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -302,16 +302,32 @@ mod tests {
             let (text, point) = point_from_cursor("Sys.getenv(@)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
+            // Inside the parentheses, multiline
+            let (text, point) = point_from_cursor("Sys.getenv(\n  @\n)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
             // Named argument
             let (text, point) = point_from_cursor("Sys.getenv(x = @)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // Named argument, multiline
+            let (text, point) = point_from_cursor("Sys.getenv(\n  x = @\n)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
             // Typed some and then requested completions
             let (text, point) = point_from_cursor("Sys.getenv(ARK_@)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
+            // Typed some and then requested completions, multiline
+            let (text, point) = point_from_cursor("Sys.getenv(\n  ARK_@\n)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
             // After a named argument
             let (text, point) = point_from_cursor("Sys.getenv(unset = '1', @)");
+            assert_has_ark_test_envvar_completion(text.as_str(), point);
+
+            // After a named argument, multiline
+            let (text, point) = point_from_cursor("Sys.getenv(\n  unset = '1',\n  @\n)");
             assert_has_ark_test_envvar_completion(text.as_str(), point);
 
             // Should not have it here

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -30,6 +30,7 @@ use crate::lsp::completions::types::CompletionData;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::signature_help::r_signature_help;
 use crate::treesitter::node_in_string;
+use crate::treesitter::node_text;
 use crate::treesitter::NodeTypeExt;
 
 pub(super) struct CustomSource;
@@ -426,6 +427,36 @@ mod tests {
     }
 
     #[test]
+    fn test_completion_custom_sys_setenv_value_position() {
+        r_task(|| {
+            // Test that no completions are offered in the value position
+            let assert_no_completions = |text: &str, point: Point| {
+                let document = Document::new(text, None);
+                let context = DocumentContext::new(&document, point, None);
+
+                let completions = completions_from_custom_source(&context).unwrap();
+                assert!(completions.is_none());
+            };
+
+            // Single line, with space
+            let (text, point) = point_from_cursor("Sys.setenv(AAA = @)");
+            assert_no_completions(text.as_str(), point);
+
+            // Single line, no space
+            let (text, point) = point_from_cursor("Sys.setenv(AAA =@)");
+            assert_no_completions(text.as_str(), point);
+
+            // Multiline case, with space
+            let (text, point) = point_from_cursor("Sys.setenv(\n  AAA = @\n)");
+            assert_no_completions(text.as_str(), point);
+
+            // Multiline case, no space
+            let (text, point) = point_from_cursor("Sys.setenv(\n  AAA =@\n)");
+            assert_no_completions(text.as_str(), point);
+        })
+    }
+
+    #[test]
     fn test_completion_custom_get_option() {
         r_task(|| {
             let name = "ARK_TEST_OPTION";
@@ -509,6 +540,36 @@ mod tests {
             assert_has_ark_test_option_completion(text.as_str(), point);
 
             harp::parse_eval_base(format!("options({name} = NULL)").as_str()).unwrap();
+        })
+    }
+
+    #[test]
+    fn test_completion_custom_options_value_position() {
+        r_task(|| {
+            // Test that no completions are offered in the value position
+            let assert_no_completions = |text: &str, point: Point| {
+                let document = Document::new(text, None);
+                let context = DocumentContext::new(&document, point, None);
+
+                let completions = completions_from_custom_source(&context).unwrap();
+                assert!(completions.is_none());
+            };
+
+            // Single line, with space
+            let (text, point) = point_from_cursor("options(AAA = @)");
+            assert_no_completions(text.as_str(), point);
+
+            // Single line, no space
+            let (text, point) = point_from_cursor("options(AAA =@)");
+            assert_no_completions(text.as_str(), point);
+
+            // Multiline case, with space
+            let (text, point) = point_from_cursor("options(\n  AAA = @\n)");
+            assert_no_completions(text.as_str(), point);
+
+            // Multiline case, no space
+            let (text, point) = point_from_cursor("options(\n  AAA =@\n)");
+            assert_no_completions(text.as_str(), point);
         })
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -60,13 +60,6 @@ fn completions_from_custom_source(
     let point = document_context.point;
     let node = document_context.node;
 
-    log::info!(
-        "completions_from_custom_source() - Completion node text: '{node_text}', Node type: '{node_type:?}'",
-        node_text = node_text(&node, &document_context.document.contents)
-            .unwrap_or_default(),
-        node_type = node.node_type()
-    );
-
     // Use the signature help tools to figure out the necessary pieces.
     let signatures = r_signature_help(document_context)?;
     let Some(signatures) = signatures else {

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -267,9 +267,9 @@ fn completions_from_object_names_impl(
 #[cfg(test)]
 mod tests {
     use harp::eval::parse_eval_global;
-    use tree_sitter::Point;
 
     use crate::fixtures::package_is_installed;
+    use crate::fixtures::point_from_cursor;
     use crate::lsp::completions::sources::utils::call_node_position_type;
     use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
     use crate::lsp::completions::sources::utils::CallNodePositionType;
@@ -282,8 +282,8 @@ mod tests {
     #[test]
     fn test_call_node_position_type() {
         // Before `(`, but on it
-        let point = Point { row: 0, column: 3 };
-        let document = Document::new("fn ()", None);
+        let (text, point) = point_from_cursor("fn @()");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             context.node.node_type(),
@@ -295,8 +295,8 @@ mod tests {
         );
 
         // After `)`, but on it
-        let point = Point { row: 0, column: 4 };
-        let document = Document::new("fn()", None);
+        let (text, point) = point_from_cursor("fn()@");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             context.node.node_type(),
@@ -308,8 +308,8 @@ mod tests {
         );
 
         // After `(`, but on it
-        let point = Point { row: 0, column: 3 };
-        let document = Document::new("fn()", None);
+        let (text, point) = point_from_cursor("fn(@)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             context.node.node_type(),
@@ -321,8 +321,8 @@ mod tests {
         );
 
         // After `x`
-        let point = Point { row: 0, column: 4 };
-        let document = Document::new("fn(x)", None);
+        let (text, point) = point_from_cursor("fn(x@)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             call_node_position_type(&context.node, context.point),
@@ -330,8 +330,8 @@ mod tests {
         );
 
         // After `x`
-        let point = Point { row: 0, column: 7 };
-        let document = Document::new("fn(1, x)", None);
+        let (text, point) = point_from_cursor("fn(1, x@)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             call_node_position_type(&context.node, context.point),
@@ -339,8 +339,8 @@ mod tests {
         );
 
         // Directly after `,`
-        let point = Point { row: 0, column: 5 };
-        let document = Document::new("fn(x, )", None);
+        let (text, point) = point_from_cursor("fn(x,@ )");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(context.node.node_type(), NodeType::Comma);
         assert_eq!(
@@ -349,8 +349,8 @@ mod tests {
         );
 
         // After `,`, but on `)`
-        let point = Point { row: 0, column: 6 };
-        let document = Document::new("fn(x, )", None);
+        let (text, point) = point_from_cursor("fn(x, @)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             context.node.node_type(),
@@ -362,8 +362,8 @@ mod tests {
         );
 
         // After `=`
-        let point = Point { row: 0, column: 6 };
-        let document = Document::new("fn(x =)", None);
+        let (text, point) = point_from_cursor("fn(x =@ )");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             context.node.node_type(),
@@ -375,8 +375,8 @@ mod tests {
         );
 
         // In an expression
-        let point = Point { row: 0, column: 4 };
-        let document = Document::new("fn(1 + 1)", None);
+        let (text, point) = point_from_cursor("fn(1@ + 1)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(context.node.node_type(), NodeType::Float);
         assert_eq!(
@@ -384,8 +384,8 @@ mod tests {
             CallNodePositionType::Value
         );
 
-        let point = Point { row: 0, column: 8 };
-        let document = Document::new("fn(1 + 1)", None);
+        let (text, point) = point_from_cursor("fn(1 + 1@)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(context.node.node_type(), NodeType::Float);
         assert_eq!(
@@ -395,8 +395,8 @@ mod tests {
 
         // Right before an expression
         // (special case where we still provide argument completions)
-        let point = Point { row: 0, column: 6 };
-        let document = Document::new("fn(1, 1 + 1)", None);
+        let (text, point) = point_from_cursor("fn(1, @1 + 1)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(context.node.node_type(), NodeType::Float);
         assert_eq!(
@@ -406,8 +406,8 @@ mod tests {
 
         // After an identifier, before the `)`, with whitespace between them,
         // but on the `)`
-        let point = Point { row: 0, column: 5 };
-        let document = Document::new("fn(x )", None);
+        let (text, point) = point_from_cursor("fn(x @)");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
             context.node.node_type(),
@@ -420,8 +420,8 @@ mod tests {
 
         // After an identifier, before the `)`, with whitespace between them,
         // but on the identifier
-        let point = Point { row: 0, column: 4 };
-        let document = Document::new("fn(x )", None);
+        let (text, point) = point_from_cursor("fn(x@ )");
+        let document = Document::new(text.as_str(), None);
         let context = DocumentContext::new(&document, point, None);
         assert!(context.node.is_identifier());
         assert_eq!(

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -435,6 +435,7 @@ mod tests {
         let document = Document::new(&text, None);
         let context = DocumentContext::new(&document, point, None);
 
+        assert_eq!(context.node.node_type(), NodeType::Arguments);
         assert_eq!(
             call_node_position_type(&context.node, context.point),
             CallNodePositionType::Name

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -428,6 +428,27 @@ mod tests {
             call_node_position_type(&context.node, context.point),
             CallNodePositionType::Ambiguous
         );
+
+        // After `(`, and on own line
+        let (text, point) = point_from_cursor("fn(\n  @\n)");
+        let document = Document::new(&text, None);
+        let context = DocumentContext::new(&document, point, None);
+
+        // On `main`, this passes
+        // assert_eq!(
+        //     context.node.node_type(),
+        //     NodeType::Anonymous(String::from("("))
+        // );
+
+        // On this pr, `(`, doesn't contain the user's cursor, so instead it selects
+        // the surrounding `Arguments` node
+        assert_eq!(context.node.node_type(), NodeType::Arguments);
+
+        // On `main`, this passes, and this should also still pass on this PR, but currently does not
+        assert_eq!(
+            call_node_position_type(&context.node, context.point),
+            CallNodePositionType::Name
+        );
     }
 
     #[test]

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -101,6 +101,7 @@ pub(super) enum CallNodePositionType {
 
 pub(super) fn call_node_position_type(node: &Node, point: Point) -> CallNodePositionType {
     match node.node_type() {
+        NodeType::Arguments => return CallNodePositionType::Name,
         NodeType::Anonymous(kind) if kind == "(" => {
             if point.is_before_or_equal(node.start_position()) {
                 // Before the `(`
@@ -434,17 +435,6 @@ mod tests {
         let document = Document::new(&text, None);
         let context = DocumentContext::new(&document, point, None);
 
-        // On `main`, this passes
-        // assert_eq!(
-        //     context.node.node_type(),
-        //     NodeType::Anonymous(String::from("("))
-        // );
-
-        // On this pr, `(`, doesn't contain the user's cursor, so instead it selects
-        // the surrounding `Arguments` node
-        assert_eq!(context.node.node_type(), NodeType::Arguments);
-
-        // On `main`, this passes, and this should also still pass on this PR, but currently does not
         assert_eq!(
             call_node_position_type(&context.node, context.point),
             CallNodePositionType::Name

--- a/crates/ark/src/lsp/document_context.rs
+++ b/crates/ark/src/lsp/document_context.rs
@@ -59,7 +59,7 @@ impl<'a> DocumentContext<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lsp::traits::rope::RopeExt;
+    use crate::treesitter::node_text;
     use crate::treesitter::NodeType;
     use crate::treesitter::NodeTypeExt;
 
@@ -71,26 +71,16 @@ mod tests {
         let document = Document::new("", None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
-            context
-                .document
-                .contents
-                .node_slice(&context.node)
-                .unwrap()
-                .to_string(),
-            "".to_string()
+            node_text(&context.node, &context.document.contents).unwrap(),
+            ""
         );
 
         // Start of document with text
         let document = Document::new("1 + 1", None);
         let context = DocumentContext::new(&document, point, None);
         assert_eq!(
-            context
-                .document
-                .contents
-                .node_slice(&context.node)
-                .unwrap()
-                .to_string(),
-            "1".to_string()
+            node_text(&context.node, &context.document.contents).unwrap(),
+            "1"
         );
     }
 
@@ -102,12 +92,7 @@ mod tests {
 
         assert_eq!(context.node.node_type(), NodeType::Program);
         assert_eq!(
-            context
-                .document
-                .contents
-                .node_slice(&context.node)
-                .unwrap()
-                .to_string(),
+            node_text(&context.node, &context.document.contents).unwrap(),
             "toupper(letters)\n"
         );
 
@@ -116,12 +101,7 @@ mod tests {
             NodeType::Anonymous(String::from(")"))
         );
         assert_eq!(
-            context
-                .document
-                .contents
-                .node_slice(&context.closest_node)
-                .unwrap()
-                .to_string(),
+            node_text(&context.closest_node, &context.document.contents).unwrap(),
             ")"
         );
     }

--- a/crates/ark/src/lsp/document_context.rs
+++ b/crates/ark/src/lsp/document_context.rs
@@ -15,6 +15,12 @@ use crate::lsp::traits::node::NodeExt;
 pub struct DocumentContext<'a> {
     pub document: &'a Document,
     pub node: Node<'a>,
+    /// Formerly known just as "node". This renaming unblocks completion
+    /// improvements, where we really do want to focus on the smallest node
+    /// that **actually contains** the point. Future cleanup elsewhere in the
+    /// language server might allow us to standardize on just "node" again,
+    /// although I suspect hover might always require a notion of closest node.
+    pub closest_node: Node<'a>,
     pub point: Point,
     pub trigger: Option<String>,
 }
@@ -24,8 +30,15 @@ impl<'a> DocumentContext<'a> {
         // get reference to AST
         let ast = &document.ast;
 
-        // find node at point
-        let Some(node) = ast.root_node().find_closest_node_to_point(point) else {
+        let Some(node) = ast.root_node().find_smallest_spanning_node(point) else {
+            let contents = document.contents.to_string();
+            panic!(
+                "Failed to find spanning node containing point: {point} with contents '{contents}'"
+            );
+        };
+
+        // find closest node at point
+        let Some(closest_node) = ast.root_node().find_closest_node_to_point(point) else {
             // TODO: We really want to track this down and figure out what's happening
             // and fix it in `find_closest_node_to_point()`.
             let contents = document.contents.to_string();
@@ -36,6 +49,7 @@ impl<'a> DocumentContext<'a> {
         DocumentContext {
             document,
             node,
+            closest_node,
             point,
             trigger,
         }
@@ -46,6 +60,8 @@ impl<'a> DocumentContext<'a> {
 mod tests {
     use super::*;
     use crate::lsp::traits::rope::RopeExt;
+    use crate::treesitter::NodeType;
+    use crate::treesitter::NodeTypeExt;
 
     #[test]
     fn test_document_context_start_of_document() {
@@ -75,6 +91,38 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "1".to_string()
+        );
+    }
+
+    #[test]
+    fn test_document_context_cursor_on_empty_line() {
+        let document = Document::new("toupper(letters)\n", None);
+        let point = Point { row: 1, column: 0 }; // as if we're about to type on the second line
+        let context = DocumentContext::new(&document, point, None);
+
+        assert_eq!(context.node.node_type(), NodeType::Program);
+        assert_eq!(
+            context
+                .document
+                .contents
+                .node_slice(&context.node)
+                .unwrap()
+                .to_string(),
+            "toupper(letters)\n"
+        );
+
+        assert_eq!(
+            context.closest_node.node_type(),
+            NodeType::Anonymous(String::from(")"))
+        );
+        assert_eq!(
+            context
+                .document
+                .contents
+                .node_slice(&context.closest_node)
+                .unwrap()
+                .to_string(),
+            ")"
         );
     }
 }

--- a/crates/ark/src/lsp/hover.rs
+++ b/crates/ark/src/lsp/hover.rs
@@ -68,7 +68,7 @@ fn hover_context(node: Node, context: &DocumentContext) -> Result<Option<HoverCo
 
 pub(crate) fn r_hover(context: &DocumentContext) -> anyhow::Result<Option<MarkupContent>> {
     // get the node
-    let node = &context.node;
+    let node = &context.closest_node;
 
     // check for identifier
     if !node.is_identifier_or_string() && !node.is_keyword() {

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -536,3 +536,33 @@ pub(crate) fn args_find_call_args<'tree>(
     let call = args_find_call(args, name, contents)?;
     call.child_by_field_name("arguments")
 }
+
+/// Walks up the tree from the given [Node] to find the call node it's contained
+/// within, if there is such a [Node].
+/// Stops at the first call node or, otherwise, when encountering a braced
+/// expression or the root.
+/// If there is no containing call node, returns `None`.
+///
+/// Shared logic for call, custom, and pipe completions.
+pub(crate) fn node_find_containing_call<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    let mut current = node;
+
+    loop {
+        if current.is_call() {
+            return Some(current);
+        }
+
+        // If we reach a brace list, stop searching
+        if current.is_braced_expression() {
+            break;
+        }
+
+        // Move up the tree
+        current = match current.parent() {
+            Some(parent) => parent,
+            None => break,
+        };
+    }
+
+    None
+}


### PR DESCRIPTION
Fixes #778 

When we create a new `DocumentContext`, one of the pieces of data reflects some notion of the current node in the AST. Previously this was constructed as `ast.root_node().find_closest_node_to_point()` and I propose that we (mostly) switch to `ast.root_node().find_smallest_spanning_node()` instead. In this PR, I:

* Retain the previous notion of the current node under the name `closest_node`
* Recast the `node` field to mean "the node that point is actually in". (Frankly this is still somewhat aspirational, because so much existing code expects to start from something like a `"="` node, but this is a start. See #808 for more.)

This new definition of `node` is more favorable for completions (next I'll take #772 out of draft form, which will address #770), which is certainly the biggest user of `DocumentContext`, in terms of downstream code.

(The fact that redefining `node` has such a small impact on *anything else* below `crates/ark/src/lsp/` is sort of telling. It feels like there's a lot of bespoke fiddling around with the AST and nodes tucked away in various corners that could potentially be centralized/deduplicated over time. But not today.)