### PR TITLE
Use consistent argument name in `frame_info_from_srcref()`

### DIFF
--- a/crates/ark/src/modules/positron/debug.R
+++ b/crates/ark/src/modules/positron/debug.R
@@ -254,7 +254,7 @@ frame_info <- function(
 }
 
 frame_info_from_srcref <- function(
-    source_name_fallback,
+    source_name,
     frame_name,
     srcref,
     environment
@@ -266,8 +266,6 @@ frame_info_from_srcref <- function(
 
     if (is_string(info$file)) {
         source_name <- basename(info$file)
-    } else {
-        source_name <- source_name_fallback
     }
 
     new_frame_info(


### PR DESCRIPTION
@DavisVaughan I reverted your suggestion to fix @jennybc's issue with:

<img width="1494" height="374" alt="Screenshot 2026-01-27 at 11 33 06 AM" src="https://github.com/user-attachments/assets/cd09ba9a-5aef-4081-b9ae-29593473e249" />

It's less error prone to have the same argument name everywhere, even if slightly less accurate.