### PR TITLE
Add `connections` to allowed packages for ark methods table

### DIFF
--- a/crates/ark/src/modules/positron/methods.R
+++ b/crates/ark/src/modules/positron/methods.R
@@ -104,7 +104,12 @@ ark_methods_table$ark_positron_variable_view <- new.env(
 
 lockEnvironment(ark_methods_table, TRUE)
 
-ark_methods_allowed_packages <- c("torch", "reticulate", "duckplyr")
+ark_methods_allowed_packages <- c(
+    "torch",
+    "reticulate",
+    "duckplyr",
+    "connections"
+)
 
 # check if the calling package is allowed to touch the methods table
 check_caller_allowed <- function() {


### PR DESCRIPTION
## Summary
- Add `connections` package to the list of allowed packages that can register methods with the ark methods table
- This enables implementing the new connections viewer for the `connections` package in Positron

🤖 Generated with [Claude Code](https://claude.com/claude-code)