### PR TITLE
Use up to date rustc-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3450ed37fe9609abb6bc3b8891b6e078404e4c53c7332350e2e15126a95229bf"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -60,7 +60,7 @@ futures = "0.3.30"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-appender = "0.2.3"
-rustc-hash = "1.2.0"
+rustc-hash = "2.1.1"
 tracing-error = "0.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
@jennybc noted that 1.2.0 is yanked

https://github.com/rust-lang/rustc-hash/blob/master/CHANGELOG.md