### PR TITLE
Fix the range of sections in document symbols (#846)

### DIFF
--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_assignment_function_nested_section.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_assignment_function_nested_section.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ark/src/lsp/symbols.rs
+assertion_line: 542
 expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ----\n  ### title2 ----\n  ## title3 ----\n  # title4 ----\n}\n# title5 ----\")"
 ---
 [
@@ -15,8 +16,8 @@ expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ---
                 character: 0,
             },
             end: Position {
-                line: 1,
-                character: 14,
+                line: 7,
+                character: 0,
             },
         },
         selection_range: Range {
@@ -73,8 +74,8 @@ expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ---
                                         character: 2,
                                     },
                                     end: Position {
-                                        line: 3,
-                                        character: 15,
+                                        line: 5,
+                                        character: 0,
                                     },
                                 },
                                 selection_range: Range {
@@ -102,7 +103,7 @@ expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ---
                                                 },
                                                 end: Position {
                                                     line: 4,
-                                                    character: 17,
+                                                    character: 0,
                                                 },
                                             },
                                             selection_range: Range {
@@ -132,7 +133,7 @@ expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ---
                                                 },
                                                 end: Position {
                                                     line: 5,
-                                                    character: 16,
+                                                    character: 0,
                                                 },
                                             },
                                             selection_range: Range {
@@ -164,8 +165,8 @@ expression: "test_symbol(\"\n## title0 ----\nfoo <- function() {\n  # title1 ---
                                         character: 2,
                                     },
                                     end: Position {
-                                        line: 6,
-                                        character: 15,
+                                        line: 7,
+                                        character: 0,
                                     },
                                 },
                                 selection_range: Range {


### PR DESCRIPTION
This solution fixes https://github.com/posit-dev/ark/issues/846 and https://github.com/posit-dev/positron/issues/6137.

The problem comes from here: 
https://github.com/posit-dev/ark/blob/fac7824615157269de80a0bb0fe37b5c75af1e23/crates/ark/src/lsp/symbols.rs#L231-L271

- `node` is the single comment line, so the "section" is defined as the single line.

The solution I settled on was to take the created nested symbols and then "correct" the the end positions of the sections
  - I did this to avoid a O(n^2) loop where you loop through the lines to find section starts and then loop through the lines again to find where the next header starts.


This also fixes the sticky scroll which was also breaking from the sections having "1-line height"
![Example of headers working in outline and sticky header](https://github.com/user-attachments/assets/aba1cb66-7857-4e24-8d25-057146409a58)