### PR TITLE
Add folding ranges

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -24,6 +24,7 @@ use tower_lsp::jsonrpc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::request::GotoImplementationParams;
 use tower_lsp::lsp_types::request::GotoImplementationResponse;
+use tower_lsp::lsp_types::FoldingRange;
 use tower_lsp::lsp_types::SelectionRange;
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -131,6 +131,7 @@ pub(crate) enum LspRequest {
     Initialize(InitializeParams),
     WorkspaceSymbol(WorkspaceSymbolParams),
     DocumentSymbol(DocumentSymbolParams),
+    FoldingRange(FoldingRangeParams),
     ExecuteCommand(ExecuteCommandParams),
     Completion(CompletionParams),
     CompletionResolve(CompletionItem),
@@ -152,6 +153,7 @@ pub(crate) enum LspResponse {
     Initialize(InitializeResult),
     WorkspaceSymbol(Option<Vec<SymbolInformation>>),
     DocumentSymbol(Option<DocumentSymbolResponse>),
+    FoldingRange(Option<Vec<FoldingRange>>),
     ExecuteCommand(Option<Value>),
     Completion(Option<CompletionResponse>),
     CompletionResolve(CompletionItem),
@@ -258,6 +260,14 @@ impl LanguageServer for Backend {
             self,
             self.request(LspRequest::DocumentSymbol(params)).await,
             LspResponse::DocumentSymbol
+        )
+    }
+
+    async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
+        cast_response!(
+            self,
+            self.request(LspRequest::FoldingRange(params)).await,
+            LspResponse::FoldingRange
         )
     }
 

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use tower_lsp::lsp_types::FoldingRange;
 use tower_lsp::lsp_types::FoldingRangeKind;
 
+use super::symbols::parse_comment_as_section;
 use crate::lsp::documents::Document;
 
 pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
@@ -236,21 +237,6 @@ fn count_leading_whitespaces(document: &Document, line_num: usize) -> usize {
 
 pub static RE_COMMENT_SECTION: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(#+)\s*(.*?)\s*[#=-]{4,}\s*$").unwrap());
-
-fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
-    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
-    // Ensure that there's actual content between the start and the trailing symbols.
-    if let Some(caps) = RE_COMMENT_SECTION.captures(comment) {
-        let hashes = caps.get(1)?.as_str().len(); // Count the number of '#'
-        let title = caps.get(2)?.as_str().trim().to_string(); // Extract the title text without trailing punctuations
-        if title.is_empty() {
-            return None; // Return None for lines with only hashtags
-        }
-        return Some((hashes, title)); // Return the level based on the number of '#' and the title
-    }
-
-    None
-}
 
 fn nested_processor(
     document: &Document,

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -67,13 +67,13 @@ fn parse_ts_node(
 
     match node_type {
         "parameters" | "arguments" | "braced_expression" => {
-            // ignore same line folding
+            // Ignore same line folding
             if start.row == end.row {
                 return;
             }
             let folding_range = bracket_range(
                 start.row,
-                start.column,
+                start.column + 1, // Start after the opening delimiter
                 end.row,
                 end.column - 1,
                 count_leading_whitespaces(document, end.row),

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -322,8 +322,8 @@ fn region_processor(
 }
 
 fn parse_region_type(line_text: &str) -> Option<RegionType> {
-    let region_start = Regex::new(r"^\s*#\s*region\b").unwrap();
-    let region_end = Regex::new(r"^\s*#\s*endregion\b").unwrap();
+    let region_start = Regex::new(r"^\s*#+ #region\b").unwrap();
+    let region_end = Regex::new(r"^\s*#+ #endregion\b").unwrap();
 
     if region_start.is_match(line_text) {
         Some(RegionType::Start)

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -1,0 +1,492 @@
+//
+// folding_range.rs
+//
+// Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+//
+//
+
+use regex::Regex;
+use std::cmp::Ordering;
+use std::sync::LazyLock;
+
+use tower_lsp::lsp_types::FoldingRange;
+use tower_lsp::lsp_types::FoldingRangeKind;
+
+use crate::documents::Document;
+
+pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
+    let mut folding_ranges: Vec<FoldingRange> = Vec::new();
+
+    // Activate the parser
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_r::LANGUAGE.into())
+        .unwrap();
+
+    let ast = parser.parse(&document.contents, None).unwrap();
+
+    if ast.root_node().has_error() {
+        tracing::error!("Folding range service: Parse error");
+        return Err(anyhow::anyhow!("Parse error"));
+    }
+
+    // Traverse the AST
+    let mut cursor = ast.root_node().walk();
+    parse_ts_node(
+        &mut cursor,
+        0,
+        &mut folding_ranges,
+        document,
+        &mut vec![Vec::new()],
+        &mut None,
+        &mut None,
+    );
+
+    // Add indent folding ranges
+    append_indent_folding_ranges(document, &mut folding_ranges);
+    Ok(folding_ranges)
+}
+
+fn parse_ts_node(
+    cursor: &mut tree_sitter::TreeCursor,
+    _depth: usize,
+    folding_ranges: &mut Vec<FoldingRange>,
+    document: &Document,
+    comment_stack: &mut Vec<Vec<(usize, usize)>>,
+    region_marker: &mut Option<usize>,
+    cell_marker: &mut Option<usize>,
+) {
+    let node = cursor.node();
+    let _field_name = match cursor.field_name() {
+        Some(name) => format!("{name}: "),
+        None => String::new(),
+    };
+
+    let start = node.start_position();
+    let end = node.end_position();
+    let node_type = node.kind();
+
+    match node_type {
+        "parameters" | "arguments" | "braced_expression" => {
+            // ignore same line folding
+            if start.row == end.row {
+                return;
+            }
+            let folding_range = bracket_range(
+                start.row,
+                start.column,
+                end.row,
+                end.column - 1,
+                count_leading_whitespaces(document, end.row),
+            );
+            folding_ranges.push(folding_range);
+        }
+        "comment" => {
+            // Only process standalone comment
+            if count_leading_whitespaces(document, start.row) != start.column {
+                return;
+            }
+
+            // Nested comment section handling
+            let comment_line = get_line_text(document, start.row, None, None);
+
+            nested_processor(
+                document,
+                comment_stack,
+                folding_ranges,
+                start.row,
+                &comment_line,
+            );
+            region_processor(folding_ranges, region_marker, start.row, &comment_line);
+            cell_processor(folding_ranges, cell_marker, start.row, &comment_line);
+        }
+        _ => (),
+    }
+
+    if cursor.goto_first_child() {
+        // create node child stacks
+        // This is a stack of stacks for each bracket level, within each stack is a vector of (level, start_line) tuples
+        let mut child_comment_stack: Vec<Vec<(usize, usize)>> = vec![Vec::new()];
+        let mut child_region_marker: Option<usize> = None;
+        let mut child_cell_marker: Option<usize> = None;
+
+        // recursive loop
+        loop {
+            parse_ts_node(
+                cursor,
+                _depth + 1,
+                folding_ranges,
+                document,
+                &mut child_comment_stack,
+                &mut child_region_marker,
+                &mut child_cell_marker,
+            );
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        // End of node handling
+        end_node_handler(
+            document,
+            folding_ranges,
+            end.row,
+            &mut child_comment_stack,
+            &mut child_region_marker,
+            &mut child_cell_marker,
+        );
+
+        cursor.goto_parent();
+    }
+}
+
+// Function to create a folding range that specifically deals with bracket ending
+fn bracket_range(
+    start_line: usize,
+    start_char: usize,
+    end_line: usize,
+    end_char: usize,
+    white_space_count: usize,
+) -> FoldingRange {
+    let mut end_line: u32 = end_line.try_into().unwrap();
+    let mut end_char: Option<u32> = Some(end_char.try_into().unwrap());
+
+    let adjusted_end_char = end_char.and_then(|val| val.checked_sub(white_space_count as u32));
+
+    match adjusted_end_char {
+        Some(0) => {
+            end_line -= 1;
+            end_char = None;
+        }
+        Some(_) => {
+            if let Some(ref mut value) = end_char {
+                *value -= 1;
+            }
+        }
+        None => {
+            tracing::error!(
+                "Folding Range (bracket_range): adjusted_end_char should not be None here"
+            );
+        }
+    }
+
+    FoldingRange {
+        start_line: start_line.try_into().unwrap(),
+        start_character: Some(start_char as u32),
+        end_line,
+        end_character: end_char,
+        kind: Some(FoldingRangeKind::Region),
+        collapsed_text: None,
+    }
+}
+
+fn comment_range(start_line: usize, end_line: usize) -> FoldingRange {
+    FoldingRange {
+        start_line: start_line.try_into().unwrap(),
+        start_character: None,
+        end_line: end_line.try_into().unwrap(),
+        end_character: None,
+        kind: Some(FoldingRangeKind::Region),
+        collapsed_text: None,
+    }
+}
+
+fn get_line_text(
+    document: &Document,
+    line_num: usize,
+    start_char: Option<usize>,
+    end_char: Option<usize>,
+) -> String {
+    let text = &document.contents;
+    // Split the text into lines
+    let lines: Vec<&str> = text.lines().collect();
+
+    // Ensure the start_line is within bounds
+    if line_num >= lines.len() {
+        return String::new(); // Return an empty string if out of bounds
+    }
+
+    // Get the line corresponding to start_line
+    let line = lines[line_num];
+
+    // Determine the start and end character indices
+    let start_idx = start_char.unwrap_or(0); // Default to 0 if None
+    let end_idx = end_char.unwrap_or(line.len()); // Default to the line's length if None
+
+    // Ensure indices are within bounds for the line
+    let start_idx = start_idx.min(line.len());
+    let end_idx = end_idx.min(line.len());
+
+    // Extract the substring and return it
+    line[start_idx..end_idx].to_string() // TODO
+}
+
+fn find_last_non_empty_line(document: &Document, start_line: usize, end_line: usize) -> usize {
+    for idx in (start_line..=end_line).rev() {
+        if !get_line_text(document, idx, None, None).trim().is_empty() {
+            return idx;
+        }
+    }
+    start_line
+}
+
+fn count_leading_whitespaces(document: &Document, line_num: usize) -> usize {
+    let line_text = get_line_text(document, line_num, None, None);
+    line_text.chars().take_while(|c| c.is_whitespace()).count()
+}
+
+pub static RE_COMMENT_SECTION: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*(#+)\s*(.*?)\s*[#=-]{4,}\s*$").unwrap());
+
+fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
+    // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
+    // Ensure that there's actual content between the start and the trailing symbols.
+    if let Some(caps) = RE_COMMENT_SECTION.captures(comment) {
+        let hashes = caps.get(1)?.as_str().len(); // Count the number of '#'
+        let title = caps.get(2)?.as_str().trim().to_string(); // Extract the title text without trailing punctuations
+        if title.is_empty() {
+            return None; // Return None for lines with only hashtags
+        }
+        return Some((hashes, title)); // Return the level based on the number of '#' and the title
+    }
+
+    None
+}
+
+fn nested_processor(
+    document: &Document,
+    comment_stack: &mut Vec<Vec<(usize, usize)>>,
+    folding_ranges: &mut Vec<FoldingRange>,
+    line_num: usize,
+    comment_line: &str,
+) {
+    let Some((level, _title)) = parse_comment_as_section(comment_line) else {
+        return; // return if the line is not a comment section
+    };
+    if comment_stack.is_empty() {
+        tracing::error!(
+            "Folding Range: comment_stack should always contain at least one element here"
+        );
+        return;
+    }
+    loop {
+        if comment_stack.last().unwrap().is_empty() {
+            comment_stack.last_mut().unwrap().push((level, line_num));
+            return; // return if the stack is empty
+        }
+
+        let Some((last_level, _)) = comment_stack.last().unwrap().last() else {
+            tracing::error!("Folding Range: comment_stacks should not be empty here");
+            return;
+        };
+        match last_level.cmp(&level) {
+            Ordering::Less => {
+                comment_stack.last_mut().unwrap().push((level, line_num));
+                break;
+            }
+            Ordering::Equal => {
+                let start_line = comment_stack.last().unwrap().last().unwrap().1;
+                folding_ranges.push(comment_range(
+                    start_line,
+                    find_last_non_empty_line(document, start_line, line_num - 1),
+                ));
+                comment_stack.last_mut().unwrap().pop();
+                comment_stack.last_mut().unwrap().push((level, line_num));
+                break;
+            }
+            Ordering::Greater => {
+                let start_line = comment_stack.last().unwrap().last().unwrap().1;
+                folding_ranges.push(comment_range(
+                    start_line,
+                    find_last_non_empty_line(document, start_line, line_num - 1),
+                ));
+                comment_stack.last_mut().unwrap().pop(); // Safe: the loop exits early if the stack becomes empty
+            }
+        }
+    }
+}
+
+fn region_processor(
+    folding_ranges: &mut Vec<FoldingRange>,
+    region_marker: &mut Option<usize>,
+    line_idx: usize,
+    line_text: &str,
+) {
+    let Some(region_type) = parse_region_type(line_text) else {
+        return; // return if the line is not a region section
+    };
+    match region_type.as_str() {
+        "start" => {
+            region_marker.replace(line_idx);
+        }
+        "end" => {
+            if let Some(region_start) = region_marker {
+                let folding_range = comment_range(*region_start, line_idx);
+                folding_ranges.push(folding_range);
+                *region_marker = None;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_region_type(line_text: &str) -> Option<String> {
+    // return the region type
+    // "start": "^\\s*#\\s*region\\b"
+    // "end": "^\\s*#\\s*endregion\\b"
+    // None: otherwise
+    let region_start = Regex::new(r"^\s*#\s*region\b").unwrap();
+    let region_end = Regex::new(r"^\s*#\s*endregion\b").unwrap();
+
+    if region_start.is_match(line_text) {
+        Some("start".to_string())
+    } else if region_end.is_match(line_text) {
+        Some("end".to_string())
+    } else {
+        None
+    }
+}
+
+fn cell_processor(
+    // Almost identical to region_processor
+    folding_ranges: &mut Vec<FoldingRange>,
+    cell_marker: &mut Option<usize>,
+    line_idx: usize,
+    line_text: &str,
+) {
+    let cell_pattern: Regex = Regex::new(r"^#\s*(%%|\+)(.*)").unwrap();
+
+    if !cell_pattern.is_match(line_text) {
+    } else {
+        let Some(start_line) = cell_marker else {
+            cell_marker.replace(line_idx);
+            return;
+        };
+
+        let folding_range = comment_range(*start_line, line_idx - 1);
+        folding_ranges.push(folding_range);
+        cell_marker.replace(line_idx);
+    }
+}
+
+fn end_node_handler(
+    document: &Document,
+    folding_ranges: &mut Vec<FoldingRange>,
+    line_idx: usize,
+    comment_stack: &mut Vec<Vec<(usize, usize)>>,
+    region_marker: &mut Option<usize>,
+    cell_marker: &mut Option<usize>,
+) {
+    // Nested comment handling
+    // Iterate over the last element of the comment stack and add it to the folding ranges by using the comment_range function
+    if let Some(last_section) = comment_stack.last() {
+        // Iterate over each (start level, start line) in the last section
+        for &(_level, start_line) in last_section.iter() {
+            // Add a new folding range for each range in the last section
+            let folding_range = comment_range(
+                start_line,
+                find_last_non_empty_line(document, start_line, line_idx - 1),
+            );
+
+            folding_ranges.push(folding_range);
+        }
+    }
+    // Remove the last element from the comment stack after processing
+    comment_stack.pop();
+
+    // Unclosed region handling
+    if let Some(region_start) = region_marker {
+        let folding_range = comment_range(*region_start, line_idx - 1);
+        folding_ranges.push(folding_range);
+        *region_marker = None;
+    }
+
+    // End cell Handling
+    if let Some(cell_start) = cell_marker {
+        let folding_range = comment_range(*cell_start, line_idx - 1);
+        folding_ranges.push(folding_range);
+        *cell_marker = None;
+    }
+}
+
+fn append_indent_folding_ranges(document: &Document, folding_ranges: &mut Vec<FoldingRange>) {
+    let lines: Vec<&str> = document.contents.lines().collect();
+    // usize::MAX is used as a placeholder for start lines which should not be included in the folding range
+    let mut indent_stack: Vec<(usize, usize)> = vec![(usize::MAX, 0)]; // (start_line, indent_level)
+    let mut last_line_is_empty = true; // folding ranges should not start with empty lines
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_end();
+        let indent = line.chars().take_while(|c| c.is_whitespace()).count();
+
+        // Pop all deeper indents
+        loop {
+            let Some(&(start_line, start_indent)) = indent_stack.last() else {
+                indent_stack = vec![(usize::MAX, indent)];
+                break;
+            };
+
+            if trimmed.is_empty() {
+                if last_line_is_empty {
+                    break; // end of indent block handling has been done
+                };
+                end_indent_handler(folding_ranges, &mut indent_stack, line_idx - 1); // flush indent block
+                break;
+            }
+
+            match start_indent.cmp(&indent) {
+                Ordering::Less => {
+                    if last_line_is_empty {
+                        // we need to update the placeholder indent level
+                        indent_stack = vec![(usize::MAX, indent)];
+                        break;
+                    }
+                    indent_stack.push((line_idx - 1, indent));
+                    break;
+                }
+                Ordering::Equal => break,
+                Ordering::Greater => {
+                    if start_line != usize::MAX {
+                        folding_ranges.push(FoldingRange {
+                            start_line: start_line as u32,
+                            end_line: (line_idx - 1) as u32,
+                            kind: Some(FoldingRangeKind::Region),
+                            start_character: None,
+                            end_character: None,
+                            collapsed_text: None,
+                        });
+                    }
+                    indent_stack.pop();
+                }
+            }
+        }
+        last_line_is_empty = trimmed.is_empty();
+    }
+
+    // Final flush: any unfinished indent block to End of Document
+    let last_line = lines.len().saturating_sub(1);
+    end_indent_handler(folding_ranges, &mut indent_stack, last_line);
+}
+
+// end of indent block handling
+fn end_indent_handler(
+    folding_ranges: &mut Vec<FoldingRange>,
+    indent_stack: &mut Vec<(usize, usize)>,
+    line_idx: usize,
+) {
+    for (start_line, _) in indent_stack.into_iter() {
+        if *start_line == usize::MAX {
+            continue; // Skip the placeholder
+        }
+        if line_idx > *start_line {
+            folding_ranges.push(FoldingRange {
+                start_line: *start_line as u32,
+                end_line: line_idx as u32,
+                kind: Some(FoldingRangeKind::Region),
+                start_character: None,
+                end_character: None,
+                collapsed_text: None,
+            });
+        }
+    }
+    indent_stack.push((usize::MAX, 0)); // Add the placeholder back to the stack
+}

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -291,6 +291,13 @@ fn nested_processor(
     }
 }
 
+/// Enum representing the type of region marker
+#[derive(Debug, PartialEq, Eq)]
+enum RegionType {
+    Start,
+    End,
+}
+
 fn region_processor(
     folding_ranges: &mut Vec<FoldingRange>,
     region_marker: &mut Option<usize>,
@@ -300,33 +307,28 @@ fn region_processor(
     let Some(region_type) = parse_region_type(line_text) else {
         return; // return if the line is not a region section
     };
-    match region_type.as_str() {
-        "start" => {
+    match region_type {
+        RegionType::Start => {
             region_marker.replace(line_idx);
         },
-        "end" => {
+        RegionType::End => {
             if let Some(region_start) = region_marker {
                 let folding_range = comment_range(*region_start, line_idx);
                 folding_ranges.push(folding_range);
                 *region_marker = None;
             }
         },
-        _ => {},
     }
 }
 
-fn parse_region_type(line_text: &str) -> Option<String> {
-    // return the region type
-    // "start": "^\\s*#\\s*region\\b"
-    // "end": "^\\s*#\\s*endregion\\b"
-    // None: otherwise
+fn parse_region_type(line_text: &str) -> Option<RegionType> {
     let region_start = Regex::new(r"^\s*#\s*region\b").unwrap();
     let region_end = Regex::new(r"^\s*#\s*endregion\b").unwrap();
 
     if region_start.is_match(line_text) {
-        Some("start".to_string())
+        Some(RegionType::Start)
     } else if region_end.is_match(line_text) {
-        Some("end".to_string())
+        Some(RegionType::End)
     } else {
         None
     }

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -390,7 +390,8 @@ fn end_node_handler(
 
     // End cell Handling
     if let Some(cell_start) = cell_marker {
-        let folding_range = comment_range(*cell_start, line_idx - 1);
+        // For the last cell, include the current line in the folding range
+        let folding_range = comment_range(*cell_start, find_last_non_empty_line(document, *cell_start, line_idx));
         folding_ranges.push(folding_range);
         *cell_marker = None;
     }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -285,6 +285,9 @@ impl GlobalState {
                         LspRequest::DocumentSymbol(params) => {
                             respond(tx, || handlers::handle_document_symbol(params, &self.world), LspResponse::DocumentSymbol)?;
                         },
+                        LspRequest::FoldingRange(params) => {
+                            respond(tx, || handlers::handle_folding_range(params, &self.world), LspResponse::FoldingRange)?;
+                        },
                         LspRequest::ExecuteCommand(_params) => {
                             let response = handlers::handle_execute_command(&self.client).await;
                             respond(tx, || response, LspResponse::ExecuteCommand)?;

--- a/crates/ark/src/lsp/mod.rs
+++ b/crates/ark/src/lsp/mod.rs
@@ -17,6 +17,7 @@ pub mod document_context;
 pub mod documents;
 pub mod encoding;
 pub mod events;
+pub mod folding_range;
 pub mod handler;
 pub mod handlers;
 pub mod help;

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brackets.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brackets.snap
@@ -1,0 +1,94 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    doSomething();\n  } else {\n    doSomethingElse();\n  }\n}\n\nlist <- list(\n  a = 1,\n  b = 2,\n  c = 3\n)\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            11,
+        ),
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: Some(
+            17,
+        ),
+        end_line: 3,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: None,
+        end_line: 3,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 4,
+        start_character: Some(
+            9,
+        ),
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 4,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 9,
+        start_character: Some(
+            12,
+        ),
+        end_line: 12,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 9,
+        start_character: None,
+        end_line: 12,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brackets.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brackets.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    a\n  }
     FoldingRange {
         start_line: 1,
         start_character: Some(
-            11,
+            12,
         ),
         end_line: 6,
         end_character: None,
@@ -18,7 +18,7 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    a\n  }
     FoldingRange {
         start_line: 2,
         start_character: Some(
-            17,
+            18,
         ),
         end_line: 3,
         end_character: None,
@@ -30,7 +30,7 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    a\n  }
     FoldingRange {
         start_line: 4,
         start_character: Some(
-            9,
+            10,
         ),
         end_line: 5,
         end_character: None,
@@ -42,7 +42,7 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    a\n  }
     FoldingRange {
         start_line: 9,
         start_character: Some(
-            12,
+            13,
         ),
         end_line: 12,
         end_character: None,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brackets.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brackets.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    doSomething();\n  } else {\n    doSomethingElse();\n  }\n}\n\nlist <- list(\n  a = 1,\n  b = 2,\n  c = 3\n)\")"
+expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    a\n  } else {\n    b\n  }\n}\n\nlist <- list(\n  a = 1,\n  b = 2,\n  c = 3\n)\")"
 ---
 [
     FoldingRange {
@@ -8,16 +8,6 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    doSome
         start_character: Some(
             11,
         ),
-        end_line: 6,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
-        start_line: 1,
-        start_character: None,
         end_line: 6,
         end_character: None,
         kind: Some(
@@ -38,16 +28,6 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    doSome
         collapsed_text: None,
     },
     FoldingRange {
-        start_line: 2,
-        start_character: None,
-        end_line: 3,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
         start_line: 4,
         start_character: Some(
             9,
@@ -60,30 +40,10 @@ expression: "test_folding_range(\"\nfunction() {\n  if (condition) {\n    doSome
         collapsed_text: None,
     },
     FoldingRange {
-        start_line: 4,
-        start_character: None,
-        end_line: 5,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
         start_line: 9,
         start_character: Some(
             12,
         ),
-        end_line: 12,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
-        start_line: 9,
-        start_character: None,
         end_line: 12,
         end_character: None,
         kind: Some(

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_cells.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_cells.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\n# %% First cell\nx <- 1\ny <- 2\n\n# %% Second cell\nz <- x + y\n\n# %% Third cell\nplot(z)\")"
+expression: "test_folding_range(\"\n# %% First cell\na\nb\n\n# %% Second cell\nc\n\n# %% Third cell\nd\")"
 ---
 [
     FoldingRange {
@@ -26,7 +26,7 @@ expression: "test_folding_range(\"\n# %% First cell\nx <- 1\ny <- 2\n\n# %% Seco
     FoldingRange {
         start_line: 8,
         start_character: None,
-        end_line: 8,
+        end_line: 9,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_cells.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_cells.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# %% First cell\nx <- 1\ny <- 2\n\n# %% Second cell\nz <- x + y\n\n# %% Third cell\nplot(z)\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 4,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 5,
+        start_character: None,
+        end_line: 7,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 8,
+        start_character: None,
+        end_line: 8,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_complex_nested.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_complex_nested.snap
@@ -16,7 +16,7 @@ expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\
     FoldingRange {
         start_line: 2,
         start_character: Some(
-            18,
+            19,
         ),
         end_line: 15,
         end_character: None,
@@ -38,7 +38,7 @@ expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\
     FoldingRange {
         start_line: 7,
         start_character: Some(
-            13,
+            14,
         ),
         end_line: 9,
         end_character: None,
@@ -50,7 +50,7 @@ expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\
     FoldingRange {
         start_line: 10,
         start_character: Some(
-            9,
+            10,
         ),
         end_line: 11,
         end_character: None,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_complex_nested.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_complex_nested.snap
@@ -1,0 +1,102 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\n  # region inner calculations\n  x <- a + b\n  y <- b + c\n  \n  if (x > y) {\n    # %% cell inside function\n    result <- x * y\n  } else {\n    result <- x / y\n  }\n  # endregion\n  \n  return(result)\n}\n\n## Subsection ----\n# This is a regular comment, not a section or region\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 18,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: Some(
+            18,
+        ),
+        end_line: 15,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 3,
+        start_character: None,
+        end_line: 13,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 7,
+        start_character: Some(
+            13,
+        ),
+        end_line: 9,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 7,
+        start_character: None,
+        end_line: 9,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 10,
+        start_character: Some(
+            9,
+        ),
+        end_line: 11,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 10,
+        start_character: None,
+        end_line: 11,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 18,
+        start_character: None,
+        end_line: 18,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_complex_nested.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_complex_nested.snap
@@ -1,22 +1,12 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\n  # region inner calculations\n  x <- a + b\n  y <- b + c\n  \n  if (x > y) {\n    # %% cell inside function\n    result <- x * y\n  } else {\n    result <- x / y\n  }\n  # endregion\n  \n  return(result)\n}\n\n## Subsection ----\n# This is a regular comment, not a section or region\")"
+expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\n  # #region inner calculations\n  x <- a + b\n  y <- b + c\n\n  if (x > y) {\n    # %% cell inside function\n    result <- x * y\n  } else {\n    result <- x / y\n  }\n  # #endregion\n\n  result\n}\n\n## Subsection ----\n# This is a regular comment, not a section or region\")"
 ---
 [
     FoldingRange {
         start_line: 1,
         start_character: None,
         end_line: 18,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
-        start_line: 2,
-        start_character: None,
-        end_line: 5,
         end_character: None,
         kind: Some(
             Region,
@@ -58,30 +48,10 @@ expression: "test_folding_range(\"\n# Complex example ----\nfunction(a, b, c) {\
         collapsed_text: None,
     },
     FoldingRange {
-        start_line: 7,
-        start_character: None,
-        end_line: 9,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
         start_line: 10,
         start_character: Some(
             9,
         ),
-        end_line: 11,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
-        start_line: 10,
-        start_character: None,
         end_line: 11,
         end_character: None,
         kind: Some(

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_empty_sections.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_empty_sections.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# Empty section ----\n\n# Another empty section ----\n\n# Section with content ----\nThis one has content\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 1,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 3,
+        start_character: None,
+        end_line: 3,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 5,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_indentation.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_indentation.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\nif (condition)\n  doSomething()\n  doAnotherThing()\n  andOneMoreThing()\nelse\n  doSomethingElse()\n  andAnotherElseThing()\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 4,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 5,
+        start_character: None,
+        end_line: 7,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
@@ -16,7 +16,7 @@ expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #reg
     FoldingRange {
         start_line: 2,
         start_character: Some(
-            11,
+            12,
         ),
         end_line: 5,
         end_character: None,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
@@ -1,0 +1,78 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #region nested region\n  a\n  # #endregion\n}\n\n## Subsection ----\n# %% Cell in subsection\nb\n\n# Another section ----\nc\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 10,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: Some(
+            11,
+        ),
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 3,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 8,
+        start_character: None,
+        end_line: 10,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 9,
+        start_character: None,
+        end_line: 12,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 12,
+        start_character: None,
+        end_line: 12,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
@@ -26,16 +26,6 @@ expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #reg
         collapsed_text: None,
     },
     FoldingRange {
-        start_line: 2,
-        start_character: None,
-        end_line: 5,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
         start_line: 3,
         start_character: None,
         end_line: 5,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
@@ -58,7 +58,7 @@ expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #reg
     FoldingRange {
         start_line: 9,
         start_character: None,
-        end_line: 12,
+        end_line: 13,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_nested_section_comments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_nested_section_comments.snap
@@ -1,0 +1,56 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# Level 1 ----\ncode at level 1\n\n## Level 2 ----\ncode at level 2\n\n### Level 3 ----\ncode at level 3\n\n## Another Level 2 ----\nback to level 2\n\n# Back to Level 1 ----\nback to level 1\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 11,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 4,
+        start_character: None,
+        end_line: 8,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 7,
+        start_character: None,
+        end_line: 8,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 10,
+        start_character: None,
+        end_line: 11,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 13,
+        start_character: None,
+        end_line: 13,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_regions.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_regions.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# #region Important code\na\nb\nc\n# #endregion\n\n# #region Another section\nd\n# #endregion\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 7,
+        start_character: None,
+        end_line: 9,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# First section ----\na\nb\n\n## Nested section ----\nc\n\n# Another section ----\nd\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 5,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 8,
+        start_character: None,
+        end_line: 8,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments_basic.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments_basic.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# First section ----\nsome code here\nmore code\n\n# Second section ----\nother code\nfinal line\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 3,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 5,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_single_line_braces.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_single_line_braces.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\nfunction() { a }\n\nfunction() {\n  b\n}\")"
     FoldingRange {
         start_line: 3,
         start_character: Some(
-            11,
+            12,
         ),
         end_line: 4,
         end_character: None,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_single_line_braces.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_single_line_braces.snap
@@ -1,0 +1,28 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\nfunction() { return 1 }\n\nfunction() {\n  return 2\n}\")"
+---
+[
+    FoldingRange {
+        start_line: 3,
+        start_character: Some(
+            11,
+        ),
+        end_line: 4,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 3,
+        start_character: None,
+        end_line: 4,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_single_line_braces.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_single_line_braces.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\nfunction() { return 1 }\n\nfunction() {\n  return 2\n}\")"
+expression: "test_folding_range(\"\nfunction() { a }\n\nfunction() {\n  b\n}\")"
 ---
 [
     FoldingRange {
@@ -8,16 +8,6 @@ expression: "test_folding_range(\"\nfunction() { return 1 }\n\nfunction() {\n  r
         start_character: Some(
             11,
         ),
-        end_line: 4,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
-        start_line: 3,
-        start_character: None,
         end_line: 4,
         end_character: None,
         kind: Some(

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_unterminated.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_unterminated.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "format!(\"Expected error: {}\", e)"
+---
+"Expected error: Parse error"

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_with_empty_lines.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_with_empty_lines.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# Section with empty lines ----\nline1\n\nline2\n\n\nline3\n\n# Another section ----\ncontent\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 7,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 9,
+        start_character: None,
+        end_line: 9,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -19,6 +19,7 @@ use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingOptions;
 use tower_lsp::lsp_types::ExecuteCommandOptions;
+use tower_lsp::lsp_types::FoldingRangeProviderCapability;
 use tower_lsp::lsp_types::FormattingOptions;
 use tower_lsp::lsp_types::HoverProviderCapability;
 use tower_lsp::lsp_types::ImplementationProviderCapability;
@@ -139,6 +140,7 @@ pub(crate) fn initialize(
             implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
             references_provider: Some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
+            folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
             workspace_symbol_provider: Some(OneOf::Left(true)),
             execute_command_provider: Some(ExecuteCommandOptions {
                 commands: vec![],

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -348,7 +348,7 @@ fn index_assignment_with_function(
 }
 
 // Function to parse a comment and return the section level and title
-fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
+pub(crate) fn parse_comment_as_section(comment: &str) -> Option<(usize, String)> {
     // Match lines starting with one or more '#' followed by some non-empty content and must end with 4 or more '-', '#', or `=`
     // Ensure that there's actual content between the start and the trailing symbols.
     if let Some(caps) = indexer::RE_COMMENT_SECTION.captures(comment) {


### PR DESCRIPTION
Moving back from https://github.com/posit-dev/air/pull/146.

Old description:

It seems that the call for folding ranges has been quite a while: https://github.com/posit-dev/positron/issues/18, https://github.com/posit-dev/positron/issues/2924, https://github.com/posit-dev/positron/issues/3822.

I was initially only thinking about adding foldable comments, but it seems that doing this will disable the existing folding support for things like regions and brackets. Therefore, I rewrote these functionalities also.

The PR already supports the folding-range-handling of brackets, regions, code cells, indentations and *nested* comment sections:

(The screenshot is new, though)
![image](https://github.com/user-attachments/assets/19ed3e13-47ad-48d0-977d-5d2a722fa9f2)

Note that, compared to the [old PR](https://github.com/posit-dev/ark/pull/615), this PR no longer relies on a naive search for brackets. Instead it uses the new `tree_sitter` of air to walk down the AST for node handling.
