### PR TITLE
Bump Ark to 0.1.208

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.207"
+version = "0.1.208"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
This brings in:

- https://github.com/posit-dev/ark/pull/914
- https://github.com/posit-dev/ark/pull/916

### Release Notes

#### New Features

- New selection backend for R Data Explorer

#### Bug Fixes

- R: Fixed how `Surv` objects are represented and formatted in the Data Explorer and Variables pane https://github.com/posit-dev/positron/issues/8053