### PR TITLE
Add support for table summary tool

### DIFF
--- a/crates/ark/src/variables/r_variables.rs
+++ b/crates/ark/src/variables/r_variables.rs
@@ -119,7 +119,7 @@ impl RVariables {
         // Validate that the RObject we were passed is actually an environment
         if let Err(err) = r_assert_type(env.sexp, &[ENVSXP]) {
             log::warn!(
-                "Environment: Attempt to monitor or list non-environment object {env:?} ({err:?})"
+                "Variables: Attempt to monitor or list non-environment object {env:?} ({err:?})"
             );
         }
 
@@ -191,17 +191,17 @@ impl RVariables {
                             // appropriate. Retrying is likely to just lead to a busy
                             // loop.
                             log::error!(
-                                "Environment: Error receiving message from frontend: {err:?}"
+                                "Variables: Error receiving message from frontend: {err:?}"
                             );
 
                             break;
                         },
                     };
-                    log::info!("Environment: Received message from frontend: {msg:?}");
+                    log::info!("Variables: Received message from frontend: {msg:?}");
 
                     // Break out of the loop if the frontend has closed the channel
                     if let CommMsg::Close = msg {
-                        log::info!("Environment: Closing down after receiving comm_close from frontend.");
+                        log::info!("Variables: Closing down after receiving comm_close from frontend.");
 
                         // Remember that the user initiated the close so that we can
                         // avoid sending a duplicate close message from the back end
@@ -415,7 +415,7 @@ impl RVariables {
                 self.comm.outgoing_tx.send(comm_msg).unwrap()
             },
             Err(err) => {
-                log::error!("Environment: Failed to serialize environment data: {err}");
+                log::error!("Variables: Failed to serialize environment data: {err}");
             },
         }
     }
@@ -449,7 +449,7 @@ impl RVariables {
                 Err(err) => {
                     // This isn't a critical error but would also be very
                     // unexpected.
-                    log::error!("Environment: Could not evaluate .Last.value ({err:?})");
+                    log::error!("Variables: Could not evaluate .Last.value ({err:?})");
                     None
                 },
             }

--- a/crates/ark/tests/environment.rs
+++ b/crates/ark/tests/environment.rs
@@ -9,17 +9,20 @@ use amalthea::comm::comm_channel::CommMsg;
 use amalthea::comm::event::CommManagerEvent;
 use amalthea::comm::variables_comm::ClearParams;
 use amalthea::comm::variables_comm::DeleteParams;
+use amalthea::comm::variables_comm::QueryTableSummaryParams;
 use amalthea::comm::variables_comm::VariablesBackendReply;
 use amalthea::comm::variables_comm::VariablesBackendRequest;
 use amalthea::comm::variables_comm::VariablesFrontendEvent;
 use amalthea::socket::comm::CommInitiator;
 use amalthea::socket::comm::CommSocket;
+use ark::fixtures::r_test_lock;
 use ark::lsp::events::EVENTS;
 use ark::r_task::r_task;
 use ark::thread::RThreadSafe;
 use ark::variables::r_variables::LastValue;
 use ark::variables::r_variables::RVariables;
 use crossbeam::channel::bounded;
+use harp::environment::R_ENVS;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::object::RObject;
@@ -44,6 +47,7 @@ use libr::Rf_xlength;
  */
 #[test]
 fn test_environment_list() {
+    let _lock = r_test_lock();
     // Create a new environment for the test. We use a new, empty environment
     // (with the empty environment as its parent) so that each test in this
     // file can run independently.
@@ -302,6 +306,8 @@ fn test_environment_list() {
  */
 #[test]
 fn test_environment_last_value_enabled() {
+    let _lock = r_test_lock();
+
     // Create a new environment for the test
     let test_env = r_task(|| unsafe {
         let env = RFunction::new("base", "new.env")
@@ -523,4 +529,237 @@ fn test_environment_last_value_disabled() {
 
     // Close the comm
     incoming_tx.send(CommMsg::Close).unwrap();
+}
+
+#[test]
+fn test_query_table_summary() {
+    let _lock = r_test_lock();
+
+    // Create a sender/receiver pair for the comm channel
+    let comm = CommSocket::new(
+        CommInitiator::FrontEnd,
+        String::from("test-table-summary-comm-id"),
+        String::from("positron.environment"),
+    );
+    let incoming_tx = comm.incoming_tx.clone();
+    let outgoing_rx = comm.outgoing_rx.clone();
+
+    // Simulate comm manager
+    let (comm_manager_tx, _) = bounded::<CommManagerEvent>(0);
+
+    r_task(|| {
+        // Create a new variables comm
+        RVariables::start(RObject::from(R_ENVS.global), comm.clone(), comm_manager_tx);
+
+        // Create test datasets
+        let code = r#"
+        test_df <- data.frame(
+            numeric_col = c(1.5, 2.5, 3.5, NA),
+            integer_col = c(1L, 2L, 3L, 4L),
+            character_col = c('a', 'b', 'c', ''),
+            logical_col = c(TRUE, FALSE, TRUE, NA),
+            stringsAsFactors = FALSE
+        )
+        "#;
+        harp::parse_eval_global(code).unwrap();
+
+        let code = r#"
+        test_matrix <- matrix(
+            1:12,
+            nrow = 4,
+            ncol = 3,
+            dimnames = list(
+                c('row1', 'row2', 'row3', 'row4'),
+                c('col1', 'col2', 'col3')
+            )
+        )"#;
+
+        harp::parse_eval_global(code).unwrap();
+    });
+
+    // Simulate a prompt signal to refresh the variable list
+    // and consume the update event
+    EVENTS.console_prompt.emit(());
+    let _ = outgoing_rx.recv().unwrap();
+
+    // --- TEST 1: Query summary for data.frame with summary_stats query type ---
+
+    // Request table summary for data.frame
+    let query_df = VariablesBackendRequest::QueryTableSummary(QueryTableSummaryParams {
+        path: vec![String::from("test_df")],
+        query_types: vec![String::from("summary_stats")],
+    });
+
+    let data = serde_json::to_value(query_df).unwrap();
+    let request_id = String::from("df-summary-id");
+
+    incoming_tx
+        .send(CommMsg::Rpc(request_id.clone(), data))
+        .unwrap();
+
+    // Get the response
+    let data = match outgoing_rx.recv().unwrap() {
+        CommMsg::Rpc(reply_id, data) => {
+            assert_eq!(request_id, reply_id);
+            data
+        },
+        _ => panic!("Expected RPC message"),
+    };
+
+    // Verify the response
+    let reply: VariablesBackendReply = serde_json::from_value(data).unwrap();
+    match reply {
+        VariablesBackendReply::QueryTableSummaryReply(result) => {
+            assert_eq!(result.num_rows, 4);
+            assert_eq!(result.num_columns, 4);
+            assert_eq!(result.column_schemas.len(), 4);
+            assert_eq!(result.column_profiles.len(), 4);
+
+            let schemas: Vec<serde_json::Value> = result
+                .column_schemas
+                .iter()
+                .map(|s| serde_json::from_str(s).unwrap())
+                .collect();
+
+            assert_eq!(schemas[0]["column_name"], "numeric_col");
+            assert_eq!(schemas[1]["column_name"], "integer_col");
+            assert_eq!(schemas[2]["column_name"], "character_col");
+            assert_eq!(schemas[3]["column_name"], "logical_col");
+
+            assert_eq!(schemas[0]["type_display"], "number");
+            assert_eq!(schemas[1]["type_display"], "number");
+            assert_eq!(schemas[2]["type_display"], "string");
+            assert_eq!(schemas[3]["type_display"], "boolean");
+
+            let profiles: Vec<serde_json::Value> = result
+                .column_profiles
+                .iter()
+                .map(|p| serde_json::from_str(p).unwrap())
+                .collect();
+
+            // Check that summary stats exists for each column
+            for profile in &profiles {
+                assert!(profile["summary_stats"].is_object());
+            }
+
+            // Check numeric column stats
+            let numeric_stats = &profiles[0]["summary_stats"];
+            assert!(numeric_stats["number_stats"].is_object());
+
+            // Check logical column stats
+            let logical_stats = &profiles[3]["summary_stats"];
+            assert!(logical_stats["boolean_stats"].is_object());
+        },
+
+        _ => panic!("Expected QueryTableSummaryReply"),
+    }
+
+    // --- TEST 2: Query summary for matrix with empty query type list ---
+
+    // Request table summary for matrix without summary_stats
+    let query_matrix = VariablesBackendRequest::QueryTableSummary(QueryTableSummaryParams {
+        path: vec![String::from("test_matrix")],
+        query_types: vec![], // Empty query types list
+    });
+
+    let data = serde_json::to_value(query_matrix).unwrap();
+    let request_id = String::from("matrix-summary-id");
+
+    incoming_tx
+        .send(CommMsg::Rpc(request_id.clone(), data))
+        .unwrap();
+
+    // Get the response
+    let data = match outgoing_rx.recv().unwrap() {
+        CommMsg::Rpc(reply_id, data) => {
+            assert_eq!(request_id, reply_id);
+            data
+        },
+        _ => panic!("Expected RPC message"),
+    };
+
+    // Verify the response
+    let reply: VariablesBackendReply = serde_json::from_value(data).unwrap();
+    match reply {
+        VariablesBackendReply::QueryTableSummaryReply(result) => {
+            // Check basic structure
+            assert_eq!(result.num_rows, 4);
+            assert_eq!(result.num_columns, 3);
+            assert_eq!(result.column_schemas.len(), 3);
+
+            // No profiles should be generated (empty query_types)
+            assert_eq!(result.column_profiles.len(), 0);
+
+            // Parse and check column schemas
+            let schemas: Vec<serde_json::Value> = result
+                .column_schemas
+                .iter()
+                .map(|s| serde_json::from_str(s).unwrap())
+                .collect();
+
+            // Check column names match the dimnames we set
+            assert_eq!(schemas[0]["column_name"], "col1");
+            assert_eq!(schemas[1]["column_name"], "col2");
+            assert_eq!(schemas[2]["column_name"], "col3");
+
+            // Matrix should have numeric columns
+            for schema in &schemas {
+                assert_eq!(schema["type_display"], "number");
+            }
+        },
+        _ => panic!("Expected QueryTableSummaryReply"),
+    }
+
+    // --- TEST 3: Test query for an object that is not a table ---
+
+    // Create a non-table object
+    r_task(|| {
+        let code = "non_table_obj <- list(a = 1, b = 2)";
+        harp::parse_eval_global(code).unwrap();
+    });
+
+    // Simulate a prompt signal to refresh the variable list
+    // and consume the update event
+    EVENTS.console_prompt.emit(());
+    let _ = outgoing_rx.recv().unwrap();
+
+    // Request table summary for non-table object
+    let query_non_table = VariablesBackendRequest::QueryTableSummary(QueryTableSummaryParams {
+        path: vec![String::from("non_table_obj")],
+        query_types: vec![String::from("summary_stats")],
+    });
+
+    let data = serde_json::to_value(query_non_table).unwrap();
+    let request_id = String::from("non-table-summary-id");
+
+    incoming_tx
+        .send(CommMsg::Rpc(request_id.clone(), data))
+        .unwrap();
+
+    // Get the error response
+    let data = match outgoing_rx.recv().unwrap() {
+        CommMsg::Rpc(reply_id, data) => {
+            assert_eq!(request_id, reply_id);
+            data
+        },
+        _ => panic!("Expected RPC message"),
+    };
+
+    // Check if the response contains an error field (JSON-RPC error)
+    if data.get("error").is_some() {
+        let error_message = data["error"]["message"].as_str().unwrap();
+        assert!(error_message.contains("not a supported table type"));
+    } else {
+        // If no error, it must be a successful reply which is unexpected
+        panic!("Expected error response, but got successful reply");
+    }
+
+    // Close the comm
+    incoming_tx.send(CommMsg::Close).unwrap();
+
+    // Clean up
+    r_task(|| {
+        let code = "rm(test_df, test_matrix, non_table_obj)";
+        harp::parse_eval_global(code).unwrap();
+    });
 }

--- a/crates/ark/tests/variables.rs
+++ b/crates/ark/tests/variables.rs
@@ -1,5 +1,5 @@
 //
-// environment.rs
+// variables.rs
 //
 // Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 //

--- a/crates/ark/tests/variables.rs
+++ b/crates/ark/tests/variables.rs
@@ -46,7 +46,7 @@ use libr::Rf_xlength;
  * 5. Ensures that the environment list contains the new variable
  */
 #[test]
-fn test_environment_list() {
+fn test_variables_list() {
     let _lock = r_test_lock();
     // Create a new environment for the test. We use a new, empty environment
     // (with the empty environment as its parent) so that each test in this
@@ -305,7 +305,7 @@ fn test_environment_list() {
  *
  */
 #[test]
-fn test_environment_last_value_enabled() {
+fn test_variables_last_value_enabled() {
     let _lock = r_test_lock();
 
     // Create a new environment for the test
@@ -442,7 +442,7 @@ fn test_environment_last_value_enabled() {
  *
  */
 #[test]
-fn test_environment_last_value_disabled() {
+fn test_variables_last_value_disabled() {
     // Create a new environment for the test
     let test_env = r_task(|| unsafe {
         let env = RFunction::new("base", "new.env")

--- a/crates/harp/src/column_names.rs
+++ b/crates/harp/src/column_names.rs
@@ -54,4 +54,15 @@ impl ColumnNames {
         }
         None
     }
+
+    pub fn get(&self, index: isize) -> anyhow::Result<Option<String>> {
+        if let Some(names) = &self.names {
+            if let Some(name) = names.get(index)? {
+                if name.len() > 0 {
+                    return Ok(Some(name));
+                }
+            }
+        }
+        Ok(None)
+    }
 }


### PR DESCRIPTION
For https://github.com/posit-dev/positron/issues/8343

Implemented by Claude ✨, including the tests. Everything looks legit and I've verified the summaries match those emitted on the Python side.

Claude had access to the Python side implementation which is more complicated as it opens up a temporary data explorer comm to make requests. It decided to use the internal profile summary utils, which is simpler here.

I've also cleaned up a bit:

- Environment → Variables renames
- Use a lock in tests to avoid them confusing in eacher.