### PR TITLE
Bump test timeout to attempt fixing plot flakes

### DIFF
--- a/crates/amalthea/src/fixtures/dummy_frontend.rs
+++ b/crates/amalthea/src/fixtures/dummy_frontend.rs
@@ -359,7 +359,7 @@ impl DummyFrontend {
     pub fn recv(socket: &Socket) -> Message {
         // It's important to wait with a timeout because the kernel thread might have
         // panicked, preventing it from sending the expected message. The tests would then
-        // hang indefinitely. We wait a decently long time (10s), as test processes are
+        // hang indefinitely. We wait a decently long time (30s), as test processes are
         // run in parallel and we think they seem to slow each other down occasionally
         // (we've definitely seen false positive failures with a timeout of just 1s,
         // particularly when running with nextest).
@@ -368,7 +368,7 @@ impl DummyFrontend {
         // expected panic information in the test output.
         //
         // If you're debugging tests, you'll need to bump this timeout to a large value.
-        if socket.poll_incoming(10000).unwrap() {
+        if socket.poll_incoming(30000).unwrap() {
             return Message::read_from_socket(socket).unwrap();
         }
 


### PR DESCRIPTION
Attempt at fixing the plot failures we see on the Windows CI.

I took a look at some of the failing tests and could not see any async issues. So possibly the plots are taking a very long time? We have a 10s timeout, which seems like it should be amply sufficient. But in:

https://github.com/posit-dev/ark/actions/runs/21667681084/job/62467251434#step:9:701

I see successful tests with long running times, e.g. the ragg test here:

```
        PASS [   1.953s] (638/757) ark::plots test_graphics_device_initialization
        PASS [   4.280s] (639/757) ark::plots test_inability_to_load_ragg_falls_back_to_base_graphics
        FAIL [  11.777s] (640/757) ark::plots test_basic_plot
```

The PR bumps the timeout to 30s. Which will unfortunately slow down CI reports when real timeouts are hit due to bugs during development. Should hopefully fix the intermittent failures though.