### PR TITLE
Add `--default-cran-repo` CLI argument

### DIFF
--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -50,6 +50,7 @@ Available options:
 --repos-conf                 Set the default repositories to use from a configuration file
                              containing a list of named repositories (`name = url`)
 --default-ppm-repo           Set the default repositories to a custom Posit Package Manager URL.
+--default-cran-repo          Set the default CRAN repository to a custom URL.
 --version                    Print the version of Ark
 --log FILE                   Log to the given file (if not specified, stdout/stderr
                              will be used)
@@ -159,7 +160,7 @@ fn main() -> anyhow::Result<()> {
                 if let Some(repos) = argv.next() {
                     if default_repos != DefaultRepos::Auto {
                         return Err(anyhow::anyhow!(
-                            "Only one of `--default-repos`, `--repos-conf`, or `--default-ppm-repo` can be specified."
+                            "Only one of `--default-repos`, `--repos-conf`, `--default-ppm-repo`, or `--default-cran-repo` can be specified."
                         ));
                     }
                     default_repos = match repos.as_str() {
@@ -182,7 +183,7 @@ fn main() -> anyhow::Result<()> {
                 if let Some(repos) = argv.next() {
                     if default_repos != DefaultRepos::Auto {
                         return Err(anyhow::anyhow!(
-                            "Only one of `--default-repos`, `--repos-conf`, or `--default-ppm-repo` can be specified."
+                            "Only one of `--default-repos`, `--repos-conf`, `--default-ppm-repo`, or `--default-cran-repo` can be specified."
                         ));
                     }
                     let path = std::path::PathBuf::from(repos.clone());
@@ -204,7 +205,7 @@ fn main() -> anyhow::Result<()> {
                 if let Some(url) = argv.next() {
                     if default_repos != DefaultRepos::Auto {
                         return Err(anyhow::anyhow!(
-                            "Only one of `--default-repos`, `--repos-conf`, or `--default-ppm-repo` can be specified."
+                            "Only one of `--default-repos`, `--repos-conf`, `--default-ppm-repo`, or `--default-cran-repo` can be specified."
                         ));
                     }
                     let parsed =
@@ -225,6 +226,22 @@ fn main() -> anyhow::Result<()> {
                 } else {
                     return Err(anyhow::anyhow!(
                         "The `--default-ppm-repo` option must be followed by a repository URL."
+                    ));
+                }
+            },
+            "--default-cran-repo" => {
+                if let Some(url) = argv.next() {
+                    if default_repos != DefaultRepos::Auto {
+                        return Err(anyhow::anyhow!(
+                            "Only one of `--default-repos`, `--repos-conf`, `--default-ppm-repo`, or `--default-cran-repo` can be specified."
+                        ));
+                    }
+                    let parsed =
+                        url::Url::parse(&url).context("Failed to parse --default-cran-repo URL")?;
+                    default_repos = DefaultRepos::CranRepo(parsed)
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "The `--default-cran-repo` option must be followed by a URL."
                     ));
                 }
             },

--- a/crates/ark/src/repos.rs
+++ b/crates/ark/src/repos.rs
@@ -47,6 +47,9 @@ pub enum DefaultRepos {
 
     /// Use the repositories specified in the given configuration file.
     ConfFile(PathBuf),
+
+    /// Set the CRAN repository to a custom URL.
+    CranRepo(url::Url),
 }
 
 pub fn apply_default_repos(repos: DefaultRepos) -> anyhow::Result<()> {
@@ -97,6 +100,12 @@ pub fn apply_default_repos(repos: DefaultRepos) -> anyhow::Result<()> {
             );
             let mut repos = HashMap::new();
             repos.insert("CRAN".to_string(), get_ppm_binary_package_repo(Some(url)));
+            apply_repos(repos)
+        },
+        DefaultRepos::CranRepo(url) => {
+            log::info!("Setting default CRAN repository to: {}", url);
+            let mut repos = HashMap::new();
+            repos.insert("CRAN".to_string(), url.to_string());
             apply_repos(repos)
         },
     }


### PR DESCRIPTION
This PR adds a new `--default-cran-repo <url>` CLI argument that sets the default CRAN repository to a custom URL. This is simpler than the existing `--default-ppm-repo` option (no path segment validation or Linux distro detection); it just sets the CRAN repository to the provided URL directly. We need this to support the r-versions `Repo` field implementation in Positron (posit-dev/positron#12205).

## Usage

```bash
ark --default-cran-repo https://cran.case.edu/ --connection_file ...
```

This is mutually exclusive with `--default-repos`, `--repos-conf`, and `--default-ppm-repo`.
