### PR TITLE
Add infrastructure for Code Actions 💡, and our first action for generating a roxygen template

### DIFF
--- a/crates/ark/src/fixtures/utils.rs
+++ b/crates/ark/src/fixtures/utils.rs
@@ -37,11 +37,18 @@ pub(crate) fn r_test_init() {
 }
 
 pub fn point_from_cursor(x: &str) -> (String, Point) {
+    let (text, point, _byte) = point_and_byte_from_cursor(x);
+    (text, point)
+}
+
+pub fn point_and_byte_from_cursor(x: &str) -> (String, Point, usize) {
     let lines = x.split("\n").collect::<Vec<&str>>();
 
     // i.e. looking for `@` in something like `fn(x = @1, y = 2)`, and it treats the
     // `@` as the cursor position
     let cursor = b'@';
+
+    let mut byte = 0;
 
     for (line_row, line) in lines.into_iter().enumerate() {
         for (char_column, char) in line.as_bytes().into_iter().enumerate() {
@@ -51,9 +58,12 @@ pub fn point_from_cursor(x: &str) -> (String, Point) {
                     row: line_row,
                     column: char_column,
                 };
-                return (x, point);
+                byte += char_column;
+                return (x, point, byte);
             }
         }
+        // `+ 1` for the removed `\n` at the end of this line
+        byte += line.as_bytes().len() + 1;
     }
 
     panic!("`x` must include a `@` character!");
@@ -107,14 +117,15 @@ pub fn package_is_installed(package: &str) -> bool {
 mod tests {
     use tree_sitter::Point;
 
-    use crate::fixtures::point_from_cursor;
+    use crate::fixtures::point_and_byte_from_cursor;
 
     #[test]
     #[rustfmt::skip]
-    fn test_point_from_cursor() {
-        let (text, point) = point_from_cursor("1@ + 2");
+    fn test_point_and_byte_from_cursor() {
+        let (text, point, byte) = point_and_byte_from_cursor("1@ + 2");
         assert_eq!(text, "1 + 2".to_string());
         assert_eq!(point, Point::new(0, 1));
+        assert_eq!(byte, 1);
 
         let text =
 "fn(
@@ -124,8 +135,9 @@ mod tests {
 "fn(
   arg = 3
 )";
-        let (text, point) = point_from_cursor(text);
+        let (text, point, byte) = point_and_byte_from_cursor(text);
         assert_eq!(text, expect);
         assert_eq!(point, Point::new(1, 7));
+        assert_eq!(byte, 11);
     }
 }

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -143,6 +143,7 @@ pub(crate) enum LspRequest {
     StatementRange(StatementRangeParams),
     HelpTopic(HelpTopicParams),
     OnTypeFormatting(DocumentOnTypeFormattingParams),
+    CodeAction(CodeActionParams),
     VirtualDocument(VirtualDocumentParams),
     InputBoundaries(InputBoundariesParams),
 }
@@ -164,6 +165,7 @@ pub(crate) enum LspResponse {
     StatementRange(Option<StatementRangeResponse>),
     HelpTopic(Option<HelpTopicResponse>),
     OnTypeFormatting(Option<Vec<TextEdit>>),
+    CodeAction(Option<CodeActionResponse>),
     VirtualDocument(VirtualDocumentResponse),
     InputBoundaries(InputBoundariesResponse),
 }
@@ -369,6 +371,14 @@ impl LanguageServer for Backend {
             self,
             self.request(LspRequest::OnTypeFormatting(params)).await,
             LspResponse::OnTypeFormatting
+        )
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        cast_response!(
+            self,
+            self.request(LspRequest::CodeAction(params)).await,
+            LspResponse::CodeAction
         )
     }
 }

--- a/crates/ark/src/lsp/capabilities.rs
+++ b/crates/ark/src/lsp/capabilities.rs
@@ -1,0 +1,115 @@
+//
+// capabilities.rs
+//
+// Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+//
+//
+
+use tower_lsp::lsp_types;
+use tower_lsp::lsp_types::CodeActionKind;
+use tower_lsp::lsp_types::CodeActionOptions;
+use tower_lsp::lsp_types::CodeActionProviderCapability;
+use tower_lsp::lsp_types::WorkDoneProgressOptions;
+
+/// Capabilities negotiated with [lsp_types::ClientCapabilities]
+#[derive(Debug)]
+pub(crate) struct Capabilities {
+    dynamic_registration_for_did_change_configuration: bool,
+    code_action_literal_support: bool,
+    workspace_edit_document_changes: bool,
+}
+
+impl Capabilities {
+    pub(crate) fn new(client_capabilities: lsp_types::ClientCapabilities) -> Self {
+        let dynamic_registration_for_did_change_configuration = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.did_change_configuration)
+            .and_then(|did_change_configuration| did_change_configuration.dynamic_registration)
+            .unwrap_or(false);
+
+        // In theory the client also tells us which code action kinds it supports inside
+        // `code_action_literal_support`, but clients are guaranteed to ignore any they
+        // don't support, so we just return `true` if the field exists (same as
+        // rust-analyzer).
+        let code_action_literal_support = client_capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.code_action.as_ref())
+            .and_then(|code_action| code_action.code_action_literal_support.as_ref())
+            .map_or(false, |_| true);
+
+        let workspace_edit_document_changes = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_edit.as_ref())
+            .and_then(|workspace_edit| workspace_edit.document_changes)
+            .map_or(false, |document_changes| document_changes);
+
+        Self {
+            dynamic_registration_for_did_change_configuration,
+            code_action_literal_support,
+            workspace_edit_document_changes,
+        }
+    }
+
+    pub(crate) fn dynamic_registration_for_did_change_configuration(&self) -> bool {
+        self.dynamic_registration_for_did_change_configuration
+    }
+
+    pub(crate) fn code_action_literal_support(&self) -> bool {
+        self.code_action_literal_support
+    }
+
+    // Currently only used for testing
+    #[cfg(test)]
+    pub(crate) fn with_code_action_literal_support(
+        mut self,
+        code_action_literal_support: bool,
+    ) -> Self {
+        self.code_action_literal_support = code_action_literal_support;
+        return self;
+    }
+
+    pub(crate) fn workspace_edit_document_changes(&self) -> bool {
+        self.workspace_edit_document_changes
+    }
+
+    // Currently only used for testing
+    #[cfg(test)]
+    pub(crate) fn with_workspace_edit_document_changes(
+        mut self,
+        workspace_edit_document_changes: bool,
+    ) -> Self {
+        self.workspace_edit_document_changes = workspace_edit_document_changes;
+        return self;
+    }
+
+    pub(crate) fn code_action_provider_capability(&self) -> Option<CodeActionProviderCapability> {
+        if !self.code_action_literal_support() {
+            return None;
+        }
+
+        // Currently we only support documentation generating code actions, which don't
+        // map to an existing kind. rust-analyzer maps them to `EMPTY`, so we follow suit.
+        // Currently no code actions require delayed resolution.
+        Some(CodeActionProviderCapability::Options(CodeActionOptions {
+            code_action_kinds: Some(vec![CodeActionKind::EMPTY]),
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+            resolve_provider: Some(false),
+        }))
+    }
+}
+
+// This is unfortunately required right now, because `LspState` is initialized before we
+// get the `Initialize` LSP request. We immediately overwrite the `LspState`
+// `capabilities` field after receiving the `Initialize` request.
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self {
+            dynamic_registration_for_did_change_configuration: false,
+            code_action_literal_support: false,
+            workspace_edit_document_changes: false,
+        }
+    }
+}

--- a/crates/ark/src/lsp/code_action.rs
+++ b/crates/ark/src/lsp/code_action.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::CodeAction;
+use tower_lsp::lsp_types::CodeActionKind;
+use tower_lsp::lsp_types::CodeActionOrCommand;
+use tower_lsp::lsp_types::CodeActionResponse;
+use tower_lsp::lsp_types::DocumentChanges;
+use tower_lsp::lsp_types::OneOf;
+use tower_lsp::lsp_types::OptionalVersionedTextDocumentIdentifier;
+use tower_lsp::lsp_types::TextDocumentEdit;
+use tower_lsp::lsp_types::TextEdit;
+use tower_lsp::lsp_types::WorkspaceEdit;
+use tree_sitter::Range;
+use url::Url;
+
+use crate::lsp::capabilities::Capabilities;
+use crate::lsp::code_action::roxygen::roxygen_documentation;
+use crate::lsp::documents::Document;
+
+mod roxygen;
+
+/// A small wrapper around [CodeActionResponse] that make a few things more ergonomic
+pub(crate) struct CodeActions {
+    response: CodeActionResponse,
+}
+
+pub(crate) fn code_actions(
+    uri: &Url,
+    document: &Document,
+    range: Range,
+    capabilities: &Capabilities,
+) -> CodeActionResponse {
+    let mut actions = CodeActions::new();
+
+    roxygen_documentation(&mut actions, uri, document, range, capabilities);
+
+    actions.into_response()
+}
+
+pub(crate) fn code_action(title: String, kind: CodeActionKind, edit: WorkspaceEdit) -> CodeAction {
+    CodeAction {
+        title,
+        kind: Some(kind),
+        edit: Some(edit),
+        diagnostics: None,
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    }
+}
+
+/// Creates a common kind of `WorkspaceEdit` composed of one or more `TextEdit`s to
+/// apply to a single document
+pub(crate) fn code_action_workspace_text_edit(
+    uri: Url,
+    version: Option<i32>,
+    edits: Vec<TextEdit>,
+    capabilities: &Capabilities,
+) -> WorkspaceEdit {
+    if capabilities.workspace_edit_document_changes() {
+        // Prefer the versioned `DocumentChanges` feature
+        let edit = TextDocumentEdit {
+            text_document: OptionalVersionedTextDocumentIdentifier { uri, version },
+            edits: edits.into_iter().map(|edit| OneOf::Left(edit)).collect(),
+        };
+
+        let document_changes = DocumentChanges::Edits(vec![edit]);
+
+        WorkspaceEdit {
+            changes: None,
+            document_changes: Some(document_changes),
+            change_annotations: None,
+        }
+    } else {
+        // Fall back to hash map of `TextEdit`s if the client doesn't support `DocumentChanges`
+        let mut changes = HashMap::new();
+        changes.insert(uri, edits);
+
+        WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        }
+    }
+}
+
+impl CodeActions {
+    pub(crate) fn new() -> Self {
+        Self {
+            response: CodeActionResponse::new(),
+        }
+    }
+
+    pub(crate) fn add_action(&mut self, x: CodeAction) -> Option<()> {
+        self.response.push(CodeActionOrCommand::CodeAction(x));
+        Some(())
+    }
+
+    pub(crate) fn into_response(self) -> CodeActionResponse {
+        self.response
+    }
+}

--- a/crates/ark/src/lsp/code_action.rs
+++ b/crates/ark/src/lsp/code_action.rs
@@ -1,3 +1,12 @@
+//! Code actions
+//!
+//! These are contextual light bulbs that appear when the user's cursor is at a particular
+//! position. They allow for small context specific quick fixes, refactors, documentation
+//! generation, and other small code adjustments.
+//!
+//! Modeled after rust-analyzer's blog post:
+//! https://rust-analyzer.github.io/blog/2020/09/28/how-to-make-a-light-bulb.html
+
 use std::collections::HashMap;
 
 use tower_lsp::lsp_types::CodeAction;

--- a/crates/ark/src/lsp/code_action/roxygen.rs
+++ b/crates/ark/src/lsp/code_action/roxygen.rs
@@ -1,0 +1,419 @@
+use tower_lsp::lsp_types::CodeActionKind;
+use tower_lsp::lsp_types::TextEdit;
+use url::Url;
+
+use crate::lsp::capabilities::Capabilities;
+use crate::lsp::code_action::code_action;
+use crate::lsp::code_action::code_action_workspace_text_edit;
+use crate::lsp::code_action::CodeActions;
+use crate::lsp::documents::Document;
+use crate::lsp::encoding::convert_point_to_position;
+use crate::lsp::traits::rope::RopeExt;
+use crate::treesitter::BinaryOperatorType;
+use crate::treesitter::NodeTypeExt;
+
+pub(crate) fn roxygen_documentation(
+    actions: &mut CodeActions,
+    uri: &Url,
+    document: &Document,
+    range: tree_sitter::Range,
+    capabilities: &Capabilities,
+) -> Option<()> {
+    if !capabilities.code_action_literal_support() {
+        // This code action returns literal `CodeAction`s, so must have support for them
+        return None;
+    }
+
+    // For cursors (the common case), start and end points are the same.
+    // For selections, we require that the start point be touching the function name.
+    let start = range.start_point;
+
+    let node = document
+        .ast
+        .root_node()
+        .named_descendant_for_point_range(start, start)?;
+
+    // User must be sitting on the function name
+    if !node.is_identifier() {
+        return None;
+    }
+
+    // Parent must be a `<-` or `=` assignment node
+    let parent = node.parent()?;
+
+    if !parent.is_binary_operator_of_kind(BinaryOperatorType::LeftAssignment) &&
+        !parent.is_binary_operator_of_kind(BinaryOperatorType::EqualsAssignment)
+    {
+        return None;
+    }
+
+    // And the rhs must be a function definition
+    let function = parent.child_by_field_name("rhs")?;
+
+    if !function.is_function_definition() {
+        return None;
+    }
+
+    let position = node.start_position();
+
+    // Fairly simple detection of existing `#'` on the previous line (but starting at the
+    // same `column` offset), which tells us not to provide this code action
+    if let Some(previous_line) = document.contents.get_line(position.row.saturating_sub(1)) {
+        if let Some(previous_line) = previous_line.get_byte_slice(position.column..) {
+            let mut previous_line = previous_line.bytes();
+
+            if previous_line
+                .next()
+                .map(|byte| byte == b'#')
+                .unwrap_or(false) &&
+                previous_line
+                    .next()
+                    .map(|byte| byte == b'\'')
+                    .unwrap_or(false)
+            {
+                return None;
+            }
+        }
+    }
+
+    // Okay, looks like we are going to provide the code action, collect all parameter
+    // names
+    let parameters = function.child_by_field_name("parameters")?;
+
+    let mut parameter_names = vec![];
+    let mut cursor = parameters.walk();
+
+    for child in parameters.children_by_field_name("parameter", &mut cursor) {
+        let parameter_name = child.child_by_field_name("name")?;
+        let parameter_name = document
+            .contents
+            .node_slice(&parameter_name)
+            .ok()?
+            .to_string();
+        parameter_names.push(parameter_name);
+    }
+
+    let indent_size = position.column;
+    let documentation = documentation_builder(parameter_names, indent_size);
+
+    // We insert the documentation string at the start position of the function name.
+    // This handles the indentation of the first documentation line, and makes new line
+    // handling trivial (we just add a new line to every documentation line).
+    let position = convert_point_to_position(&document.contents, position);
+    let range = tower_lsp::lsp_types::Range::new(position, position);
+    let edit = TextEdit::new(range, documentation);
+    let edit =
+        code_action_workspace_text_edit(uri.clone(), document.version, vec![edit], capabilities);
+
+    actions.add_action(code_action(
+        "Generate a roxygen template".to_string(),
+        CodeActionKind::EMPTY,
+        edit,
+    ))
+}
+
+fn documentation_builder(parameter_names: Vec<String>, indent_size: usize) -> String {
+    let mut lines = vec![];
+
+    lines.push("#' Title".to_string());
+
+    if !parameter_names.is_empty() {
+        lines.push("#'".to_string());
+        lines.append(&mut parameters_builder(parameter_names));
+    }
+
+    lines.push("#'".to_string());
+    lines.push("#' @returns".to_string());
+    lines.push("#'".to_string());
+    lines.push("#' @export".to_string());
+    lines.push("#' @examples".to_string());
+
+    documentation_from_lines(lines, indent_size)
+}
+
+fn parameters_builder(names: Vec<String>) -> Vec<String> {
+    names
+        .into_iter()
+        .map(|name| format!("#' @param {name}"))
+        .collect()
+}
+
+/// Combine lines into a single documentation string used within a `TextEdit`
+///
+/// This is done in a clever way:
+/// - We don't apply indentation to the first line, as our `TextEdit` will do that for us,
+///   by inserting at the specified column position.
+/// - We insert a newline after every line, even the last one. This allows us to cleanly
+///   insert the documentation at the start position of the function name.
+fn documentation_from_lines(lines: Vec<String>, indent_size: usize) -> String {
+    let mut documentation = String::new();
+    for line in lines {
+        documentation.push_str(&line);
+        documentation.push('\n');
+        documentation.push_str(&" ".repeat(indent_size));
+    }
+    documentation
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::CodeActionOrCommand;
+    use tower_lsp::lsp_types::DocumentChanges;
+    use tower_lsp::lsp_types::OneOf;
+    use tower_lsp::lsp_types::Position;
+    use tree_sitter::Point;
+    use tree_sitter::Range;
+    use url::Url;
+
+    use crate::fixtures::point_and_byte_from_cursor;
+    use crate::lsp::capabilities::Capabilities;
+    use crate::lsp::code_action::roxygen::roxygen_documentation;
+    use crate::lsp::code_action::CodeActions;
+    use crate::lsp::documents::Document;
+
+    fn point_range(point: Point, byte: usize) -> Range {
+        Range {
+            start_byte: byte,
+            end_byte: byte,
+            start_point: point,
+            end_point: point,
+        }
+    }
+
+    fn roxygen_documentation_test(text: &str, position: Position) -> String {
+        let mut actions = CodeActions::new();
+
+        let uri = Url::parse("file:///test.R").unwrap();
+
+        let capabilities = Capabilities::default()
+            .with_code_action_literal_support(true)
+            .with_workspace_edit_document_changes(true);
+
+        let (text, point, byte) = point_and_byte_from_cursor(text);
+        let document = Document::new(&text, None);
+
+        roxygen_documentation(
+            &mut actions,
+            &uri,
+            &document,
+            point_range(point, byte),
+            &capabilities,
+        );
+
+        let mut actions = actions.into_response();
+        assert_eq!(actions.len(), 1);
+
+        let CodeActionOrCommand::CodeAction(action) = actions.pop().unwrap() else {
+            panic!("Unexpected");
+        };
+        let workspace_edit = action.edit.unwrap();
+
+        let document_changes = workspace_edit.document_changes.unwrap();
+        let DocumentChanges::Edits(mut text_document_edits) = document_changes else {
+            panic!("Unexpected");
+        };
+        assert_eq!(text_document_edits.len(), 1);
+
+        let mut text_document_edit = text_document_edits.pop().unwrap();
+        assert_eq!(text_document_edit.text_document.uri, uri);
+        assert_eq!(text_document_edit.edits.len(), 1);
+
+        let OneOf::Left(text_edit) = text_document_edit.edits.pop().unwrap() else {
+            panic!("Unexpected");
+        };
+        assert_eq!(text_edit.range.start.line, position.line);
+        assert_eq!(text_edit.range.start.character, position.character);
+        assert_eq!(text_edit.range.end, text_edit.range.start);
+
+        text_edit.new_text
+    }
+
+    #[test]
+    fn test_adds_parameters() {
+        let new_text = roxygen_documentation_test("fu@n <- function(a, b = 2) {}", Position {
+            line: 0,
+            character: 0,
+        });
+        insta::assert_snapshot!(new_text);
+
+        let new_text = roxygen_documentation_test("fu@n <- function(...) {}", Position {
+            line: 0,
+            character: 0,
+        });
+        insta::assert_snapshot!(new_text);
+
+        // Mock some new lines and indentation
+        // (It's correct for the first line to not be indented in the snapshot,
+        // since the `Position` handles the indentation through `character`)
+        let new_text = roxygen_documentation_test("\n\n    fu@n <- function(...) {}", Position {
+            line: 2,
+            character: 4,
+        });
+        insta::assert_snapshot!(new_text);
+    }
+
+    #[test]
+    fn test_no_parameters() {
+        let new_text = roxygen_documentation_test("fu@n <- function() {}", Position {
+            line: 0,
+            character: 0,
+        });
+        insta::assert_snapshot!(new_text);
+    }
+
+    #[test]
+    fn test_supports_equals_assignment() {
+        let new_text = roxygen_documentation_test("fu@n = function(a, b = 2) {}", Position {
+            line: 0,
+            character: 0,
+        });
+        insta::assert_snapshot!(new_text);
+    }
+
+    #[test]
+    fn test_adds_documentation_when_direct_preceding_line_is_not_documentation() {
+        let new_text = roxygen_documentation_test("#'\n\nfu@n = function(a, b = 2) {}", Position {
+            line: 2,
+            character: 0,
+        });
+        insta::assert_snapshot!(new_text);
+    }
+
+    #[test]
+    fn test_no_action_when_documentation_on_previous_line() {
+        let mut actions = CodeActions::new();
+
+        let uri = Url::parse("file:///test.R").unwrap();
+
+        let capabilities = Capabilities::default()
+            .with_code_action_literal_support(true)
+            .with_workspace_edit_document_changes(true);
+
+        let text = "
+#' Title
+f@n <- function(a, b) {}
+        ";
+
+        let (text, point, byte) = point_and_byte_from_cursor(text);
+        let document = Document::new(&text, None);
+
+        roxygen_documentation(
+            &mut actions,
+            &uri,
+            &document,
+            point_range(point, byte),
+            &capabilities,
+        );
+        let actions = actions.into_response();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_no_action_when_cursor_is_after_function_name() {
+        let mut actions = CodeActions::new();
+
+        let uri = Url::parse("file:///test.R").unwrap();
+
+        let capabilities = Capabilities::default()
+            .with_code_action_literal_support(true)
+            .with_workspace_edit_document_changes(true);
+
+        // This is just how tree-sitter works, it uses a half open range of `[)`.
+        let text = "
+fn@ <- function(a, b) {}
+        ";
+
+        let (text, point, byte) = point_and_byte_from_cursor(text);
+        let document = Document::new(&text, None);
+
+        roxygen_documentation(
+            &mut actions,
+            &uri,
+            &document,
+            point_range(point, byte),
+            &capabilities,
+        );
+        let actions = actions.into_response();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_no_action_without_code_action_literal_support() {
+        let mut actions = CodeActions::new();
+
+        let uri = Url::parse("file:///test.R").unwrap();
+
+        // NOTE: `with_code_action_literal_support(false)`
+        let capabilities = Capabilities::default()
+            .with_code_action_literal_support(false)
+            .with_workspace_edit_document_changes(true);
+
+        let text = "
+f@n <- function(a, b) {}
+        ";
+
+        let (text, point, byte) = point_and_byte_from_cursor(text);
+        let document = Document::new(&text, None);
+
+        roxygen_documentation(
+            &mut actions,
+            &uri,
+            &document,
+            point_range(point, byte),
+            &capabilities,
+        );
+        let actions = actions.into_response();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_uses_hash_map_of_text_edits_without_document_changes_support() {
+        let mut actions = CodeActions::new();
+
+        let uri = Url::parse("file:///test.R").unwrap();
+
+        // NOTE: `with_workspace_edit_document_changes(false)`
+        let capabilities = Capabilities::default()
+            .with_code_action_literal_support(true)
+            .with_workspace_edit_document_changes(false);
+
+        let text = "
+f@n <- function(a, b) {}
+        ";
+
+        let (text, point, byte) = point_and_byte_from_cursor(text);
+        let document = Document::new(&text, None);
+
+        roxygen_documentation(
+            &mut actions,
+            &uri,
+            &document,
+            point_range(point, byte),
+            &capabilities,
+        );
+
+        let mut actions = actions.into_response();
+        assert_eq!(actions.len(), 1);
+
+        let CodeActionOrCommand::CodeAction(action) = actions.pop().unwrap() else {
+            panic!("Unexpected");
+        };
+        let workspace_edit = action.edit.unwrap();
+
+        // This is now `None`
+        assert!(workspace_edit.document_changes.is_none());
+
+        // The edits are here instead
+        let changes = workspace_edit.changes.unwrap();
+        assert_eq!(changes.len(), 1);
+        let text_edits = changes.get(&uri).unwrap();
+        assert_eq!(text_edits.len(), 1);
+
+        let text_edit = text_edits.get(0).unwrap();
+        assert_eq!(text_edit.range.start.line, 1);
+        assert_eq!(text_edit.range.start.character, 0);
+        assert_eq!(text_edit.range.end, text_edit.range.start);
+
+        insta::assert_snapshot!(text_edit.new_text);
+    }
+}

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_documentation_when_direct_preceding_line_is_not_documentation.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_documentation_when_direct_preceding_line_is_not_documentation.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: new_text
+---
+#' Title
+#'
+#' @param a
+#' @param b
+#'
+#' @returns
+#'
+#' @export
+#' @examples

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_parameters-2.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_parameters-2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: new_text
+---
+#' Title
+#'
+#' @param ...
+#'
+#' @returns
+#'
+#' @export
+#' @examples

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_parameters-3.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_parameters-3.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: new_text
+---
+#' Title
+    #'
+    #' @param ...
+    #'
+    #' @returns
+    #'
+    #' @export
+    #' @examples

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_parameters.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__adds_parameters.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: new_text
+---
+#' Title
+#'
+#' @param a
+#' @param b
+#'
+#' @returns
+#'
+#' @export
+#' @examples

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__no_parameters.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__no_parameters.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: new_text
+---
+#' Title
+#'
+#' @returns
+#'
+#' @export
+#' @examples

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__supports_equals_assignment.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__supports_equals_assignment.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: new_text
+---
+#' Title
+#'
+#' @param a
+#' @param b
+#'
+#' @returns
+#'
+#' @export
+#' @examples

--- a/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__uses_hash_map_of_text_edits_without_document_changes_support.snap
+++ b/crates/ark/src/lsp/code_action/snapshots/ark__lsp__code_action__roxygen__tests__uses_hash_map_of_text_edits_without_document_changes_support.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ark/src/lsp/code_action/roxygen.rs
+expression: text_edit.new_text
+---
+#' Title
+#'
+#' @param a
+#' @param b
+#'
+#' @returns
+#'
+#' @export
+#' @examples

--- a/crates/ark/src/lsp/documents.rs
+++ b/crates/ark/src/lsp/documents.rs
@@ -15,8 +15,7 @@ use tree_sitter::Point;
 use tree_sitter::Tree;
 
 use crate::lsp::config::DocumentConfig;
-use crate::lsp::encoding::convert_position_to_point;
-use crate::lsp::traits::rope::RopeExt;
+use crate::lsp::encoding::convert_lsp_range_to_tree_sitter_range;
 
 fn compute_point(point: Point, text: &str) -> Point {
     // figure out where the newlines in this edit are
@@ -127,11 +126,12 @@ impl Document {
         // offsets can be computed correctly.
         let ast = &mut self.ast;
 
-        let start_point = convert_position_to_point(&self.contents, range.start);
-        let start_byte = self.contents.point_to_byte(start_point);
-
-        let old_end_point = convert_position_to_point(&self.contents, range.end);
-        let old_end_byte = self.contents.point_to_byte(old_end_point);
+        let tree_sitter::Range {
+            start_byte,
+            end_byte: old_end_byte,
+            start_point,
+            end_point: old_end_point,
+        } = convert_lsp_range_to_tree_sitter_range(&self.contents, range);
 
         let new_end_point = compute_point(start_point, &change.text);
         let new_end_byte = start_byte + change.text.as_bytes().len();

--- a/crates/ark/src/lsp/encoding.rs
+++ b/crates/ark/src/lsp/encoding.rs
@@ -9,6 +9,8 @@ use ropey::Rope;
 use tower_lsp::lsp_types::Position;
 use tree_sitter::Point;
 
+use crate::lsp::traits::rope::RopeExt;
+
 /// `PositionEncodingKind` describes the encoding used for the `Position` `character`
 /// column offset field. The `Position` `line` field is encoding agnostic, but the
 /// `character` field specifies the number of characters offset from the beginning of
@@ -50,6 +52,24 @@ pub fn convert_tree_sitter_range_to_lsp_range(
     let start = convert_point_to_position(x, range.start_point);
     let end = convert_point_to_position(x, range.end_point);
     tower_lsp::lsp_types::Range::new(start, end)
+}
+
+pub fn convert_lsp_range_to_tree_sitter_range(
+    x: &Rope,
+    range: tower_lsp::lsp_types::Range,
+) -> tree_sitter::Range {
+    let start_point = convert_position_to_point(x, range.start);
+    let start_byte = x.point_to_byte(start_point);
+
+    let end_point = convert_position_to_point(x, range.end);
+    let end_byte = x.point_to_byte(end_point);
+
+    tree_sitter::Range {
+        start_byte,
+        end_byte,
+        start_point,
+        end_point,
+    }
 }
 
 pub fn convert_position_to_point(x: &Rope, position: Position) -> Point {

--- a/crates/ark/src/lsp/mod.rs
+++ b/crates/ark/src/lsp/mod.rs
@@ -6,6 +6,8 @@
 //
 
 pub mod backend;
+pub mod capabilities;
+pub mod code_action;
 pub mod comm;
 pub mod completions;
 mod config;

--- a/crates/ark/src/lsp/traits/rope.rs
+++ b/crates/ark/src/lsp/traits/rope.rs
@@ -16,6 +16,9 @@ pub trait RopeExt<'a> {
 }
 
 impl<'a> RopeExt<'a> for Rope {
+    /// Converts a tree-sitter [Point] into a byte offset
+    ///
+    /// Useful when constructing [tree_sitter::Range] or [tree_sitter::InputEdit]
     fn point_to_byte(&self, point: Point) -> usize {
         self.line_to_byte(point.row) + point.column
     }

--- a/crates/ark/src/treesitter.rs
+++ b/crates/ark/src/treesitter.rs
@@ -296,6 +296,7 @@ pub trait NodeTypeExt: Sized {
     fn is_namespace_internal_operator(&self) -> bool;
     fn is_unary_operator(&self) -> bool;
     fn is_binary_operator(&self) -> bool;
+    fn is_binary_operator_of_kind(&self, kind: BinaryOperatorType) -> bool;
     fn is_native_pipe_operator(&self) -> bool;
     fn is_magrittr_pipe_operator(&self, contents: &ropey::Rope) -> anyhow::Result<bool>;
     fn is_pipe_operator(&self, contents: &ropey::Rope) -> anyhow::Result<bool>;
@@ -388,6 +389,10 @@ impl NodeTypeExt for Node<'_> {
 
     fn is_binary_operator(&self) -> bool {
         matches!(self.node_type(), NodeType::BinaryOperator(_))
+    }
+
+    fn is_binary_operator_of_kind(&self, kind: BinaryOperatorType) -> bool {
+        matches!(self.node_type(), NodeType::BinaryOperator(node_kind) if node_kind == kind)
     }
 
     fn is_native_pipe_operator(&self) -> bool {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1744

This PR implements our first Code Action 💡, generating roxygen documentation templates

Code Actions show up as contextual 💡 in the user's UI. I've followed the rust-analyzer model, which enables this code action when the user's cursor is _on the function's name_.
https://rust-analyzer.github.io/book/assists.html#generate_documentation_template

I hope this is the first of many 💡s that we create for users, because these are very cool!

https://github.com/user-attachments/assets/6fc9cf0d-1726-42ef-9a8a-5c708db69488

A few notes:
- The code action is _not_ enabled if the previous line starts with a `#'` already (i.e. it somewhat looks like you've already got docs)
- The code action does handle indentation, i.e. if you are for some reason documenting a function that is nested
- The code action does not handle R6 class names `Foo <- R6::R6Class()`, nor does it handle R6 methods `list(fn = function() {})`, but neither does RStudio and I think that is okay for now. We could probably handle R6 methods with a little extra effort if we feel it is important.