### PR TITLE
Bump Ark to 0.1.227

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ark"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "actix-web",
  "aether_lsp_utils",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.226"
+version = "0.1.227"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
For:

- #1014
- #1015 
- #1016
- #1017 
- #1018
- #1019
