### PR TITLE
Remove experimental option from support status for data explorer

### DIFF
--- a/crates/amalthea/src/comm/data_explorer_comm.rs
+++ b/crates/amalthea/src/comm/data_explorer_comm.rs
@@ -1004,11 +1004,7 @@ pub enum SupportStatus {
 
 	#[serde(rename = "supported")]
 	#[strum(to_string = "supported")]
-	Supported,
-
-	#[serde(rename = "experimental")]
-	#[strum(to_string = "experimental")]
-	Experimental
+	Supported
 }
 
 /// Union type ColumnValue


### PR DESCRIPTION
Related to: [posit-dev/positron#8528](https://github.com/posit-dev/positron/issues/8528)

For features that require frontend and backend coordination, we have a system for declaring what features are supported. The `SupportedFeatures` interface communicates the list of features that are supported/unsupported by each backend. Each feature declares its support status via a value from the `SupportStatus` enum. This enum has three possible options: `Supported`, `Unsupported`, and `Experimental`.

We are removing the `Experimental` option from `SupportStatus` for the Data Explorer. This option has an accompanying setting in the Positron UI called `dataExplorer.Experimental` which is how users opt into `Experimental` features. This setting doesn't do anything and is more confusing so we're doing away with it.