### PR TITLE
Add a built-in for setting the PPM repo in a running session

### DIFF
--- a/crates/ark/src/modules/positron/repos.R
+++ b/crates/ark/src/modules/positron/repos.R
@@ -19,10 +19,13 @@ apply_repo_defaults <- function(
         repos <- defaults
     } else {
         if ("CRAN" %in% names(repos) && "CRAN" %in% names(defaults)) {
-            # If a CRAN repository is set to @CRAN@, and a default provides a
-            # specific URL, override it. This is the only instance in which we
-            # replace an already-set repository option with a default.
-            if (identical(repos[["CRAN"]], "@CRAN@")) {
+            # If a CRAN repository is set to @CRAN@ or is marked as having been
+            # updated by "the IDE" *and* a default provides a specific URL,
+            # override it.
+            #
+            # This is the only instance in which we replace an already-set
+            # repository option with a default.
+            if (identical(repos[["CRAN"]], "@CRAN@") || isTRUE(attr(repos, "IDE"))) {
                 repos[["CRAN"]] <- defaults[["CRAN"]]
 
                 # Flag this CRAN repository as being set by the IDE. This flag is
@@ -38,4 +41,26 @@ apply_repo_defaults <- function(
         }
     }
     options(repos = repos)
+}
+
+#' Set the Posit Package Manager repository
+#'
+#' Sets the Posit Package Manager repository URL for the current session. The
+#' URL will be processed to point to a Linux distribution-specific binary URL if
+#' applicable.
+#'
+#' This function only overrides the CRAN repository when Ark has previously set
+#' it or when it uses placeholder `"@CRAN@"`.
+#'
+#' @param url A PPM repository URL. Must be in the form
+#'   `"https://host/repo/snapshot"`, e.g.,
+#'   `"https://packagemanager.posit.co/cran/latest"`.
+#'
+#' @return `NULL`, invisibly.
+#'
+#' @export
+.ps.set_ppm_repo <- function(url) {
+    # Use Ark's built-in PPM binary URL detection.
+    url <- .ps.Call("ps_get_ppm_binary_url", url)
+    apply_repo_defaults(c(CRAN = url))
 }


### PR DESCRIPTION
This commit adds a `.ps.set_ppm_repo()` built-in that works the same way as the existing CLI option, but allows the repo to be set at runtime.

It is intended to support making the `positron.r.packageManagerRepository` setting apply without needing to restart/recreate existing R sessions.

Part of https://github.com/posit-dev/positron/issues/10965.