### PR TITLE
Use Ark URIs for fallback sources in the debugger

### DIFF
--- a/crates/ark/src/dap/dap.rs
+++ b/crates/ark/src/dap/dap.rs
@@ -61,7 +61,7 @@ pub struct Dap {
     /// associated files (i.e. no `srcref` attribute). The `source` is the key to
     /// ensure that we don't insert the same function multiple times, which would result
     /// in duplicate virtual editors being opened on the client side.
-    pub fallback_sources: HashMap<String, i32>,
+    pub fallback_sources: HashMap<String, String>,
 
     /// Maps a frame `id` from within the `stack` to a unique
     /// `variables_reference` id, which then allows you to use
@@ -126,7 +126,7 @@ impl Dap {
         &mut self,
         mut stack: Vec<FrameInfo>,
         preserve_focus: bool,
-        fallback_sources: HashMap<String, i32>,
+        fallback_sources: HashMap<String, String>,
     ) {
         self.fallback_sources.extend(fallback_sources);
 

--- a/crates/ark/src/dap/dap_r_main.rs
+++ b/crates/ark/src/dap/dap_r_main.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -120,16 +121,22 @@ impl RMainDap {
         self.debugging
     }
 
-    pub fn start_debug(&mut self, stack: Vec<FrameInfo>, preserve_focus: bool) {
+    pub fn start_debug(
+        &mut self,
+        stack: Vec<FrameInfo>,
+        preserve_focus: bool,
+        fallback_sources: HashMap<String, i32>,
+    ) {
         self.debugging = true;
         let mut dap = self.dap.lock().unwrap();
-        dap.start_debug(stack, preserve_focus)
+        dap.start_debug(stack, preserve_focus, fallback_sources)
     }
 
     pub fn stop_debug(&mut self) {
         let mut dap = self.dap.lock().unwrap();
         dap.stop_debug();
         drop(dap);
+
         self.reset_frame_id();
         self.debugging = false;
     }

--- a/crates/ark/src/dap/dap_r_main.rs
+++ b/crates/ark/src/dap/dap_r_main.rs
@@ -125,7 +125,7 @@ impl RMainDap {
         &mut self,
         stack: Vec<FrameInfo>,
         preserve_focus: bool,
-        fallback_sources: HashMap<String, i32>,
+        fallback_sources: HashMap<String, String>,
     ) {
         self.debugging = true;
         let mut dap = self.dap.lock().unwrap();

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -576,6 +576,8 @@ fn into_dap_frame(frame: &FrameInfo, fallback_sources: &HashMap<String, i32>) ->
     let end_line = frame.end_line;
     let end_column = frame.end_column;
 
+    // WIP! here
+
     // Retrieve either `path` or `source_reference` depending on the `source` type.
     // In the `Text` case, a `source_reference` should always exist because we loaded
     // the map with all possible text values in `start_debug()`.

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -80,6 +80,7 @@ pub(crate) enum Event {
 pub(crate) enum KernelNotification {
     DidChangeConsoleInputs(ConsoleInputs),
     DidOpenVirtualDocument(DidOpenVirtualDocumentParams),
+    DidCloseVirtualDocument(DidCloseVirtualDocumentParams),
 }
 
 /// A thin wrapper struct with a custom `Debug` method more appropriate for trace logs
@@ -91,6 +92,11 @@ pub(crate) struct TraceKernelNotification<'a> {
 pub(crate) struct DidOpenVirtualDocumentParams {
     pub(crate) uri: String,
     pub(crate) contents: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct DidCloseVirtualDocumentParams {
+    pub(crate) uri: String,
 }
 
 #[derive(Debug)]
@@ -344,6 +350,9 @@ impl GlobalState {
                     },
                     KernelNotification::DidOpenVirtualDocument(params) => {
                         state_handlers::did_open_virtual_document(params, &mut self.world)?;
+                    },
+                    KernelNotification::DidCloseVirtualDocument(params) => {
+                        state_handlers::did_close_virtual_document(params, &mut self.world)?
                     }
                 }
             },
@@ -657,8 +666,10 @@ impl std::fmt::Debug for TraceKernelNotification<'_> {
                 .field("uri", &params.uri)
                 .field("contents", &"<snip>")
                 .finish(),
-            // NOTE: Uncomment if we have notifications we don't care to specially handle
-            //notification => std::fmt::Debug::fmt(notification, f),
+            KernelNotification::DidCloseVirtualDocument(params) => f
+                .debug_struct("DidCloseVirtualDocument")
+                .field("uri", &params.uri)
+                .finish(),
         }
     }
 }

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -49,6 +49,7 @@ use crate::lsp::diagnostics::DiagnosticsConfig;
 use crate::lsp::documents::Document;
 use crate::lsp::encoding::get_position_encoding_kind;
 use crate::lsp::indexer;
+use crate::lsp::main_loop::DidCloseVirtualDocumentParams;
 use crate::lsp::main_loop::DidOpenVirtualDocumentParams;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::state::workspace_uris;
@@ -398,6 +399,15 @@ pub(crate) fn did_open_virtual_document(
 ) -> anyhow::Result<()> {
     // Insert new document, replacing any old one
     state.virtual_documents.insert(params.uri, params.contents);
+    Ok(())
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn did_close_virtual_document(
+    params: DidCloseVirtualDocumentParams,
+    state: &mut WorldState,
+) -> anyhow::Result<()> {
+    state.virtual_documents.remove(&params.uri);
     Ok(())
 }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2689.

Before this PR, fallback sources, i.e. generated sources for functions that don't have source references, were handled via the DAP protocol. Because of this we didn't have any control over what kind of editor would be opened on the frontend side and what file extension it would use. This caused these fallback editors to not behave as R files:

- No syntax highlighting
- No Positron-R features such as evaluating with Cmd+Enter

With this PR, we now open virtual documents managed by Ark when the debug session starts or updates. The DAP frames now point to these documents via URIs instead of the DAP "source references".

The URIs have the following scheme: `ark:ark-*pid*/debug/*session-id*/*source-hash*/*source-name*.R`

- The session ID disambiguates between debug sessions, though on hindsight I don't think we actually need it.
- The source-hash disambiguates between frames that have the same source name but different source code.
- The source name is the frame call.

These URIs remain valid for the duration of the debugging session, just like with DAP vdocs.


### QA Notes

Executing the following with Cmd+Enter (sourcing will have different behaviour) should take you to a virtual document (see also notes about vdocs in https://github.com/posit-dev/ark/pull/848).

Stepping in with F11 should take you to different vdocs.

In these documents you should see syntax highlighting and be able to evaluate code with Cmd+Enter.

```r
f <- function() {
    browser()
    g()
}

g <- function() {
    h()
}

h <- function() {
    browser()
    1
    2
    3
}

f()
```

I don't have any tests but I have verified via logs that we clean up these documents on session exit.
