### PR TITLE
Fix navigate to file on Windows

### DIFF
--- a/crates/ark/src/modules/positron/frontend-methods.R
+++ b/crates/ark/src/modules/positron/frontend-methods.R
@@ -38,8 +38,8 @@
     line = 0L,
     column = 0L
 ) {
-    # Don't normalize if there's a scheme, e.g. an `ark:` URI
-    if (!grepl("^[a-zA-Z][a-zA-Z0-9+.-]*:", file)) {
+    # Don't normalize if that's an `ark:` URI
+    if (!grepl("^ark:", file)) {
         file <- normalizePath(file)
     }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8374

I think the scheme detection was getting tripped up by windows paths like `C:\`


### QA Notes

I'll add a positron-r extension test for this.

To test, open a file called `foo.R`, navigate to another tab, then run:

```r
.rs.api.navigateToFile("foo.R")
```
