### PR TITLE
Prefer current file in jump to definition

### DIFF
--- a/crates/ark/src/lsp/definitions.rs
+++ b/crates/ark/src/lsp/definitions.rs
@@ -105,7 +105,7 @@ foo <- 42
 print(foo)
 "#;
         let doc = Document::new(code, None);
-        let (path, uri) = test_path();
+        let (path, uri) = test_path("test.R");
 
         indexer::update(&doc, &path).unwrap();
 
@@ -142,7 +142,7 @@ foo <- 1
 print(foo)
 "#;
         let doc = Document::new(code, None);
-        let (path, uri) = test_path();
+        let (path, uri) = test_path("test.R");
 
         indexer::update(&doc, &path).unwrap();
 
@@ -186,10 +186,9 @@ foo
 
         let doc1 = Document::new(code1, None);
         let doc2 = Document::new(code2, None);
-        let path1 = std::path::PathBuf::from("/file1.R");
-        let path2 = std::path::PathBuf::from("/file2.R");
-        let uri1 = Url::from_file_path(&path1).unwrap();
-        let uri2 = Url::from_file_path(&path2).unwrap();
+
+        let (path1, uri1) = test_path("file1.R");
+        let (path2, uri2) = test_path("file2.R");
 
         indexer::update(&doc1, &path1).unwrap();
         indexer::update(&doc2, &path2).unwrap();
@@ -243,10 +242,10 @@ foo
 
         let doc1 = Document::new(code1, None);
         let doc2 = Document::new(code2, None);
-        let path1 = std::path::PathBuf::from("/file1.R");
-        let path2 = std::path::PathBuf::from("/file2.R");
-        let uri1 = Url::from_file_path(&path1).unwrap();
-        let uri2 = Url::from_file_path(&path2).unwrap();
+
+        // Use test_path for cross-platform compatibility
+        let (path1, uri1) = crate::lsp::util::test_path("file1.R");
+        let (path2, uri2) = crate::lsp::util::test_path("file2.R");
 
         indexer::update(&doc1, &path1).unwrap();
         indexer::update(&doc2, &path2).unwrap();

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -91,6 +91,7 @@ pub fn start(folders: Vec<String>) {
     );
 }
 
+/// Search the workspace files and return the first symbol match
 pub fn find(symbol: &str) -> Option<(String, IndexEntry)> {
     let index = WORKSPACE_INDEX.lock().unwrap();
 
@@ -103,6 +104,7 @@ pub fn find(symbol: &str) -> Option<(String, IndexEntry)> {
     None
 }
 
+/// Search a specific workspace file for a symbol
 pub fn find_in_file(symbol: &str, path: &std::path::Path) -> Option<(String, IndexEntry)> {
     let index = WORKSPACE_INDEX.lock().unwrap();
 

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -103,6 +103,20 @@ pub fn find(symbol: &str) -> Option<(String, IndexEntry)> {
     None
 }
 
+pub fn find_in_file(symbol: &str, path: &std::path::Path) -> Option<(String, IndexEntry)> {
+    let index = WORKSPACE_INDEX.lock().unwrap();
+
+    if let Ok(path_str) = str_from_path(path) {
+        if let Some(index) = index.get(path_str) {
+            if let Some(entry) = index.get(symbol) {
+                return Some((path_str.to_string(), entry.clone()));
+            }
+        }
+    }
+
+    None
+}
+
 pub fn map(mut callback: impl FnMut(&Path, &String, &IndexEntry)) {
     let index = WORKSPACE_INDEX.lock().unwrap();
 
@@ -194,7 +208,7 @@ impl Drop for ResetIndexerGuard {
 fn str_from_path(path: &Path) -> anyhow::Result<&str> {
     path.to_str().ok_or(anyhow!(
         "Couldn't convert path {} to string",
-        path.display()
+        path.to_string_lossy()
     ))
 }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -990,7 +990,7 @@ outer <- 4
 
             // Index the document
             let doc = Document::new(code, None);
-            let (path, _) = test_path();
+            let (path, _) = test_path("test.R");
             indexer::update(&doc, &path).unwrap();
 
             // Query for all symbols

--- a/crates/ark/src/lsp/util.rs
+++ b/crates/ark/src/lsp/util.rs
@@ -29,16 +29,12 @@ pub unsafe extern "C-unwind" fn ps_object_id(object: SEXP) -> anyhow::Result<SEX
     return Ok(Rf_mkString(value.as_ptr() as *const c_char));
 }
 
+/// Create an absolute path from a file name.
+/// File name is joined to the temp directory in a cross-platform way.
+/// Returns both a `PathBuf` and a `Url`. Does not create the file.
 #[cfg(test)]
-pub(crate) fn test_path() -> (std::path::PathBuf, url::Url) {
-    use std::path::PathBuf;
-
-    let path = if cfg!(windows) {
-        PathBuf::from(r"C:\test.R")
-    } else {
-        PathBuf::from("/test.R")
-    };
+pub(crate) fn test_path(file_name: &str) -> (std::path::PathBuf, url::Url) {
+    let path = std::env::temp_dir().join(file_name);
     let uri = url::Url::from_file_path(&path).unwrap();
-
     (path, uri)
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8630

### QA Notes

Jump to definition should now prefer definitions in current files, and still fall back to other files if not present.


https://github.com/user-attachments/assets/ccfd57f9-4ed8-4696-b885-6347d1664728

