### PR TITLE
Ignore breakpoints for non-file URIs

### DIFF
--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -345,8 +345,10 @@ impl<R: Read, W: Write> DapServer<R, W> {
         let uri = match Url::from_file_path(path) {
             Ok(uri) => uri,
             Err(()) => {
-                log::error!("Failed to convert path to URI: '{path}'");
-                let rsp = req.error(&format!("Invalid path: {path}"));
+                log::warn!("Can't set breakpoints for non-file path: '{path}'");
+                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
+                    breakpoints: vec![],
+                }));
                 self.respond(rsp);
                 return;
             },


### PR DESCRIPTION
In the `setBreakpoints` handler, we should ignore non-file URIs like `untiled:Untitled-1` instead of returning an error that shows up as a user-visible notification.

This fixes a Cmd+Enter issue. Evaluation now triggers a breakpoint update so that we can verify/inject them even in dirty docs. In untitled documents, this was causing a popup.

Report from @DavisVaughan:

> It seems like we have a fairly serious regression in Untitled R scripts in the latest daily
> 
> - Open an Untitled R script
> - Put in `1 + 1`
> - Try and Cmd + Enter to run that
> 
> Do you see a pop up that says Invalid path: untitled:Untitled-1?
> 
> I believe it is DAP related
> 

```
r-206c23de [R]   2026-01-26T14:02:53.726113Z TRACE  DAP: Got request: Request {
r-206c23de [R]     seq: 7,
r-206c23de [R]     command: SetBreakpoints(
r-206c23de [R]         SetBreakpointsArguments {
r-206c23de [R]             source: Source {
r-206c23de [R]                 name: Some(
r-206c23de [R]                     "Untitled-1",
r-206c23de [R]                 ),
r-206c23de [R]                 path: Some(
r-206c23de [R]                     "untitled:Untitled-1",
r-206c23de [R]                 ),
r-206c23de [R]                 source_reference: None,
r-206c23de [R]                 presentation_hint: None,
r-206c23de [R]                 origin: None,
r-206c23de [R]                 sources: None,
r-206c23de [R]                 adapter_data: None,
r-206c23de [R]                 checksums: None,
r-206c23de [R]             },
r-206c23de [R]             breakpoints: Some(
r-206c23de [R]                 [],
r-206c23de [R]             ),
r-206c23de [R]             lines: Some(
r-206c23de [R]                 [],
r-206c23de [R]             ),
r-206c23de [R]             source_modified: Some(
r-206c23de [R]                 true,
r-206c23de [R]             ),
r-206c23de [R]         },
r-206c23de [R]     ),
r-206c23de [R] }
r-206c23de [R]     at crates/ark/src/dap/dap_server.rs:236
r-206c23de [R] 
r-206c23de [R]   2026-01-26T14:02:53.726168Z ERROR  Failed to convert path to URI: 'untitled:Untitled-1'
r-206c23de [R]     at crates/ark/src/dap/dap_server.rs:345
r-206c23de [R] 
r-206c23de [R]   2026-01-26T14:02:53.726175Z TRACE  DAP: Responding to request: Response {
r-206c23de [R]     request_seq: 7,
r-206c23de [R]     success: false,
r-206c23de [R]     message: Some(
r-206c23de [R]         Error(
r-206c23de [R]             "Invalid path: untitled:Untitled-1",
r-206c23de [R]         ),
r-206c23de [R]     ),
r-206c23de [R]     body: None,
r-206c23de [R]     error: None,
r-206c23de [R] }
r-206c23de [R]     at crates/ark/src/dap/dap_server.rs:300
```