### PR TITLE
Util for getting active request

### DIFF
--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -2794,7 +2794,7 @@ unsafe extern "C-unwind" fn ps_get_virtual_document(uri: SEXP) -> anyhow::Result
 /// Returns the currently active execute request as an R named list,
 /// or NULL if no execute request is in flight.
 #[harp::register]
-pub unsafe extern "C-unwind" fn ps_active_request() -> anyhow::Result<SEXP> {
+pub unsafe extern "C-unwind" fn ps_get_active_request() -> anyhow::Result<SEXP> {
     let Some(req) = Console::get().get_active_execute_request() else {
         return Ok(libr::R_NilValue);
     };

--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -61,7 +61,7 @@
 #
 # Internal utility; invoke with: `.ps.internal(active_request())`
 active_request <- function() {
-    .ps.Call("ps_active_request")
+    .ps.Call("ps_get_active_request")
 }
 
 # Sleep that doesn't check for interrupts to test an unresponsive runtime.


### PR DESCRIPTION
I'm preparing to do some work to add more metadata to the execute request, and am adding this to make it easy to inspect it. 

<img width="809" height="737" alt="image" src="https://github.com/user-attachments/assets/bea0ff60-6b92-4e55-99ab-fd5bb8a1f2fa" />
