### PR TITLE
Add CI tests and releases for Windows arm64

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     build_windows:
         name: Build Windows
-        runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
+        runs-on: ${{ matrix.runs_on }}
         timeout-minutes: 40
 
         env:
@@ -26,8 +26,10 @@ jobs:
                 flavor: [debug, release]
                 include:
                     - arch: x64
+                      runs_on: windows-latest
                       rust_target_prefix: x86_64
                     - arch: arm64
+                      runs_on: windows-11-arm
                       rust_target_prefix: aarch64
 
         steps:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     build_windows:
         name: Build Windows
-        runs-on: windows-latest
+        runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
         timeout-minutes: 40
 
         env:
@@ -22,11 +22,13 @@ jobs:
 
         strategy:
             matrix:
-                arch: [x64]
+                arch: [x64, arm64]
                 flavor: [debug, release]
                 include:
                     - arch: x64
                       rust_target_prefix: x86_64
+                    - arch: arm64
+                      rust_target_prefix: aarch64
 
         steps:
             - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,11 @@ jobs:
               with:
                   name: ark-${{ matrix.flavor }}-windows-x64-archive
 
+            - name: Download Windows arm64 kernel (${{ matrix.flavor}})
+              uses: actions/download-artifact@v4
+              with:
+                  name: ark-${{ matrix.flavor }}-windows-arm64-archive
+
             - name: Download Linux x64 kernel (${{ matrix.flavor}})
               uses: actions/download-artifact@v4
               with:
@@ -146,6 +151,14 @@ jobs:
               with:
                   tag_name: ${{ needs.get_version.outputs.ARK_VERSION }}
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-windows-x64.zip
+
+            - name: Upload Windows release artifact (arm64)
+              uses: softprops/action-gh-release@v2
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  tag_name: ${{ needs.get_version.outputs.ARK_VERSION }}
+                  files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-windows-arm64.zip
 
             - name: Upload Linux release artifacts (x64)
               uses: softprops/action-gh-release@v2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-11-arm
     name: "Rust: ${{ matrix.config.rust }}, R: ${{ matrix.config.r }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -6,14 +6,21 @@ on:
 
 jobs:
   windows:
-    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
+    runs-on: ${{ matrix.runs_on }}
     name: "Rust: ${{ matrix.config.rust }}, R: ${{ matrix.config.r }}, Arch: ${{ matrix.arch }}"
+
     strategy:
       fail-fast: false
       matrix:
         arch: [x64, arm64]
         config:
           - { rust: 'stable', r: 'release' }
+        include:
+          - arch: x64
+            runs_on: windows-latest
+          - arch: arm64
+            runs_on: windows-11-arm
+
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -37,16 +37,8 @@ jobs:
           echo "C:\R\bin" >> $env:GITHUB_PATH
 
       - name: Install R Packages Required For Tests
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          packages:
-            data.table
-            dplyr
-            rstudioapi
-            tibble
-            haven
-            R6
-            survival
+        run: |
+          Rscript -e "install.packages(c('data.table', 'dplyr', 'rstudioapi', 'tibble', 'haven', 'R6', 'survival'))"
 
       - name: Build
         run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install R Packages Required For Tests
         run: |
-          Rscript -e "install.packages(c('data.table', 'dplyr', 'rstudioapi', 'tibble', 'haven', 'R6', 'survival'))"
+          Rscript -e "install.packages(c('data.table', 'dplyr', 'rstudioapi', 'tibble', 'haven', 'R6', 'survival'), repos = 'https://cloud.r-project.org')"
 
       - name: Build
         run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-11-arm
-    name: "Rust: ${{ matrix.config.rust }}, R: ${{ matrix.config.r }}"
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
+    name: "Rust: ${{ matrix.config.rust }}, R: ${{ matrix.config.r }}, Arch: ${{ matrix.arch }}"
     strategy:
       fail-fast: false
       matrix:
+        arch: [x64, arm64]
         config:
           - { rust: 'stable', r: 'release' }
     timeout-minutes: 30
@@ -30,18 +31,46 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Install R
+      # x86_64: Use setup-r
+      - name: Install R (x64)
+        if: matrix.arch == 'x64'
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+
+      # arm64: Manual R install (until setup-r supports arm64)
+      - name: Install R (arm64)
+        if: matrix.arch == 'arm64'
         run: |
           curl -L -o R-installer.exe https://www.r-project.org/nosvn/winutf8/aarch64/R-4-signed/R-4.5.1-aarch64.exe
           Start-Process -Wait -FilePath .\R-installer.exe -ArgumentList '/VERYSILENT', '/DIR=C:\R'
           echo "C:\R\bin" >> $env:GITHUB_PATH
 
-      - name: Install Rtools45
+      # arm64: Install Rtools (until setup-r supports arm64)
+      - name: Install Rtools45 (arm64)
+        if: matrix.arch == 'arm64'
         run: |
           curl -L -o rtools45-installer.exe https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe
           Start-Process -Wait -FilePath .\rtools45-installer.exe -ArgumentList '/VERYSILENT'
 
-      - name: Install R Packages Required For Tests
+      # x86_64: Use setup-r-dependencies
+      - name: Install R Packages Required For Tests (x64)
+        if: matrix.arch == 'x64'
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages:
+            data.table
+            dplyr
+            rstudioapi
+            tibble
+            haven
+            R6
+            survival
+
+      # arm64: Manual install.packages (until setup-r-dependencies supports arm64)
+      - name: Install R Packages Required For Tests (arm64)
+        if: matrix.arch == 'arm64'
         run: |
           Rscript -e "install.packages(c('data.table', 'dplyr', 'rstudioapi', 'tibble', 'haven', 'R6', 'survival'), repos = 'https://cloud.r-project.org')"
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,6 +36,11 @@ jobs:
           Start-Process -Wait -FilePath .\R-installer.exe -ArgumentList '/VERYSILENT', '/DIR=C:\R'
           echo "C:\R\bin" >> $env:GITHUB_PATH
 
+      - name: Install Rtools45
+        run: |
+          curl -L -o rtools45-installer.exe https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe
+          Start-Process -Wait -FilePath .\rtools45-installer.exe -ArgumentList '/VERYSILENT'
+
       - name: Install R Packages Required For Tests
         run: |
           Rscript -e "install.packages(c('data.table', 'dplyr', 'rstudioapi', 'tibble', 'haven', 'R6', 'survival'), repos = 'https://cloud.r-project.org')"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -31,10 +31,10 @@ jobs:
           tool: cargo-nextest
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: true
+        run: |
+          curl -L -o R-installer.exe https://www.r-project.org/nosvn/winutf8/aarch64/R-4-signed/R-4.5.1-aarch64.exe
+          Start-Process -Wait -FilePath .\R-installer.exe -ArgumentList '/VERYSILENT', '/DIR=C:\R'
+          echo "C:\R\bin" >> $env:GITHUB_PATH
 
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/crates/harp/src/sys/windows/library.rs
+++ b/crates/harp/src/sys/windows/library.rs
@@ -90,5 +90,13 @@ pub fn open_r_shared_library(path: &PathBuf) -> Result<libloading::Library, libl
 }
 
 pub fn find_r_shared_library_folder(path: &PathBuf) -> PathBuf {
-    path.join("bin").join("x64")
+    #[cfg(target_arch = "aarch64")]
+    {
+        // arm64 has a flatter structure
+        path.join("bin")
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        path.join("bin").join("x64")
+    }
 }


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/2934
See https://github.com/posit-dev/positron/issues/2934#issuecomment-3371285146 for details.

- Release build tested at https://github.com/posit-dev/ark/actions/runs/18280487687/job/52042952373

- I've added Windows arm64 to the matrix of CI tests. Since things are still in flux on that front, it seems safer to explicitly monitor reliability on this platform.