### PR TITLE
Code-sign ark binaries on Windows

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -18,7 +18,6 @@ jobs:
 
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            DEBUG_FLAG: ${{ matrix.flavor == 'debug' && '-debug' || '' }}
 
         strategy:
             matrix:


### PR DESCRIPTION
Signs `ark.exe` on Windows. 

Part of https://github.com/posit-dev/positron/issues/9962.