### PR TITLE
Set `.Platform$GUI` to "Positron" in console sessions only

### DIFF
--- a/crates/ark/src/modules/positron/positron.R
+++ b/crates/ark/src/modules/positron/positron.R
@@ -5,8 +5,8 @@
 #
 #
 
-.Platform <- base::.Platform
-.Platform$GUI <- "Positron"
 if (Sys.getenv("POSITRON") == 1) {
+    .Platform <- base::.Platform
+    .Platform$GUI <- "Positron"
     env_bind_force(baseenv(), ".Platform", .Platform)
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9933

With this change, I see results like this in the Positron console:

```
> .Platform
$OS.type
[1] "unix"

$file.sep
[1] "/"

$dynlib.ext
[1] ".so"

$GUI
[1] "Positron"

$endian
[1] "little"

$pkgType
[1] "mac.binary.big-sur-arm64"

$path.sep
[1] ":"

$r_arch
[1] ""
```


And results like this in an R session running in an integrated terminal in Positron (the same as RStudio):

```
> .Platform
$OS.type
[1] "unix"

$file.sep
[1] "/"

$dynlib.ext
[1] ".so"

$GUI
[1] "X11"

$endian
[1] "little"

$pkgType
[1] "mac.binary.big-sur-arm64"

$path.sep
[1] ":"

$r_arch
[1] ""
```

Does `SessionMode::Console` really just mean only in Positron? Is there some better way for ark to know when it's running in Positron at initialization?