### PR TITLE
Add support for determining the right Linux binary URL for Pop!_OS

### DIFF
--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -254,7 +254,7 @@ fn get_ppm_linux_repo(repo_url: Option<url::Url>, linux_name: String) -> anyhow:
 #[cfg(target_os = "linux")]
 fn get_p3m_linux_codename(id: String, version: String, version_codename: String) -> String {
     // For Debian and Ubuntu, we can just use the codename
-    if id == "debian" || id == "ubuntu" {
+    if id == "debian" || id == "ubuntu" || id == "pop" {
         return version_codename.to_string();
     } else if id == "rhel" {
         // For RHEL, we use the id and major version number


### PR DESCRIPTION
This commit is a simple fix that ensures we can generate the right Linux binary URLs for Pop!_OS users.

Pop OS is a fairly popular desktop distro that is binary-compatible with Ubuntu, so e.g. `jammy` binaries from Public Package Manager work out of the box.

We never had to worry about detecting this distro for Workbench because it's desktop-only, but it's nice to wire things up in Ark to benefit desktop Positron users (like me!) on this distro.