### PR TITLE
data explorer: switch convert to code to be unsupported

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -1125,7 +1125,7 @@ impl RDataExplorer {
                     ],
                 },
                 convert_to_code: ConvertToCodeFeatures {
-                    support_status: SupportStatus::Supported,
+                    support_status: SupportStatus::Unsupported,
                     code_syntaxes: Some(vec![
                         CodeSyntaxName {
                             code_syntax_name: "base".into(),


### PR DESCRIPTION
In the effort to turn off the feature flag for the convert to code feature, I've flipped this to be unsupported for R. 

Originally, I had planned for the button to be greyed out, but this change will totally remove the button for R data explorer instances. This seems a bit more obvious that the feature is not available for this data type, rather than just inactive. 