### PR TITLE
bump version to 0.1.212

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark"
-version = "0.1.211"
+version = "0.1.212"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.211"
+version = "0.1.212"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
Changes since last release:
* Fix histogram edge cases for 0- and 1-row data frames in Data Explorer (https://github.com/posit-dev/ark/issues/932)
* Remove experimental Data Explorer config setting (https://github.com/posit-dev/positron/issues/8528)
* Rationalize pandoc path building, especially on Windows (https://github.com/posit-dev/ark/issues/926)