### PR TITLE
Fix perf issues with folding ranges

### DIFF
--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -201,8 +201,9 @@ fn get_line_text(
 fn count_leading_whitespaces(document: &Document, line_num: usize) -> usize {
     let line_text = get_line_text(document, line_num, None, None);
     line_text
-        .chars()
-        .take_while(|c| *c == ' ' || *c == '\t')
+        .as_bytes()
+        .iter()
+        .take_while(|&&b| b == b' ' || b == b'\t')
         .count()
 }
 

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -19,14 +19,7 @@ use crate::lsp::documents::Document;
 pub fn folding_range(document: &Document) -> anyhow::Result<Vec<FoldingRange>> {
     let mut folding_ranges: Vec<FoldingRange> = Vec::new();
 
-    // Activate the parser
-    let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&tree_sitter_r::LANGUAGE.into())
-        .unwrap();
-
-    let ast = parser.parse(&document.contents.to_string(), None).unwrap();
-
+    let ast = &document.ast;
     if ast.root_node().has_error() {
         tracing::error!("Folding range service: Parse error");
         return Err(anyhow::anyhow!("Parse error"));


### PR DESCRIPTION
And fix a `tracing::error` message that showed up a ton of times in `ark:namespace:base.R`.

@kv9898 The algorithm was making a copy of the whole document split across n lines each time it materialised a line. Sorry I didn't see that while first reviewing.

Because of this, the folding range method took about 45s in the base namespace (try `debug(data.frame); data.frame()` to pop it up). Now back to 70ms.

Note that the folding range request takes a while to come in. I think the frontend also struggles with this large file.