### PR TITLE
Add a note about polled events and the later package

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -825,7 +825,8 @@ impl RMain {
 
         // Process R's polled events regularly while waiting for console input.
         // We used to poll every 200ms but that lead to visible delays for the
-        // processing of plot events.
+        // processing of plot events, it also slowed down callbacks from the later
+        // package. 50ms seems to be more in line with RStudio (posit-dev/positron#7235).
         let polled_events_rx = crossbeam::channel::tick(Duration::from_millis(50));
 
         let r_request_index = select.recv(&r_request_rx);

--- a/crates/ark/src/sys/unix/interface.rs
+++ b/crates/ark/src/sys/unix/interface.rs
@@ -108,6 +108,10 @@ pub fn run_activity_handlers() {
         //
         // We run this in a loop just to make sure the R help server can
         // be as responsive as possible when rendering help pages.
+        //
+        // Note that the later package also adds an input handler to `R_InputHandlers`
+        // which runs the later event loop, so it's also important that we are fairly
+        // responsive for that as well (posit-dev/positron#7235).
         let mut fdset = R_checkActivity(0, 1);
 
         while fdset != std::ptr::null_mut() {


### PR DESCRIPTION
Documenting that switching from 200ms to 50ms helped with https://github.com/posit-dev/positron/issues/7235

We did the switch in this commit https://github.com/posit-dev/ark/commit/452b84f459bf8777da3f03c1c6cd2ce0aec71fb2