### PR TITLE
Don't normalize HTTP URLs for the Viewer

### DIFF
--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -142,19 +142,6 @@ is_string <- function(x) {
     is.character(x) && length(x) == 1 && !is.na(x)
 }
 
-# Normalize a path to a canonical form. Does nothing to HTTP URL-like paths or
-# empty strings.
-normalize_path <- function(path) {
-    if (is_string(path)) {
-        # If the path is empty, or is an HTTP(S) URL, return it unchanged
-        if (!nzchar(path) || grepl("^https?://", path)) {
-            return(path)
-        }
-
-        # Otherwise, normalize the file path
-        return(normalizePath(path, mustWork = FALSE))
-    } else {
-        # If not a string, return it unchanged
-        return(path)
-    }
+is_http_url <- function(x) {
+    is_string(x) && grepl("^https?://", x)
 }

--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -1,7 +1,7 @@
 #
 # utils.R
 #
-# Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
 #
 #
 
@@ -140,4 +140,21 @@ node_poke_cdr <- function(node, cdr) {
 
 is_string <- function(x) {
     is.character(x) && length(x) == 1 && !is.na(x)
+}
+
+# Normalize a path to a canonical form. Does nothing to HTTP URL-like paths or
+# empty strings.
+normalize_path <- function(path) {
+    if (is_string(path)) {
+        # If the path is empty, or is an HTTP(S) URL, return it unchanged
+        if (!nzchar(path) || grepl("^https?://", path)) {
+            return(path)
+        }
+
+        # Otherwise, normalize the file path
+        return(normalizePath(path, mustWork = FALSE))
+    } else {
+        # If not a string, return it unchanged
+        return(path)
+    }
 }

--- a/crates/ark/src/modules/positron/viewer.R
+++ b/crates/ark/src/modules/positron/viewer.R
@@ -1,7 +1,7 @@
 #
 # viewer.R
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 #
 #
 
@@ -12,7 +12,7 @@ options("viewer" = function(url, height = NULL, ...) {
 
     # Normalize paths for comparison. This is necessary because on e.g. macOS,
     # the `tempdir()` may contain `//` or other non-standard path separators.
-    normalizedPath <- normalizePath(url, mustWork = FALSE)
+    normalizedPath <- normalize_path(url)
     normalizedTempdir <- normalizePath(tempdir(), mustWork = FALSE)
 
     # Validate the height argument.

--- a/crates/ark/src/modules/rstudio/stubs.R
+++ b/crates/ark/src/modules/rstudio/stubs.R
@@ -57,7 +57,10 @@
         stop("url must be a single element character vector.")
     height <- .ps.validate.viewer.height(height)
 
-    url <- normalize_path(url)
+    if (!is_http_url(url)) {
+        # Only normalize file path urls (posit-dev/positron#4843)
+        url <- normalizePath(url, mustWork = FALSE)
+    }
 
     # Derive a title for the viewer from the path.
     title <- .ps.viewer.title(url)

--- a/crates/ark/src/modules/rstudio/stubs.R
+++ b/crates/ark/src/modules/rstudio/stubs.R
@@ -57,7 +57,7 @@
         stop("url must be a single element character vector.")
     height <- .ps.validate.viewer.height(height)
 
-    url <- normalizePath(url, mustWork = FALSE)
+    url <- normalize_path(url)
 
     # Derive a title for the viewer from the path.
     title <- .ps.viewer.title(url)


### PR DESCRIPTION
This change addresses an issue that keeps URLs from being loaded into the Viewer on Windows. The issue is that we call `normalizePath` on everything that gets loaded into the Viewer, which is great for file paths but unsurprisingly doesn't work on URLs.

The fix here is to make our own wrapper for `normalizePath` that passes URLs through safely. This new function isn't vectorized (unlike the original `normalizePath`) but shouldn't need to be since the viewers accept only a single URL or path.

Addresses https://github.com/posit-dev/positron/issues/4843