### PR TITLE
Add RPCs for package documentation tools

### DIFF
--- a/crates/ark/src/modules/positron/llm_tools.R
+++ b/crates/ark/src/modules/positron/llm_tools.R
@@ -184,7 +184,7 @@
                 "No help page found for topic ",
                 topic,
                 if (!is.null(package_name)) {
-                    " in package {.pkg {package_name}}"
+                    paste(" in package", package_name)
                 } else {
                     " in all installed packages"
                 },

--- a/crates/ark/src/modules/positron/llm_tools.R
+++ b/crates/ark/src/modules/positron/llm_tools.R
@@ -25,7 +25,7 @@
     }
 
     # Search for help topics in the package
-    help_db <- help.search(
+    help_db <- utils::help.search(
         "",
         package = package_name,
         fields = c("alias", "title"),
@@ -40,20 +40,17 @@
 
     res_split <- split(res, res$Name)
     res_list <- lapply(res_split, function(group) {
-        data.frame(
+        list(
             topic_id = group$Name[1],
             title = group$Entry[group$Field == "Title"][1],
             aliases = paste(
                 group$Entry[group$Field == "alias"],
                 collapse = ", "
-            ),
-            stringsAsFactors = FALSE
+            )
         )
     })
-    res <- do.call(rbind, res_list)
-    rownames(res) <- NULL
-    res <- res[, c("topic_id", "title", "aliases")]
-    res
+    names(res_list) <- NULL
+    res_list
 }
 
 #' Get available vignettes for a package
@@ -174,11 +171,11 @@
     on.exit(options(menu.graphics = old.menu.graphics), add = TRUE)
 
     # Read the help page
-    help_page <- help(
+    help_page <- utils::help(
         package = (package_name),
         topic = (topic),
         help_type = "text",
-        try.all.packages = is.null(package_name)
+        try.all.packages = (is.null(package_name))
     )
 
     if (!length(help_page)) {

--- a/crates/ark/src/modules/positron/llm_tools.R
+++ b/crates/ark/src/modules/positron/llm_tools.R
@@ -1,0 +1,248 @@
+#
+# llm_tools.R
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+#
+#
+
+#' Get the help topics for a package
+#'
+#' This function retrieves the help topics for a specified package in R.
+#' It returns a data frame with the topic ID, title, and aliases for each help
+#' topic in the package.
+#'
+#' Adapted from btw::btw_tool_docs_package_help_topics
+#'
+#' @param package_name Name of the package to get help topics for
+#' @return A list of help topics for the package, each with a topic ID,
+#'   title, and aliases.
+#'
+#' @export
+.ps.rpc.list_package_help_topics <- function(package_name) {
+    # Check if the package is installed
+    if (!requireNamespace(package_name, quietly = TRUE)) {
+        return(paste("Package", package_name, "is not installed."))
+    }
+
+    # Search for help topics in the package
+    help_db <- help.search(
+        "",
+        package = package_name,
+        fields = c("alias", "title"),
+        ignore.case = TRUE
+    )
+    res <- help_db$matches
+
+    # Did we get any matches?
+    if (nrow(res) == 0) {
+        return(paste("No help topics found for package", package_name, "."))
+    }
+
+    res_split <- split(res, res$Name)
+    res_list <- lapply(res_split, function(group) {
+        data.frame(
+            topic_id = group$Name[1],
+            title = group$Entry[group$Field == "Title"][1],
+            aliases = paste(
+                group$Entry[group$Field == "alias"],
+                collapse = ", "
+            ),
+            stringsAsFactors = FALSE
+        )
+    })
+    res <- do.call(rbind, res_list)
+    rownames(res) <- NULL
+    res <- res[, c("topic_id", "title", "aliases")]
+    res
+}
+
+#' Get available vignettes for a package
+#'
+#' This function retrieves the vignettes available for a specified package in R.
+#' It returns a list of vignettes, each with a title and topic.
+#'
+#' Adapted from btw::btw_tool_docs_available_vignettes.
+#'
+#' @param package_name Name of the package to get vignettes for
+#' @return A list of vignettes for the package, each with a title and topic.
+#'
+#' @export
+.ps.rpc.list_available_vignettes <- function(package_name) {
+    # Check if the package is installed
+    if (!requireNamespace(package_name, quietly = TRUE)) {
+        return(paste("Package", package_name, "is not installed."))
+    }
+
+    # Get vignettes for the package
+    vignettes <- tools::getVignetteInfo(package = package_name)
+    if (length(vignettes) == 0) {
+        return(paste("Package", package_name, "has no vignettes."))
+    }
+
+    # Convert the matrix to a list of lists
+    vignette_list <- lapply(seq_len(nrow(vignettes)), function(i) {
+        list(
+            title = vignettes[i, "Title"],
+            topic = vignettes[i, "Topic"]
+        )
+    })
+    vignette_list
+}
+
+#' Get a specific vignette for a package
+#'
+#' This function retrieves a specific vignette available for a specified package in R.
+#' It returns the vignette content as a Markdown character string.
+#'
+#' Adapted from btw::btw_tool_docs_vignette.
+#'
+#' @param package_name Name of the package to get vignettes for
+#' @return A list of vignettes for the package, each with a title and topic.
+#'
+#' @export
+.ps.rpc.get_package_vignette <- function(package_name, vignette) {
+    vignettes <- as.data.frame(tools::getVignetteInfo(package = package_name))
+    if (nrow(vignettes) == 0) {
+        return(paste("Package", package_name, "has no vignettes."))
+    }
+    vignette_info <- vignettes[vignettes$Topic == vignette, , drop = FALSE]
+    if (nrow(vignette_info) == 0) {
+        return(
+            paste(
+                "No vignette",
+                vignette,
+                "for package",
+                package_name,
+                "found."
+            )
+        )
+    }
+
+    # Use Pandoc (bundled with Positron) to convert rendered vignette (PDF or
+    # HTML) to Markdown
+    output_file <- tempfile(fileext = ".md")
+    tryCatch(
+        {
+            pandoc_convert(
+                input = file.path(vignette_info$Dir, "doc", vignette_info$PDF),
+                to = "markdown",
+                output = output_file,
+                verbose = FALSE
+            )
+            # read the converted Markdown file
+            vignette_md <- readLines(output_file, warn = FALSE)
+
+            # remove the first line which is the title
+            vignette_md <- vignette_md[-1]
+            vignette_md <- paste(vignette_md, collapse = "\n")
+            vignette_md
+        },
+        error = function(e) {
+            paste("Error converting vignette:", e$message)
+        }
+    )
+}
+
+
+#' Get a specific help page
+#'
+#' This function retrieves a specific help page available for a specified package in R.
+#' It returns the help page content as a Markdown character string.
+#'
+#' Adapted from btw::btw_tool_docs_help_page.
+#'
+#' @param topic The topic to get help for
+#' @param package_name The name of the package to get help for. If empty,
+#' searches all installed packages.
+#' @return A list of help pages for the package, each with a title and topic.
+#'
+#' @export
+.ps.rpc.get_help_page <- function(topic, package_name = "") {
+    if (identical(package_name, "")) {
+        package_name <- NULL
+    }
+
+    if (!is.null(package_name)) {
+        if (!requireNamespace(package_name, quietly = TRUE)) {
+            return(paste("Package", package_name, "is not installed."))
+        }
+    }
+
+    # Temporarily disable menu graphics
+    old.menu.graphics <- getOption("menu.graphics", default = TRUE)
+    options(menu.graphics = FALSE)
+    on.exit(options(menu.graphics = old.menu.graphics), add = TRUE)
+
+    # Read the help page
+    help_page <- help(
+        package = (package_name),
+        topic = (topic),
+        help_type = "text",
+        try.all.packages = is.null(package_name)
+    )
+
+    if (!length(help_page)) {
+        return(
+            paste0(
+                "No help page found for topic ",
+                topic,
+                if (!is.null(package_name)) {
+                    " in package {.pkg {package_name}}"
+                } else {
+                    " in all installed packages"
+                },
+                "."
+            )
+        )
+    }
+
+    # Resolve the help page to a specific topic and package
+    resolved <- help_package_topic(help_page)
+
+    if (length(resolved$resolved) > 1) {
+        calls <- sprintf(
+            '{"topic":"%s", "package_name":"%s"}',
+            resolved$resolved,
+            resolved$package
+        )
+        calls <- stats::setNames(calls, "*")
+        return(
+            paste(
+                "Topic",
+                topic,
+                "matched",
+                length(resolved$resolved),
+                "different topics. Choose one or submit individual tool calls for each topic.",
+            )
+        )
+    }
+
+    # Convert the help page to Markdown using Pandoc
+    md_file <- tempfile(fileext = ".md")
+    format_help_page_markdown(
+        help_page,
+        output = md_file,
+        options = c("--shift-heading-level-by=1")
+    )
+    md <- readLines(md_file, warn = FALSE)
+
+    # Remove up to the first empty line
+    first_empty <- match(TRUE, !nzchar(md), nomatch = 1) - 1
+    if (first_empty > 0) {
+        md <- md[-seq_len(first_empty)]
+    }
+
+    # Add a heading for the help page
+    heading <- sprintf(
+        "## `help(package = \"%s\", \"%s\")`",
+        resolved$package,
+        topic
+    )
+
+    # Return the help page as a list
+    list(
+        help_text = paste0(md, collapse = "\n"),
+        topic = basename(resolved$topic),
+        package = resolved$package
+    )
+}

--- a/crates/ark/src/modules/positron/pandoc.R
+++ b/crates/ark/src/modules/positron/pandoc.R
@@ -81,14 +81,24 @@ pandoc_convert <- function(
         args <- c(args, "--output", pandoc_path_arg(output))
     }
 
-    # set pandoc stack size
-    args <- prepend_pandoc_stack_size(args)
-
     # additional command line options
     args <- c(args, options)
 
+    # ensure pandoc is available
+    pandoc_info <- find_pandoc()
+    if (is.null(pandoc_info$dir) || !utils::file_test("-x", pandoc())) {
+        stop(
+            "pandoc is not available. Please install pandoc or set the ",
+            "RSTUDIO_PANDOC environment variable to the directory containing ",
+            "the pandoc executable."
+        )
+    }
+
     # build the conversion command
-    command <- paste(quoted(pandoc()), paste(quoted(args), collapse = " "))
+    command <- paste(
+        quoted(file.path(pandoc_info$dir, "pandoc")),
+        paste(quoted(args), collapse = " ")
+    )
 
     # show it in verbose mode
     if (verbose) {
@@ -141,12 +151,6 @@ pandoc <- function() {
         find_pandoc()$dir,
         "pandoc"
     )
-}
-
-#' Prepend pandoc stack size to command line arguments
-prepend_pandoc_stack_size <- function(args) {
-    stack_size <- getOption("pandoc.stack.size", default = "512m")
-    c(c("+RTS", paste0("-K", stack_size), "-RTS"), args)
 }
 
 #' Test if a directory exists

--- a/crates/ark/src/modules/positron/pandoc.R
+++ b/crates/ark/src/modules/positron/pandoc.R
@@ -1,0 +1,310 @@
+#
+# pandoc.R
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+#
+
+# This file provides functions to convert documents using the pandoc utility.
+# Most are ported from the rmarkdown package and adapted for use in Positron.
+
+#' Convert a document with pandoc
+#'
+#' Convert documents to and from various formats using the pandoc utility.
+#'
+#' Supported input and output formats are described in the
+#' \href{https://pandoc.org/MANUAL.html}{pandoc user guide}.
+#'
+#' The system path as well as the version of pandoc shipped with Positron
+#' are scanned for pandoc and the highest version available is used.
+#'
+#' Adapted from rmarkdown::pandoc_convert()
+#'
+#' @param input Character vector containing paths to input files
+#'   (files must be UTF-8 encoded)
+#' @param to Format to convert to (if not specified, you must specify
+#'   \code{output})
+#' @param from Format to convert from (if not specified then the format is
+#'   determined based on the file extension of \code{input}).
+#' @param output Output file (if not specified then determined based on format
+#'   being converted to).
+#' @param options Character vector of command line options to pass to pandoc.
+#' @param verbose \code{TRUE} to show the pandoc command line which was executed
+#' @param wd Working directory in which code will be executed. If not
+#'   supplied, defaults to the common base directory of \code{input}.
+#' @examples
+#' \dontrun{
+#'
+#' # convert markdown to various formats
+#' pandoc_convert("input.md", to = "html")
+#' pandoc_convert("input.md", to = "latex")
+#'
+#' # add some pandoc options
+#' pandoc_convert("input.md", to = "latex", options = c("--listings"))
+#' }
+pandoc_convert <- function(
+    input,
+    to = NULL,
+    from = NULL,
+    output = NULL,
+    options = NULL,
+    verbose = FALSE,
+    wd = NULL
+) {
+    # evaluate path arguments before changing working directory
+    force(output)
+
+    # execute in specified working directory
+    if (is.null(wd)) {
+        wd <- dirname(input)
+    }
+
+    oldwd <- setwd(wd)
+    on.exit(setwd(oldwd), add = TRUE)
+
+    # input file and formats
+    args <- pandoc_path_arg(input)
+    if (!is.null(to)) {
+        if (to == 'html') {
+            to <- 'html4'
+        }
+        if (to == 'pdf') {
+            to <- 'latex'
+        }
+        args <- c(args, "--to", to)
+    }
+    if (!is.null(from)) {
+        args <- c(args, "--from", from)
+    }
+
+    # output file
+    if (!is.null(output)) {
+        args <- c(args, "--output", pandoc_path_arg(output))
+    }
+
+    # set pandoc stack size
+    args <- prepend_pandoc_stack_size(args)
+
+    # additional command line options
+    args <- c(args, options)
+
+    # build the conversion command
+    command <- paste(quoted(pandoc()), paste(quoted(args), collapse = " "))
+
+    # show it in verbose mode
+    if (verbose) {
+        cat(command, "\n")
+    }
+
+    # run the conversion
+    with_pandoc_safe_environment({
+        result <- system(command)
+    })
+    if (result != 0) {
+        stop("pandoc document conversion failed with error ", result)
+    }
+
+    invisible(NULL)
+}
+
+#' Convert path arguments for pandoc
+#'
+#' Adapted from rmarkdown:::pandoc_path_arg()
+pandoc_path_arg <- function(path, backslash = TRUE) {
+    path <- path.expand(path)
+    path <- sub("^[.]/", "", path)
+    i <- grepl("^-", path) & xfun::is_rel_path(path)
+    path[i] <- paste0("./", path[i])
+    if (identical(.Platform$OS.type, "windows")) {
+        i <- grep(" ", path)
+        if (length(i)) {
+            path[i] <- utils::shortPathName(path[i])
+        }
+        if (backslash) {
+            path <- gsub("/", "\\\\", path)
+        }
+    }
+    path
+}
+
+#' Quote arguments for shell commands
+#'
+#' Adapted from rmarkdown:::quoted()
+quoted <- function(args) {
+    shell_chars <- grepl("[ <>()|\\:&;#?*']", args)
+    args[shell_chars] <- shQuote(args[shell_chars])
+    args
+}
+
+#' Get the path to the pandoc executable
+pandoc <- function() {
+    file.path(
+        find_pandoc()$dir,
+        "pandoc"
+    )
+}
+
+#' Prepend pandoc stack size to command line arguments
+prepend_pandoc_stack_size <- function(args) {
+    stack_size <- getOption("pandoc.stack.size", default = "512m")
+    c(c("+RTS", paste0("-K", stack_size), "-RTS"), args)
+}
+
+#' Test if a directory exists
+dir_exists <- function(x) {
+    length(x) > 0 && utils::file_test('-d', x)
+}
+
+#' Find the pandoc executable in the system path or specified directory
+find_pandoc <- function(dir = NULL, version = NULL) {
+    # look up pandoc in potential sources unless user has supplied `dir`
+    sources <- if (length(dir) == 0) {
+        c(
+            Sys.getenv("RSTUDIO_PANDOC"),
+            dirname(find_program("pandoc")),
+            "~/opt/pandoc"
+        )
+    } else {
+        dir
+    }
+    sources <- path.expand(sources)
+
+    # determine the versions of the sources
+    versions <- lapply(sources, function(src) {
+        if (dir_exists(src)) get_pandoc_version(src) else numeric_version("0")
+    })
+
+    # find the maximum version
+    found_src <- NULL
+    found_ver <- numeric_version("0")
+    for (i in seq_along(sources)) {
+        ver <- versions[[i]]
+        if (
+            (!is.null(version) && ver == version) ||
+                (is.null(version) && ver > found_ver)
+        ) {
+            found_ver <- ver
+            found_src <- sources[[i]]
+        }
+    }
+
+    list(
+        dir = found_src,
+        version = found_ver
+    )
+}
+
+# Find a program within the PATH. On OSX we need to explictly call
+# /usr/bin/which with a forwarded PATH since OSX Yosemite strips
+# the PATH from the environment of child processes
+#
+# Ported from rmarkdown::find_program()
+find_program <- function(program) {
+    if (Sys.info()["sysname"] == "Darwin") {
+        res <- suppressWarnings({
+            # Quote the path (so it can contain spaces, etc.) and escape any quotes
+            # and escapes in the path itself
+            sanitized_path <- gsub(
+                "\\",
+                "\\\\",
+                Sys.getenv("PATH"),
+                fixed = TRUE
+            )
+            sanitized_path <- gsub("\"", "\\\"", sanitized_path, fixed = TRUE)
+            system(
+                paste0(
+                    "PATH=\"",
+                    sanitized_path,
+                    "\" /usr/bin/which ",
+                    program
+                ),
+                intern = TRUE
+            )
+        })
+        if (length(res) == 0) {
+            ""
+        } else {
+            res
+        }
+    } else {
+        Sys.which(program)
+    }
+}
+
+# wrap a system call to pandoc so that LC_ALL is not set
+# see: https://github.com/rstudio/rmarkdown/issues/31
+# see: https://ghc.haskell.org/trac/ghc/ticket/7344
+with_pandoc_safe_environment <- function(code) {
+    lc_all <- Sys.getenv("LC_ALL", unset = NA)
+
+    if (!is.na(lc_all)) {
+        Sys.unsetenv("LC_ALL")
+        on.exit(Sys.setenv(LC_ALL = lc_all), add = TRUE)
+    }
+
+    lc_ctype <- Sys.getenv("LC_CTYPE", unset = NA)
+
+    if (!is.na(lc_ctype)) {
+        Sys.unsetenv("LC_CTYPE")
+        on.exit(Sys.setenv(LC_CTYPE = lc_ctype), add = TRUE)
+    }
+
+    if (
+        Sys.info()['sysname'] == "Linux" &&
+            is.na(Sys.getenv("HOME", unset = NA))
+    ) {
+        stop(
+            "The 'HOME' environment variable must be set before running Pandoc."
+        )
+    }
+
+    if (
+        Sys.info()['sysname'] == "Linux" &&
+            is.na(Sys.getenv("LANG", unset = NA))
+    ) {
+        # fill in a the LANG environment variable if it doesn't exist
+        Sys.setenv(LANG = detect_generic_lang())
+        on.exit(Sys.unsetenv("LANG"), add = TRUE)
+    }
+
+    if (
+        Sys.info()['sysname'] == "Linux" &&
+            identical(Sys.getenv("LANG"), "en_US")
+    ) {
+        Sys.setenv(LANG = "en_US.UTF-8")
+        on.exit(Sys.setenv(LANG = "en_US"), add = TRUE)
+    }
+
+    force(code)
+}
+
+# Get an S3 numeric_version for the pandoc utility at the specified path
+get_pandoc_version <- function(pandoc_dir) {
+    path <- file.path(pandoc_dir, "pandoc")
+    if (identical(.Platform$OS.type, "windows")) {
+        path <- paste0(path, ".exe")
+    }
+    if (!utils::file_test("-x", path)) {
+        return(numeric_version("0"))
+    }
+    info <- with_pandoc_safe_environment(
+        system(paste(shQuote(path), "--version"), intern = TRUE)
+    )
+    version <- strsplit(info, "\n", useBytes = TRUE)[[1]][1]
+    version <- strsplit(version, " ")[[1]][2]
+    components <- strsplit(version, "-")[[1]]
+    version <- components[1]
+    # pandoc nightly adds -nightly-YYYY-MM-DD to last release version
+    # https://github.com/jgm/pandoc/issues/8016
+    # mark it as devel appending YYYY.MM.DD
+    nightly <- match("nightly", components)
+    if (!is.na(nightly)) {
+        version <- paste(
+            c(
+                version,
+                grep("^[0-9]+$", components[-(1:nightly)], value = TRUE)
+            ),
+            collapse = "."
+        )
+    }
+    numeric_version(version)
+}


### PR DESCRIPTION
This change ports some package documentation tools from the `btw` package into ark, exposing them as RPCs that we can call from Positron (where we'll hook them up to language model tool calls).

Specifically, the changes from btw are as follows:

- remove dependency on tidyverse (dplyr, etc.) by rewriting transformations in base R
- return plain-text results rather than throwing errors in most cases
- remove dependency on rmarkdown by bundling the needed pandoc conversion bits 

Source for most RPCs: https://github.com/posit-dev/btw/blob/main/R/tool-docs.R

Part of https://github.com/posit-dev/positron/issues/8016. 
