### PR TITLE
data explorer: set edges to value of single bin

### DIFF
--- a/crates/ark/src/data_explorer/histogram.rs
+++ b/crates/ark/src/data_explorer/histogram.rs
@@ -379,8 +379,8 @@ mod tests {
     fn test_constant_column() {
         r_task(|| {
             // This is the default `hist` behavior, single bin containing all info.
-            test_histogram("c(1, 1, 1)", 4, vec!["0.00", "1.00"], vec![3]);
-            test_histogram_method("c(1, 1, 1)", "sturges", vec!["0.00", "1.00"], vec![3])
+            test_histogram("c(1, 1, 1)", 4, vec!["1.00", "1.00"], vec![3]);
+            test_histogram_method("c(1, 1, 1)", "sturges", vec!["1.00", "1.00"], vec![3])
         })
     }
 

--- a/crates/ark/src/modules/positron/r_data_explorer.R
+++ b/crates/ark/src/modules/positron/r_data_explorer.R
@@ -473,6 +473,17 @@ profile_histogram <- function(
     bin_edges <- h$breaks
     bin_counts <- h$counts
 
+    # Special case: if we have a single bin, check if all values are the same
+    # If so, override the bin edges to be the same value instead of value +/- 1
+    if (length(bin_counts) == 1 && length(x) > 0) {
+        # Check if all values are the same
+        unique_values <- unique(x)
+        if (length(unique_values) == 1) {
+            # All values are the same, set bin edges to [value, value]
+            bin_edges <- c(unique_values[1], unique_values[1])
+        }
+    }
+
     # For dates, we convert back the breaks to the date representation.
     if (inherits(x, "POSIXct")) {
         # Must supply an `origin` on R <= 4.2


### PR DESCRIPTION
R half of https://github.com/posit-dev/positron/pull/8611
Addressing https://github.com/posit-dev/positron/issues/8095


```
View(data.frame(values = rep(10, 10)))
```

Upper and lower values should be equal on hover.

<img width="372" height="128" alt="Screenshot 2025-07-29 at 10 48 00 AM" src="https://github.com/user-attachments/assets/462b4629-9f5f-4606-bb69-c3eef7d4da1f" />
