### PR TITLE
Add showPrompt API handlers

### DIFF
--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -194,6 +194,14 @@ pub struct ShowDialogParams {
 	pub message: String,
 }
 
+/// Parameters for the ShowPrompt method.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ShowPromptParams {
+	/// The prompt, such as 'What is the airspeed velocity of an unladen
+	/// swallow?'
+	pub prompt: String,
+}
+
 /// Parameters for the AskForPassword method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AskForPasswordParams {
@@ -379,6 +387,12 @@ pub enum UiFrontendRequest {
 	#[serde(rename = "show_dialog")]
 	ShowDialog(ShowDialogParams),
 
+	/// Show a prompt
+	///
+	/// Use this for an input box where user can input any string
+	#[serde(rename = "show_prompt")]
+	ShowPrompt(ShowPromptParams),
+
 	/// Ask the user for a password
 	///
 	/// Use this for an input box where the user can input a password
@@ -446,6 +460,9 @@ pub enum UiFrontendReply {
 
 	/// Reply for the show_dialog method (no result)
 	ShowDialogReply(),
+
+	/// The input from the user
+	ShowPromptReply(Option<String>),
 
 	/// The input from the user
 	AskForPasswordReply(Option<String>),
@@ -548,6 +565,7 @@ pub fn ui_frontend_reply_from_value(
 		UiFrontendRequest::NewDocument(_) => Ok(UiFrontendReply::NewDocumentReply()),
 		UiFrontendRequest::ShowQuestion(_) => Ok(UiFrontendReply::ShowQuestionReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::ShowDialog(_) => Ok(UiFrontendReply::ShowDialogReply()),
+		UiFrontendRequest::ShowPrompt(_) => Ok(UiFrontendReply::ShowPromptReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::AskForPassword(_) => Ok(UiFrontendReply::AskForPasswordReply(serde_json::from_value(reply)?)),
 		UiFrontendRequest::DebugSleep(_) => Ok(UiFrontendReply::DebugSleepReply()),
 		UiFrontendRequest::ExecuteCommand(_) => Ok(UiFrontendReply::ExecuteCommandReply()),

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -201,7 +201,7 @@ pub struct ShowPromptParams {
 	pub title: String,
 
 	/// The message prompting the user for text, such as 'What is the airspeed
-	/// velocity of an unladen swallow?
+	/// velocity of an unladen swallow?'
 	pub message: String,
 
 	/// The value to return if the user does not enter one, such as 'African

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -197,9 +197,19 @@ pub struct ShowDialogParams {
 /// Parameters for the ShowPrompt method.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ShowPromptParams {
-	/// The prompt, such as 'What is the airspeed velocity of an unladen
-	/// swallow?'
-	pub prompt: String,
+	/// The title of the prompt dialog, such as 'Enter Swallow Velocity'
+	pub title: String,
+
+	/// The message prompting the user for text, such as 'What is the airspeed
+	/// velocity of an unladen swallow?
+	pub message: String,
+
+	/// The value to return if the user does not enter one, such as 'African
+	/// or European?'
+	pub default: String,
+
+	/// The number of seconds to wait for the user to reply before giving up.
+	pub timeout: i64,
 }
 
 /// Parameters for the AskForPassword method.

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -2131,22 +2131,7 @@ impl RMain {
     }
 
     pub fn call_frontend_method(&self, request: UiFrontendRequest) -> anyhow::Result<RObject> {
-        match self.call_frontend_method_with_timeout(request, None)? {
-            Some(result) => Ok(result),
-            None => unreachable!("Should never get None when no timeout is specified"),
-        }
-    }
-
-    pub fn call_frontend_method_with_timeout(
-        &self,
-        request: UiFrontendRequest,
-        timeout: Option<std::time::Duration>,
-    ) -> anyhow::Result<Option<RObject>> {
-        let timeout_desc = match timeout {
-            Some(duration) => format!(" with timeout {}s", duration.as_secs()),
-            None => String::new(),
-        };
-        log::trace!("Calling frontend method{timeout_desc}: {request:?}");
+        log::trace!("Calling frontend method {request:?}");
 
         let ui_comm_tx = self.get_ui_comm_tx().ok_or_else(|| {
             anyhow::anyhow!("UI comm is not connected. Can't execute request {request:?}")
@@ -2167,25 +2152,8 @@ impl RMain {
             request: request.clone(),
         });
 
-        // Block for reply, with or without timeout
-        let reply = match timeout {
-            Some(duration) => match reply_rx.recv_timeout(duration) {
-                Ok(reply) => reply,
-                Err(crossbeam::channel::RecvTimeoutError::Timeout) => {
-                    log::trace!(
-                        "Frontend method timed out after {}s: {request:?}",
-                        duration.as_secs()
-                    );
-                    return Ok(None);
-                },
-                Err(crossbeam::channel::RecvTimeoutError::Disconnected) => {
-                    return Err(anyhow::anyhow!(
-                        "UI comm disconnected while waiting for reply"
-                    ));
-                },
-            },
-            None => reply_rx.recv().unwrap(),
-        };
+        // Block for reply
+        let reply = reply_rx.recv().unwrap();
 
         log::trace!("Got reply from frontend method: {reply:?}");
 
@@ -2201,7 +2169,7 @@ impl RMain {
                     }
 
                     // Now deserialize to an R object
-                    Ok(Some(RObject::try_from(reply.result)?))
+                    Ok(RObject::try_from(reply.result)?)
                 },
                 JsonRpcReply::Error(reply) => {
                     let message = reply.error.message;
@@ -2215,7 +2183,7 @@ impl RMain {
             // If an interrupt was signalled, return `NULL`. This should not be
             // visible to the caller since `r_unwrap()` (called e.g. by
             // `harp::register`) will trigger an interrupt jump right away.
-            StdInRpcReply::Interrupt => Ok(Some(RObject::null())),
+            StdInRpcReply::Interrupt => Ok(RObject::null()),
         }
     }
 

--- a/crates/ark/src/modules/positron/frontend-methods.R
+++ b/crates/ark/src/modules/positron/frontend-methods.R
@@ -88,6 +88,11 @@
 }
 
 #' @export
+.ps.ui.showPrompt <- function(title, message, default, timeout) {
+    .ps.Call("ps_ui_show_prompt", title, message, default, timeout)
+}
+
+#' @export
 .ps.ui.askForPassword <- function(prompt) {
     .ps.Call("ps_ui_ask_for_password", prompt)
 }

--- a/crates/ark/src/modules/rstudio/dialogs.R
+++ b/crates/ark/src/modules/rstudio/dialogs.R
@@ -14,6 +14,9 @@
 
 
 #' @export
-.rs.api.showPrompt <- function(title, message, default, timeout = 60L) {
+.rs.api.showPrompt <- function(title, message, default) {
+    # rstudioapi doesn't pass the timeout directly but sets it as
+    # `rstudioapi.remote.timeout` option
+    timeout <- getOption('rstudioapi.remote.timeout', 60L)
     .ps.ui.showPrompt(title, message, default, timeout)
 }

--- a/crates/ark/src/modules/rstudio/dialogs.R
+++ b/crates/ark/src/modules/rstudio/dialogs.R
@@ -11,3 +11,9 @@
 .rs.api.showQuestion <- function(title, message, ok = NULL, cancel = NULL) {
     .ps.ui.showQuestion(title, message, ok, cancel)
 }
+
+
+#' @export
+.rs.api.showPrompt <- function(title, message, default, timeout = 60L) {
+    .ps.ui.showPrompt(title, message, default, timeout)
+}

--- a/crates/ark/src/ui/methods.rs
+++ b/crates/ark/src/ui/methods.rs
@@ -117,17 +117,9 @@ pub extern "C-unwind" fn ps_ui_show_prompt(
         timeout: timeout_secs,
     };
 
-    let request = UiFrontendRequest::ShowPrompt(params);
-
-    let timeout_duration = std::time::Duration::from_secs(timeout_secs as u64);
-    match RMain::get().call_frontend_method_with_timeout(request, Some(timeout_duration))? {
-        Some(result) => Ok(result.sexp),
-        None => {
-            // Timeout occurred, return null
-            let default_obj = RObject::null();
-            Ok(default_obj.sexp)
-        },
-    }
+    let main = RMain::get();
+    let out = main.call_frontend_method(UiFrontendRequest::ShowPrompt(params))?;
+    Ok(out.sexp)
 }
 
 #[harp::register]

--- a/crates/ark/src/ui/methods.rs
+++ b/crates/ark/src/ui/methods.rs
@@ -13,6 +13,7 @@ use amalthea::comm::ui_comm::ExecuteCommandParams;
 use amalthea::comm::ui_comm::ModifyEditorSelectionsParams;
 use amalthea::comm::ui_comm::NewDocumentParams;
 use amalthea::comm::ui_comm::ShowDialogParams;
+use amalthea::comm::ui_comm::ShowPromptParams;
 use amalthea::comm::ui_comm::ShowQuestionParams;
 use amalthea::comm::ui_comm::UiFrontendRequest;
 use harp::object::RObject;
@@ -94,6 +95,25 @@ pub unsafe extern "C-unwind" fn ps_ui_show_question(
 
     let main = RMain::get();
     let out = main.call_frontend_method(UiFrontendRequest::ShowQuestion(params))?;
+    Ok(out.sexp)
+}
+
+#[harp::register]
+pub unsafe extern "C-unwind" fn ps_ui_show_prompt(
+    title: SEXP,
+    message: SEXP,
+    default: SEXP,
+    timeout: SEXP,
+) -> anyhow::Result<SEXP> {
+    let params = ShowPromptParams {
+        title: RObject::view(title).try_into()?,
+        message: RObject::view(message).try_into()?,
+        default: RObject::view(default).try_into()?,
+        timeout: RObject::view(timeout).try_into()?,
+    };
+
+    let main = RMain::get();
+    let out = main.call_frontend_method(UiFrontendRequest::ShowPrompt(params))?;
     Ok(out.sexp)
 }
 


### PR DESCRIPTION
Adds API handlers for `rstudioapi::showPrompt` and creates a UI event of the name name.

The only interesting thing here is that the RStudio implementation of this method implements the timeout by (theoretically) limiting the amount of time the backend waits for the frontend. In Positron, we implement the timeout entirely on the frontend. 

In practice, it doesn't look like the `timeout` parameter works at all on RStudio, so the difference is probably academic. 

Part of the fix for https://github.com/posit-dev/positron/issues/9099.