### PR TITLE
Shut down DAP server gracefully on disconnection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ If changes are needed in these files, that must happen in the separate Positron 
 
 - When a `match` expression is the last expression in a function, omit `return` keywords in match arms. Let the expression evaluate to the function's return value.
 
-- For error messages and logging, prefer direct formatting syntax: `Err(anyhow!("Message: {err}"))` instead of `Err(anyhow!("Message: {}", err))`. This also applies to `log::error!` and `log::warn!` and `log::info!` macros.
+- For error messages and logging, prefer direct formatting syntax: `Err(anyhow!("Message: {err}"))` instead of `Err(anyhow!("Message: {}", err))`. This also applies to `log::error!` and `log::warn!` and `log::info!` macros. For logging errors specifically, use Debug formatting `{err:?}` to get more detailed error information.
 
 - Use `log::trace!` instead of `log::debug!`.
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -202,7 +202,7 @@ fn listen_dap_events<W: Write>(
 
                 let mut output = output.lock().unwrap();
                 if let Err(err) = output.send_event(event) {
-                    log::warn!("DAP: Failed to send event, closing: {err}");
+                    log::warn!("DAP: Failed to send event, closing: {err:?}");
                     return;
                 }
             },
@@ -246,7 +246,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
             Ok(Some(req)) => req,
             Ok(None) => return false,
             Err(err) => {
-                log::warn!("DAP: Connection closed: {err}");
+                log::warn!("DAP: Connection closed: {err:?}");
                 return false;
             },
         };
@@ -291,7 +291,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
         };
 
         if let Err(err) = result {
-            log::warn!("DAP: Handler failed, closing connection: {err}");
+            log::warn!("DAP: Handler failed, closing connection: {err:?}");
             return false;
         }
 
@@ -368,7 +368,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
             Ok(content) => content,
             Err(err) => {
                 // TODO: What do we do with breakpoints in virtual documents?
-                log::warn!("Failed to read file '{path}': {err}");
+                log::warn!("Failed to read file '{path}': {err:?}");
                 let rsp = req.error(&format!("Failed to read file: {path}"));
                 return self.respond(rsp);
             },


### PR DESCRIPTION
Branched on #1016.

Follow up to https://github.com/posit-dev/positron/pull/11407 and https://github.com/posit-dev/positron/pull/11497 where we disabled the exthost restart test on Windows (Slack discussion at https://positpbc.slack.com/archives/C06DNFJSHPD/p1769113239000079).

Not sure what this only surfaced on Windows, but the cause was an Ark crash due to sloppy Unwraps on connection events. This PR makes sure connection errors are propagated, logged, and cause the DAP server to shut down gracefully.

It was a bit tricky to debug because the logs were not showing the crash. The only clue that surfaced was a message in the Console:

<img width="400" height="106" alt="Screenshot 2026-01-28 at 12 07 27" src="https://github.com/user-attachments/assets/3f1e3444-e89e-4e5f-b631-e4e58b9953c7" />

and these messages in the Supervisor logs:

```log
10:00:05 [DEBUG] (2) kcserver::kernel_session::process: End of output stream (kind: Stderr)
10:00:05 [DEBUG] (18) kcserver::kernel_session::process: End of output stream (kind: Stdout)
10:00:05 [INFO] Child process for session r-68064bdf exited with status: exit code: 0xc0000409
10:00:05 [DEBUG] (17) kcserver::kernel_state: [session r-68064bdf] status 'idle' => 'exited' (child process exited)
10:00:05 [DEBUG] (17) kcserver::heartbeat: [session r-68064bdf] Stopping heartbeat monitor (exit event signaled).
```

`0xc0000409` is the code for `STATUS_STACK_BUFFER_OVERRUN`.

Attaching Ark with a debugger then restarting the exthost gave enough time to the process to emit log messages before exit, revealing the DAP panic.