### PR TITLE
Prevent error when expression is invalid for obtaining a help handler

### DIFF
--- a/crates/ark/src/help/r_help.rs
+++ b/crates/ark/src/help/r_help.rs
@@ -283,7 +283,7 @@ impl RHelp {
                 Ok(obj) => obj,
                 Err(err) => {
                     // Could not parse/eval the topic; no custom handler.
-                    log::trace!("Could not parse/eval help topic expression '{}': {:?}", topic, err);
+                    log::warn!("Could not parse/eval help topic expression '{}': {:?}", topic, err);
                     return Ok(None);
                 }
             };


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7430#issuecomment-3656663284

When an invalid expression is evaluated, we should return `false` so that we show the 'no R help available for topic' popup instead of an error.