### PR TITLE
Key by `Url` instead of `Path` in workspace indexer

### DIFF
--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -91,19 +91,17 @@ fn completions_from_workspace(
                 let mut path = uri.as_str().to_owned();
 
                 if uri.scheme() == "file" {
-                    let Ok(file_path) = uri.to_file_path() else {
-                        return;
-                    };
-
-                    for folder in &state.workspace.folders {
-                        let Ok(folder_path) = folder.to_file_path() else {
-                            continue;
-                        };
-                        if let Ok(relative_path) = file_path.strip_prefix(&folder_path) {
-                            path = relative_path.to_string_lossy().to_string();
-                            break;
+                    if let Ok(file_path) = uri.to_file_path() {
+                        for folder in &state.workspace.folders {
+                            let Ok(folder_path) = folder.to_file_path() else {
+                                continue;
+                            };
+                            if let Ok(relative_path) = file_path.strip_prefix(&folder_path) {
+                                path = relative_path.to_string_lossy().to_string();
+                                break;
+                            }
                         }
-                    }
+                    };
                 }
 
                 let value = format!(

--- a/crates/ark/src/lsp/definitions.rs
+++ b/crates/ark/src/lsp/definitions.rs
@@ -51,7 +51,7 @@ pub fn goto_definition<'a>(
             indexer::find_in_file(symbol.as_str(), uri).or_else(|| indexer::find(symbol.as_str()));
 
         if let Some((file_id, entry)) = info {
-            let target_uri = file_id.as_url().clone();
+            let target_uri = file_id.as_uri().clone();
             let link = LocationLink {
                 origin_selection_range: None,
                 target_uri,

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -159,7 +159,7 @@ pub(crate) fn generate_diagnostics(
     context.document_symbols.push(HashMap::new());
 
     // Add the current workspace symbols.
-    indexer::map(|_path, _symbol, entry| match &entry.data {
+    indexer::map(|_uri, _symbol, entry| match &entry.data {
         indexer::IndexEntryData::Function { name, arguments: _ } => {
             context.workspace_symbols.insert(name.to_string());
         },

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -43,7 +43,6 @@ impl FileId {
         Self { uri }
     }
 
-    #[allow(unused)]
     pub fn as_str(&self) -> &str {
         self.uri.as_str()
     }

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -261,8 +261,6 @@ pub(crate) fn create(uri: &Url) -> anyhow::Result<()> {
     // Only index R files for file URIs. This discards `inmemory` (Console) and
     // `ark` schemes in particular.
 
-    log::error!("=== Creating index for URI: {uri:?}");
-
     if uri.scheme() != "file" {
         return Ok(());
     }

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -492,7 +492,6 @@ fn index_comment(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
 
     use assert_matches::assert_matches;
     use insta::assert_debug_snapshot;
@@ -500,12 +499,12 @@ mod tests {
 
     use super::*;
     use crate::lsp::documents::Document;
+    use crate::lsp::util::test_path;
 
     macro_rules! test_index {
         ($code:expr) => {
             let doc = Document::new($code, None);
-            let path = PathBuf::from("/path/to/file.R");
-            let uri = Url::from_file_path(&path).unwrap();
+            let uri = test_path("/path/to/file.R");
             let root = doc.ast.root_node();
             let mut cursor = root.walk();
 

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -808,37 +808,26 @@ async fn process_indexer_batch(batch: Vec<IndexerTask>) {
         summary = summarize_indexer_task(&batch)
     );
 
-    let to_path_buf = |uri: &url::Url| {
-        uri.to_file_path()
-            .map_err(|_| anyhow!("Failed to convert URI '{uri}' to file path"))
-    };
-
     for task in batch {
         let result: anyhow::Result<()> = (|| async {
             match &task {
                 IndexerTask::Create { uri } => {
-                    let path = to_path_buf(uri)?;
-                    indexer::create(&path)?;
+                    indexer::create(uri)?;
                 },
 
                 IndexerTask::Update { uri, document } => {
-                    let path = to_path_buf(uri)?;
-                    indexer::update(&document, &path)?;
+                    indexer::update(&document, uri)?;
                 },
 
                 IndexerTask::Delete { uri } => {
-                    let path = to_path_buf(uri)?;
-                    indexer::delete(&path)?;
+                    indexer::delete(uri)?;
                 },
 
                 IndexerTask::Rename {
                     uri: old_uri,
                     new: new_uri,
                 } => {
-                    let old_path = to_path_buf(old_uri)?;
-                    let new_path = to_path_buf(new_uri)?;
-
-                    indexer::rename(&old_path, &new_path)?;
+                    indexer::rename(old_uri, new_uri)?;
                 },
             }
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -213,6 +213,12 @@ pub(crate) fn did_open(
 ) -> anyhow::Result<()> {
     let contents = params.text_document.text.as_str();
     let uri = params.text_document.uri;
+
+    if !is_lsp_uri(&uri) {
+        tracing::trace!("Skipping non-file URI in did_open: {uri}");
+        return Ok(());
+    }
+
     let version = params.text_document.version;
 
     let mut parser = Parser::new();
@@ -240,6 +246,12 @@ pub(crate) fn did_change(
     state: &mut WorldState,
 ) -> anyhow::Result<()> {
     let uri = &params.text_document.uri;
+
+    if !is_lsp_uri(uri) {
+        tracing::trace!("Skipping non-file URI in did_change: {uri}");
+        return Ok(());
+    }
+
     let document = state.get_document_mut(uri)?;
 
     let mut parser = lsp_state
@@ -261,6 +273,11 @@ pub(crate) fn did_close(
     state: &mut WorldState,
 ) -> anyhow::Result<()> {
     let uri = params.text_document.uri;
+
+    if !is_lsp_uri(&uri) {
+        tracing::trace!("Skipping non-file URI in did_close: {uri}");
+        return Ok(());
+    }
 
     // Publish empty set of diagnostics to clear them
     lsp::publish_diagnostics(uri.clone(), Vec::new(), None);
@@ -364,6 +381,11 @@ pub(crate) fn did_change_formatting_options(
     opts: &FormattingOptions,
     state: &mut WorldState,
 ) {
+    if !is_lsp_uri(uri) {
+        tracing::trace!("Skipping non-file URI in did_change_formatting_options: {uri}");
+        return;
+    }
+
     let Ok(doc) = state.get_document_mut(uri) else {
         return;
     };
@@ -505,4 +527,11 @@ pub(crate) fn did_close_virtual_document(
 ) -> anyhow::Result<()> {
     state.virtual_documents.remove(&params.uri);
     Ok(())
+}
+
+/// Can a URI be opened by the LSP?
+/// Discards e.g. `inmemory:` URIs.
+/// https://github.com/posit-dev/positron/issues/8790
+pub(crate) fn is_lsp_uri(uri: &url::Url) -> bool {
+    uri.scheme() == "file" || uri.scheme() == "ark"
 }

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -17,7 +17,6 @@ use tower_lsp::lsp_types::Location;
 use tower_lsp::lsp_types::Range;
 use tower_lsp::lsp_types::SymbolInformation;
 use tower_lsp::lsp_types::SymbolKind;
-use tower_lsp::lsp_types::Url;
 use tower_lsp::lsp_types::WorkspaceSymbolParams;
 use tree_sitter::Node;
 
@@ -63,7 +62,7 @@ pub(crate) fn symbols(
     let query = &params.query;
     let mut info: Vec<SymbolInformation> = Vec::new();
 
-    indexer::map(|path, symbol, entry| {
+    indexer::map(|uri, symbol, entry| {
         if !symbol.fuzzy_matches(query) {
             return;
         }
@@ -74,7 +73,7 @@ pub(crate) fn symbols(
                     name: name.to_string(),
                     kind: SymbolKind::FUNCTION,
                     location: Location {
-                        uri: Url::from_file_path(path).unwrap(),
+                        uri: uri.clone(),
                         range: entry.range,
                     },
                     tags: None,
@@ -89,7 +88,7 @@ pub(crate) fn symbols(
                         name: title.to_string(),
                         kind: SymbolKind::STRING,
                         location: Location {
-                            uri: Url::from_file_path(path).unwrap(),
+                            uri: uri.clone(),
                             range: entry.range,
                         },
                         tags: None,
@@ -104,7 +103,7 @@ pub(crate) fn symbols(
                     name: name.clone(),
                     kind: SymbolKind::VARIABLE,
                     location: Location {
-                        uri: Url::from_file_path(path).unwrap(),
+                        uri: uri.clone(),
                         range: entry.range,
                     },
                     tags: None,
@@ -118,7 +117,7 @@ pub(crate) fn symbols(
                     name: name.clone(),
                     kind: SymbolKind::METHOD,
                     location: Location {
-                        uri: Url::from_file_path(path).unwrap(),
+                        uri: uri.clone(),
                         range: entry.range,
                     },
                     tags: None,
@@ -1176,8 +1175,8 @@ outer <- 4
 
             // Index the document
             let doc = Document::new(code, None);
-            let (path, _) = test_path("test.R");
-            indexer::update(&doc, &path).unwrap();
+            let uri = test_path("test.R");
+            indexer::update(&doc, &uri).unwrap();
 
             // Query for all symbols
             let params = WorkspaceSymbolParams {

--- a/crates/ark/src/lsp/util.rs
+++ b/crates/ark/src/lsp/util.rs
@@ -29,12 +29,11 @@ pub unsafe extern "C-unwind" fn ps_object_id(object: SEXP) -> anyhow::Result<SEX
     return Ok(Rf_mkString(value.as_ptr() as *const c_char));
 }
 
-/// Create an absolute path from a file name.
+/// Create a URI from a file name.
 /// File name is joined to the temp directory in a cross-platform way.
-/// Returns both a `PathBuf` and a `Url`. Does not create the file.
+/// Returns a `Url`. Does not create the file.
 #[cfg(test)]
-pub(crate) fn test_path(file_name: &str) -> (std::path::PathBuf, url::Url) {
+pub(crate) fn test_path(file_name: &str) -> url::Url {
     let path = std::env::temp_dir().join(file_name);
-    let uri = url::Url::from_file_path(&path).unwrap();
-    (path, uri)
+    url::Url::from_file_path(&path).unwrap()
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8790

The warnings only appear on Windows because the conversion to `Path` actually succeeds on Unixes. So we were calling `create() with non-file URIs on Unixes but not on Windows. To fix the warnings and make things more consistent, this PR:

- Now uses `Url` (wrapped in a new `FileId` struct) as key in our map of file to indexer. This is more general and simplifies a bunch of `Path` to `Url` conversions, avoiding by the same token potential warnings. The `FileId` wrapper is used for stronger internal type checking / self-documentation, but not exposed in the public API.

- Declines to index non-file URIs. This makes the check for `[rR]` files stronger.