### PR TITLE
Handle absent target name in comm info request

### DIFF
--- a/crates/amalthea/src/socket/shell.rs
+++ b/crates/amalthea/src/socket/shell.rs
@@ -396,8 +396,14 @@ impl Shell {
         let mut info = serde_json::Map::new();
 
         for comm in open_comms.iter() {
-            // Only include comms that match the target name, if one was specified
-            if req.target_name.is_empty() || req.target_name == comm.comm_name {
+            // Only include comms that match the target name, if one was specified.
+            // Also treat `""` as absent for backward compatibility, since the field
+            // was previously modeled as `String` (be liberal in what you accept).
+            if req
+                .target_name
+                .as_ref()
+                .is_none_or(|name| name.is_empty() || name == &comm.comm_name)
+            {
                 let comm_info_target = CommInfoTargetName {
                     target_name: comm.comm_name.clone(),
                 };

--- a/crates/amalthea/src/wire/comm_info_request.rs
+++ b/crates/amalthea/src/wire/comm_info_request.rs
@@ -13,7 +13,8 @@ use crate::wire::jupyter_message::MessageType;
 /// Represents a request from the frontend to show open comms
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommInfoRequest {
-    pub target_name: String,
+    #[serde(default)]
+    pub target_name: Option<String>,
 }
 
 impl MessageType for CommInfoRequest {

--- a/crates/amalthea/tests/client.rs
+++ b/crates/amalthea/tests/client.rs
@@ -149,9 +149,7 @@ fn test_amalthea_comms() {
     frontend.recv_iopub_idle();
     frontend.assert_no_incoming();
 
-    frontend.send_shell(CommInfoRequest {
-        target_name: "".to_string(),
-    });
+    frontend.send_shell(CommInfoRequest { target_name: None });
     frontend.recv_iopub_busy();
 
     assert_matches!(frontend.recv_shell(), Message::CommInfoReply(request) => {
@@ -163,11 +161,25 @@ fn test_amalthea_comms() {
     frontend.recv_iopub_idle();
     frontend.assert_no_incoming();
 
+    // Empty string is treated as absent for backward compatibility
+    frontend.send_shell(CommInfoRequest {
+        target_name: Some("".to_string()),
+    });
+    frontend.recv_iopub_busy();
+
+    assert_matches!(frontend.recv_shell(), Message::CommInfoReply(request) => {
+        let comms = request.content.comms;
+        assert!(comms.contains_key(comm_id));
+    });
+
+    frontend.recv_iopub_idle();
+    frontend.assert_no_incoming();
+
     // Test requesting comm info and filtering by target name. We should get
     // back an empty list of comms, since we haven't opened any comms with
     // the target name "i-think-not".
     frontend.send_shell(CommInfoRequest {
-        target_name: "i-think-not".to_string(),
+        target_name: Some("i-think-not".to_string()),
     });
     frontend.recv_iopub_busy();
 
@@ -237,7 +249,7 @@ fn test_amalthea_comms() {
     // Test to see if the comm is still in the list of comms after closing it
     // (it should not be)
     frontend.send_shell(CommInfoRequest {
-        target_name: "variables".to_string(),
+        target_name: Some("variables".to_string()),
     });
     frontend.recv_iopub_busy();
 
@@ -286,7 +298,7 @@ fn test_amalthea_comm_open_from_kernel() {
     // the kernel is correctly tracking the list of comms regardless of where
     // they originated.
     frontend.send_shell(CommInfoRequest {
-        target_name: test_comm_name.clone(),
+        target_name: Some(test_comm_name.clone()),
     });
 
     frontend.recv_iopub_busy();


### PR DESCRIPTION
Progress towards #1069.

The `target_name` field of `comm_info_request` is optional in the Jupyter protocol. When absent, the server should provide info for all comms.

Currently we're treating `""` as the all comm sentinel, but the protocol really specifies the field as optional (can be absent). To fix this, the field is now an `Option<String>` instead of a `String`.