### PR TITLE
Localize special logic in `is_http_url()` helper

### DIFF
--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -142,19 +142,6 @@ is_string <- function(x) {
     is.character(x) && length(x) == 1 && !is.na(x)
 }
 
-# Normalize a path to a canonical form. Does nothing to HTTP URL-like paths or
-# empty strings.
-normalize_path <- function(path) {
-    if (is_string(path)) {
-        # If the path is empty, or is an HTTP(S) URL, return it unchanged
-        if (!nzchar(path) || grepl("^https?://", path)) {
-            return(path)
-        }
-
-        # Otherwise, normalize the file path
-        return(normalizePath(path, mustWork = FALSE))
-    } else {
-        # If not a string, return it unchanged
-        return(path)
-    }
+is_http_url <- function(x) {
+    is_string(x) && grepl("^https?://", x)
 }

--- a/crates/ark/src/modules/rstudio/stubs.R
+++ b/crates/ark/src/modules/rstudio/stubs.R
@@ -57,7 +57,10 @@
         stop("url must be a single element character vector.")
     height <- .ps.validate.viewer.height(height)
 
-    url <- normalize_path(url)
+    if (!is_http_url(url)) {
+        # Only normalize file path urls (posit-dev/positron#4843)
+        url <- normalizePath(url, mustWork = FALSE)
+    }
 
     # Derive a title for the viewer from the path.
     title <- .ps.viewer.title(url)


### PR DESCRIPTION
Merges into https://github.com/posit-dev/ark/pull/818

We use `normalizePath()` with its intended meaning in a number of other places, so it feels a little confusing to me to have a shim of `normalize_path()` that we only use in these two places. With its current definition I'm not sure we'd want to use it everywhere in place of our current usage of `normalizePath()`.

Instead, how do you feel about an `is_http_url()` helper that we use in these two places, but still call `normalizePath()` our standard way?

I also was a little iffy about how we were comparing a known http url of `normalizedPath` against the `normalizedTempdir` - that comparison was really only meant for file paths. So I've tweaked that path to early exit when we recognize an http url.

---

I don't have my windows machine up and running, but I tested some urls on my mac just to make sure I didn't make any glaring typos.