### PR TITLE
Simpler error formatting for `evaluate` requests

### DIFF
--- a/crates/ark/src/dap/dap.rs
+++ b/crates/ark/src/dap/dap.rs
@@ -645,6 +645,7 @@ impl Dap {
 fn evaluate_error_message(err: harp::Error) -> String {
     match err {
         harp::Error::TryCatchError { message, .. } => message,
+        harp::Error::ParseSyntaxError { message } => message,
         err => format!("{err}"),
     }
 }

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -821,7 +821,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
                         let response = state.lock().unwrap().into_evaluate_response(variable);
                         req.success(ResponseBody::Evaluate(response))
                     },
-                    Err(err) => req.error(&format!("Can't evaluate variable: {err:?}")),
+                    Err(err) => req.error(&format!("Error: {err}")),
                 }
             };
 

--- a/crates/ark/tests/dap_evaluate.rs
+++ b/crates/ark/tests/dap_evaluate.rs
@@ -201,16 +201,13 @@ local({
         "Expected incomplete code error, got: {err}"
     );
 
+    // Evaluate syntax error
+    let err = dap.evaluate_error("foo)", Some(frame_id));
+    assert_eq!(err, "Error: unexpected ')'");
+
     // Cause an R error during evaluation
-    let err = dap.evaluate_error("stop('intentional error')", Some(frame_id));
-    assert!(
-        err.contains("intentional error"),
-        "Expected error message, got: {err}"
-    );
-    assert!(
-        !err.contains("backtrace"),
-        "Error should not contain backtrace, got: {err}"
-    );
+    let err = dap.evaluate_error("stop('foo')", Some(frame_id));
+    assert_eq!(err, "Error: foo");
 
     // Debug session should still be alive and stopped after all these errors
     let result = dap.evaluate("x", Some(frame_id));

--- a/crates/ark_test/src/dap_client.rs
+++ b/crates/ark_test/src/dap_client.rs
@@ -36,6 +36,7 @@ use dap::requests::StepInArguments;
 use dap::requests::VariablesArguments;
 use dap::responses::Response;
 use dap::responses::ResponseBody;
+use dap::responses::ResponseMessage;
 use dap::responses::StackTraceResponse;
 use dap::types::Breakpoint;
 use dap::types::Capabilities;
@@ -320,11 +321,7 @@ impl DapClient {
     /// Request a page of the stack trace, returning the full response
     /// including `total_frames`.
     #[track_caller]
-    pub fn stack_trace_paged(
-        &mut self,
-        start_frame: i64,
-        levels: i64,
-    ) -> StackTraceResponse {
+    pub fn stack_trace_paged(&mut self, start_frame: i64, levels: i64) -> StackTraceResponse {
         let seq = self
             .send(Command::StackTrace(StackTraceArguments {
                 thread_id: -1,
@@ -449,7 +446,11 @@ impl DapClient {
             response
         );
 
-        format!("{:?}", response.message)
+        match response.message {
+            Some(ResponseMessage::Error(msg)) => msg,
+            Some(other) => format!("{other:?}"),
+            None => String::new(),
+        }
     }
 
     /// Request the list of threads.


### PR DESCRIPTION
Before:

<img width="511" height="124" alt="Screenshot 2026-02-26 at 10 20 40" src="https://github.com/user-attachments/assets/98247a49-240d-4161-b849-39e4608e7cb2" />

After:

<img width="345" height="124" alt="Screenshot 2026-02-26 at 10 18 41" src="https://github.com/user-attachments/assets/da63693e-74b4-4c52-b063-c9f85dbf2f8e" />
