### PR TITLE
Bugfix: folding ranges within brackets

### DIFF
--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -123,7 +123,7 @@ fn parse_ts_node(
         // End of node handling
         end_node_handler(
             folding_ranges,
-            end.row + 1,
+            if _depth == 0 { end.row + 1 } else { end.row },
             &mut child_comment_stack,
             &mut child_region_marker,
             &mut child_cell_marker,

--- a/crates/ark/src/lsp/folding_range.rs
+++ b/crates/ark/src/lsp/folding_range.rs
@@ -742,4 +742,18 @@ function() {
         assert_eq!(count_leading_whitespaces(&doc, 2), 4);
         assert_eq!(count_leading_whitespaces(&doc, 3), 1); // Tab counts as 1 char
     }
+
+    #[test]
+    fn test_nested_sibling_levels() {
+        insta::assert_debug_snapshot!(test_folding_range(
+            "
+{
+    # level 1 ####
+    1
+    # another level 1 ####
+    2
+}
+"
+        ));
+    }
 }

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__nested_sibling_levels.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__nested_sibling_levels.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ark/src/lsp/folding_range.rs
+expression: "test_folding_range(\"\n{\n    # level 1 ####\n    1\n    # another level 1 ####\n    2\n}\n\")"
+---
+[
+    FoldingRange {
+        start_line: 1,
+        start_character: Some(
+            1,
+        ),
+        end_line: 5,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 2,
+        start_character: None,
+        end_line: 3,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+    FoldingRange {
+        start_line: 4,
+        start_character: None,
+        end_line: 6,
+        end_character: None,
+        kind: Some(
+            Region,
+        ),
+        collapsed_text: None,
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__nested_sibling_levels.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__folding_range__tests__nested_sibling_levels.snap
@@ -28,7 +28,7 @@ expression: "test_folding_range(\"\n{\n    # level 1 ####\n    1\n    # another 
     FoldingRange {
         start_line: 4,
         start_character: None,
-        end_line: 6,
+        end_line: 5,
         end_character: None,
         kind: Some(
             Region,


### PR DESCRIPTION
This partly addresses https://github.com/posit-dev/positron/issues/8059, where folding ranges within brackets do not work normally.

Before this fix, code such as:
```r
foo <- function(
  x = "}"
) {
  # inside level 1 ####
  b = 2
  b <- b |> # indentations should also be folded
    summary()
  # another level 1 ####
  hi <- 2
}
```
would see only the first comment section folded properly, but not the second one. After this fix, both would be folded.