### PR TITLE
Make protocol assertions macros

### DIFF
--- a/crates/amalthea/tests/dummy_frontend/mod.rs
+++ b/crates/amalthea/tests/dummy_frontend/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Mutex;
 use std::sync::MutexGuard;
 use std::sync::OnceLock;
 
+use amalthea::assert_no_incoming;
 use amalthea::comm::event::CommManagerEvent;
 use amalthea::fixtures::dummy_frontend::DummyConnection;
 use amalthea::fixtures::dummy_frontend::DummyFrontend;
@@ -106,7 +107,7 @@ impl DummyAmaltheaFrontend {
 // Check that we haven't left crumbs behind
 impl Drop for DummyAmaltheaFrontend {
     fn drop(&mut self) {
-        self.assert_no_incoming()
+        assert_no_incoming!(self)
     }
 }
 

--- a/crates/ark/src/fixtures/dummy_frontend.rs
+++ b/crates/ark/src/fixtures/dummy_frontend.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use std::sync::MutexGuard;
 use std::sync::OnceLock;
 
+use amalthea::assert_no_incoming;
 use amalthea::fixtures::dummy_frontend::DummyConnection;
 use amalthea::fixtures::dummy_frontend::DummyFrontend;
 
@@ -125,7 +126,7 @@ impl DummyArkFrontend {
 // Check that we haven't left crumbs behind
 impl Drop for DummyArkFrontend {
     fn drop(&mut self) {
-        self.assert_no_incoming()
+        assert_no_incoming!(self);
     }
 }
 

--- a/crates/ark/tests/plots.rs
+++ b/crates/ark/tests/plots.rs
@@ -1,4 +1,11 @@
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use amalthea::recv_iopub_busy;
+use amalthea::recv_iopub_display_data;
+use amalthea::recv_iopub_execute_input;
+use amalthea::recv_iopub_execute_result;
+use amalthea::recv_iopub_idle;
+use amalthea::recv_iopub_update_display_data;
+use amalthea::recv_shell_execute_reply;
 use ark::fixtures::DummyArkFrontend;
 
 #[test]
@@ -7,15 +14,15 @@ fn test_basic_plot() {
 
     let code = "plot(1:10)";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
 
-    frontend.recv_iopub_display_data();
+    recv_iopub_display_data!(frontend);
 
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 }
 
 #[test]
@@ -28,19 +35,19 @@ for (i in 1:5) {
 }"#;
 
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
 
-    frontend.recv_iopub_display_data();
-    frontend.recv_iopub_display_data();
-    frontend.recv_iopub_display_data();
-    frontend.recv_iopub_display_data();
-    frontend.recv_iopub_display_data();
+    recv_iopub_display_data!(frontend);
+    recv_iopub_display_data!(frontend);
+    recv_iopub_display_data!(frontend);
+    recv_iopub_display_data!(frontend);
+    recv_iopub_display_data!(frontend);
 
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 }
 
 #[test]
@@ -68,16 +75,16 @@ if (file.exists(temp_file)) {
 "#;
 
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
 
-    frontend.recv_iopub_display_data();
-    frontend.recv_iopub_display_data();
+    recv_iopub_display_data!(frontend);
+    recv_iopub_display_data!(frontend);
 
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 }
 
 #[test]
@@ -96,18 +103,18 @@ par(mfrow = c(1, 1))
 "#;
 
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
 
-    frontend.recv_iopub_display_data();
-    frontend.recv_iopub_update_display_data();
-    frontend.recv_iopub_update_display_data();
-    frontend.recv_iopub_display_data();
+    recv_iopub_display_data!(frontend);
+    recv_iopub_update_display_data!(frontend);
+    recv_iopub_update_display_data!(frontend);
+    recv_iopub_display_data!(frontend);
 
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 }
 
 #[test]
@@ -117,51 +124,51 @@ fn test_graphics_device_initialization() {
     // On startup we are in the interactive list, but not current device
     let code = "'.ark.graphics.device' %in% grDevices::deviceIsInteractive()";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
-    let input = frontend.recv_iopub_execute_input();
+    recv_iopub_busy!(frontend);
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] TRUE");
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] TRUE");
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 
     // The current device is `"null device"`
     let code = ".Device";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
-    let input = frontend.recv_iopub_execute_input();
+    recv_iopub_busy!(frontend);
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] \"null device\"");
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] \"null device\"");
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 
     // The current `"null device"` is not interactive
     let code = "grDevices::dev.interactive()";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
-    let input = frontend.recv_iopub_execute_input();
+    recv_iopub_busy!(frontend);
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] FALSE");
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] FALSE");
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 
     // But `orNone = TRUE` looks at `options(device =)` in this case, which
     // we set to us, so this works (and is used by `demo(graphics)`)
     let code = "grDevices::dev.interactive(orNone = TRUE)";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
-    let input = frontend.recv_iopub_execute_input();
+    recv_iopub_busy!(frontend);
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] TRUE");
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] TRUE");
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 
     // Now simulate the user creating a plot, which makes us the current graphics device
     let code = "x <- .ark.graphics.device(); grDevices::dev.interactive()";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
-    let input = frontend.recv_iopub_execute_input();
+    recv_iopub_busy!(frontend);
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] TRUE");
-    frontend.recv_iopub_idle();
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] TRUE");
+    recv_iopub_idle!(frontend);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 }

--- a/crates/ark/tests/r-profile-cat.rs
+++ b/crates/ark/tests/r-profile-cat.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 
+use amalthea::recv_iopub_stream_stdout;
 use ark::fixtures::DummyArkFrontendRprofile;
 
 // SAFETY:
@@ -30,5 +31,5 @@ fn test_r_profile_can_cat() {
     // Ok, load up R now. It should `cat()` the `message` over iopub.
     let frontend = DummyArkFrontendRprofile::lock();
 
-    frontend.recv_iopub_stream_stdout(message)
+    recv_iopub_stream_stdout!(frontend, message)
 }

--- a/crates/ark/tests/r-profile-once.rs
+++ b/crates/ark/tests/r-profile-once.rs
@@ -1,6 +1,11 @@
 use std::io::Write;
 
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use amalthea::recv_iopub_busy;
+use amalthea::recv_iopub_execute_input;
+use amalthea::recv_iopub_execute_result;
+use amalthea::recv_iopub_idle;
+use amalthea::recv_shell_execute_reply;
 use ark::fixtures::DummyArkFrontendRprofile;
 
 // SAFETY:
@@ -38,13 +43,13 @@ if (exists("x")) {
     let frontend = DummyArkFrontendRprofile::lock();
 
     frontend.send_execute_request("x", ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, "x");
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] 1");
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] 1");
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 }

--- a/crates/ark/tests/repos-auto.rs
+++ b/crates/ark/tests/repos-auto.rs
@@ -8,6 +8,11 @@
 use std::io::Write;
 
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use amalthea::recv_iopub_busy;
+use amalthea::recv_iopub_execute_input;
+use amalthea::recv_iopub_execute_result;
+use amalthea::recv_iopub_idle;
+use amalthea::recv_shell_execute_reply;
 use ark::fixtures::DummyArkFrontendDefaultRepos;
 
 /// Using the automatic repos setting, the default CRAN repo should be set to the global RStudio
@@ -28,16 +33,16 @@ fn test_auto_repos() {
 
     let code = r#"getOption("repos")[["CRAN"]]"#;
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
     assert_eq!(
-        frontend.recv_iopub_execute_result(),
+        recv_iopub_execute_result!(frontend),
         r#"[1] "https://cran.rstudio.com/""#
     );
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }

--- a/crates/ark/tests/repos-conf-file.rs
+++ b/crates/ark/tests/repos-conf-file.rs
@@ -7,6 +7,11 @@
 use std::io::Write;
 
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use amalthea::recv_iopub_busy;
+use amalthea::recv_iopub_execute_input;
+use amalthea::recv_iopub_execute_result;
+use amalthea::recv_iopub_idle;
+use amalthea::recv_shell_execute_reply;
 use ark::fixtures::DummyArkFrontendDefaultRepos;
 
 /// Using a configuration file, set the default CRAN repo to a custom value,
@@ -36,31 +41,31 @@ Internal=https://internal.cran.mirror/
 
     let code = r#"getOption("repos")[["CRAN"]]"#;
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
     assert_eq!(
-        frontend.recv_iopub_execute_result(),
+        recv_iopub_execute_result!(frontend),
         r#"[1] "https://my.cran.mirror/""#
     );
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 
     let code = r#"getOption("repos")[["Internal"]]"#;
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
     assert_eq!(
-        frontend.recv_iopub_execute_result(),
+        recv_iopub_execute_result!(frontend),
         r#"[1] "https://internal.cran.mirror/""#
     );
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }

--- a/crates/ark/tests/rstudioapi.rs
+++ b/crates/ark/tests/rstudioapi.rs
@@ -1,4 +1,9 @@
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use amalthea::recv_iopub_busy;
+use amalthea::recv_iopub_execute_input;
+use amalthea::recv_iopub_execute_result;
+use amalthea::recv_iopub_idle;
+use amalthea::recv_shell_execute_reply;
 use ark::fixtures::DummyArkFrontend;
 
 #[test]
@@ -18,18 +23,18 @@ fn test_get_version() {
 
     let code = "as.character(rstudioapi::getVersion())";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
     assert_eq!(
-        frontend.recv_iopub_execute_result(),
+        recv_iopub_execute_result!(frontend),
         format!("[1] \"{value}\"")
     );
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }
 
 #[test]
@@ -49,42 +54,42 @@ fn test_get_mode() {
 
     let code = "rstudioapi::getMode()";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
     assert_eq!(
-        frontend.recv_iopub_execute_result(),
+        recv_iopub_execute_result!(frontend),
         format!("[1] \"{value}\"")
     );
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }
 
 fn set_var(key: &str, value: &str, frontend: &DummyArkFrontend) {
     let code = format!("Sys.setenv({key} = \"{value}\")");
     frontend.send_execute_request(code.as_str(), ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }
 
 fn has_rstudioapi(frontend: &DummyArkFrontend) -> bool {
     let code = ".ps.is_installed('rstudioapi')";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
 
-    let result = frontend.recv_iopub_execute_result();
+    let result = recv_iopub_execute_result!(frontend);
 
     let out = if result == "[1] TRUE" {
         true
@@ -94,9 +99,9 @@ fn has_rstudioapi(frontend: &DummyArkFrontend) -> bool {
         panic!("Expected `TRUE` or `FALSE`, got '{result}'.");
     };
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count);
 
     out
 }

--- a/crates/ark/tests/stack.rs
+++ b/crates/ark/tests/stack.rs
@@ -1,4 +1,9 @@
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use amalthea::recv_iopub_busy;
+use amalthea::recv_iopub_execute_input;
+use amalthea::recv_iopub_execute_result;
+use amalthea::recv_iopub_idle;
+use amalthea::recv_shell_execute_reply;
 use ark::fixtures::DummyArkFrontend;
 
 // These tests assert that we've correctly turned off the `R_StackLimit` check during integration
@@ -11,15 +16,15 @@ fn test_stack_info_size() {
 
     let code = "Cstack_info()[['size']]";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] NA");
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] NA");
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }
 
 #[test]
@@ -28,13 +33,13 @@ fn test_stack_info_current() {
 
     let code = "Cstack_info()[['current']]";
     frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
+    recv_iopub_busy!(frontend);
 
-    let input = frontend.recv_iopub_execute_input();
+    let input = recv_iopub_execute_input!(frontend);
     assert_eq!(input.code, code);
-    assert_eq!(frontend.recv_iopub_execute_result(), "[1] NA");
+    assert_eq!(recv_iopub_execute_result!(frontend), "[1] NA");
 
-    frontend.recv_iopub_idle();
+    recv_iopub_idle!(frontend);
 
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count)
+    assert_eq!(recv_shell_execute_reply!(frontend), input.execution_count)
 }


### PR DESCRIPTION
So that downstream assertions can expose file and line location in the test files, instead of `dummy_frontend.rs`. This way we're able to click on the reported locations to jump to the relevant test failure.