### PR TITLE
Rationalize pandoc path building, especially on Windows

### DIFF
--- a/crates/ark/src/modules/positron/pandoc.R
+++ b/crates/ark/src/modules/positron/pandoc.R
@@ -147,10 +147,11 @@ quoted <- function(args) {
 
 #' Get the path to the pandoc executable
 pandoc <- function() {
-    file.path(
-        find_pandoc()$dir,
-        "pandoc"
-    )
+    pandoc_info <- find_pandoc()
+    if (is.null(pandoc_info$dir)) {
+        return(NULL)
+    }
+    build_pandoc_path(pandoc_info$dir)
 }
 
 #' Test if a directory exists
@@ -195,6 +196,15 @@ find_pandoc <- function(dir = NULL, version = NULL) {
         dir = found_src,
         version = found_ver
     )
+}
+
+# Build the full path to the pandoc executable, handling Windows .exe suffix
+build_pandoc_path <- function(pandoc_dir) {
+    path <- file.path(pandoc_dir, "pandoc")
+    if (identical(.Platform$OS.type, "windows")) {
+        path <- paste0(path, ".exe")
+    }
+    path
 }
 
 # Find a program within the PATH. On OSX we need to explictly call
@@ -283,10 +293,7 @@ with_pandoc_safe_environment <- function(code) {
 
 # Get an S3 numeric_version for the pandoc utility at the specified path
 get_pandoc_version <- function(pandoc_dir) {
-    path <- file.path(pandoc_dir, "pandoc")
-    if (identical(.Platform$OS.type, "windows")) {
-        path <- paste0(path, ".exe")
-    }
+    path <- build_pandoc_path(pandoc_dir)
     if (!utils::file_test("-x", path)) {
         return(numeric_version("0"))
     }

--- a/crates/ark/src/modules/positron/pandoc.R
+++ b/crates/ark/src/modules/positron/pandoc.R
@@ -85,8 +85,8 @@ pandoc_convert <- function(
     args <- c(args, options)
 
     # ensure pandoc is available
-    pandoc_info <- find_pandoc()
-    if (is.null(pandoc_info$dir) || !utils::file_test("-x", pandoc())) {
+    pandoc_path <- pandoc()
+    if (is.null(pandoc_path) || !utils::file_test("-x", pandoc_path)) {
         stop(
             "pandoc is not available. Please install pandoc or set the ",
             "RSTUDIO_PANDOC environment variable to the directory containing ",
@@ -96,7 +96,7 @@ pandoc_convert <- function(
 
     # build the conversion command
     command <- paste(
-        quoted(file.path(pandoc_info$dir, "pandoc")),
+        quoted(pandoc_path),
         paste(quoted(args), collapse = " ")
     )
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9574

I can successfully invoke the R code that backs the help-reading tool in the R Console (e.g. via `.ps.rpc.get_help_page("trim", "glue")`), but when I can convince Positron Assistant to call the tool, it just hangs indefinitely. I'm using a release build of Positron with a locally built ark (from this PR). I'm pushing so that @sharon-wang can brainstorm with me tomorrow.