### PR TITLE
Make ragg optional in tests

### DIFF
--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -464,6 +464,31 @@ impl DummyFrontend {
             eprintln!("---");
         }
     }
+
+    pub fn is_installed(&self, package: &str) -> bool {
+        let code = format!(".ps.is_installed('{package}')");
+        self.send_execute_request(&code, ExecuteRequestOptions::default());
+        self.recv_iopub_busy();
+
+        let input = self.recv_iopub_execute_input();
+        assert_eq!(input.code, code);
+
+        let result = self.recv_iopub_execute_result();
+
+        let out = if result == "[1] TRUE" {
+            true
+        } else if result == "[1] FALSE" {
+            false
+        } else {
+            panic!("Expected `TRUE` or `FALSE`, got '{result}'.");
+        };
+
+        self.recv_iopub_idle();
+
+        assert_eq!(self.recv_shell_execute_reply(), input.execution_count);
+
+        out
+    }
 }
 
 impl Default for ExecuteRequestOptions {

--- a/crates/ark/tests/rstudioapi.rs
+++ b/crates/ark/tests/rstudioapi.rs
@@ -77,28 +77,7 @@ fn set_var(key: &str, value: &str, frontend: &DummyArkFrontend) {
 }
 
 fn has_rstudioapi(frontend: &DummyArkFrontend) -> bool {
-    let code = ".ps.is_installed('rstudioapi')";
-    frontend.send_execute_request(code, ExecuteRequestOptions::default());
-    frontend.recv_iopub_busy();
-
-    let input = frontend.recv_iopub_execute_input();
-    assert_eq!(input.code, code);
-
-    let result = frontend.recv_iopub_execute_result();
-
-    let out = if result == "[1] TRUE" {
-        true
-    } else if result == "[1] FALSE" {
-        false
-    } else {
-        panic!("Expected `TRUE` or `FALSE`, got '{result}'.");
-    };
-
-    frontend.recv_iopub_idle();
-
-    assert_eq!(frontend.recv_shell_execute_reply(), input.execution_count);
-
-    out
+    frontend.is_installed("rstudioapi")
 }
 
 fn report_skipped(f: &str) {


### PR DESCRIPTION
Not sure what R ark in unit tests is linking to, but it doesn't have ragg installed (the R on the path does have it, weird).

Our current convention is to opt out of the test gracefully if the package is not installed.