### PR TITLE
Emit functions passed as named arguments as document symbols

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,3 +19,6 @@ _below_ the calling function. A general goal is to be able to read linearly from
 top to bottom with the relevant context and main logic first. The code should be
 organised like a call stack. Of course that's not always possible, use best
 judgement to produce the clearest code organization.
+
+ Keep the main logic as unnested as possible. Favour Rust's `let ... else`
+ syntax to return early or continue a loop in the `else` clause, over `if let`.

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_arguments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_arguments.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n# section ----\nlocal({\n    a <- function() {\n        1\n    }\n})\n\")"
+---
+[
+    DocumentSymbol {
+        name: "section",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 6,
+                character: 2,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 6,
+                character: 2,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "a",
+                    detail: Some(
+                        "function()",
+                    ),
+                    kind: Function,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 3,
+                            character: 4,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 5,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 3,
+                            character: 4,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 5,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_methods.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_methods.snap
@@ -1,0 +1,101 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n        1\n    }, # matched\n    function() {\n        2\n    }, # not matched\n    bar = function() {\n        3\n    }, # matched\n    baz = (function() {\n        4\n    }) # not matched\n)\n\")"
+---
+[
+    DocumentSymbol {
+        name: "section",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 15,
+                character: 1,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 15,
+                character: 1,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "foo",
+                    detail: Some(
+                        "function()",
+                    ),
+                    kind: Method,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 3,
+                            character: 10,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 5,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 3,
+                            character: 10,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 5,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "bar",
+                    detail: Some(
+                        "function()",
+                    ),
+                    kind: Method,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 9,
+                            character: 10,
+                        },
+                        end: Position {
+                            line: 11,
+                            character: 5,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 9,
+                            character: 10,
+                        },
+                        end: Position {
+                            line: 11,
+                            character: 5,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_methods.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_call_methods.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/symbols.rs
-expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n        1\n    }, # matched\n    function() {\n        2\n    }, # not matched\n    bar = function() {\n        3\n    }, # matched\n    baz = (function() {\n        4\n    }) # not matched\n)\n\")"
+expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n        1\n        # nested section ----\n        nested <- function() {}\n    }, # matched\n    function() {\n        2\n        # `nested` is a symbol even if the unnamed method is not\n        nested <- function () {\n    }\n    }, # not matched\n    bar = function() {\n        3\n    }, # matched\n    baz = (function() {\n        4\n    }) # not matched\n)\n\")"
 ---
 [
     DocumentSymbol {
@@ -15,7 +15,7 @@ expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n    
                 character: 0,
             },
             end: Position {
-                line: 15,
+                line: 20,
                 character: 1,
             },
         },
@@ -25,7 +25,7 @@ expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n    
                 character: 0,
             },
             end: Position {
-                line: 15,
+                line: 20,
                 character: 1,
             },
         },
@@ -45,7 +45,7 @@ expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n    
                             character: 10,
                         },
                         end: Position {
-                            line: 5,
+                            line: 7,
                             character: 5,
                         },
                     },
@@ -55,7 +55,103 @@ expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n    
                             character: 10,
                         },
                         end: Position {
-                            line: 5,
+                            line: 7,
+                            character: 5,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "nested section",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 5,
+                                        character: 8,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 31,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 5,
+                                        character: 8,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 31,
+                                    },
+                                },
+                                children: Some(
+                                    [
+                                        DocumentSymbol {
+                                            name: "nested",
+                                            detail: Some(
+                                                "function()",
+                                            ),
+                                            kind: Function,
+                                            tags: None,
+                                            deprecated: None,
+                                            range: Range {
+                                                start: Position {
+                                                    line: 6,
+                                                    character: 8,
+                                                },
+                                                end: Position {
+                                                    line: 6,
+                                                    character: 31,
+                                                },
+                                            },
+                                            selection_range: Range {
+                                                start: Position {
+                                                    line: 6,
+                                                    character: 8,
+                                                },
+                                                end: Position {
+                                                    line: 6,
+                                                    character: 31,
+                                                },
+                                            },
+                                            children: Some(
+                                                [],
+                                            ),
+                                        },
+                                    ],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "nested",
+                    detail: Some(
+                        "function()",
+                    ),
+                    kind: Function,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 11,
+                            character: 8,
+                        },
+                        end: Position {
+                            line: 12,
+                            character: 5,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 11,
+                            character: 8,
+                        },
+                        end: Position {
+                            line: 12,
                             character: 5,
                         },
                     },
@@ -73,21 +169,21 @@ expression: "test_symbol(\"\n# section ----\nlist(\n    foo = function() {\n    
                     deprecated: None,
                     range: Range {
                         start: Position {
-                            line: 9,
+                            line: 14,
                             character: 10,
                         },
                         end: Position {
-                            line: 11,
+                            line: 16,
                             character: 5,
                         },
                     },
                     selection_range: Range {
                         start: Position {
-                            line: 9,
+                            line: 14,
                             character: 10,
                         },
                         end: Position {
-                            line: 11,
+                            line: 16,
                             character: 5,
                         },
                     },

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs.snap
@@ -1,0 +1,164 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n# section ----\nclass <- r6::r6class(\n  'class',\n  public = list(\n    initialize = function() 'initialize',\n    foo = function() 'foo'\n  ),\n  private = list(\n    bar = function() 'bar'\n  )\n)\n\")"
+---
+[
+    DocumentSymbol {
+        name: "section",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 11,
+                character: 1,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 11,
+                character: 1,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "class",
+                    detail: None,
+                    kind: Variable,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 5,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 5,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "initialize",
+                                detail: Some(
+                                    "function()",
+                                ),
+                                kind: Method,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 5,
+                                        character: 17,
+                                    },
+                                    end: Position {
+                                        line: 5,
+                                        character: 40,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 5,
+                                        character: 17,
+                                    },
+                                    end: Position {
+                                        line: 5,
+                                        character: 40,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "foo",
+                                detail: Some(
+                                    "function()",
+                                ),
+                                kind: Method,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 6,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 26,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 6,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 26,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "bar",
+                                detail: Some(
+                                    "function()",
+                                ),
+                                kind: Method,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 9,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        character: 26,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 9,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        character: 26,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_braced_list.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_braced_list.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\nfoo <- {\n    bar <- function() {}\n}\n\")"
+---
+[
+    DocumentSymbol {
+        name: "foo",
+        detail: None,
+        kind: Variable,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 3,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 3,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "bar",
+                    detail: Some(
+                        "function()",
+                    ),
+                    kind: Function,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 4,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 24,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 4,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 24,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_methods.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_methods.snap
@@ -1,0 +1,164 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n# section ----\nclass <- r6::r6class(\n  'class',\n  public = list(\n    initialize = function() 'initialize',\n    foo = function() 'foo'\n  ),\n  private = list(\n    bar = function() 'bar'\n  )\n)\n\")"
+---
+[
+    DocumentSymbol {
+        name: "section",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 11,
+                character: 1,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 11,
+                character: 1,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "class",
+                    detail: None,
+                    kind: Variable,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 5,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 5,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "initialize",
+                                detail: Some(
+                                    "function()",
+                                ),
+                                kind: Method,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 5,
+                                        character: 17,
+                                    },
+                                    end: Position {
+                                        line: 5,
+                                        character: 40,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 5,
+                                        character: 17,
+                                    },
+                                    end: Position {
+                                        line: 5,
+                                        character: 40,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "foo",
+                                detail: Some(
+                                    "function()",
+                                ),
+                                kind: Method,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 6,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 26,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 6,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 6,
+                                        character: 26,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "bar",
+                                detail: Some(
+                                    "function()",
+                                ),
+                                kind: Method,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 9,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        character: 26,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 9,
+                                        character: 10,
+                                    },
+                                    end: Position {
+                                        line: 9,
+                                        character: 26,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -295,19 +295,22 @@ fn collect_call_arguments(
             continue;
         };
 
-        // Recurse into arguments. They might be a braced list, another call
-        // that might contain functions, etc.
-        collect_symbols(&arg_value, contents, 0, symbols)?;
-
-        if arg_value.kind() == "function_definition" {
-            if let Some(arg_fun) = arg.child_by_field_name("name") {
-                // If this is a named function, collect it as a method
-                collect_method(&arg_fun, &arg_value, contents, symbols)?;
-            } else {
-                // Otherwise, just recurse into the function
-                let body = arg_value.child_by_field_name("body").into_result()?;
-                collect_symbols(&body, contents, 0, symbols)?;
-            };
+        match arg_value.kind() {
+            "function_definition" => {
+                if let Some(arg_fun) = arg.child_by_field_name("name") {
+                    // If this is a named function, collect it as a method
+                    collect_method(&arg_fun, &arg_value, contents, symbols)?;
+                } else {
+                    // Otherwise, just recurse into the function
+                    let body = arg_value.child_by_field_name("body").into_result()?;
+                    collect_symbols(&body, contents, 0, symbols)?;
+                };
+            },
+            _ => {
+                // Recurse into arguments. They might be a braced list, another call
+                // that might contain functions, etc.
+                collect_symbols(&arg_value, contents, 0, symbols)?;
+            },
         }
     }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -290,11 +290,7 @@ fn collect_call_arguments(
     };
 
     let mut cursor = node.walk();
-    for arg in arguments.children(&mut cursor) {
-        if arg.kind() != "argument" {
-            continue;
-        }
-
+    for arg in arguments.children_by_field_name("argument", &mut cursor) {
         let Some(arg_value) = arg.child_by_field_name("value") else {
             continue;
         };


### PR DESCRIPTION
Branched from #856 
Addresses https://github.com/posit-dev/positron/issues/6546
Addresses https://github.com/posit-dev/positron/issues/6107 and https://github.com/posit-dev/positron/issues/5241

The main functionality this PR aims to implement is inclusion of R6 symbols in the outline.

```r
class <- R6::R6Class(
  'class',
  public = list(
    initialize = function() 'initialize',
    foo = function() 'foo'
  ),
  private = list(
    bar = function() 'bar'
  )
)
```

I think it makes sense to include _all_ functions passed as named arguments, to any calls and not just `R6Class`. This is in contrast to _workspace symbols_ reachable across files. In this case I think only R6 methods should be registered as workspace symbols (see https://github.com/posit-dev/positron/issues/6549). In general document symbols are more exhaustive than workspace one, offering access to local objects.


Changes:

- We now collect symbols in the RHS of assigned objects. In particular this means we get a chance to collect methods in the `r6class()` call above. This also means we'll collect symbols in cases like this, which I think makes sense:

  ```r
  foo <- {
    bar <- function() {}
  }
  ```

- We now collect symbols across call arguments. This allows us to collect methods nested deeply inside the `r6class()` call. This also means we also collect symbols in cases like the following, which I also think makes sense:

  ```r
  local({
    a <- function() {
      1
    }
  })
  ```

  Addresses https://github.com/posit-dev/positron/issues/6107 and https://github.com/posit-dev/positron/issues/5241

- Finally, functions passed as named arguments are collected as Method symbols. Previously only functions assigned with `<-` at top level or in `{}` would be collected.


### QA Notes:

All these changes are tested in the backend. On the frontend you should now see the outline/breadcrumbs filled with `initialize`, `foo`, and `bar` methods.

```r
# section ----
class <- R6::R6Class(
  'class',
  public = list(
    initialize = function() 'initialize',
    foo = function() {
      1
      # section2 ----
      nested <- function() {}
      2
    }
  ),
  private = list(
    bar = function() {
      3
    }
  )
)

list(
  foo = function() {
    1
  }, # matched
  function() {
    nested <- function () {
        # `nested` is a symbol even if the unnamed method is not
    }
  }, # not matched
  bar = function() {
    3
  }, # matched
  baz = (function() {
    4
  }) # not matched
)

local({
  a <- function() {
    1
  }
})
```


https://github.com/user-attachments/assets/c369c5bc-2506-482b-a3f2-fa1a8146ba58

