### PR TITLE
fix: warning: hiding a lifetime that's elided elsewhere is confusing

### DIFF
--- a/crates/ark/src/lsp/help.rs
+++ b/crates/ark/src/lsp/help.rs
@@ -129,7 +129,7 @@ impl RHtmlHelp {
     }
 
     #[allow(unused)]
-    pub fn section(&self, name: &str) -> Option<Vec<ElementRef>> {
+    pub fn section(&self, name: &str) -> Option<Vec<ElementRef<'_>>> {
         // find all h3 headers in the document
         let selector = Selector::parse("h3").unwrap();
         let mut headers = self.html.select(&selector);

--- a/crates/ark/src/lsp/help_topic.rs
+++ b/crates/ark/src/lsp/help_topic.rs
@@ -64,7 +64,7 @@ pub(crate) fn help_topic(
     Ok(Some(response))
 }
 
-fn locate_help_node(tree: &Tree, point: Point) -> Option<Node> {
+fn locate_help_node(tree: &Tree, point: Point) -> Option<Node<'_>> {
     let root = tree.root_node();
 
     let Some(mut node) = root.find_closest_node_to_point(point) else {

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -665,7 +665,7 @@ pub(crate) fn publish_diagnostics(uri: Url, diagnostics: Vec<Diagnostic>, versio
 }
 
 impl KernelNotification {
-    pub(crate) fn trace(&self) -> TraceKernelNotification {
+    pub(crate) fn trace(&self) -> TraceKernelNotification<'_> {
         TraceKernelNotification { inner: self }
     }
 }


### PR DESCRIPTION
fixes rustc warnings about hidden lifetimes