### PR TITLE
Initialize graphics device on startup

### DIFF
--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -513,6 +513,16 @@ impl RMain {
             startup::source_user_r_profile();
         }
 
+        // Initialise graphics device so `grDevices::dev.interactive()` returns `TRUE`.
+        // See https://github.com/posit-dev/positron/issues/7681.
+        // Needs to happen _after_ sourcing R profiles so users can override the
+        // graphics device in Rprofile.
+        unsafe {
+            if let Err(err) = graphics_device::ps_graphics_device_impl() {
+                log::warn!("Can't initialize graphics device: {err:?}");
+            }
+        }
+
         // Start the REPL. Does not return!
         crate::sys::interface::run_r();
     }

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -899,7 +899,7 @@ unsafe extern "C-unwind" fn callback_new_page(dd: pGEcontext, dev: pDevDesc) {
     });
 }
 
-unsafe fn ps_graphics_device_impl() -> anyhow::Result<SEXP> {
+pub(crate) unsafe fn ps_graphics_device_impl() -> anyhow::Result<SEXP> {
     // TODO: Don't allow creation of more than one graphics device.
 
     // Create the graphics device.


### PR DESCRIPTION
Branched from #894.
Addresses https://github.com/posit-dev/positron/issues/7681.

### QA Notes

Running `demo(graphics)` _in a fresh session_  with release Positron should render all the plots non-interactively:

https://github.com/user-attachments/assets/94c7504c-d912-4386-b94d-718a822d0f97

With the fix, this should now prompt you to type Enter between each plot.

https://github.com/user-attachments/assets/ea96eab4-f2ef-4a99-93a1-3d1b03c8d50b