### PR TITLE
Check /etc/rstudio/repos.conf

### DIFF
--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -149,6 +149,18 @@ fn find_repos_conf() -> Option<PathBuf> {
     if let Some(path) = find_repos_conf_xdg("ark".to_string()) {
         return Some(path);
     }
+
+    // RStudio respects a system-wide repos.conf in /etc/rstudio/repos.conf.
+    //
+    // https://solutions.posit.co/envs-pkgs/rsw_defaults/#repos.conf
+    //
+    // This isn't strictly XDG-compliant, but we check for it for compatibility.
+    let rstudio_etc = PathBuf::from("/etc/rstudio/repos.conf");
+    if rstudio_etc.exists() {
+        return Some(rstudio_etc);
+    }
+
+    // No repos.conf file found
     None
 }
 


### PR DESCRIPTION
Currently, ark checks for `repos.conf` in a variety of XDG compliant directories. Unfortunately, RStudio uses `/etc/rstudio/repos.conf` which is not XDG compliant (strictly speaking it should be `/etc/xdg/rstudio/repos.conf`). 

This change adds `/etc/rstudio/repos.conf` to the set of directories that are checked for `repos.conf`. It's at the end, so any XDG directories (including user-scoped directories) are searched first. 

See: https://solutions.posit.co/envs-pkgs/rsw_defaults/#repos.conf

Addresses https://github.com/posit-dev/positron/issues/10094.