### PR TITLE
`r-lib/actions/setup-r` supports arm64 Windows now!

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -23,7 +23,7 @@ jobs:
           - { rust: 'stable',  r: '4.2' }
           # Nightly rust
           - { rust: 'nightly', r: 'release' }
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -14,7 +14,7 @@ jobs:
         config:
           - { rust: 'nightly', r: 'release', runs_on: 'macos-latest' }
           - { rust: 'stable', r: '4.2', runs_on: 'macos-14' }
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -16,7 +16,7 @@ jobs:
           - { rust: 'stable', r: 'release', runs_on: 'windows-latest' }
           # arm64
           - { rust: 'stable', r: 'release', runs_on: 'windows-11-arm' }
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
I noticed our ark CI is getting held up by the arm64 windows build on the R package install step.

It's installing the R packages over and over "fresh" without any caching because it wasn't using `setup-r`.

But supposedly that and `setup-r-dependencies` does support arm64 windows now!

So lets give that a shot. This PR should build the dependencies "slowly" from source, but after that it _should_ start to pull them from a cache.