### PR TITLE
Restore `top_level` state on exit

### DIFF
--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_nested_assignments.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_nested_assignments.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ark/src/lsp/symbols.rs
-expression: "test_symbol(\"\nlocal({\n  inner1 <- 1            # Not a symbol\n})\na <- function() {\n  inner2 <- 2            # Not a symbol\n  inner3 <- function() 3 # Symbol\n}\n\")"
+expression: "test_symbol(\"\nlocal({\n  inner1 <- 1            # Not a symbol\n})\na <- function() {\n  inner2 <- 2            # Not a symbol\n  inner3 <- function() 3 # Symbol\n}\nouter <- 4\n\")"
 ---
 [
     DocumentSymbol {
@@ -66,6 +66,36 @@ expression: "test_symbol(\"\nlocal({\n  inner1 <- 1            # Not a symbol\n}
                     ),
                 },
             ],
+        ),
+    },
+    DocumentSymbol {
+        name: "outer",
+        detail: None,
+        kind: Variable,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 8,
+                character: 0,
+            },
+            end: Position {
+                line: 8,
+                character: 10,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 8,
+                character: 0,
+            },
+            end: Position {
+                line: 8,
+                character: 10,
+            },
+        },
+        children: Some(
+            [],
         ),
     },
 ]

--- a/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_nested_assignments_enabled.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__symbols__tests__symbol_nested_assignments_enabled.snap
@@ -128,4 +128,34 @@ expression: symbols
             ],
         ),
     },
+    DocumentSymbol {
+        name: "outer",
+        detail: None,
+        kind: Variable,
+        tags: None,
+        deprecated: None,
+        range: Range {
+            start: Position {
+                line: 8,
+                character: 0,
+            },
+            end: Position {
+                line: 8,
+                character: 10,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 8,
+                character: 0,
+            },
+            end: Position {
+                line: 8,
+                character: 10,
+            },
+        },
+        children: Some(
+            [],
+        ),
+    },
 ]

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -195,8 +195,10 @@ fn collect_symbols(
         },
 
         NodeType::BracedExpression => {
+            let old = ctx.top_level;
             ctx.top_level = false;
             collect_list_sections(ctx, node, contents, current_level, symbols)?;
+            ctx.top_level = old;
         },
 
         NodeType::Call => {
@@ -940,6 +942,7 @@ a <- function() {
   inner2 <- 2            # Not a symbol
   inner3 <- function() 3 # Symbol
 }
+outer <- 4
 "
         ));
         assert_eq!(test_symbol("{ foo <- 1 }"), vec![]);
@@ -956,6 +959,7 @@ a <- function() {
   inner2 <- 2
   inner3 <- function() 3
 }
+outer <- 4
 ",
             None,
         );


### PR DESCRIPTION
Bug revealed by E2E Positron tests: I was not restoring the top-level state after leaving a nested state. So top-level variables appearing _after_ a context with nested blocks were not shown in the outline.

This is now also tested on the backend-side.

cc @DavisVaughan 