### PR TITLE
Bump Ark to 0.1.219

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ark"
-version = "0.1.218"
+version = "0.1.219"
 dependencies = [
  "actix-web",
  "amalthea",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.218"
+version = "0.1.219"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/960