### PR TITLE
Get rid of warnings about unnecessary transmutation

### DIFF
--- a/crates/libr/src/sys/windows/types.rs
+++ b/crates/libr/src/sys/windows/types.rs
@@ -213,8 +213,8 @@ impl structRstart {
     }
     #[inline]
     pub fn set_RstartVersion(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = i32::cast_unsigned(val);
-        self._bitfield_1.set(16usize, 16u8, val as u64)
+        self._bitfield_1
+            .set(16usize, 16u8, i32::cast_unsigned(val) as u64)
     }
     #[inline]
     pub fn new_bitfield_1(
@@ -226,10 +226,7 @@ impl structRstart {
             let NoRenviron: u32 = unsafe { ::std::mem::transmute(NoRenviron) };
             NoRenviron as u64
         });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let RstartVersion: u32 = i32::cast_unsigned(RstartVersion);
-            RstartVersion as u64
-        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, i32::cast_unsigned(RstartVersion) as u64);
         __bindgen_bitfield_unit
     }
 }


### PR DESCRIPTION
I'm about to do ark dev work on Windows, so I tried to make sure it was building and testing cleanly first. I discovered some warnings about unnecessary transmutation. I'm not sure if we want to handle this with changes like this PR or by turning off such warnings? I used Copilot to create these changes.

Also, I see that this file was originally created with a code generation process, but it seems like it's received various manual tweaks since then, so I assume it's fair game.

I paste the warnings below and also link to a recent CI run, where these are also showing up:

https://github.com/posit-dev/ark/actions/runs/17880174813/job/50846807788#step:8:22

```
   Compiling libr v0.1.0 (C:\Users\jenny\ark\crates\libr)
warning: unnecessary transmute
   --> crates\libr\src\sys\windows\types.rs:211:18
    |
211 |         unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
    |                  ---------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
    |                  help: replace this with: `u32::cast_signed`
    |
    = note: `#[warn(unnecessary_transmutes)]` on by default

warning: unnecessary transmute
   --> crates\libr\src\sys\windows\types.rs:216:28
    |
216 |             let val: u32 = ::std::mem::transmute(val);
    |                            ---------------------^^^^^
    |                            |
    |                            help: replace this with: `i32::cast_unsigned`

warning: unnecessary transmute
   --> crates\libr\src\sys\windows\types.rs:231:47
    |
231 |             let RstartVersion: u32 = unsafe { ::std::mem::transmute(RstartVersion) };
    |                                               ---------------------^^^^^^^^^^^^^^^
    |                                               |
    |                                               help: replace this with: `i32::cast_unsigned`
```