### PR TITLE
Add `copilot-swe-agent[bot]` to the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,7 +49,7 @@ jobs:
             before we accept your contribution. You can sign the CLA by posting
             a comment on this PR saying:
 
-          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, copilot[bot]
+          allowlist: DavisVaughan, dependabot[bot], dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, positron-bot[bot], seeM, sharon-wang, softwarenerd, timtmok, wesm, copilot[bot], copilot-swe-agent[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
Related to #999

I think these are different bot accounts:

- `copilot[bot]`: GitHub Copilot (code suggestions)
- `copilot-swe-agent[bot]`: GitHub Copilot SWE Agent (autonomous coding agent)