### PR TITLE
Don't index or diagnose virtual documents

### DIFF
--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -260,6 +260,8 @@ pub fn filter_entry(entry: &DirEntry) -> bool {
     true
 }
 
+// Only called for actual files during workspace walking. Documents managed by
+// the LSP go through `update()` instead.
 pub(crate) fn create(uri: &Url) -> anyhow::Result<()> {
     if uri.scheme() != "file" {
         return Ok(());

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -1008,7 +1008,7 @@ pub(crate) fn diagnostics_refresh_all(state: WorldState) {
     );
 
     for (uri, _document) in state.documents.iter() {
-        if !ExtUrl::is_indexable(uri) {
+        if !ExtUrl::should_diagnose(uri) {
             continue;
         }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11887

Debugger virtual documents (`ark://` URIs) were getting distracting diagnostics squiggles on foreign code the user can't edit. We now skip non-file URIs in `diagnostics_refresh_all()`.

Also added a symmetric guard in `indexer::update()` to match what `indexer::create()` already had, and unified both to use a new `ExtUrl::is_local()` helper. We're now checking at both main loop and handler level, for defensiveness.

Unfortunately it's not possible to test diagnostics because we don't have integration tests for the LSP yet.