### PR TITLE
Support graphics engine version 17

### DIFF
--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -723,6 +723,10 @@ macro_rules! with_device {
             let $ge_name = $ge_value as *mut libr::GEDevDescVersion16;
             let $name = (*$ge_name).dev;
             $block;
+        } else if version == 17 {
+            let $ge_name = $ge_value as *mut libr::GEDevDescVersion17;
+            let $name = (*$ge_name).dev;
+            $block;
         } else {
             panic!(
                 "R graphics engine version {} is not supported by this version of Positron.",

--- a/crates/libr/src/graphics.rs
+++ b/crates/libr/src/graphics.rs
@@ -1,7 +1,7 @@
 //
 // graphics.rs
 //
-// Copyright (C) 2024 by Posit Software, PBC
+// Copyright (C) 2025 by Posit Software, PBC
 //
 //
 
@@ -118,6 +118,21 @@ pub struct GEDevDescVersion15 {
 #[repr(C)]
 pub struct GEDevDescVersion16 {
     pub dev: pDevDescVersion16,
+    pub displayListOn: Rboolean,
+    pub displayList: SEXP,
+    pub DLlastElt: SEXP,
+    pub savedSnapshot: SEXP,
+    pub dirty: Rboolean,
+    pub recordGraphics: Rboolean,
+    pub gesd: [*mut GESystemDesc; 24usize],
+    pub ask: Rboolean,
+    pub appending: Rboolean,
+}
+
+// Graphics Engine Wrapper version 17 (R 4.6.0)
+#[repr(C)]
+pub struct GEDevDescVersion17 {
+    pub dev: pDevDescVersion17,
     pub displayListOn: Rboolean,
     pub displayList: SEXP,
     pub DLlastElt: SEXP,
@@ -969,3 +984,238 @@ pub struct DevDescVersion16 {
     pub reserved: [std::ffi::c_char; 64usize],
 }
 pub type pDevDescVersion16 = *mut DevDescVersion16;
+
+// Graphics Engine version 17 (R 4.6.0)
+#[repr(C)]
+pub struct DevDescVersion17 {
+    pub left: f64,
+    pub right: f64,
+    pub bottom: f64,
+    pub top: f64,
+    pub clipLeft: f64,
+    pub clipRight: f64,
+    pub clipBottom: f64,
+    pub clipTop: f64,
+    pub xCharOffset: f64,
+    pub yCharOffset: f64,
+    pub yLineBias: f64,
+    pub ipr: [f64; 2usize],
+    pub cra: [f64; 2usize],
+    pub gamma: f64,
+    pub canClip: Rboolean,
+    pub canChangeGamma: Rboolean,
+    pub canHAdj: std::ffi::c_int,
+    pub startps: f64,
+    pub startcol: std::ffi::c_int,
+    pub startfill: std::ffi::c_int,
+    pub startlty: std::ffi::c_int,
+    pub startfont: std::ffi::c_int,
+    pub startgamma: f64,
+    pub deviceSpecific: *mut std::ffi::c_void,
+    pub displayListOn: Rboolean,
+    pub canGenMouseDown: Rboolean,
+    pub canGenMouseMove: Rboolean,
+    pub canGenMouseUp: Rboolean,
+    pub canGenKeybd: Rboolean,
+    pub canGenIdle: Rboolean,
+    pub gettingEvent: Rboolean,
+    pub activate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub circle:
+        Option<unsafe extern "C-unwind" fn(x: f64, y: f64, r: f64, gc: pGEcontext, dd: pDevDesc)>,
+    pub clip: Option<unsafe extern "C-unwind" fn(x0: f64, x1: f64, y0: f64, y1: f64, dd: pDevDesc)>,
+    pub close: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub deactivate: Option<unsafe extern "C-unwind" fn(arg1: pDevDesc)>,
+    pub locator:
+        Option<unsafe extern "C-unwind" fn(x: *mut f64, y: *mut f64, dd: pDevDesc) -> Rboolean>,
+    pub line: Option<
+        unsafe extern "C-unwind" fn(
+            x1: f64,
+            y1: f64,
+            x2: f64,
+            y2: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub metricInfo: Option<
+        unsafe extern "C-unwind" fn(
+            c: std::ffi::c_int,
+            gc: pGEcontext,
+            ascent: *mut f64,
+            descent: *mut f64,
+            width: *mut f64,
+            dd: pDevDesc,
+        ),
+    >,
+    pub mode: Option<unsafe extern "C-unwind" fn(mode: std::ffi::c_int, dd: pDevDesc)>,
+    pub newPage: Option<unsafe extern "C-unwind" fn(gc: pGEcontext, dd: pDevDesc)>,
+    pub polygon: Option<
+        unsafe extern "C-unwind" fn(
+            n: std::ffi::c_int,
+            x: *mut f64,
+            y: *mut f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub polyline: Option<
+        unsafe extern "C-unwind" fn(
+            n: std::ffi::c_int,
+            x: *mut f64,
+            y: *mut f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub rect: Option<
+        unsafe extern "C-unwind" fn(
+            x0: f64,
+            y0: f64,
+            x1: f64,
+            y1: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub path: Option<
+        unsafe extern "C-unwind" fn(
+            x: *mut f64,
+            y: *mut f64,
+            npoly: std::ffi::c_int,
+            nper: *mut std::ffi::c_int,
+            winding: Rboolean,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub raster: Option<
+        unsafe extern "C-unwind" fn(
+            raster: *mut std::ffi::c_uint,
+            w: std::ffi::c_int,
+            h: std::ffi::c_int,
+            x: f64,
+            y: f64,
+            width: f64,
+            height: f64,
+            rot: f64,
+            interpolate: Rboolean,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub cap: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> SEXP>,
+    pub size: Option<
+        unsafe extern "C-unwind" fn(
+            left: *mut f64,
+            right: *mut f64,
+            bottom: *mut f64,
+            top: *mut f64,
+            dd: pDevDesc,
+        ),
+    >,
+    pub strWidth: Option<
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
+    >,
+    pub text: Option<
+        unsafe extern "C-unwind" fn(
+            x: f64,
+            y: f64,
+            str: *const std::ffi::c_char,
+            rot: f64,
+            hadj: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub onExit: Option<unsafe extern "C-unwind" fn(dd: pDevDesc)>,
+    pub getEvent:
+        Option<unsafe extern "C-unwind" fn(arg1: SEXP, arg2: *const std::ffi::c_char) -> SEXP>,
+    pub newFrameConfirm: Option<unsafe extern "C-unwind" fn(dd: pDevDesc) -> Rboolean>,
+    pub hasTextUTF8: Rboolean,
+    pub textUTF8: Option<
+        unsafe extern "C-unwind" fn(
+            x: f64,
+            y: f64,
+            str: *const std::ffi::c_char,
+            rot: f64,
+            hadj: f64,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub strWidthUTF8: Option<
+        unsafe extern "C-unwind" fn(
+            str: *const std::ffi::c_char,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ) -> f64,
+    >,
+    pub wantSymbolUTF8: Rboolean,
+    pub useRotatedTextInContour: Rboolean,
+    pub eventEnv: SEXP,
+    pub eventHelper: Option<unsafe extern "C-unwind" fn(dd: pDevDesc, code: std::ffi::c_int)>,
+    pub holdflush: Option<
+        unsafe extern "C-unwind" fn(dd: pDevDesc, level: std::ffi::c_int) -> std::ffi::c_int,
+    >,
+    pub haveTransparency: std::ffi::c_int,
+    pub haveTransparentBg: std::ffi::c_int,
+    pub haveRaster: std::ffi::c_int,
+    pub haveCapture: std::ffi::c_int,
+    pub haveLocator: std::ffi::c_int,
+    pub setPattern: Option<unsafe extern "C-unwind" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releasePattern: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setClipPath:
+        Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseClipPath: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub setMask: Option<unsafe extern "C-unwind" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
+    pub releaseMask: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub deviceVersion: std::ffi::c_int,
+    pub deviceClip: Rboolean,
+    pub defineGroup: Option<
+        unsafe extern "C-unwind" fn(
+            source: SEXP,
+            op: std::ffi::c_int,
+            destination: SEXP,
+            dd: pDevDesc,
+        ) -> SEXP,
+    >,
+    pub useGroup: Option<unsafe extern "C-unwind" fn(ref_: SEXP, trans: SEXP, dd: pDevDesc)>,
+    pub releaseGroup: Option<unsafe extern "C-unwind" fn(ref_: SEXP, dd: pDevDesc)>,
+    pub stroke: Option<unsafe extern "C-unwind" fn(path: SEXP, gc: pGEcontext, dd: pDevDesc)>,
+    pub fill: Option<
+        unsafe extern "C-unwind" fn(
+            path: SEXP,
+            rule: std::ffi::c_int,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub fillStroke: Option<
+        unsafe extern "C-unwind" fn(
+            path: SEXP,
+            rule: std::ffi::c_int,
+            gc: pGEcontext,
+            dd: pDevDesc,
+        ),
+    >,
+    pub capabilities: Option<unsafe extern "C-unwind" fn(cap: SEXP) -> SEXP>,
+    pub glyph: Option<
+        unsafe extern "C-unwind" fn(
+            n: std::ffi::c_int,
+            glyphs: *mut std::ffi::c_int,
+            x: *mut f64,
+            y: *mut f64,
+            font: SEXP,
+            size: f64,
+            colour: std::ffi::c_int,
+            rot: f64,
+            dd: pDevDesc,
+        ),
+    >,
+    pub reserved: [std::ffi::c_char; 64usize],
+}
+pub type pDevDescVersion17 = *mut DevDescVersion17;


### PR DESCRIPTION
Closes #838 

Here is the R commit bumping to graphics engine 17:
https://github.com/wch/r-source/commit/a98d9f88c7f73e5f4da8209d9373bf4316ee2d10#diff-f28e48750631b022aa07416a102087eb10c48bbec71234002e20bc46c52599e9R2493

IIUC the changes really only come into play with the pre-existing `glyph()` callback, but no changes to its signature are required
https://github.com/wch/r-source/blob/4765fe9d29d89916db03d0f3552ce2df6fbea99f/src/include/R_ext/GraphicsDevice.h#L793-L795

i.e. in the R commit from above, you see in `cairoFns.c` that `Cairo_Glyph()` now does

```c
    /* Apply font variations, if any */
    int numVar = R_GE_glyphFontNumVar(font);
    if (numVar > 0) {
        applyFontVar(cairo_face, font, numVar, xd);
    }
```

Where `R_GE_glyphFontNumVar()` is a new C function from base R, and `applyFontVar()` is a new cairo helper, but `font` is the preexisting `SEXP` from the `glyph()` callback.

All of this means there is basically nothing to change on the ark side besides saying "we support this graphics version". We do that by:
- Copying and pasting `GEDevDescVersion16` -> `GEDevDescVersion17`
- Copying and pasting `DevDescVersion16` -> `DevDescVersion17`
- Copying and pasting `pDevDescVersion16` -> `pDevDescVersion17`
- Updating the `with_device!` macro with a version 17 branch

Here's a basic plot with R-devel that works now, previously it would crash R because it hit the `panic!` in `with_device!`:

<img width="805" alt="Screenshot 2025-06-12 at 9 54 31 AM" src="https://github.com/user-attachments/assets/d5386a22-3813-4c51-98a3-de63eddc2144" />

