### PR TITLE
Fixes for folding ranges

### DIFF
--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -159,11 +159,7 @@ fn bracket_range(
             end_line -= 1;
             end_char = None;
         },
-        Some(_) => {
-            if let Some(ref mut value) = end_char {
-                *value -= 1;
-            }
-        },
+        Some(_) => {},
         None => {
             tracing::error!(
                 "Folding Range (bracket_range): adjusted_end_char should not be None here"

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -146,8 +146,8 @@ fn bracket_range(
     end_char: usize,
     white_space_count: usize,
 ) -> FoldingRange {
-    let mut end_line: u32 = end_line.try_into().unwrap();
-    let mut end_char: Option<u32> = Some(end_char.try_into().unwrap());
+    let mut end_line: u32 = end_line as u32;
+    let mut end_char: Option<u32> = Some(end_char as u32);
 
     let adjusted_end_char = end_char.and_then(|val| val.checked_sub(white_space_count as u32));
 
@@ -169,7 +169,7 @@ fn bracket_range(
     }
 
     FoldingRange {
-        start_line: start_line.try_into().unwrap(),
+        start_line: start_line as u32,
         start_character: Some(start_char as u32),
         end_line,
         end_character: end_char,
@@ -180,9 +180,9 @@ fn bracket_range(
 
 fn comment_range(start_line: usize, end_line: usize) -> FoldingRange {
     FoldingRange {
-        start_line: start_line.try_into().unwrap(),
+        start_line: start_line as u32,
         start_character: None,
-        end_line: end_line.try_into().unwrap(),
+        end_line: end_line as u32,
         end_character: None,
         kind: Some(FoldingRangeKind::Region),
         collapsed_text: None,

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -362,7 +362,7 @@ fn cell_processor(
     line_idx: usize,
     line_text: &str,
 ) {
-    let cell_pattern: Regex = Regex::new(r"^#\s*(%%|\+)(.*)").unwrap();
+    let cell_pattern: Regex = Regex::new(r"^#+( %%|\+) (.*)").unwrap();
 
     if !cell_pattern.is_match(line_text) {
     } else {
@@ -468,6 +468,7 @@ mod tests {
 
     #[test]
     fn test_folding_section_comments_basic() {
+        // Note the chunks are nested in comment sections
         insta::assert_debug_snapshot!(test_folding_range(
             "
 # First section ----
@@ -476,7 +477,16 @@ b
 
 # Second section ----
 c
-d"
+d
+
+# %% Chunk section (jupyter-style)
+e
+f
+
+#+ Chunk section (knitr-style)
+g
+# + This is not a chunk
+h"
         ));
     }
 
@@ -497,7 +507,13 @@ c
 d
 
 # Back to Level 1 ----
-e"
+e
+
+# %% Chunk at Level 1
+f
+
+## %% Another chunk at Level 1
+g"
         ));
     }
 

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -467,6 +467,24 @@ mod tests {
     }
 
     #[test]
+    fn test_folding_section_chunks_with_section_in_middle() {
+        // FIXME: First chunk overlaps section, and section overlaps second
+        // chunk. Causes section folding to not appear in Positron.
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+#+ Cell
+a
+
+# Section ----
+b
+
+#+ Other cell
+c
+"
+        ));
+    }
+
+    #[test]
     fn test_folding_section_comments_basic() {
         // Note the chunks are nested in comment sections
         insta::assert_debug_snapshot!(test_folding_range(

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -259,7 +259,6 @@ fn nested_processor(
         }
 
         let Some((last_level, _)) = comment_stack.last_or_error()?.last() else {
-            tracing::error!("Folding Range: comment_stacks should not be empty here");
             return Err(anyhow::anyhow!("Empty comment stack"));
         };
 
@@ -284,10 +283,7 @@ fn nested_processor(
                     start_line,
                     find_last_non_empty_line(document, start_line, line_num - 1),
                 ));
-                comment_stack
-                    .last_mut()
-                    .ok_or_else(|| anyhow::anyhow!("Empty comment stack"))?
-                    .pop(); // Safe: the loop exits early if the stack becomes empty
+                comment_stack.last_mut_or_error()?.pop(); // Safe: the loop exits early if the stack becomes empty
             },
         }
     }

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -499,6 +499,23 @@ h"
     }
 
     #[test]
+    fn test_folding_section_comments() {
+        // FIXME: First section doesn't span whole section
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+# Section ----
+a
+
+b
+c
+
+# Section ----
+d
+"
+        ));
+    }
+
+    #[test]
     fn test_folding_nested_section_comments() {
         insta::assert_debug_snapshot!(test_folding_range(
             "
@@ -551,6 +568,27 @@ b
 
 #+ Other cell
 c
+"
+        ));
+    }
+
+    #[test]
+    fn test_folding_section_chunks_with_sections() {
+        // Chunks should be nested in sections
+        // FIXME: First section doesn't span whole cell
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+# Section ----
+a
+
+#+ Cell
+b
+
+# Section ----
+c
+
+#+ Other cell
+d
 "
         ));
     }

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -607,6 +607,58 @@ function() {
         ));
     }
 
+    // Braces in function call
+    //
+    // FIXME: Ideally folding should look like:
+    // ```
+    // call({ ...
+    // })
+    // ```
+    //
+    // Currently it looks like:
+    // ```
+    // call({ ...
+    // ```
+    //
+    // That's because the frontend selects the largest range, which in this case
+    // is the range for `(`. Our adjustment logic to shift the end of the range
+    // one line up when the closing delimiter is on its own line doesn't work
+    // for `)` because `}` is in the way. As a consequence `end_character` is
+    // `Some` in these snapshots and `end_line` is one line too high.
+    #[test]
+    fn test_folding_brace_in_call() {
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+call({
+  1
+})
+"
+        ));
+    }
+
+    #[test]
+    fn test_folding_brace_in_call_prefix_arg() {
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+call(foo, {
+  1
+})
+"
+        ));
+    }
+
+    #[test]
+    fn test_folding_brace_in_call_prefix_postfix_args() {
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+call(foo, {
+  1
+},
+bar)
+"
+        ));
+    }
+
     // Test for nested, complex code structures
     #[test]
     fn test_folding_complex_nested() {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call.snap
@@ -22,7 +22,7 @@ expression: "test_folding_range(\"\ncall({\n  1\n})\n\")"
         ),
         end_line: 3,
         end_character: Some(
-            0,
+            1,
         ),
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\ncall({\n  1\n})\n\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            6,
+        ),
+        end_line: 2,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            5,
+        ),
+        end_line: 3,
+        end_character: Some(
+            0,
+        ),
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_arg.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_arg.snap
@@ -22,7 +22,7 @@ expression: "test_folding_range(\"\ncall(foo, {\n  1\n})\n\")"
         ),
         end_line: 3,
         end_character: Some(
-            0,
+            1,
         ),
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_arg.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_arg.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\ncall(foo, {\n  1\n})\n\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            11,
+        ),
+        end_line: 2,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            5,
+        ),
+        end_line: 3,
+        end_character: Some(
+            0,
+        ),
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_postfix_args.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_postfix_args.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\ncall(foo, {\n  1\n},\nbar)\n\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            11,
+        ),
+        end_line: 2,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            5,
+        ),
+        end_line: 4,
+        end_character: Some(
+            2,
+        ),
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_postfix_args.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_brace_in_call_prefix_postfix_args.snap
@@ -22,7 +22,7 @@ expression: "test_folding_range(\"\ncall(foo, {\n  1\n},\nbar)\n\")"
         ),
         end_line: 4,
         end_character: Some(
-            2,
+            3,
         ),
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_empty_sections.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_empty_sections.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n# Empty section ----\n\n# Another empty sect
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 1,
+        end_line: 2,
         end_character: None,
         kind: Some(
             Region,
@@ -16,7 +16,7 @@ expression: "test_folding_range(\"\n# Empty section ----\n\n# Another empty sect
     FoldingRange {
         start_line: 3,
         start_character: None,
-        end_line: 3,
+        end_line: 4,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_empty_sections.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_empty_sections.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\n# Empty section ----\n\n# Another empty section ----\n\n# Section with content ----\nThis one has content\")"
+expression: "test_folding_range(\"\n# Empty section ----\n\n# Another empty section ----\n\n# Section with content ----\na\")"
 ---
 [
     FoldingRange {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
@@ -48,7 +48,7 @@ expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #reg
     FoldingRange {
         start_line: 9,
         start_character: None,
-        end_line: 13,
+        end_line: 11,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_mixed.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #reg
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 10,
+        end_line: 11,
         end_character: None,
         kind: Some(
             Region,
@@ -38,7 +38,7 @@ expression: "test_folding_range(\"\n# First section ----\nfunction() {\n  # #reg
     FoldingRange {
         start_line: 8,
         start_character: None,
-        end_line: 10,
+        end_line: 11,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_nested_section_comments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_nested_section_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\n# Level 1 ----\ncode at level 1\n\n## Level 2 ----\ncode at level 2\n\n### Level 3 ----\ncode at level 3\n\n## Another Level 2 ----\nback to level 2\n\n# Back to Level 1 ----\nback to level 1\")"
+expression: "test_folding_range(\"\n# Level 1 ----\na\n\n## Level 2 ----\nb\n\n### Level 3 ----\nc\n\n## Another Level 2 ----\nd\n\n# Back to Level 1 ----\ne\n\n# %% Chunk at Level 1\nf\n\n## %% Another chunk at Level 1\ng\")"
 ---
 [
     FoldingRange {
@@ -46,7 +46,27 @@ expression: "test_folding_range(\"\n# Level 1 ----\ncode at level 1\n\n## Level 
     FoldingRange {
         start_line: 13,
         start_character: None,
-        end_line: 13,
+        end_line: 19,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 16,
+        start_character: None,
+        end_line: 18,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 19,
+        start_character: None,
+        end_line: 20,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_nested_section_comments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_nested_section_comments.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n# Level 1 ----\na\n\n## Level 2 ----\nb\n\n#
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 11,
+        end_line: 12,
         end_character: None,
         kind: Some(
             Region,
@@ -16,7 +16,7 @@ expression: "test_folding_range(\"\n# Level 1 ----\na\n\n## Level 2 ----\nb\n\n#
     FoldingRange {
         start_line: 4,
         start_character: None,
-        end_line: 8,
+        end_line: 9,
         end_character: None,
         kind: Some(
             Region,
@@ -26,7 +26,7 @@ expression: "test_folding_range(\"\n# Level 1 ----\na\n\n## Level 2 ----\nb\n\n#
     FoldingRange {
         start_line: 7,
         start_character: None,
-        end_line: 8,
+        end_line: 9,
         end_character: None,
         kind: Some(
             Region,
@@ -36,7 +36,7 @@ expression: "test_folding_range(\"\n# Level 1 ----\na\n\n## Level 2 ----\nb\n\n#
     FoldingRange {
         start_line: 10,
         start_character: None,
-        end_line: 11,
+        end_line: 12,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_section_in_middle.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_section_in_middle.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n#+ Cell\na\n\n# Section ----\nb\n\n#+ Other cell\nc\n\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 4,
+        start_character: None,
+        end_line: 8,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 7,
+        start_character: None,
+        end_line: 8,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_section_in_middle.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_section_in_middle.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n#+ Cell\na\n\n# Section ----\nb\n\n#+ Other 
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 6,
+        end_line: 3,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_sections.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_sections.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n# Section ----\na\n\n#+ Cell\nb\n\n# Section
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 5,
+        end_line: 6,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_sections.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_chunks_with_sections.snap
@@ -1,0 +1,46 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n# Section ----\na\n\n#+ Cell\nb\n\n# Section ----\nc\n\n#+ Other cell\nd\n\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: None,
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 4,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 7,
+        start_character: None,
+        end_line: 11,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 10,
+        start_character: None,
+        end_line: 11,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n# Section ----\na\n\nb\nc\n\n# Section ----\
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 5,
+        end_line: 6,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\n# First section ----\na\nb\n\n## Nested section ----\nc\n\n# Another section ----\nd\")"
+expression: "test_folding_range(\"\n# Section ----\na\n\nb\nc\n\n# Section ----\nd\n\")"
 ---
 [
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 6,
+        end_line: 5,
         end_character: None,
         kind: Some(
             Region,
@@ -14,17 +14,7 @@ expression: "test_folding_range(\"\n# First section ----\na\nb\n\n## Nested sect
         collapsed_text: None,
     },
     FoldingRange {
-        start_line: 5,
-        start_character: None,
-        end_line: 6,
-        end_character: None,
-        kind: Some(
-            Region,
-        ),
-        collapsed_text: None,
-    },
-    FoldingRange {
-        start_line: 8,
+        start_line: 7,
         start_character: None,
         end_line: 8,
         end_character: None,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments_basic.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments_basic.snap
@@ -6,7 +6,7 @@ expression: "test_folding_range(\"\n# First section ----\na\nb\n\n# Second secti
     FoldingRange {
         start_line: 1,
         start_character: None,
-        end_line: 3,
+        end_line: 4,
         end_character: None,
         kind: Some(
             Region,

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments_basic.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__folding_section_comments_basic.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/folding_range.rs
-expression: "test_folding_range(\"\n# First section ----\nsome code here\nmore code\n\n# Second section ----\nother code\nfinal line\")"
+expression: "test_folding_range(\"\n# First section ----\na\nb\n\n# Second section ----\nc\nd\n\n# %% Chunk section (jupyter-style)\ne\nf\n\n#+ Chunk section (knitr-style)\ng\n# + This is not a chunk\nh\")"
 ---
 [
     FoldingRange {
@@ -16,7 +16,27 @@ expression: "test_folding_range(\"\n# First section ----\nsome code here\nmore c
     FoldingRange {
         start_line: 5,
         start_character: None,
-        end_line: 6,
+        end_line: 15,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 9,
+        start_character: None,
+        end_line: 12,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 13,
+        start_character: None,
+        end_line: 16,
         end_character: None,
         kind: Some(
             Region,


### PR DESCRIPTION
Follow up to #815.

- Fix detection of code chunks. `# %%` are now supported, `# +` is no longer recognised as chunk.
- Remove unwraps for safety.
- Fix end range of comment sections. They now extend up to the next section, including empty lines. Important because chunks do the same and they need to be nested in the comment sections. Otherwise the frontend is confused and removes the ranges that don't match its expectations.