### PR TITLE
Add package management RPC functions

### DIFF
--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -1,7 +1,7 @@
 #
 # packages_pane.R
 #
-# Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2026 Posit Software, PBC. All rights reserved.
 #
 #
 


### PR DESCRIPTION
This PR is to move R code from Positron into Ark. This provides two key features:

1. We can use the `LanguageRuntimeSession.callMethod()` function to execute this code and return the result.
2. The code is guaranteed to be loaded and we therefore do not need to load it from Positron

Related tickets:
https://github.com/posit-dev/positron/issues/12076
https://github.com/posit-dev/positron/issues/11842

Add new RPC endpoints for the Positron packages pane:
- `pkg_install`: Install packages via pak or base R
- `pkg_list`: List installed packages with metadata
- `pkg_update_all`: Update all outdated packages
- `pkg_uninstall`: Remove packages and unload namespaces
- `pkg_search`: Search CRAN for packages by name
- `pkg_search_versions`: Get available versions for a package

Each function supports both `pak` and `base` methods to allow flexibility depending on user preference and environment.

Related Positron PR that consumes this change: https://github.com/posit-dev/positron/pull/12280