### PR TITLE
Support functions in `View()`

### DIFF
--- a/crates/amalthea/src/comm/variables_comm.rs
+++ b/crates/amalthea/src/comm/variables_comm.rs
@@ -295,7 +295,7 @@ pub enum VariablesBackendReply {
 	ClipboardFormatReply(FormattedVariable),
 
 	/// The ID of the viewer that was opened.
-	ViewReply(String),
+	ViewReply(Option<String>),
 
 }
 

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -2004,7 +2004,13 @@ impl RMain {
         }
     }
 
+    pub fn has_virtual_document(&self, uri: &String) -> bool {
+        self.lsp_virtual_documents.contains_key(uri)
+    }
+
     pub fn insert_virtual_document(&mut self, uri: String, contents: String) {
+        log::trace!("Inserting vdoc for `{uri}`");
+
         // Strip scheme if any. We're only storing the path.
         let uri = uri.strip_prefix("ark:").unwrap_or(&uri).to_string();
 

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -2004,10 +2004,6 @@ impl RMain {
         }
     }
 
-    pub fn has_virtual_document(&self, uri: &String) -> bool {
-        self.lsp_virtual_documents.contains_key(uri)
-    }
-
     pub fn insert_virtual_document(&mut self, uri: String, contents: String) {
         log::trace!("Inserting vdoc for `{uri}`");
 
@@ -2024,6 +2020,11 @@ impl RMain {
         self.send_lsp_notification(KernelNotification::DidOpenVirtualDocument(
             DidOpenVirtualDocumentParams { uri, contents },
         ))
+    }
+
+    pub fn has_virtual_document(&self, uri: &String) -> bool {
+        let uri = uri.strip_prefix("ark:").unwrap_or(&uri).to_string();
+        self.lsp_virtual_documents.contains_key(&uri)
     }
 
     pub fn call_frontend_method(&self, request: UiFrontendRequest) -> anyhow::Result<RObject> {

--- a/crates/ark/src/lib.rs
+++ b/crates/ark/src/lib.rs
@@ -43,6 +43,7 @@ pub mod treesitter;
 pub mod ui;
 pub mod variables;
 pub mod version;
+pub mod view;
 pub mod viewer;
 
 pub(crate) use r_task::r_task;

--- a/crates/ark/src/modules/positron/frontend-methods.R
+++ b/crates/ark/src/modules/positron/frontend-methods.R
@@ -35,10 +35,22 @@
 #' @export
 .ps.ui.navigateToFile <- function(
     file = character(0),
-    line = -1L,
-    column = -1L
+    line = 0L,
+    column = 0L
 ) {
-    file <- normalizePath(file)
+    # Don't normalize if there's a scheme, e.g. an `ark:` URI
+    if (!grepl("^[a-zA-Z][a-zA-Z0-9+.-]*:", file)) {
+        file <- normalizePath(file)
+    }
+
+    # Convert `-1L` for compatibility with RStudioAPI
+    if (line < 0L) {
+        line <- 0L
+    }
+    if (column < 0L) {
+        column <- 0L
+    }
+
     .ps.Call("ps_ui_navigate_to_file", file, line, column)
 }
 

--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -6,7 +6,7 @@
 #
 
 register_hooks <- function() {
-    rebind("utils", "View", .ps.view_data_frame, namespace = TRUE)
+    rebind("utils", "View", view, namespace = TRUE)
     rebind("base", "debug", new_ark_debug(base::debug), namespace = TRUE)
     rebind(
         "base",

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -5,35 +5,13 @@
 #
 #
 
-#' @export
-.ps.view_data_frame <- function(x, title) {
-    # Derive the name of the object from the expression passed to View()
-    object_name <- .ps.as_label(substitute(x))
-
-    # Create a title from the name of the object if one is not provided
-    if (missing(title)) {
-        title <- object_name
-    }
-
-    stopifnot(
-        is.data.frame(x) || is.matrix(x),
-        is.character(title) && length(title) == 1L && !is.na(title)
-    )
-
-    # If the variable is defined in the parent frame using the same name as was
-    # passed to View(), we can watch it for updates.
-    #
-    # Note that this means that (for example) View(foo) will watch the variable
-    # foo in the parent frame, but Viewing temporary variables like
-    # View(cbind(foo, bar)) does not create something that can be watched.
-    var <- ""
-    env <- NULL
-    if (isTRUE(exists(object_name, envir = parent.frame(), inherits = FALSE))) {
-        var <- object_name
-        env <- parent.frame()
-    }
-
+view_data_frame <- function(x, title, var, env) {
+    stopifnot(is_viewable_data_frame(x))
     invisible(.ps.Call("ps_view_data_frame", x, title, var, env))
+}
+
+is_viewable_data_frame <- function(x) {
+    is.data.frame(x) || is.matrix(x)
 }
 
 .ps.null_count <- function(column) {

--- a/crates/ark/src/modules/positron/srcref.R
+++ b/crates/ark/src/modules/positron/srcref.R
@@ -83,3 +83,65 @@ do_resource_namespaces <- function(default) {
 resource_namespaces <- function(pkgs) {
     .ps.Call("ps_resource_namespaces", pkgs)
 }
+
+srcref_info <- function(srcref) {
+    srcfile <- attr(srcref, "srcfile")
+    if (is.null(srcfile)) {
+        return(NULL)
+    }
+
+    # If the file name is missing but there is a `srcref`, then we can try to use
+    # the `lines` to reconstruct a fake source file that `srcref` can point into.
+    # This is used when debugging user functions that are entered directly into the console,
+    # and for functions parsed with `parse(text = <text>, keep.source = TRUE)`.
+    file <- srcfile$filename
+    lines <- srcfile$lines
+
+    if (!identical(file, "") && !identical(file, "<text>")) {
+        # TODO: Handle absolute paths by using `wd`
+        file <- normalizePath(file, mustWork = FALSE)
+        content <- NULL
+    } else if (!is.null(lines)) {
+        file <- NULL
+        content <- paste0(lines, collapse = "\n")
+    } else {
+        return(NULL)
+    }
+
+    range <- srcref_to_range(srcref)
+
+    list(
+        file = file,
+        content = content,
+        range = range
+    )
+}
+
+srcref_to_range <- function(x) {
+    n <- length(x)
+
+    # The first and third fields are sensitive to #line directives if they exist,
+    # which we want to honour in order to jump to original files
+    # rather than generated files.
+    loc_start_line <- 1L
+    loc_end_line <- 3L
+
+    # We need the `column` value rather than the `byte` value, so we
+    # can index into a character. However the srcref documentation
+    # allows a 4 elements vector when the bytes and column values are
+    # the same. We account for this here.
+    if (n >= 6) {
+        loc_start_column <- 5L
+        loc_end_column <- 6L
+    } else {
+        loc_start_column <- 2L
+        loc_end_column <- 4L
+    }
+
+    list(
+        start_line = x[[loc_start_line]],
+        start_column = x[[loc_start_column]],
+        end_line = x[[loc_end_line]],
+        end_column = x[[loc_end_column]]
+    )
+}

--- a/crates/ark/src/modules/positron/srcref.R
+++ b/crates/ark/src/modules/positron/srcref.R
@@ -1,8 +1,23 @@
-# For debugging from R
+# Populate source references right there and then instead of at idle time. Used
+# for `View()` when called from top-level. Also useful for debugging from R. Be
+# careful with this one because it produces session-wide side effects that
+# mutate source references for all functions in the given namespace. This could
+# invalidate reasonable assumptions made by currently running code.
 ns_populate_srcref <- function(ns_name) {
     loadNamespace(ns_name)
     .ps.Call("ps_ns_populate_srcref", ns_name)
 }
+
+fn_populate_srcref <- function(fn) {
+    fn_env <- topenv(environment(fn))
+    if (!isNamespace(fn_env)) {
+        return()
+    }
+
+    pkg <- getNamespaceName(fn_env)
+    ns_populate_srcref(pkg)
+}
+
 
 # Called from Rust
 reparse_with_srcref <- function(x, name, uri, line) {

--- a/crates/ark/src/modules/positron/srcref.R
+++ b/crates/ark/src/modules/positron/srcref.R
@@ -8,14 +8,19 @@ ns_populate_srcref <- function(ns_name) {
     .ps.Call("ps_ns_populate_srcref", ns_name)
 }
 
-fn_populate_srcref <- function(fn) {
+ns_populate_srcref_without_vdoc_insertion <- function(ns_name) {
+    loadNamespace(ns_name)
+    .ps.Call("ps_ns_populate_srcref_without_vdoc_insertion", ns_name)
+}
+
+fn_populate_srcref_without_vdoc_insertion <- function(fn) {
     fn_env <- topenv(environment(fn))
     if (!isNamespace(fn_env)) {
-        return()
+        return(NULL)
     }
 
     pkg <- getNamespaceName(fn_env)
-    ns_populate_srcref(pkg)
+    ns_populate_srcref_without_vdoc_insertion(pkg)
 }
 
 

--- a/crates/ark/src/modules/positron/tools.R
+++ b/crates/ark/src/modules/positron/tools.R
@@ -127,10 +127,6 @@ push_rds <- function(x, path = NULL, context = "") {
     xs
 }
 
-is_string <- function(x) {
-    is.character(x) && length(x) == 1 && !is.na(x)
-}
-
 local_options <- function(..., .frame = parent.frame()) {
     options <- list(...)
     old <- options(options)

--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -63,8 +63,7 @@
 }
 
 # Extracts a character label from a syntactically valid quoted R expression
-#' @export
-.ps.as_label <- function(expr) {
+as_label <- function(expr) {
     paste(deparse(expr, backtick = TRUE), collapse = "")
 }
 

--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -144,3 +144,11 @@ is_string <- function(x) {
 is_http_url <- function(x) {
     is_string(x) && grepl("^https?://", x)
 }
+
+obj_address <- function(x) {
+    .ps.Call("ps_obj_address", x)
+}
+
+paste_line <- function(x) {
+    paste(x, collapse = "\n")
+}

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -33,8 +33,30 @@ view <- function(x, title) {
         return(view_data_frame(x, title, var, env))
     }
 
+    if (is.function(x)) {
+        return(view_function(x, title, var, env))
+    }
+
     stop(sprintf(
         "Can't `View()` an object of class `%s`",
         paste(class(x), collapse = "/")
     ))
+}
+
+view_function <- function(x, title, var, env) {
+    stopifnot(is.function(x))
+
+    info <- srcref_info(attr(x, "srcref"))
+
+    if (!is.null(info) && is_string(info$file) && file.exists(info$file)) {
+        # Request frontend to display file
+        .ps.ui.navigateToFile(
+            info$file,
+            info$range$start_line,
+            info$range$start_column
+        )
+        return(invisible())
+    }
+
+    print(x)
 }

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -1,0 +1,40 @@
+#
+# view.R
+#
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+#
+#
+
+view <- function(x, title) {
+    # Derive the name of the object from the expression passed to View()
+    name <- as_label(substitute(x))
+
+    # Create a title from the name of the object if one is not provided
+    if (missing(title)) {
+        title <- name
+    }
+    stopifnot(is_string(title))
+
+    # If the variable is defined in the parent frame using the same name as was
+    # passed to View(), we can watch it for updates.
+    #
+    # Note that this means that (for example) View(foo) will watch the variable
+    # foo in the parent frame, but Viewing temporary variables like
+    # View(cbind(foo, bar)) does not create something that can be watched.
+    if (isTRUE(exists(name, envir = parent.frame(), inherits = FALSE))) {
+        var <- name
+        env <- parent.frame()
+    } else {
+        var <- ""
+        env <- NULL
+    }
+
+    if (is_viewable_data_frame(x)) {
+        return(view_data_frame(x, title, var, env))
+    }
+
+    stop(sprintf(
+        "Can't `View()` an object of class `%s`",
+        paste(class(x), collapse = "/")
+    ))
+}

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -9,9 +9,10 @@
 # These are only passed if we could infer a variable name from the input and if
 # that variable exists in the calling environment. This is used for live
 # updating the objects, if supported (e.g. data frames in the data viewer).
-view <- function(x, title) {
+view <- function(x, title, name = NULL, env = parent.frame()) {
     # Derive the name of the object from the expression passed to View()
-    name <- as_label(substitute(x))
+    name <- name %||% as_label(substitute(x))
+    stopifnot(is_string(name))
 
     # Create a title from the name of the object if one is not provided
     if (missing(title)) {
@@ -25,9 +26,8 @@ view <- function(x, title) {
     # Note that this means that (for example) View(foo) will watch the variable
     # foo in the parent frame, but Viewing temporary variables like
     # View(cbind(foo, bar)) does not create something that can be watched.
-    if (isTRUE(exists(name, envir = parent.frame(), inherits = FALSE))) {
+    if (nzchar(name) && isTRUE(exists(name, envir = env, inherits = FALSE))) {
         var <- name
-        env <- parent.frame()
     } else {
         var <- ""
         env <- NULL

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -98,6 +98,11 @@ view_function_info <- function(
 ) {
     stopifnot(is.function(x))
 
+    # Extract original function if `x` has been `trace()`d
+    if (inherits(x, "functionWithTrace") && is.function(x@original)) {
+        x <- x@original
+    }
+
     # Only resource the namespace if we're at top-level. Doing it while
     # arbitrary code is running is unsafe as the source references are mutated
     # globally. The mutation could invalidate assumptions made by running code.

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -63,7 +63,7 @@ view_function <- function(x, title, var, env, top_level = FALSE) {
             return(invisible())
         }
 
-        if (file.exists(info$file)) {
+        if (is_virtual_file(info$file) || file.exists(info$file)) {
             # Request frontend to display file
             .ps.ui.navigateToFile(
                 info$file,
@@ -88,6 +88,10 @@ view_function <- function(x, title, var, env, top_level = FALSE) {
     .ps.ui.newDocument(contents, "r")
 
     return(invisible())
+}
+
+is_virtual_file <- function(path) {
+    startsWith(path, "ark:")
 }
 
 paste_line <- function(x) {

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -5,6 +5,10 @@
 #
 #
 
+# Dispatches to object handlers. The handlers take `var` and `env` arguments.
+# These are only passed if we could infer a variable name from the input and if
+# that variable exists in the calling environment. This is used for live
+# updating the objects, if supported (e.g. data frames in the data viewer).
 view <- function(x, title) {
     # Derive the name of the object from the expression passed to View()
     name <- as_label(substitute(x))
@@ -44,14 +48,68 @@ view <- function(x, title) {
     ))
 }
 
-view_function <- function(x, title, var = "", env = NULL, top_level = FALSE) {
+view_function <- function(
+    x,
+    title = "",
+    var = "",
+    env = NULL,
+    top_level = FALSE
+) {
+    stopifnot(is.function(x))
+
+    info <- view_function_info(
+        x,
+        title,
+        var = var,
+        env = env,
+        top_level = top_level
+    )
+
+    switch(
+        info$kind,
+
+        vdoc = {
+            insert_virtual_document(info$uri, info$contents)
+        },
+
+        srcref = {
+            # Only non-NULL if a new vdoc for a namespace was generated
+            if (!is.null(info$contents)) {
+                insert_virtual_document(info$uri, info$contents)
+            }
+        }
+    )
+
+    .ps.ui.navigateToFile(
+        info$uri,
+        line = info$line,
+        column = info$column
+    )
+
+    invisible()
+}
+
+view_function_info <- function(
+    x,
+    title = "",
+    var = "",
+    env = NULL,
+    top_level = FALSE
+) {
     stopifnot(is.function(x))
 
     # Only resource the namespace if we're at top-level. Doing it while
     # arbitrary code is running is unsafe as the source references are mutated
     # globally. The mutation could invalidate assumptions made by running code.
     if (top_level) {
-        fn_populate_srcref(x)
+        # `NULL` if srcref are already present or couldn't be generated
+        ns_srcref_info <- fn_populate_srcref_without_vdoc_insertion(x)
+
+        # Extract contents, if any from `list(uri, contents)`. Ideally would be
+        # a named list but currently inconvenient to do across FFI boundary.
+        ns_srcref_info <- ns_srcref_info[[2]]
+    } else {
+        ns_srcref_info <- NULL
     }
 
     # Get srcref _after_ potentially resourcing from a virtual namespace file
@@ -61,13 +119,13 @@ view_function <- function(x, title, var = "", env = NULL, top_level = FALSE) {
             !is.null(info$file) &&
             (is_ark_uri(info$file) || file.exists(info$file))
     ) {
-        # Request frontend to display file
-        .ps.ui.navigateToFile(
-            info$file,
-            info$range$start_line,
-            info$range$start_column
-        )
-        return(invisible())
+        return(list(
+            kind = "srcref",
+            uri = info$file,
+            contents = ns_srcref_info,
+            line = info$range$start_line,
+            column = info$range$start_column
+        ))
     }
 
     # We don't have a valid source reference to point to so we'll create a new
@@ -82,11 +140,7 @@ view_function <- function(x, title, var = "", env = NULL, top_level = FALSE) {
         contents <- paste_line(deparse(x))
     }
 
-    if (is.null(env)) {
-        env_name <- "unknown"
-    } else {
-        env_name <- .ps.env_name(env) %||% obj_address(env)
-    }
+    env_name <- .ps.env_name(env) %||% obj_address(env)
 
     if (!nzchar(var)) {
         var <- "unknown"
@@ -97,10 +151,31 @@ view_function <- function(x, title, var = "", env = NULL, top_level = FALSE) {
     # up correctly. Instead this could be fixed by sending the document to the
     # frontend and let it manage the lifetime of the virtual docs.
     uri <- ark_uri(sprintf("%s/%s.R", env_name, var))
-    insert_virtual_document(uri, contents)
 
-    .ps.ui.navigateToFile(uri)
-    invisible()
+    list(
+        kind = "vdoc",
+        uri = uri,
+        contents = contents,
+        line = 0L,
+        column = 0L
+    )
+}
+
+# For unit tests
+view_function_test <- function(x, var, env) {
+    info <- view_function_info(
+        x,
+        var = var,
+        env = env,
+        top_level = TRUE
+    )
+
+    paste_line(c(
+        sprintf("URI: %s", info$uri),
+        "",
+        # Expected to be `NULL` for srcref case
+        info$contents
+    ))
 }
 
 insert_virtual_document <- function(uri, contents) {
@@ -113,4 +188,8 @@ ark_uri <- function(path) {
 
 is_ark_uri <- function(path) {
     startsWith(path, "ark:")
+}
+
+ark_ns_uri <- function(path) {
+    .ps.Call("ps_ark_ns_uri", path)
 }

--- a/crates/ark/src/snapshots/ark__view__tests__view_function.snap
+++ b/crates/ark/src/snapshots/ark__view__tests__view_function.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ark/src/view.rs
+expression: doc
+---
+URI: ark:ark-*pid*/global/foo.R
+
+function (arg) 
+body

--- a/crates/ark/src/snapshots/ark__view__tests__view_function_local.snap
+++ b/crates/ark/src/snapshots/ark__view__tests__view_function_local.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ark/src/view.rs
+expression: doc
+---
+URI: ark:ark-*pid*/0x*address*/foo.R
+
+function (arg) 
+body

--- a/crates/ark/src/snapshots/ark__view__tests__view_function_namespace.snap
+++ b/crates/ark/src/snapshots/ark__view__tests__view_function_namespace.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ark/src/view.rs
+expression: doc
+---
+URI: ark:ark-*pid*/namespace/base.R

--- a/crates/ark/src/snapshots/ark__view__tests__view_function_trace.snap
+++ b/crates/ark/src/snapshots/ark__view__tests__view_function_trace.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ark/src/view.rs
+expression: doc
+---
+URI: ark:ark-*pid*/global/foo.R
+
+function (arg) 
+body

--- a/crates/ark/src/snapshots/ark__view__tests__view_function_unknown.snap
+++ b/crates/ark/src/snapshots/ark__view__tests__view_function_unknown.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ark/src/view.rs
+expression: doc
+---
+URI: ark:ark-*pid*/global/unknown.R
+
+function (arg) 
+body

--- a/crates/ark/src/srcref.rs
+++ b/crates/ark/src/srcref.rs
@@ -55,7 +55,8 @@ pub(crate) async fn ns_populate_srcref(ns_name: String) -> anyhow::Result<()> {
 
     let ns = r_ns_env(&ns_name)?;
 
-    let uri_path = format!("namespace:{ns_name}.R");
+    let id = std::process::id();
+    let uri_path = format!("ark-{id}/namespace/{ns_name}.R");
     let uri = format!("ark:{uri_path}");
 
     let mut vdoc: Vec<String> = vec![

--- a/crates/ark/src/srcref.rs
+++ b/crates/ark/src/srcref.rs
@@ -52,6 +52,7 @@ async fn ns_populate_srcref_without_vdoc_insertion(
     let span = tracing::trace_span!("ns_populate_srcref", ns = ns_name);
 
     // Don't redo the work if we already did it. We don't expect a namespace to change.
+    #[cfg(not(test))]
     if RMain::with(|main| main.has_virtual_document(&ark_ns_uri(&ns_name))) {
         return Ok(None);
     }

--- a/crates/ark/src/ui/events.rs
+++ b/crates/ark/src/ui/events.rs
@@ -60,13 +60,13 @@ pub unsafe extern "C-unwind" fn ps_ui_open_workspace(
 #[harp::register]
 pub unsafe extern "C-unwind" fn ps_ui_navigate_to_file(
     file: SEXP,
-    _line: SEXP,
-    _column: SEXP,
+    line: SEXP,
+    column: SEXP,
 ) -> anyhow::Result<SEXP> {
     let params = OpenEditorParams {
         file: RObject::view(file).try_into()?,
-        line: 0,
-        column: 0,
+        line: RObject::view(line).try_into()?,
+        column: RObject::view(column).try_into()?,
     };
 
     let event = UiFrontendEvent::OpenEditor(params);

--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -367,16 +367,16 @@ impl RVariables {
     /// Open a data viewer for the given variable.
     ///
     /// - `path`: The path to the variable to view, as an array of access keys
-    fn view(&mut self, path: &Vec<String>) -> Result<String, harp::error::Error> {
+    ///
+    /// Returns the ID of the comm managing the view, if any.
+    fn view(&mut self, path: &Vec<String>) -> Result<Option<String>, harp::error::Error> {
         r_task(|| {
             let env = self.env.get().clone();
             let obj = PositronVariable::resolve_data_object(env.clone(), &path)?;
 
             if r_is_function(obj.sexp) {
                 harp::as_result(view(&obj, &path, &env))?;
-
-                // Return a falsy `viewerId`. Should ideally be a more explicit `None`.
-                return Ok(String::from(""));
+                return Ok(None);
             }
 
             let name = unsafe { path.get_unchecked(path.len() - 1) };
@@ -392,7 +392,7 @@ impl RVariables {
                 Some(binding),
                 self.comm_manager_tx.clone(),
             )?;
-            Ok(viewer_id)
+            Ok(Some(viewer_id))
         })
     }
 

--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -29,6 +29,7 @@ use harp::exec::RFunctionExt;
 use harp::get_option;
 use harp::object::RObject;
 use harp::utils::r_assert_type;
+use harp::utils::r_is_function;
 use harp::vector::CharacterVector;
 use harp::vector::Vector;
 use libr::R_GlobalEnv;
@@ -42,6 +43,7 @@ use crate::lsp::events::EVENTS;
 use crate::r_task;
 use crate::thread::RThreadSafe;
 use crate::variables::variable::PositronVariable;
+use crate::view::view;
 
 /// Enumeration of treatments for the .Last.value variable
 pub enum LastValue {
@@ -368,15 +370,25 @@ impl RVariables {
     fn view(&mut self, path: &Vec<String>) -> Result<String, harp::error::Error> {
         r_task(|| {
             let env = self.env.get().clone();
-            let data = PositronVariable::resolve_data_object(env, &path)?;
+            let obj = PositronVariable::resolve_data_object(env.clone(), &path)?;
+
+            if r_is_function(obj.sexp) {
+                harp::as_result(view(&obj, &path, &env))?;
+
+                // Return a falsy `viewerId`. Should ideally be a more explicit `None`.
+                return Ok(String::from(""));
+            }
+
             let name = unsafe { path.get_unchecked(path.len() - 1) };
+
             let binding = DataObjectEnvInfo {
                 name: name.to_string(),
-                env: RThreadSafe::new(self.env.get().clone()),
+                env: RThreadSafe::new(env),
             };
+
             let viewer_id = RDataExplorer::start(
                 name.clone(),
-                data,
+                obj,
                 Some(binding),
                 self.comm_manager_tx.clone(),
             )?;

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -33,6 +33,7 @@ use harp::utils::r_format_s4;
 use harp::utils::r_inherits;
 use harp::utils::r_is_altrep;
 use harp::utils::r_is_data_frame;
+use harp::utils::r_is_function;
 use harp::utils::r_is_matrix;
 use harp::utils::r_is_null;
 use harp::utils::r_is_s4;
@@ -589,6 +590,10 @@ fn has_children(value: SEXP) -> bool {
 }
 
 fn has_viewer(value: SEXP) -> bool {
+    if r_is_function(value) {
+        return true;
+    }
+
     if !(r_is_data_frame(value) || r_is_matrix(value)) {
         return false;
     }

--- a/crates/ark/src/view.rs
+++ b/crates/ark/src/view.rs
@@ -5,7 +5,28 @@
 //
 //
 
-// Tests for `view.R`
+use harp::exec::RFunction;
+use harp::exec::RFunctionExt;
+use harp::RObject;
+
+use crate::modules::ARK_ENVS;
+
+pub(crate) fn view(x: &RObject, path: &Vec<String>, env: &RObject) -> anyhow::Result<()> {
+    // Currently `view()` only supports identifiers
+    let name = if path.len() == 1 {
+        path.last().unwrap().clone()
+    } else {
+        String::from("")
+    };
+
+    RFunction::new("", "view")
+        .add(x.sexp)
+        .param("name", name)
+        .param("env", env.sexp)
+        .call_in(ARK_ENVS.positron_ns)?;
+
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ark/src/view.rs
+++ b/crates/ark/src/view.rs
@@ -61,11 +61,13 @@ mod tests {
 
     #[test]
     fn test_view_function_namespace() {
+        // FIXME: Looks like namespace generation doesn't work on Windows
+        #[cfg(not(target_os = "windows"))]
         crate::r_task(|| {
             let doc = harp::parse_eval_global(
                 "
             {
-                .ps.internal(view_function_test(identity, 'identity', globalenv()))
+                .ps.internal(view_function_test(identity, '', globalenv()))
             }",
             )
             .unwrap();

--- a/crates/ark/src/view.rs
+++ b/crates/ark/src/view.rs
@@ -62,12 +62,21 @@ mod tests {
     #[test]
     fn test_view_function_namespace() {
         crate::r_task(|| {
-            eval_and_snapshot!(
+            let doc = harp::parse_eval_global(
                 "
-                {
-                    .ps.internal(view_function_test(identity, 'identity', globalenv()))
-                }"
-            );
+            {
+                .ps.internal(view_function_test(identity, 'identity', globalenv()))
+            }",
+            )
+            .unwrap();
+            let doc: String = doc.try_into().unwrap();
+
+            let doc = regex::Regex::new(r"ark:ark-\d+")
+                .unwrap()
+                .replace_all(&doc, "ark:ark-*pid*")
+                .to_string();
+
+            assert!(doc.contains("ark:ark-*pid*/namespace/base.R"));
         });
     }
 

--- a/crates/ark/src/view.rs
+++ b/crates/ark/src/view.rs
@@ -76,7 +76,11 @@ mod tests {
                 .replace_all(&doc, "ark:ark-*pid*")
                 .to_string();
 
-            assert!(doc.contains("ark:ark-*pid*/namespace/base.R"));
+            assert!(
+                doc.contains("ark:ark-*pid*/namespace/base.R"),
+                "doc did not contain expected URI. doc was:\n{}",
+                doc
+            );
         });
     }
 

--- a/crates/ark/src/view.rs
+++ b/crates/ark/src/view.rs
@@ -100,4 +100,18 @@ mod tests {
             )
         });
     }
+
+    #[test]
+    fn test_view_function_trace() {
+        crate::r_task(|| {
+            eval_and_snapshot!(
+                "
+                {
+                    foo <- function(arg) body
+                    trace(foo, identity)
+                    .ps.internal(view_function_test(foo, 'foo', globalenv()))
+                }"
+            )
+        });
+    }
 }

--- a/crates/ark/src/view.rs
+++ b/crates/ark/src/view.rs
@@ -1,0 +1,88 @@
+//
+// view.rs
+//
+// Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+//
+//
+
+// Tests for `view.R`
+
+#[cfg(test)]
+mod tests {
+    macro_rules! eval_and_snapshot {
+        ($source:expr) => {{
+            let doc = harp::parse_eval_global($source).unwrap();
+            let doc: String = doc.try_into().unwrap();
+
+            // Replace addresses like 0x12345 with 0x*address* for snapshot stability
+            let doc = regex::Regex::new(r"0x[0-9a-fA-F]+")
+                .unwrap()
+                .replace_all(&doc, "0x*address*")
+                .to_string();
+
+            // Replace PID by a constant for snapshot stability
+            let doc = regex::Regex::new(r"ark:ark-\d+")
+                .unwrap()
+                .replace_all(&doc, "ark:ark-*pid*")
+                .to_string();
+
+            insta::assert_snapshot!(doc);
+
+            // Clean up our `foo` objects
+            harp::parse_eval_global("if (exists('foo', inherits = FALSE)) rm(foo)").unwrap();
+        }};
+    }
+
+    #[test]
+    fn test_view_function() {
+        crate::r_task(|| {
+            eval_and_snapshot!(
+                "
+                {
+                    foo <- function(arg) body
+                    .ps.internal(view_function_test(foo, 'foo', globalenv()))
+                }"
+            );
+        });
+    }
+
+    #[test]
+    fn test_view_function_unknown() {
+        crate::r_task(|| {
+            eval_and_snapshot!(
+                "
+                {
+                    foo <- function(arg) body
+                    .ps.internal(view_function_test(foo, '', globalenv()))
+                }"
+            );
+        });
+    }
+
+    #[test]
+    fn test_view_function_namespace() {
+        crate::r_task(|| {
+            eval_and_snapshot!(
+                "
+                {
+                    .ps.internal(view_function_test(identity, 'identity', globalenv()))
+                }"
+            );
+        });
+    }
+
+    #[test]
+    fn test_view_function_local() {
+        crate::r_task(|| {
+            eval_and_snapshot!(
+                "
+                {
+                    local({
+                        foo <- function(arg) body
+                        .ps.internal(view_function_test(foo, 'foo', environment()))
+                    })
+                }"
+            )
+        });
+    }
+}

--- a/crates/harp/src/lib.rs
+++ b/crates/harp/src/lib.rs
@@ -59,6 +59,7 @@ pub use vector::list::*;
 // resolve to the correct symbols
 extern crate self as harp;
 
+pub use harp::error::as_result;
 pub use harp::exec::top_level_exec;
 pub use harp::exec::try_catch;
 pub use harp::exec::try_eval;

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -837,6 +837,14 @@ impl TryFrom<RObject> for Option<i32> {
     }
 }
 
+impl TryFrom<RObject> for Option<i64> {
+    type Error = crate::error::Error;
+    fn try_from(value: RObject) -> Result<Self, Self::Error> {
+        let value: Option<i32> = value.try_into()?;
+        Ok(value.map(|x| x as i64))
+    }
+}
+
 impl TryFrom<RObject> for Option<f64> {
     type Error = crate::error::Error;
     fn try_from(value: RObject) -> Result<Self, Self::Error> {
@@ -906,6 +914,16 @@ impl TryFrom<RObject> for i32 {
     type Error = crate::error::Error;
     fn try_from(value: RObject) -> Result<Self, Self::Error> {
         match Option::<i32>::try_from(value)? {
+            Some(x) => Ok(x),
+            None => Err(Error::MissingValueError),
+        }
+    }
+}
+
+impl TryFrom<RObject> for i64 {
+    type Error = crate::error::Error;
+    fn try_from(value: RObject) -> Result<Self, Self::Error> {
+        match Option::<i64>::try_from(value)? {
             Some(x) => Ok(x),
             None => Err(Error::MissingValueError),
         }

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -368,6 +368,11 @@ impl RObject {
         r_typeof(self.sexp)
     }
 
+    /// Address in hexadecimal format
+    pub fn address(&self) -> String {
+        format!("{:p}", self.sexp as *const _)
+    }
+
     /// String accessor; get a string value from a vector of strings.
     ///
     /// - `idx` - The index of the string to return.
@@ -1176,6 +1181,12 @@ where
     } else {
         Ok(Some(x.try_into()?))
     }
+}
+
+#[harp::register]
+unsafe extern "C-unwind" fn ps_obj_address(x: SEXP) -> anyhow::Result<SEXP> {
+    let address: RObject = RObject::view(x).address().into();
+    Ok(address.sexp)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Addresses posit-dev/positron#2945.

This PR adds support for functions in `View()`.

- For functions with valid source references, `View()` jumps to the function location in the source file.

- For functions in packages that don't have source references, `View()` first generates a virtual namespace document (the same as for debugging) and jumps into that file.

  Note we only generate the virtual namespace source if `View()` is called at top-level. The generation process causes global mutation of the namespace objects to attach the source refs, and we can't do that if code is already running as it might make assumptions about the srcrefs.

- As a fallback, we deparse the function and generate a virtual document for it.

Currently the virtual documents in the fallback approach are never cleaned up.  I'm not too worried about the memory leaks that this causes but we would ideally do better. The `TextDocumentContentProvider` API doesn't have any facilities for clean up but we could in principle open an editor for the vdoc, then watch over editors and trigger clean up when the editor is closed. However that would require lots of communication between the frontend and the backend and being careful about synchronisation. So I think this would be better handled entirely on the frontend side. This can be done as follow-up work.

I also made a small change to the Ark URI scheme to disambiguate multiple sessions. The URIs now contain the process ID of the Ark that generated them. If for some reason the frontend tries to open a vdoc for a session that's now in the background, you'll get an invalid vdoc editor. With the frontend-side PR, this sort of errors are now more user friendly. The error is mentioned in the virtual editor and the error message is logged.

All this is mostly defensive, it would be hard to trigger this error. But since the vdocs are currently provided by the LSP, and since the LSP is now transient, I just wanted to make sure we dealt with this more gracefully. In principle the vdocs should be provided via Jupyter instead of LSP and we'd dispatch to the relevant session based on an URI session parameter. It's not a priority to do it that way for now though.


### QA Notes

I've added some backend tests but there's some subtle behaviour and interactions on the frontend side that's not tested.

When viewing a function from a package, a virtual document containing the entire package should be generated and `View()` will take you at the appropriate location in that document. For instance with `lm()` from the stats package:

```r
View(lm)
```

Note that this is the same file that is used when you `debug()` a function in that package. The two features must not interfere with each other, i.e. you can do the following before and after `View(lm)` and everything should still work:

```r
debug(lm)
lm()
undebug(lm)
```

For functions with valid source references, `View()` should take you to the source file. This should be a regular editor that can be edited, unlike the virtual namespace file. Here's an example with a tempfile:

```r
# Source file with a function definition for `foo`
file <- tempfile(fileext = "R")
cat("foo <- function() 1", file = file)
source(file)

# Now view it
View(foo)
```

For functions that don't have source references, for instance script functions evaluated in the global environment, a virtual document is opened with the deparsed source:

```r
foo <- function() 1
View(foo)
```

You can see the URI for this document by hovering over the editor tab. The URI contains the Ark PID for disambiguation, as well as the environment name if it has one (in this case, "global"). The filename is based on the identifier provided to `View()` (in this case, "foo.R").

When the environment in which `View()` is called doesn't have a name, the URI contains the environment's address instead of a name:

```r
# Local function -> URL includes environment address
local({
    foo <- function() 1
    View(foo)
})
```

When `View()` is called with an expression instead of an identifier, the file is "unknown.R". Note that the environment address is shown instead of the name, due to a limitation of the current implementation:

```r
# Non-named function -> unknown.R
View(identity(foo))

# Same
xs <- list(foo = foo)
View(xs$foo)
```

A related change made to this PR is that trying to open an Ark URI that doesn't exists is now more user friendly. We no longer open an error dialog, instead an editor is opened with an error message inside and an error is logged in the extension output.

```r
# No longer opens an error dialog
.rs.api.navigateToFile("ark:hello")
```

Finally, we've also made functions viewable from the variable pane. After running the examples above you should see `foo` and `xs` defined. You can view the source by clicking the view button that has now appeared in the Variables pane:

<img width="769" alt="Screenshot 2025-06-25 at 10 36 05" src="https://github.com/user-attachments/assets/7852e37a-2c13-4e66-9b00-04d09109a28a" />

I don't have any backend tests for this feature.
