### PR TITLE
Extend range of assignment symbols to end of node

### DIFF
--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_nested_assignments_enabled.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_nested_assignments_enabled.snap
@@ -16,7 +16,7 @@ expression: symbols
             },
             end: Position {
                 line: 2,
-                character: 8,
+                character: 13,
             },
         },
         selection_range: Range {
@@ -26,7 +26,7 @@ expression: symbols
             },
             end: Position {
                 line: 2,
-                character: 8,
+                character: 13,
             },
         },
         children: Some(
@@ -76,7 +76,7 @@ expression: symbols
                         },
                         end: Position {
                             line: 5,
-                            character: 8,
+                            character: 13,
                         },
                     },
                     selection_range: Range {
@@ -86,7 +86,7 @@ expression: symbols
                         },
                         end: Position {
                             line: 5,
-                            character: 8,
+                            character: 13,
                         },
                     },
                     children: Some(

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_braced_list.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_braced_list.snap
@@ -15,8 +15,8 @@ expression: "test_symbol(\"\nfoo <- {\n    bar <- function() {}\n}\n\")"
                 character: 0,
             },
             end: Position {
-                line: 1,
-                character: 3,
+                line: 3,
+                character: 1,
             },
         },
         selection_range: Range {
@@ -25,8 +25,8 @@ expression: "test_symbol(\"\nfoo <- {\n    bar <- function() {}\n}\n\")"
                 character: 0,
             },
             end: Position {
-                line: 1,
-                character: 3,
+                line: 3,
+                character: 1,
             },
         },
         children: Some(

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_methods.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_rhs_methods.snap
@@ -43,8 +43,8 @@ expression: "test_symbol(\"\n# section ----\nclass <- r6::r6class(\n  'class',\n
                             character: 0,
                         },
                         end: Position {
-                            line: 2,
-                            character: 5,
+                            line: 11,
+                            character: 1,
                         },
                     },
                     selection_range: Range {
@@ -53,8 +53,8 @@ expression: "test_symbol(\"\n# section ----\nclass <- r6::r6class(\n  'class',\n
                             character: 0,
                         },
                         end: Position {
-                            line: 2,
-                            character: 5,
+                            line: 11,
+                            character: 1,
                         },
                     },
                     children: Some(

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -453,8 +453,8 @@ fn collect_assignment(
         // too busy.
         let name = contents.node_slice(&lhs)?.to_string();
 
-        let start = convert_point_to_position(contents, lhs.start_position());
-        let end = convert_point_to_position(contents, lhs.end_position());
+        let start = convert_point_to_position(contents, node.start_position());
+        let end = convert_point_to_position(contents, node.end_position());
 
         // Now recurse into RHS
         let mut children = Vec::new();
@@ -624,7 +624,7 @@ mod tests {
             },
             end: Position {
                 line: 0,
-                character: 3,
+                character: 8,
             },
         };
         assert_eq!(test_symbol("foo <- 1"), vec![new_symbol(


### PR DESCRIPTION
Branched from #858 

This fix is similar to https://github.com/posit-dev/ark/pull/855

It makes sure the range of document symbol of assigned objects fully extends up to the end of the RHS. This allows the breadcrumbs to behave much better with the method symbols implemented in #858.

Before:

https://github.com/user-attachments/assets/737ab393-89c2-4471-a08a-1d50d7e78982

After:

https://github.com/user-attachments/assets/50d41990-2019-4f9b-9e32-8e699f31d6fe

