### PR TITLE
Use `track_caller` approach for logging from a method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ If changes are needed in these files, that must happen in the separate Positron 
 
 - Use fully qualified result types (`anyhow::Result`) instead of importing them.
 
+- You can log `Result::Err` by using the `.log_err()` method from the extension trait `stdext::ResultExt`. Add some `.context()` if that would be helpful, but never do it for errors that are quite unexpected, such as from `.send()` to a channel (that would be too verbose).
+
 - When writing tests, prefer simple assertion macros without custom error messages:
     - Use `assert_eq!(actual, expected);` instead of `assert_eq!(actual, expected, "custom message");`
     - Use `assert!(condition);` instead of `assert!(condition, "custom message");`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ark"
@@ -2703,6 +2703,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stdext"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "log",
 ]
 

--- a/crates/amalthea/src/comm/comm_manager.rs
+++ b/crates/amalthea/src/comm/comm_manager.rs
@@ -12,7 +12,7 @@ use crossbeam::channel::Select;
 use crossbeam::channel::Sender;
 use log::info;
 use log::warn;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use stdext::spawn;
 
 use crate::comm::comm_channel::CommMsg;
@@ -161,9 +161,7 @@ impl CommManager {
                     if let Some(index) = index {
                         // Notify the comm that it's been closed
                         let comm = self.open_comms.get(index).unwrap();
-                        comm.incoming_tx
-                            .send(CommMsg::Close)
-                            .or_log_error("Failed to send comm_close to comm.");
+                        comm.incoming_tx.send(CommMsg::Close).log_err();
 
                         // Remove it from our list of open comms
                         self.open_comms.remove(index);

--- a/crates/amalthea/src/socket/shell.rs
+++ b/crates/amalthea/src/socket/shell.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
 use futures::executor::block_on;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 
 use crate::comm::comm_channel::comm_rpc_message;
 use crate::comm::comm_channel::Comm;
@@ -429,10 +429,7 @@ impl Shell {
         // comm has been opened
         self.comm_manager_tx
             .send(CommManagerEvent::Opened(comm_socket.clone(), comm_data))
-            .or_log_warning(&format!(
-                "Failed to send '{}' comm open notification to listener thread",
-                comm_socket.comm_name
-            ));
+            .log_err();
 
         // If the comm wraps a server, send notification once the server is ready to
         // accept connections. This also sends back the port number to connect on. Failing

--- a/crates/ark/src/dap/dap_r_main.rs
+++ b/crates/ark/src/dap/dap_r_main.rs
@@ -27,7 +27,7 @@ use libr::INTSXP;
 use libr::SET_INTEGER_ELT;
 use libr::SEXP;
 use libr::VECTOR_ELT;
-use stdext::log_error;
+use stdext::result::ResultExt;
 
 use crate::dap::dap::DapBackendEvent;
 use crate::dap::Dap;
@@ -180,7 +180,7 @@ impl RMainDap {
     pub fn send_dap(&self, event: DapBackendEvent) {
         let dap = self.dap.lock().unwrap();
         if let Some(tx) = &dap.backend_events_tx {
-            log_error!(tx.send(event));
+            tx.send(event).log_err();
         }
     }
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -28,7 +28,7 @@ use dap::requests::*;
 use dap::responses::*;
 use dap::server::ServerOutput;
 use dap::types::*;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use stdext::spawn;
 
 use super::dap::Dap;
@@ -73,7 +73,7 @@ pub fn start_dap(
     // Send the port back to `Shell` and eventually out to the frontend so it can connect
     server_started_tx
         .send(ServerStartedMessage::new(port))
-        .or_log_error("DAP: Can't send init notification");
+        .log_err();
 
     loop {
         log::trace!("DAP: Waiting for client");

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -66,6 +66,7 @@ use amalthea::socket::comm::CommInitiator;
 use amalthea::socket::comm::CommSocket;
 use anyhow::anyhow;
 use anyhow::bail;
+use anyhow::Context;
 use crossbeam::channel::unbounded;
 use crossbeam::channel::Sender;
 use crossbeam::select;
@@ -84,7 +85,7 @@ use libr::*;
 use serde::Deserialize;
 use serde::Serialize;
 use stdext::local;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use stdext::spawn;
 use stdext::unwrap;
 use tracing::Instrument;
@@ -236,7 +237,7 @@ impl RDataExplorer {
                     // the schema
                     comm_manager_tx
                         .send(CommManagerEvent::Closed(comm.comm_id))
-                        .or_log_error("Error sending comm closed event")
+                        .log_err();
                 },
             }
         });
@@ -680,7 +681,8 @@ impl RDataExplorer {
             handle_columns_profiles_requests(params, comm)
                 .instrument(tracing::info_span!("get_columns_profile", ns = id))
                 .await
-                .or_log_error("Unable to handle get_columns_profile");
+                .context("Unable to handle get_columns_profile")
+                .log_err();
         });
     }
 

--- a/crates/ark/src/interface.rs
+++ b/crates/ark/src/interface.rs
@@ -87,7 +87,7 @@ use libr::SEXP;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde_json::json;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use stdext::*;
 use tokio::sync::mpsc::UnboundedReceiver as AsyncUnboundedReceiver;
 use uuid::Uuid;
@@ -440,7 +440,8 @@ impl RMain {
             // Optionally run a frontend specified R startup script (after harp init)
             if let Some(file) = &startup_file {
                 harp::source(file)
-                    .or_log_error(&format!("Failed to source startup file '{file}' due to"));
+                    .context(format!("Failed to source startup file '{file}' due to"))
+                    .log_err();
             }
 
             // Initialize support functions (after routine registration, after r_task initialization)

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -14,9 +14,10 @@ use amalthea::comm::server_comm::ServerStartMessage;
 use amalthea::comm::server_comm::ServerStartedMessage;
 use amalthea::comm::ui_comm::ShowMessageParams as UiShowMessageParams;
 use amalthea::comm::ui_comm::UiFrontendEvent;
+use anyhow::Context;
 use crossbeam::channel::Sender;
 use serde_json::Value;
-use stdext::result::ResultOrLog;
+use stdext::result::ResultExt;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::unbounded_channel as tokio_unbounded_channel;
@@ -501,7 +502,8 @@ pub fn start_lsp(
         // Send the port back to `Shell` and eventually out to the frontend so it can connect
         server_started_tx
             .send(ServerStartedMessage::new(port))
-            .or_log_error("LSP: Can't send server started notification");
+            .context("LSP: Can't send server started notification")
+            .log_err();
 
         log::trace!("LSP: Waiting for client");
         let (stream, address) = listener.accept().await.unwrap();

--- a/crates/stdext/Cargo.toml
+++ b/crates/stdext/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+anyhow = "1.0.100"
 log = "0.4.18"
 
 [features]

--- a/crates/stdext/src/result.rs
+++ b/crates/stdext/src/result.rs
@@ -5,59 +5,91 @@
 //
 //
 
-use std::fmt::Display;
-
-// Since this is a macro, this correctly records call site information.
-// TODO: Should we retire the `ResultOrLog` trait?
-#[macro_export(local_inner_macros)]
-macro_rules! log_error {
-    ($res:expr) => {
-        if let Err(err) = $res {
-            log::error!("{err}");
-        }
-    };
-    ($prefix:expr, $res:expr) => {
-        if let Err(err) = $res {
-            log::error!("{}: {err}", $prefix);
+#[macro_export]
+macro_rules! debug_panic {
+    ( $($fmt_arg:tt)* ) => {
+        if cfg!(debug_assertions) {
+            panic!( $($fmt_arg)* );
+        } else {
+            let backtrace = std::backtrace::Backtrace::capture();
+            log::error!("{}\n{:?}", format_args!($($fmt_arg)*), backtrace);
         }
     };
 }
 
-pub trait ResultOrLog<T, E> {
-    /// If `self` is an error, log an error, else do nothing and consume self.
-    fn or_log_error(self, prefix: &str);
+// From https://github.com/zed-industries/zed/blob/a910c594/crates/util/src/util.rs#L554
+pub trait ResultExt<E> {
+    type Ok;
 
-    /// If `self` is an error, log a warning, else do nothing and consume self.
-    fn or_log_warning(self, prefix: &str);
-
-    /// If `self` is an error, log info, else do nothing and consume self.
-    fn or_log_info(self, prefix: &str);
+    fn log_err(self) -> Option<Self::Ok>;
+    /// Assert that this result should never be an error in development or tests
+    fn debug_assert_ok(self, reason: &str) -> Self;
+    fn warn_on_err(self) -> Option<Self::Ok>;
+    fn log_with_level(self, level: log::Level) -> Option<Self::Ok>;
+    fn anyhow(self) -> anyhow::Result<Self::Ok>
+    where
+        E: Into<anyhow::Error>;
 }
 
-// Implemented for "empty" results that never contain values,
-// but may contain errors
-impl<T, E> ResultOrLog<T, E> for Result<T, E>
+impl<T, E> ResultExt<E> for Result<T, E>
 where
-    E: Display,
+    E: std::fmt::Debug,
 {
-    fn or_log_error(self, prefix: &str) {
+    type Ok = T;
+
+    #[track_caller]
+    fn log_err(self) -> Option<T> {
+        self.log_with_level(log::Level::Error)
+    }
+
+    #[track_caller]
+    fn warn_on_err(self) -> Option<T> {
+        self.log_with_level(log::Level::Warn)
+    }
+
+    #[track_caller]
+    fn log_with_level(self, level: log::Level) -> Option<T> {
         match self {
-            Ok(_) => return,
-            Err(err) => log::error!("{}: {}", prefix, err),
+            Ok(value) => Some(value),
+            Err(error) => {
+                let location = std::panic::Location::caller();
+                let file = location.file();
+                let line = location.line();
+                log::logger().log(
+                    &log::Record::builder()
+                        // Unlike direct calls to `log::error!`, we're propagating an
+                        // error object that typically contains backtrace information.
+                        // The file/line information displayed by log is at the bottom,
+                        // which can be hard to find in case of a long backtrace, so
+                        // we mention these again before the error message to
+                        // make it easier to identify where the log message was
+                        // emitted from.
+                        .args(format_args!("at {file}:{line}: {error:?}"))
+                        .level(level)
+                        .file(Some(file))
+                        .line(Some(line))
+                        // Can't get the module path from tracked caller so
+                        // leave it blank
+                        .module_path(None)
+                        .build(),
+                );
+                None
+            },
         }
     }
 
-    fn or_log_warning(self, prefix: &str) {
-        match self {
-            Ok(_) => return,
-            Err(err) => log::warn!("{}: {}", prefix, err),
+    #[track_caller]
+    fn debug_assert_ok(self, reason: &str) -> Self {
+        if let Err(error) = &self {
+            debug_panic!("{reason} - {error:?}");
         }
+        self
     }
 
-    fn or_log_info(self, prefix: &str) {
-        match self {
-            Ok(_) => return,
-            Err(err) => log::info!("{}: {}", prefix, err),
-        }
+    fn anyhow(self) -> anyhow::Result<T>
+    where
+        E: Into<anyhow::Error>,
+    {
+        self.map_err(Into::into)
     }
 }


### PR DESCRIPTION
I noticed that Zed uses the `track_caller` approach in the log methods of their extension trait for `Result`: https://github.com/zed-industries/zed/blob/a910c594d6c5f6a808aa3c45ca4f8e5bba66ae75/crates/util/src/util.rs#L554

We've already used that `track_caller` feature to great effect in https://github.com/posit-dev/ark/pull/955.

They also have neat methods such as `debug_assert` and `anyhow`.

This PR removes the existing disparate infra we have for logging errors to use that new trait.

Compared to `log_error!`:

- The methods have postfix syntax, which is often nicer especially when you don't want to obscure the main logic.
  I was a bit confused when I stumbled upon this today:

  ```rust
  log_error!(tx.send(msg));
  ```

  This made it seem the logging was unconditional.

Compared to `ResultOrLog`:

- The `log_err()` method does not require adding context. I think that's helpful for things like `.send()` to a channel where you don't quite want to panic if not related to essential channels, but you don't want to add too much clutter/overhead to the error handling either. You can still add context if you want to with anyhow's `.context()` method.
- We do a better job of forwarding error backtraces.
- We propagate caller info (line/file).
- Because we now display backtraces that can be quite long, and because `log` displays file/line info _after_ the error message, we manually reiterate the file/line info _before_ the message so the emitter of the log message is immediately identifiable.

Before with `ResultOrLog`:

```rust
fail("ouch").or_log_error("that hurts");
```

<img width="558" height="69" alt="Screenshot 2025-11-19 at 11 13 54" src="https://github.com/user-attachments/assets/392b1757-269b-4a10-a763-907d93861e76" />

- No backtrace
- Wrong file/line

After with `ResultExt`:

```rust
fail("ouch").context("that hurts").log_err();
```

<img width="974" height="472" alt="Screenshot 2025-11-19 at 11 04 31" src="https://github.com/user-attachments/assets/62880e86-0959-47ea-ac6f-39783c0ec928" />

- Backtrace
- Correct file/line on top
- Nicely formatted context