### PR TITLE
Set as interactive on startup, set `options(device =)` to a string

### DIFF
--- a/crates/ark/src/modules/positron/options.R
+++ b/crates/ark/src/modules/positron/options.R
@@ -21,11 +21,6 @@ options(browser = function(url) {
     .ps.Call("ps_browse_url", as.character(url))
 })
 
-# Set up graphics device
-options(device = function() {
-    .ps.Call("ps_graphics_device")
-})
-
 # Register our password handler as the generic `askpass` option.
 # Same as RStudio, see `?rstudioapi::askForPassword` for rationale.
 options(askpass = function(prompt) {


### PR DESCRIPTION
My preferred alternative to https://github.com/posit-dev/ark/pull/895

In a fresh R session, `.Device` in RStudio returns `"null device"` and `getOption("device")` returns `"RStudioGD"`. i.e. R doesn't have a current device active, but it knows to use a function named `RStudioGD()` when it needs to make one (and indeed you can call `RStudioGD` at the console and you can find it yourself).

For these reasons, I do not think we should inject ourselves as the current active device on startup. I think we should also follow RStudio's lead.

To solve the problem a different way, we just recognize that the main issue is that we are calling `grDevices::deviceIsInteractive()` to register ourselves as an interactive device too late - we are calling it at first plot time, but should call it at startup time. I have made that change in this PR, and in theory that should have been enough to fix the issue.

In practice there is one other issue I had to deal with. We set `options(device = <fn>)` where RStudio sets `options(device = "RStudioGD")`. This is surprisingly important. In a fresh session, `grDevices::dev.interactive(orNone = TRUE)` (used by `demo(graphics)`) will look to see if the current device is in the set of known devices provided by `deviceIsInteractive()`. However, if that device is `"null device"`, then it will consult `getOption("device")` and see if that _name_ is in the set provided by `deviceIsInteractive()` instead. But if you set `options(device =)` to a _function_ rather than a _name_ then you don't get to take advantage of this nice feature. I've reworked a few things to take advantage of this now.

I've also updated docs and added tests to assert our beliefs about how these functions work on startup.