### PR TITLE
Only install hard dependencies for test packages

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: '"hard"'
           packages:
             data.table
             dplyr

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: '"hard"'
           packages:
             data.table
             dplyr

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -66,6 +66,7 @@ jobs:
         if: matrix.arch == 'x64'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: '"hard"'
           packages:
             data.table
             dplyr


### PR DESCRIPTION
I noticed our CI logs show that pak is installing wayyyyyyy too many dependencies.

It's installing all the dev dependencies required for a package, which makes sense as a default if you are using this in a package development situation, but we just want the package to run our tests.

This should speed up CI some

https://github.com/r-lib/actions/tree/v2-branch/setup-r-dependencies#usage