### PR TITLE
Data Explorer: Implement SearchSchema RPC, refactor and improve data explorer test suite 

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -21,11 +21,9 @@ pub struct OpenDatasetResult {
 /// Result in Methods
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SearchSchemaResult {
-	/// A schema containing matching columns up to the max_results limit
-	pub matches: TableSchema,
-
-	/// The total number of columns matching the filter
-	pub total_num_matches: i64
+	/// The column indices of the matching column indices in the indicated
+	/// sort order
+	pub matches: Vec<i64>
 }
 
 /// Exported result
@@ -691,6 +689,22 @@ pub struct ColumnSelection {
 	pub spec: ArraySelection
 }
 
+/// Possible values for SortOrder in SearchSchema
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
+pub enum SearchSchemaSortOrder {
+	#[serde(rename = "original")]
+	#[strum(to_string = "original")]
+	Original,
+
+	#[serde(rename = "ascending")]
+	#[strum(to_string = "ascending")]
+	Ascending,
+
+	#[serde(rename = "descending")]
+	#[strum(to_string = "descending")]
+	Descending
+}
+
 /// Possible values for ColumnDisplayType
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
 pub enum ColumnDisplayType {
@@ -1059,15 +1073,12 @@ pub struct GetSchemaParams {
 /// Parameters for the SearchSchema method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SearchSchemaParams {
-	/// Column filters to apply when searching
+	/// Column filters to apply when searching, can be empty
 	pub filters: Vec<ColumnFilter>,
 
-	/// Index (starting from zero) of first result to fetch (for paging)
-	pub start_index: i64,
-
-	/// Maximum number of resulting column schemas to fetch from the start
-	/// index
-	pub max_results: i64,
+	/// How to sort results: original in-schema order, alphabetical ascending
+	/// or descending
+	pub sort_order: SearchSchemaSortOrder,
 }
 
 /// Parameters for the GetDataValues method.
@@ -1181,10 +1192,9 @@ pub enum DataExplorerBackendRequest {
 	#[serde(rename = "get_schema")]
 	GetSchema(GetSchemaParams),
 
-	/// Search full, unfiltered table schema with column filters
+	/// Search table schema with column filters, optionally sort results
 	///
-	/// Search full, unfiltered table schema for column names matching one or
-	/// more column filters
+	/// Search table schema with column filters, optionally sort results
 	#[serde(rename = "search_schema")]
 	SearchSchema(SearchSchemaParams),
 

--- a/crates/amalthea/src/comm/variables_comm.rs
+++ b/crates/amalthea/src/comm/variables_comm.rs
@@ -44,6 +44,22 @@ pub struct FormattedVariable {
 	pub content: String
 }
 
+/// Result of the summarize operation
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct QueryTableSummaryResult {
+	/// The total number of rows in the table.
+	pub num_rows: i64,
+
+	/// The total number of columns in the table.
+	pub num_columns: i64,
+
+	/// The column schemas in the table.
+	pub column_schemas: Vec<String>,
+
+	/// The column profiles in the table.
+	pub column_profiles: Vec<String>
+}
+
 /// A single variable in the runtime.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Variable {
@@ -196,6 +212,16 @@ pub struct ViewParams {
 	pub path: Vec<String>,
 }
 
+/// Parameters for the QueryTableSummary method.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct QueryTableSummaryParams {
+	/// The path to the table to summarize, as an array of access keys.
+	pub path: Vec<String>,
+
+	/// A list of query types.
+	pub query_types: Vec<String>,
+}
+
 /// Parameters for the Update method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct UpdateParams {
@@ -271,6 +297,12 @@ pub enum VariablesBackendRequest {
 	#[serde(rename = "view")]
 	View(ViewParams),
 
+	/// Query table summary
+	///
+	/// Request a data summary for a table variable.
+	#[serde(rename = "query_table_summary")]
+	QueryTableSummary(QueryTableSummaryParams),
+
 }
 
 /**
@@ -296,6 +328,9 @@ pub enum VariablesBackendReply {
 
 	/// The ID of the viewer that was opened.
 	ViewReply(Option<String>),
+
+	/// Result of the summarize operation
+	QueryTableSummaryReply(QueryTableSummaryResult),
 
 }
 

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -14,6 +14,8 @@ use amalthea::comm::data_explorer_comm::BackendState;
 use amalthea::comm::data_explorer_comm::CodeSyntaxName;
 use amalthea::comm::data_explorer_comm::ColumnDisplayType;
 use amalthea::comm::data_explorer_comm::ColumnFilter;
+use amalthea::comm::data_explorer_comm::ColumnFilterType;
+use amalthea::comm::data_explorer_comm::ColumnFilterTypeSupportStatus;
 use amalthea::comm::data_explorer_comm::ColumnProfileType;
 use amalthea::comm::data_explorer_comm::ColumnProfileTypeSupportStatus;
 use amalthea::comm::data_explorer_comm::ColumnSchema;
@@ -1054,14 +1056,12 @@ impl RDataExplorer {
                 search_schema: SearchSchemaFeatures {
                     support_status: SupportStatus::Supported,
                     supported_types: vec![
-                        amalthea::comm::data_explorer_comm::ColumnFilterTypeSupportStatus {
-                            column_filter_type:
-                                amalthea::comm::data_explorer_comm::ColumnFilterType::TextSearch,
+                        ColumnFilterTypeSupportStatus {
+                            column_filter_type: ColumnFilterType::TextSearch,
                             support_status: SupportStatus::Supported,
                         },
-                        amalthea::comm::data_explorer_comm::ColumnFilterTypeSupportStatus {
-                            column_filter_type:
-                                amalthea::comm::data_explorer_comm::ColumnFilterType::MatchDataTypes,
+                        ColumnFilterTypeSupportStatus {
+                            column_filter_type: ColumnFilterType::MatchDataTypes,
                             support_status: SupportStatus::Supported,
                         },
                     ],

--- a/crates/ark/src/lsp/completions/sources/unique/colon.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/colon.rs
@@ -30,7 +30,9 @@ impl CompletionSource for SingleColonSource {
 // Don't provide completions if on a single `:`, which typically precedes
 // a `::` or `:::`. It means we don't provide completions for `1:` but we
 // accept that.
-fn completions_from_single_colon(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
+fn completions_from_single_colon(
+    context: &DocumentContext,
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     if is_single_colon(context) {
         // Return an empty vector to signal that we are done
         Ok(Some(vec![]))

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -40,7 +40,9 @@ impl CompletionSource for CommentSource {
     }
 }
 
-fn completions_from_comment(context: &DocumentContext) -> anyhow::Result<Option<Vec<CompletionItem>>> {
+fn completions_from_comment(
+    context: &DocumentContext,
+) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 
     if !node.is_comment() {

--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -294,6 +294,11 @@ impl RVariables {
                 let viewer_id = self.view(&params.path)?;
                 Ok(VariablesBackendReply::ViewReply(viewer_id))
             },
+            VariablesBackendRequest::QueryTableSummary(_) => {
+                return Err(anyhow::anyhow!(
+                    "Variables: QueryTableSummary not yet supported"
+                ));
+            },
         }
     }
 


### PR DESCRIPTION
Addresses posit-dev/positron#8805, follows backend API change in https://github.com/posit-dev/positron/pull/8810. Also pulls in variables comm changes which can be implemented in a follow up PR