### PR TITLE
Simplify LSP settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,6 @@ dependencies = [
  "serde",
  "serde_json",
  "stdext",
- "struct-field-names-as-array",
  "strum 0.26.2",
  "strum_macros 0.26.4",
  "tempfile",
@@ -2743,26 +2742,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "struct-field-names-as-array"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ba4bae771f9cc992c4f403636c54d2ef13acde6367583e99d06bb336674dd9"
-dependencies = [
- "struct-field-names-as-array-derive",
-]
-
-[[package]]
-name = "struct-field-names-as-array-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dbf8b57f3ce20e4bb171a11822b283bdfab6c4bb0fe64fa729f045f23a0938"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
 
 [[package]]
 name = "strum"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -53,7 +53,6 @@ url = "2.4.1"
 walkdir = "2"
 yaml-rust = "0.4.5"
 winsafe = { version = "0.0.19", features = ["kernel"] }
-struct-field-names-as-array = "0.3.0"
 strum = "0.26.2"
 strum_macros = "0.26.2"
 futures = "0.3.30"

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -9,7 +9,6 @@ use anyhow::anyhow;
 use serde_json::Value;
 use stdext::unwrap;
 use stdext::unwrap::IntoResult;
-use struct_field_names_as_array::FieldNamesAsArray;
 use tower_lsp::lsp_types::CodeActionParams;
 use tower_lsp::lsp_types::CodeActionResponse;
 use tower_lsp::lsp_types::CompletionItem;
@@ -46,9 +45,6 @@ use crate::lsp;
 use crate::lsp::code_action::code_actions;
 use crate::lsp::completions::provide_completions;
 use crate::lsp::completions::resolve_completion;
-use crate::lsp::config::VscDiagnosticsConfig;
-use crate::lsp::config::VscDocumentConfig;
-use crate::lsp::config::VscSymbolsConfig;
 use crate::lsp::definitions::goto_definition;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::encoding::convert_lsp_range_to_tree_sitter_range;
@@ -106,22 +102,16 @@ pub(crate) async fn handle_initialized(
         // Note that some settings, such as editor indentation properties, may be
         // changed by extensions or by the user without changing the actual
         // underlying setting. Unfortunately we don't receive updates in that case.
-        let mut config_document_regs = collect_regs(
-            VscDocumentConfig::FIELD_NAMES_AS_ARRAY.to_vec(),
-            VscDocumentConfig::section_from_key,
-        );
-        let mut config_symbols_regs: Vec<Registration> = collect_regs(
-            VscSymbolsConfig::FIELD_NAMES_AS_ARRAY.to_vec(),
-            VscSymbolsConfig::section_from_key,
-        );
-        let mut config_diagnostics_regs: Vec<Registration> = collect_regs(
-            VscDiagnosticsConfig::FIELD_NAMES_AS_ARRAY.to_vec(),
-            VscDiagnosticsConfig::section_from_key,
-        );
 
-        regs.append(&mut config_document_regs);
-        regs.append(&mut config_symbols_regs);
-        regs.append(&mut config_diagnostics_regs);
+        use crate::lsp::config::SETTINGS;
+
+        for setting in SETTINGS {
+            regs.push(Registration {
+                id: uuid::Uuid::new_v4().to_string(),
+                method: String::from("workspace/didChangeConfiguration"),
+                register_options: Some(serde_json::json!({ "section": setting.key })),
+            });
+        }
     }
 
     client
@@ -129,17 +119,6 @@ pub(crate) async fn handle_initialized(
         .instrument(span.exit())
         .await?;
     Ok(())
-}
-
-fn collect_regs(fields: Vec<&str>, into_section: impl Fn(&str) -> &str) -> Vec<Registration> {
-    fields
-        .into_iter()
-        .map(|field| Registration {
-            id: uuid::Uuid::new_v4().to_string(),
-            method: String::from("workspace/didChangeConfiguration"),
-            register_options: Some(serde_json::json!({ "section": into_section(field) })),
-        })
-        .collect()
 }
 
 #[tracing::instrument(level = "info", skip_all)]


### PR DESCRIPTION
I think you'll like this one @DavisVaughan.

Branched from #859. I was concerned at how hard it was to add a new setting and section. I think the refactor in this PR will make things much simpler and easier:

- Add a generic `Setting` type that allows us to flatten a representation of all our settings in a flat array `SETTINGS` that is easy to loop over. This drastically simplify the updating logic where we send all keys of interest to the client in a flat array, as we no longer need any bookkeeping.

- The setting objects in this array contain the conversion-from-json logic as simple methods assigned to a closure field. The default handling is still delegated to `Default` methods in our setting types.

- Remove the split between VS Code and LSP settings. If we want to add vscode agnostic settings in the future, we could add editor aliases in the `SETTINGS` array..