### PR TITLE
Treat `test_that()` tests as document symbols

### DIFF
--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_test_that.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_test_that.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/symbols.rs
-expression: "test_symbol(\"\ntest_that_not('foo', {\n  1\n})\n\n# title ----\n\ntest_that('foo', {\n  # title1 ----\n  1\n  # title2 ----\n  foo <- function() {\n    2\n  }\n})\n\")"
+expression: "test_symbol(\"\ntest_that_not('foo', {\n  1\n})\n\n# title ----\n\ntest_that('foo', {\n  # title1 ----\n  1\n  # title2 ----\n  foo <- function() {\n    2\n  }\n})\n\n# title2 ----\ntest_that('bar', {\n  1\n})\n\")"
 ---
 [
     DocumentSymbol {
@@ -15,8 +15,8 @@ expression: "test_symbol(\"\ntest_that_not('foo', {\n  1\n})\n\n# title ----\n\n
                 character: 0,
             },
             end: Position {
-                line: 14,
-                character: 2,
+                line: 15,
+                character: 0,
             },
         },
         selection_range: Range {
@@ -25,8 +25,8 @@ expression: "test_symbol(\"\ntest_that_not('foo', {\n  1\n})\n\n# title ----\n\n
                 character: 0,
             },
             end: Position {
-                line: 14,
-                character: 2,
+                line: 15,
+                character: 0,
             },
         },
         children: Some(
@@ -153,6 +153,67 @@ expression: "test_symbol(\"\ntest_that_not('foo', {\n  1\n})\n\n# title ----\n\n
                                 ),
                             },
                         ],
+                    ),
+                },
+            ],
+        ),
+    },
+    DocumentSymbol {
+        name: "title2",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 16,
+                character: 0,
+            },
+            end: Position {
+                line: 19,
+                character: 2,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 16,
+                character: 0,
+            },
+            end: Position {
+                line: 19,
+                character: 2,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "Test: bar",
+                    detail: None,
+                    kind: Function,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 17,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 19,
+                            character: 2,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 17,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 19,
+                            character: 2,
+                        },
+                    },
+                    children: Some(
+                        [],
                     ),
                 },
             ],

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_test_that.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_test_that.snap
@@ -1,0 +1,161 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\ntest_that_not('foo', {\n  1\n})\n\n# title ----\n\ntest_that('foo', {\n  # title1 ----\n  1\n  # title2 ----\n  foo <- function() {\n    2\n  }\n})\n\")"
+---
+[
+    DocumentSymbol {
+        name: "title",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 5,
+                character: 0,
+            },
+            end: Position {
+                line: 14,
+                character: 2,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 5,
+                character: 0,
+            },
+            end: Position {
+                line: 14,
+                character: 2,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "Test: foo",
+                    detail: None,
+                    kind: Function,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 7,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 14,
+                            character: 2,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 7,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 14,
+                            character: 2,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "title1",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 8,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        character: 3,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 8,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        character: 3,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "title2",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 10,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 13,
+                                        character: 3,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 10,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 13,
+                                        character: 3,
+                                    },
+                                },
+                                children: Some(
+                                    [
+                                        DocumentSymbol {
+                                            name: "foo",
+                                            detail: Some(
+                                                "function()",
+                                            ),
+                                            kind: Function,
+                                            tags: None,
+                                            deprecated: None,
+                                            range: Range {
+                                                start: Position {
+                                                    line: 11,
+                                                    character: 2,
+                                                },
+                                                end: Position {
+                                                    line: 13,
+                                                    character: 3,
+                                                },
+                                            },
+                                            selection_range: Range {
+                                                start: Position {
+                                                    line: 11,
+                                                    character: 2,
+                                                },
+                                                end: Position {
+                                                    line: 13,
+                                                    character: 3,
+                                                },
+                                            },
+                                            children: Some(
+                                                [],
+                                            ),
+                                        },
+                                    ],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -676,6 +676,11 @@ test_that('foo', {
     2
   }
 })
+
+# title2 ----
+test_that('bar', {
+  1
+})
 "
         ));
     }


### PR DESCRIPTION
Addresses posit-dev/positron#1428.

`test_that()` blocks are now recorded as document symbols. This enables the following features:

- Hierarchical outline
- Breadcrumbs
- Document symbol search (`@` prefix in the command palette)

The tests are registered with "Test: " prefix, followed by the test title.

I've purposely not made them _workspace_ symbols, so you can't search for tests across files with a workspace symbol search (`#` prefix in the command palette). The markdown extension does that for markdown sections and I find it gets in the way a lot when searching for variables and functions.


### QA Notes

I've added backend side tests.

On the frontend with:

```r
test_that("foo", {
    # section ----
    bar <- function() {
        1
    }
    1
})
```

You should see `Test: foo`:

- in the outline (and be able to interact with it)
- in breadcrumbs (and be able to interact with them)
- in document symbols

<img width="347" alt="Screenshot 2025-06-26 at 16 47 52" src="https://github.com/user-attachments/assets/4d73c249-15af-4fef-aa8e-011d05b8b2a8" />


https://github.com/user-attachments/assets/c2130ae9-942d-4cf4-8aaa-d1d3fc72f35d
