### PR TITLE
Bump Ark to 0.1.238

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ark"
-version = "0.1.237"
+version = "0.1.238"
 dependencies = [
  "actix-web",
  "aether_lsp_utils",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.237"
+version = "0.1.238"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1072
- https://github.com/posit-dev/ark/pull/1073
- https://github.com/posit-dev/ark/pull/1075
- https://github.com/posit-dev/ark/pull/1076
- https://github.com/posit-dev/ark/pull/1078
- https://github.com/posit-dev/ark/pull/1082
- https://github.com/posit-dev/ark/pull/1083
