### PR TITLE
Collect sections in calls and emit them as document symbols

### DIFF
--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_section_in_blocks.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_section_in_blocks.snap
@@ -1,0 +1,248 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n# level 1 ----\n\nlist({\n  ## foo ----\n  1\n  2 ## bar ----\n  3\n  4\n  ## baz ----\n})\n\n## level 2 ----\n\nlist({\n  # foo ----\n  1\n  2 # bar ----\n  3\n  4\n  # baz ----\n})\n\")"
+---
+[
+    DocumentSymbol {
+        name: "level 1",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 21,
+                character: 2,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 21,
+                character: 2,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "foo",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 4,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 3,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 4,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 3,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "bar",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 6,
+                            character: 4,
+                        },
+                        end: Position {
+                            line: 8,
+                            character: 3,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 6,
+                            character: 4,
+                        },
+                        end: Position {
+                            line: 8,
+                            character: 3,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "baz",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 9,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 9,
+                            character: 13,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 9,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 9,
+                            character: 13,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "level 2",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 12,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 21,
+                            character: 2,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 12,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 21,
+                            character: 2,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "foo",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 15,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 16,
+                                        character: 3,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 15,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 16,
+                                        character: 3,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "bar",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 17,
+                                        character: 4,
+                                    },
+                                    end: Position {
+                                        line: 19,
+                                        character: 3,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 17,
+                                        character: 4,
+                                    },
+                                    end: Position {
+                                        line: 19,
+                                        character: 3,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "baz",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 20,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 20,
+                                        character: 12,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 20,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 20,
+                                        character: 12,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_section_in_calls.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_section_in_calls.snap
@@ -1,0 +1,248 @@
+---
+source: crates/ark/src/lsp/symbols.rs
+expression: "test_symbol(\"\n# level 1 ----\n\nlist(\n  ## foo ----\n  1,\n  2, ## bar ----\n  3,\n  4\n  ## baz ----\n)\n\n## level 2 ----\n\nlist(\n  # foo ----\n  1,\n  2, # bar ----\n  3,\n  4\n  # baz ----\n)\n\")"
+---
+[
+    DocumentSymbol {
+        name: "level 1",
+        detail: None,
+        kind: String,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 21,
+                character: 1,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 21,
+                character: 1,
+            },
+        },
+        children: Some(
+            [
+                DocumentSymbol {
+                    name: "foo",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 4,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 4,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 4,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 4,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "bar",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 6,
+                            character: 5,
+                        },
+                        end: Position {
+                            line: 8,
+                            character: 3,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 6,
+                            character: 5,
+                        },
+                        end: Position {
+                            line: 8,
+                            character: 3,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "baz",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 9,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 9,
+                            character: 13,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 9,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 9,
+                            character: 13,
+                        },
+                    },
+                    children: Some(
+                        [],
+                    ),
+                },
+                DocumentSymbol {
+                    name: "level 2",
+                    detail: None,
+                    kind: String,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position {
+                            line: 12,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 21,
+                            character: 1,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 12,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 21,
+                            character: 1,
+                        },
+                    },
+                    children: Some(
+                        [
+                            DocumentSymbol {
+                                name: "foo",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 15,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 16,
+                                        character: 4,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 15,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 16,
+                                        character: 4,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "bar",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 17,
+                                        character: 5,
+                                    },
+                                    end: Position {
+                                        line: 19,
+                                        character: 3,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 17,
+                                        character: 5,
+                                    },
+                                    end: Position {
+                                        line: 19,
+                                        character: 3,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                            DocumentSymbol {
+                                name: "baz",
+                                detail: None,
+                                kind: String,
+                                tags: None,
+                                deprecated: None,
+                                range: Range {
+                                    start: Position {
+                                        line: 20,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 20,
+                                        character: 12,
+                                    },
+                                },
+                                selection_range: Range {
+                                    start: Position {
+                                        line: 20,
+                                        character: 2,
+                                    },
+                                    end: Position {
+                                        line: 20,
+                                        character: 12,
+                                    },
+                                },
+                                children: Some(
+                                    [],
+                                ),
+                            },
+                        ],
+                    ),
+                },
+            ],
+        ),
+    },
+]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -177,12 +177,12 @@ fn collect_symbols(
 ) -> anyhow::Result<()> {
     match node.node_type() {
         NodeType::Program => {
-            collect_sections(ctx, node, contents, current_level, symbols)?;
+            collect_list_sections(ctx, node, contents, current_level, symbols)?;
         },
 
         NodeType::BracedExpression => {
             ctx.top_level = false;
-            collect_sections(ctx, node, contents, current_level, symbols)?;
+            collect_list_sections(ctx, node, contents, current_level, symbols)?;
         },
 
         NodeType::Call => {
@@ -200,13 +200,17 @@ fn collect_symbols(
     Ok(())
 }
 
-fn collect_sections(
+fn collect_sections<F>(
     ctx: &mut CollectContext,
     node: &Node,
     contents: &Rope,
     current_level: usize,
     symbols: &mut Vec<DocumentSymbol>,
-) -> anyhow::Result<()> {
+    mut handle_child: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut(&mut CollectContext, &Node, &Rope, &mut Vec<DocumentSymbol>) -> anyhow::Result<()>,
+{
     // In lists of expressions we track and collect section comments, then
     // collect symbols from children nodes
 
@@ -249,15 +253,15 @@ fn collect_sections(
         }
 
         // If we get to this point, `child` is not a section comment.
-        // Recurse into child.
+        // Handle recursion into the child using the provided handler.
 
         if active_sections.is_empty() {
             // If no active section, extend current vector of symbols
-            collect_symbols(ctx, &child, contents, current_level, symbols)?;
+            handle_child(ctx, &child, contents, symbols)?;
         } else {
             // Otherwise create new store of symbols for the current section
             let mut child_symbols = Vec::new();
-            collect_symbols(ctx, &child, contents, current_level, &mut child_symbols)?;
+            handle_child(ctx, &child, contents, &mut child_symbols)?;
 
             // Nest them inside last section
             if !child_symbols.is_empty() {
@@ -284,6 +288,25 @@ fn collect_sections(
     }
 
     Ok(())
+}
+
+fn collect_list_sections(
+    ctx: &mut CollectContext,
+    node: &Node,
+    contents: &Rope,
+    current_level: usize,
+    symbols: &mut Vec<DocumentSymbol>,
+) -> anyhow::Result<()> {
+    collect_sections(
+        ctx,
+        node,
+        contents,
+        current_level,
+        symbols,
+        |ctx, child, contents, symbols| {
+            collect_symbols(ctx, child, contents, current_level, symbols)
+        },
+    )
 }
 
 fn collect_call(
@@ -319,29 +342,35 @@ fn collect_call_arguments(
         return Ok(());
     };
 
-    let mut cursor = arguments.walk();
-    for arg in arguments.children(&mut cursor) {
-        let Some(arg_value) = arg.child_by_field_name("value") else {
-            continue;
-        };
-
-        // Recurse into arguments. They might be a braced list, another call
-        // that might contain functions, etc.
-        collect_symbols(ctx, &arg_value, contents, 0, symbols)?;
-
-        if arg_value.kind() == "function_definition" {
-            if let Some(arg_fun) = arg.child_by_field_name("name") {
-                // If this is a named function, collect it as a method
-                collect_method(ctx, &arg_fun, &arg_value, contents, symbols)?;
-            } else {
-                // Otherwise, just recurse into the function
-                let body = arg_value.child_by_field_name("body").into_result()?;
-                collect_symbols(ctx, &body, contents, 0, symbols)?;
+    collect_sections(
+        ctx,
+        &arguments,
+        contents,
+        0,
+        symbols,
+        |ctx, child, contents, symbols| {
+            let Some(arg_value) = child.child_by_field_name("value") else {
+                return Ok(());
             };
-        }
-    }
 
-    Ok(())
+            // Recurse into arguments. They might be a braced list, another call
+            // that might contain functions, etc.
+            collect_symbols(ctx, &arg_value, contents, 0, symbols)?;
+
+            if arg_value.kind() == "function_definition" {
+                if let Some(arg_fun) = child.child_by_field_name("name") {
+                    // If this is a named function, collect it as a method
+                    collect_method(ctx, &arg_fun, &arg_value, contents, symbols)?;
+                } else {
+                    // Otherwise, just recurse into the function
+                    let body = arg_value.child_by_field_name("body").into_result()?;
+                    collect_symbols(ctx, &body, contents, 0, symbols)?;
+                };
+            }
+
+            Ok(())
+        },
+    )
 }
 
 fn collect_method(
@@ -851,5 +880,63 @@ a <- function() {
 "
         ));
         assert_eq!(test_symbol("{ foo <- 1 }"), vec![]);
+    }
+
+    #[test]
+    fn test_symbol_section_in_blocks() {
+        insta::assert_debug_snapshot!(test_symbol(
+            "
+# level 1 ----
+
+list({
+  ## foo ----
+  1
+  2 ## bar ----
+  3
+  4
+  ## baz ----
+})
+
+## level 2 ----
+
+list({
+  # foo ----
+  1
+  2 # bar ----
+  3
+  4
+  # baz ----
+})
+"
+        ));
+    }
+
+    #[test]
+    fn test_symbol_section_in_calls() {
+        insta::assert_debug_snapshot!(test_symbol(
+            "
+# level 1 ----
+
+list(
+  ## foo ----
+  1,
+  2, ## bar ----
+  3,
+  4
+  ## baz ----
+)
+
+## level 2 ----
+
+list(
+  # foo ----
+  1,
+  2, # bar ----
+  3,
+  4
+  # baz ----
+)
+"
+        ));
     }
 }


### PR DESCRIPTION

Branched from #866.
Addresses https://github.com/posit-dev/positron/issues/8402.

You can now add sections in function calls too, between arguments.

The implementation is shared with the section logic for `{}` blocks. This works a little differently than in RStudio: The sections are nested in the call and can't affect the section hierarchy outside the call. If you have:

```r
## level 2 ----

call(
  # level 1 ----
)

call({
  # level 1 ----
})
```

The "level 1" sections in the block and call do not close the top-level "level 2" section. This difference is necessary because the LSP outline is more powerful and includes syntactic elements like function definitions and assigned variables in the outline. Allowing sections to close from inside a nested element would make things complicated and I'd argue respecting the nesting of the code makes sense from a user pespective too.


### QA Notes

Sections in calls:

```r
# level 1 ----

list(
  ## foo ----
  1,
  2, ## bar ----
  3,
  4
  ## baz ----
)

## level 2 ----

list(
  # foo ----
  1,
  2, # bar ----
  3,
  4
  # baz ----
)
```

now work the same way as sections in blocks:

```r
# level 1 ----

list({
  ## foo ----
  1
  2 ## bar ----
  3
  4
  ## baz ----
})

## level 2 ----

list({
  # foo ----
  1
  2 # bar ----
  3
  4
  # baz ----
})
```

https://github.com/user-attachments/assets/34514df8-edde-48a1-a4e4-f49a2a21ad7d