### PR TITLE
Bump ark to 0.1.241

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ark"
-version = "0.1.240"
+version = "0.1.241"
 dependencies = [
  "actix-web",
  "aether_lsp_utils",

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark"
-version = "0.1.240"
+version = "0.1.241"
 description = """
 Ark, an R Kernel.
 """


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/1094 to make it into a build for Zed users, no pressure to bump on the Positron side