### PR TITLE
Auto-fix clippy lints with `--all-targets`

### DIFF
--- a/crates/amalthea/tests/client/main.rs
+++ b/crates/amalthea/tests/client/main.rs
@@ -24,7 +24,6 @@ use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::status::ExecutionState;
 use assert_matches::assert_matches;
 use dummy_frontend::DummyAmaltheaFrontend;
-use serde_json;
 
 #[test]
 fn test_amalthea_kernel_info() {
@@ -74,7 +73,7 @@ fn test_amalthea_shutdown_request() {
 
     let reply = frontend.recv_control_shutdown_reply();
     assert_eq!(reply.status, Status::Ok);
-    assert_eq!(reply.restart, false);
+    assert!(!reply.restart);
     frontend.recv_iopub_idle();
 
     // Test again with restart = true.
@@ -85,7 +84,7 @@ fn test_amalthea_shutdown_request() {
 
     let reply = frontend.recv_control_shutdown_reply();
     assert_eq!(reply.status, Status::Ok);
-    assert_eq!(reply.restart, true);
+    assert!(reply.restart);
     frontend.recv_iopub_idle();
 }
 

--- a/crates/amalthea/tests/client/shell.rs
+++ b/crates/amalthea/tests/client/shell.rs
@@ -145,7 +145,7 @@ impl ShellHandler for Shell {
     ) -> amalthea::Result<ExecuteReply> {
         // Increment counter if we are storing this execution in history
         if req.store_history {
-            self.execution_count = self.execution_count + 1;
+            self.execution_count += 1;
         }
 
         // If the code is not to be executed silently, re-broadcast the

--- a/crates/ark/src/data_explorer/export_selection.rs
+++ b/crates/ark/src/data_explorer/export_selection.rs
@@ -267,10 +267,7 @@ mod tests {
                 .unwrap()
                 .try_into()
                 .unwrap();
-        match res {
-            Some(res) => res,
-            None => false,
-        }
+        res.unwrap_or_default()
     }
 
     /// Test a selection with all supported formats (CSV, TSV, and HTML if knitr is available)

--- a/crates/ark/src/data_explorer/format.rs
+++ b/crates/ark/src/data_explorer/format.rs
@@ -539,7 +539,7 @@ mod tests {
                 thousands_sep: None,
                 max_value_length: 100,
             };
-            let expected = vec![
+            let expected = [
                 "0.00",
                 "1.00",
                 "1.01",
@@ -567,7 +567,7 @@ mod tests {
                 max_value_length: 100,
             };
 
-            let expected = vec![
+            let expected = [
                 "0.000",
                 "1.000",
                 "1.010",

--- a/crates/ark/src/data_explorer/histogram.rs
+++ b/crates/ark/src/data_explorer/histogram.rs
@@ -248,7 +248,7 @@ mod tests {
         .unwrap();
 
         assert_match!(hist, ColumnHistogram { quantiles, .. }  => {
-            format_string(RObject::try_from(expected).unwrap().sexp, &default_options()).
+            format_string(RObject::from(expected).sexp, &default_options()).
             into_iter().
             zip(quantiles.into_iter()).
             for_each(|(expected, quantile)| {
@@ -275,7 +275,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(freq_table, ColumnFrequencyTable {
-            values: format_string(RObject::try_from(values).unwrap().sexp, &default_options())
+            values: format_string(RObject::from(values).sexp, &default_options())
                 .into_iter()
                 .map(ColumnValue::FormattedValue)
                 .collect(),

--- a/crates/ark/src/lsp/capabilities.rs
+++ b/crates/ark/src/lsp/capabilities.rs
@@ -68,7 +68,7 @@ impl Capabilities {
         code_action_literal_support: bool,
     ) -> Self {
         self.code_action_literal_support = code_action_literal_support;
-        return self;
+        self
     }
 
     pub(crate) fn workspace_edit_document_changes(&self) -> bool {
@@ -82,7 +82,7 @@ impl Capabilities {
         workspace_edit_document_changes: bool,
     ) -> Self {
         self.workspace_edit_document_changes = workspace_edit_document_changes;
-        return self;
+        self
     }
 
     pub(crate) fn code_action_provider_capability(&self) -> Option<CodeActionProviderCapability> {

--- a/crates/ark/src/lsp/code_action/roxygen.rs
+++ b/crates/ark/src/lsp/code_action/roxygen.rs
@@ -446,7 +446,7 @@ f@n <- function(a, b) {}
         let text_edits = changes.get(&uri).unwrap();
         assert_eq!(text_edits.len(), 1);
 
-        let text_edit = text_edits.get(0).unwrap();
+        let text_edit = text_edits.first().unwrap();
         assert_eq!(text_edit.range.start.line, 1);
         assert_eq!(text_edit.range.start.character, 0);
         assert_eq!(text_edit.range.end, text_edit.range.start);

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -300,7 +300,7 @@ mod tests {
 
             // We detect this as a `name` position and return all possible completions
             assert_eq!(completions.len(), 4);
-            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.first().unwrap().label, "x = ");
             assert_eq!(completions.get(1).unwrap().label, "table = ");
 
             // Right after `tab`
@@ -314,7 +314,7 @@ mod tests {
             // We detect this as a `name` position and return all possible completions
             // (TODO: Should not return `x` as a possible completion)
             assert_eq!(completions.len(), 4);
-            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.first().unwrap().label, "x = ");
             assert_eq!(completions.get(1).unwrap().label, "table = ");
         })
     }
@@ -354,7 +354,7 @@ mod tests {
             assert_eq!(completions.len(), 2);
 
             // Retains positional ordering
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "y = ");
 
             let completion = completions.get(1).unwrap();
@@ -418,7 +418,7 @@ mod tests {
             let completions = completions_from_call(&context).unwrap().unwrap();
 
             assert_eq!(completions.len(), 4);
-            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.first().unwrap().label, "x = ");
             assert_eq!(completions.get(1).unwrap().label, "table = ");
 
             // Partially typed argument
@@ -430,7 +430,7 @@ mod tests {
             let completions = completions_from_call(&context).unwrap().unwrap();
 
             assert_eq!(completions.len(), 4);
-            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.first().unwrap().label, "x = ");
             assert_eq!(completions.get(1).unwrap().label, "table = ");
 
             // Partially typed second argument
@@ -442,7 +442,7 @@ mod tests {
             let completions = completions_from_call(&context).unwrap().unwrap();
 
             assert_eq!(completions.len(), 4);
-            assert_eq!(completions.get(0).unwrap().label, "x = ");
+            assert_eq!(completions.first().unwrap().label, "x = ");
             assert_eq!(completions.get(1).unwrap().label, "table = ");
         })
     }

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -115,7 +115,7 @@ mod tests {
             let completions = completions_from_subset(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 2);
 
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "b".to_string());
             assert_eq!(completion.insert_text, Some("\"b\"".to_string()));
 
@@ -159,7 +159,7 @@ mod tests {
             let completions = completions_from_subset(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 11);
 
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "mpg".to_string());
             assert_eq!(completion.insert_text, None); // No enquote, means the label is used directly
 
@@ -171,7 +171,7 @@ mod tests {
             let completions = completions_from_subset(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 11);
 
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "mpg".to_string());
             assert_eq!(completion.insert_text, None); // No enquote, means the label is used directly
 
@@ -183,7 +183,7 @@ mod tests {
             let completions = completions_from_subset(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 11);
 
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             // TODO: ideally we could assert that mpg doesn't appear again, or appears at the end
             assert_eq!(completion.label, "mpg".to_string());
             assert_eq!(completion.insert_text, None); // No enquote, means the label is used directly
@@ -196,7 +196,7 @@ mod tests {
             let completions = completions_from_subset(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 11);
 
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "mpg".to_string());
             assert_eq!(completion.insert_text, Some("\"mpg\"".to_string())); // Enquoted result
 

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -203,7 +203,7 @@ fn test_roxygen_comment() {
             .iter()
             .filter(|item| item.label == "description")
             .collect();
-        let description = description.get(0).unwrap();
+        let description = description.first().unwrap();
         assert_eq!(
             description.insert_text,
             Some(String::from(

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -231,7 +231,7 @@ mod tests {
             assert_eq!(completions.len(), 2);
 
             // Note, no sorting done!
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "b".to_string());
 
             let completion = completions.get(1).unwrap();
@@ -342,7 +342,7 @@ mod tests {
             // All names of `foo`, the frontend filters them
             let completions = completions_from_dollar(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 2);
-            assert_eq!(completions.get(0).unwrap().label, String::from("abcd"));
+            assert_eq!(completions.first().unwrap().label, String::from("abcd"));
             assert_eq!(completions.get(1).unwrap().label, String::from("wxyz"));
 
             let (text, point) = point_from_cursor("foo$a@bc");
@@ -352,7 +352,7 @@ mod tests {
             // Same as above
             let completions = completions_from_dollar(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 2);
-            assert_eq!(completions.get(0).unwrap().label, String::from("abcd"));
+            assert_eq!(completions.first().unwrap().label, String::from("abcd"));
             assert_eq!(completions.get(1).unwrap().label, String::from("wxyz"));
 
             // Clean up

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -123,21 +123,21 @@ mod tests {
             assert_match!(
                 completions_from_string(&context).unwrap(),
                 Some(items) => {
-                    assert!(items.len() > 0)
+                    assert!(!items.is_empty())
                 }
             );
 
             // `Some` trigger -> Should return empty completion set
             let context = DocumentContext::new(&document, point, Some(String::from("$")));
             let res = completions_from_string(&context).unwrap();
-            assert_match!(res, Some(items) => { assert!(items.len() == 0) });
+            assert_match!(res, Some(items) => { assert!(items.is_empty()) });
 
             // Check for same result when consulting (potentially all) unique sources
             let state = WorldState::default();
             let completion_context = CompletionContext::new(&context, &state);
             let res = unique::get_completions(&completion_context).unwrap();
 
-            assert_match!(res, Some(items) => { assert!(items.len() == 0) });
+            assert_match!(res, Some(items) => { assert!(items.is_empty()) });
         })
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -146,7 +146,7 @@ mod tests {
                 .unwrap();
             assert_eq!(completions.len(), 2);
 
-            let completion = completions.get(0).unwrap();
+            let completion = completions.first().unwrap();
             assert_eq!(completion.label, "b".to_string());
             // Not enquoting, so uses `label` directly
             assert_eq!(completion.insert_text, None);
@@ -238,7 +238,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(completions.len(), 2);
-            assert_eq!(completions.get(0).unwrap().label, "a".to_string());
+            assert_eq!(completions.first().unwrap().label, "a".to_string());
             assert_eq!(completions.get(1).unwrap().label, "b".to_string());
 
             // Clean up

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -472,7 +472,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(completions.len(), 2);
-            assert_eq!(completions.get(0).unwrap().label, String::from("a"));
+            assert_eq!(completions.first().unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
 
             parse_eval_global("remove(x)").unwrap();
@@ -484,7 +484,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(completions.len(), 3);
-            assert_eq!(completions.get(0).unwrap().label, String::from("a"));
+            assert_eq!(completions.first().unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
             assert_eq!(completions.get(2).unwrap().label, String::from("c"));
 
@@ -498,7 +498,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(completions.len(), 2);
-            assert_eq!(completions.get(0).unwrap().label, String::from("a"));
+            assert_eq!(completions.first().unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
 
             parse_eval_global("remove(x)").unwrap();
@@ -512,7 +512,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(completions.len(), 1);
-            assert_eq!(completions.get(0).unwrap().label, String::from("b"));
+            assert_eq!(completions.first().unwrap().label, String::from("b"));
 
             parse_eval_global("remove(x)").unwrap();
 
@@ -549,8 +549,8 @@ mod tests {
                 .unwrap();
 
             assert_eq!(completions.len(), 11);
-            assert_eq!(completions.get(0).unwrap().label, String::from("mpg"));
-            assert_eq!(completions.get(0).unwrap().insert_text, None);
+            assert_eq!(completions.first().unwrap().label, String::from("mpg"));
+            assert_eq!(completions.first().unwrap().insert_text, None);
 
             // Subset2 completions
             let completions =
@@ -559,9 +559,9 @@ mod tests {
                     .unwrap();
 
             assert_eq!(completions.len(), 11);
-            assert_eq!(completions.get(0).unwrap().label, String::from("mpg"));
+            assert_eq!(completions.first().unwrap().label, String::from("mpg"));
             assert_eq!(
-                completions.get(0).unwrap().insert_text,
+                completions.first().unwrap().insert_text,
                 Some("\"mpg\"".to_string())
             );
 

--- a/crates/ark/src/lsp/declarations.rs
+++ b/crates/ark/src/lsp/declarations.rs
@@ -131,26 +131,26 @@ mod test {
     fn test_declare_diagnostics() {
         let doc = Document::new("", None);
         let decls = top_level_declare(&doc.ast, &doc.contents);
-        assert_eq!(decls.diagnostics, true);
+        assert!(decls.diagnostics);
 
         let doc = Document::new("declare(ark(diagnostics(enable = TRUE)))", None);
         let decls = top_level_declare(&doc.ast, &doc.contents);
-        assert_eq!(decls.diagnostics, true);
+        assert!(decls.diagnostics);
 
         let doc = Document::new("declare(ark(diagnostics(enable = NULL)))", None);
         let decls = top_level_declare(&doc.ast, &doc.contents);
-        assert_eq!(decls.diagnostics, true);
+        assert!(decls.diagnostics);
 
         let doc = Document::new("declare(ark(diagnostics(enable = invalid())))", None);
         let decls = top_level_declare(&doc.ast, &doc.contents);
-        assert_eq!(decls.diagnostics, true);
+        assert!(decls.diagnostics);
 
         let doc = Document::new("~declare()", None);
         let decls = top_level_declare(&doc.ast, &doc.contents);
-        assert_eq!(decls.diagnostics, true);
+        assert!(decls.diagnostics);
 
         let doc = Document::new("declare(ark(diagnostics(enable = FALSE)))", None);
         let decls = top_level_declare(&doc.ast, &doc.contents);
-        assert_eq!(decls.diagnostics, false);
+        assert!(!decls.diagnostics);
     }
 }

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1147,7 +1147,7 @@ mod tests {
     use crate::r_task;
 
     // Default state that includes installed packages and default scopes.
-    static DEFAULT_STATE: Lazy<WorldState> = Lazy::new(|| current_state());
+    static DEFAULT_STATE: Lazy<WorldState> = Lazy::new(current_state);
 
     fn generate_diagnostics(doc: Document, state: WorldState) -> Vec<lsp_types::Diagnostic> {
         super::generate_diagnostics(doc, state, false)
@@ -1176,7 +1176,7 @@ foo
             let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 2);
 
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
             assert_eq!(diagnostic.range.start, Position::new(3, 2));
             assert_eq!(diagnostic.range.end, Position::new(3, 3));
@@ -1209,7 +1209,7 @@ foo
             let document = Document::new(text, None);
             let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
         })
     }
@@ -1296,7 +1296,7 @@ foo
             assert_eq!(diagnostics.len(), 1);
 
             // Only marks the `x` before the `x <- 1`
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             assert_eq!(diagnostic.range.start.line, 1)
         })
     }
@@ -1331,7 +1331,7 @@ foo
             let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);
 
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
         })
     }
@@ -1351,7 +1351,7 @@ foo
             let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);
 
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
         })
     }
@@ -1372,7 +1372,7 @@ foo
             let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);
 
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
         })
     }
@@ -1392,7 +1392,7 @@ foo
             let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
             assert_eq!(diagnostics.len(), 1);
 
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
         })
     }
@@ -1688,7 +1688,7 @@ foo
             assert_eq!(diagnostics.len(), 2);
 
             assert!(diagnostics
-                .get(0)
+                .first()
                 .unwrap()
                 .message
                 .contains("No symbol named 'undefined' in scope"));

--- a/crates/ark/src/lsp/diagnostics_syntax.rs
+++ b/crates/ark/src/lsp/diagnostics_syntax.rs
@@ -449,7 +449,7 @@ mod tests {
         let newlines = "\n".repeat(20);
         let text = String::from("('") + newlines.as_str() + ")";
         let diagnostics = text_diagnostics(text.as_str());
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 0));
@@ -459,21 +459,21 @@ mod tests {
     fn test_unmatched_call_delimiter() {
         let diagnostics = text_diagnostics("match(a, b");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         assert_eq!(diagnostic.range.start, Position::new(0, 5));
         assert_eq!(diagnostic.range.end, Position::new(0, 6));
         insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("foo[a, b");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         assert_eq!(diagnostic.range.start, Position::new(0, 3));
         assert_eq!(diagnostic.range.end, Position::new(0, 4));
         insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("foo[[a, b");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         assert_eq!(diagnostic.range.start, Position::new(0, 3));
         assert_eq!(diagnostic.range.end, Position::new(0, 5));
         insta::assert_snapshot!(diagnostic.message);
@@ -494,7 +494,7 @@ identity(1)
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the unmatched `(`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(1, 5));
         assert_eq!(diagnostic.range.end, Position::new(1, 6));
@@ -504,12 +504,12 @@ identity(1)
     fn test_unmatched_braces() {
         let diagnostics = text_diagnostics("{");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("{ 1 + 2");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("{}");
@@ -523,24 +523,24 @@ identity(1)
     fn test_unmatched_parentheses() {
         let diagnostics = text_diagnostics("(");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("( 1 + 2");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
 
         // tree-sitter grammar knows R doesn't allow empty `()` without a body
         let diagnostics = text_diagnostics("()");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
 
         // tree-sitter grammar knows R doesn't allow >1 expressions in `()`
         let diagnostics = text_diagnostics("(1+2\n1+2)");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
 
         let diagnostics = text_diagnostics("( 1 + 2 )");
@@ -553,7 +553,7 @@ identity(1)
         // but it should always be decent
         let diagnostics = text_diagnostics("sum(1 * 2 + )");
         assert_eq!(diagnostics.len(), 1);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 12));
         assert_eq!(diagnostic.range.end, Position::new(0, 13));
@@ -561,7 +561,7 @@ identity(1)
 
     #[test]
     fn test_unmatched_closing_token() {
-        let close = vec!["}", ")", "]"];
+        let close = ["}", ")", "]"];
 
         for delimiter in close.iter() {
             // i.e. `1 + 1 }`
@@ -571,7 +571,7 @@ identity(1)
             assert_eq!(diagnostics.len(), 1);
 
             // Diagnostic highlights the `{delimiter}`
-            let diagnostic = diagnostics.get(0).unwrap();
+            let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
             assert_eq!(diagnostic.range.start, Position::new(0, 6));
             assert_eq!(diagnostic.range.end, Position::new(0, 7));
@@ -584,7 +584,7 @@ identity(1)
         // Should target the `}` specifically, not `+ }`.
         let text = "1 + }";
         let diagnostics = text_diagnostics(text);
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 4));
         assert_eq!(diagnostic.range.end, Position::new(0, 5));
@@ -602,7 +602,7 @@ identity(1)
         let diagnostics = text_diagnostics(text);
         assert_eq!(diagnostics.len(), 1);
 
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(3, 0));
         assert_eq!(diagnostic.range.end, Position::new(3, 1));
@@ -620,7 +620,7 @@ function(x {
         let diagnostics = text_diagnostics(text);
         assert_eq!(diagnostics.len(), 2);
 
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(1, 11));
         assert_eq!(diagnostic.range.end, Position::new(1, 12));
@@ -639,7 +639,7 @@ function(x {
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the `for`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 3));
@@ -653,7 +653,7 @@ function(x {
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the `while`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 5));
@@ -667,7 +667,7 @@ function(x {
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the `repeat`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(1, 0));
         assert_eq!(diagnostic.range.end, Position::new(1, 6));
@@ -682,7 +682,7 @@ function(x {
 
         // Diagnostic highlights the `if`
         // We call if an if "body" even though tree-sitter calls it a "consequence"
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 2));
@@ -696,7 +696,7 @@ function(x {
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the `function`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 8));
@@ -708,7 +708,7 @@ function(x {
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the `function`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 0));
         assert_eq!(diagnostic.range.end, Position::new(0, 1));
@@ -722,7 +722,7 @@ function(x {
         assert_eq!(diagnostics.len(), 1);
 
         // Diagnostic highlights the `2`
-        let diagnostic = diagnostics.get(0).unwrap();
+        let diagnostic = diagnostics.first().unwrap();
         insta::assert_snapshot!(diagnostic.message);
         assert_eq!(diagnostic.range.start, Position::new(0, 9));
         assert_eq!(diagnostic.range.end, Position::new(0, 10));

--- a/crates/ark/src/lsp/inputs/package.rs
+++ b/crates/ark/src/lsp/inputs/package.rs
@@ -128,6 +128,39 @@ impl Package {
 }
 
 #[cfg(test)]
+pub(crate) fn temp_palmerpenguin() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Write DESCRIPTION
+    let description = "\
+Package: penguins
+Version: 1.0
+";
+    fs::write(dir.path().join("DESCRIPTION"), description).unwrap();
+
+    // Write NAMESPACE
+    let namespace = "\
+export(path_to_file)
+export(penguins)
+";
+    fs::write(dir.path().join("NAMESPACE"), namespace).unwrap();
+
+    // Write INDEX
+    let index = "\
+path_to_file            Get file path to 'penguins.csv' and
+                    'penguins_raw.csv' files
+penguins                Size measurements for adult foraging penguins
+                    near Palmer Station, Antarctica
+penguins_raw            Penguin size, clutch, and blood isotope data
+                    for foraging adults near Palmer Station,
+                    Antarctica
+";
+    fs::write(dir.path().join("INDEX"), index).unwrap();
+
+    dir
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::lsp::inputs::package_description::Description;
@@ -180,37 +213,4 @@ mod tests {
         ]);
         assert_eq!(pkg.description.name, "penguins");
     }
-}
-
-#[cfg(test)]
-pub(crate) fn temp_palmerpenguin() -> tempfile::TempDir {
-    let dir = tempfile::tempdir().unwrap();
-
-    // Write DESCRIPTION
-    let description = "\
-Package: penguins
-Version: 1.0
-";
-    fs::write(dir.path().join("DESCRIPTION"), description).unwrap();
-
-    // Write NAMESPACE
-    let namespace = "\
-export(path_to_file)
-export(penguins)
-";
-    fs::write(dir.path().join("NAMESPACE"), namespace).unwrap();
-
-    // Write INDEX
-    let index = "\
-path_to_file            Get file path to 'penguins.csv' and
-                    'penguins_raw.csv' files
-penguins                Size measurements for adult foraging penguins
-                    near Palmer Station, Antarctica
-penguins_raw            Penguin size, clutch, and blood isotope data
-                    for foraging adults near Palmer Station,
-                    Antarctica
-";
-    fs::write(dir.path().join("INDEX"), index).unwrap();
-
-    dir
 }

--- a/crates/ark/src/lsp/selection_range.rs
+++ b/crates/ark/src/lsp/selection_range.rs
@@ -154,7 +154,7 @@ mod tests {
         let selections = selection_range(&tree, points).unwrap();
 
         // Two selections, the braces and the whole document
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(1, 0));
         assert_eq!(selection.range.end_point, Point::new(3, 1));
 
@@ -189,7 +189,7 @@ mod tests {
         let selections = selection_range(&tree, points).unwrap();
 
         // Just 1 selection, the whole document
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(0, 0));
         assert_eq!(selection.range.end_point, Point::new(6, 0));
         assert!(selection.parent.is_none());
@@ -221,7 +221,7 @@ fn <- function(x, arg) {
         let selections = selection_range(&tree, points).unwrap();
 
         // Braces for if statement
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(2, 20));
         assert_eq!(selection.range.end_point, Point::new(4, 3));
 
@@ -272,7 +272,7 @@ fn <- function() {
         let selections = selection_range(&tree, points).unwrap();
 
         // `f` identifier
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(2, 9));
         assert_eq!(selection.range.end_point, Point::new(2, 10));
 
@@ -306,7 +306,7 @@ fn(@a, b, c)
         let selections = selection_range(&tree, points).unwrap();
 
         // `<<a>>` `identifier` node
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(1, 3));
         assert_eq!(selection.range.end_point, Point::new(1, 4));
 
@@ -346,7 +346,7 @@ x[a, @fn(), c]
         let selections = selection_range(&tree, points).unwrap();
 
         // `<<fn>>` `identifier` node
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(1, 5));
         assert_eq!(selection.range.end_point, Point::new(1, 7));
 
@@ -391,7 +391,7 @@ x[[a, @fn(), c]]
         let selections = selection_range(&tree, points).unwrap();
 
         // `<<fn>>` `identifier` node
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(1, 6));
         assert_eq!(selection.range.end_point, Point::new(1, 8));
 
@@ -436,7 +436,7 @@ p@kg::fn(a)
         let selections = selection_range(&tree, points).unwrap();
 
         // `<<pkg>>` `identifier` node
-        let selection = selections.get(0).unwrap();
+        let selection = selections.first().unwrap();
         assert_eq!(selection.range.start_point, Point::new(1, 0));
         assert_eq!(selection.range.end_point, Point::new(1, 3));
 

--- a/crates/ark/src/lsp/signature_help.rs
+++ b/crates/ark/src/lsp/signature_help.rs
@@ -526,8 +526,14 @@ mod tests {
             assert_eq!(help.signatures.len(), 1);
 
             // Looking for the label offset into `library(package, ...etc)` for `package`
-            let signature = help.signatures.get(0).unwrap();
-            let label = &signature.parameters.as_ref().unwrap().get(0).unwrap().label;
+            let signature = help.signatures.first().unwrap();
+            let label = &signature
+                .parameters
+                .as_ref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .label;
             assert_eq!(label, &ParameterLabel::LabelOffsets([8, 15]));
         })
     }
@@ -577,7 +583,7 @@ fn <- function(
             let help = help.unwrap().unwrap();
 
             // Check expected signature label
-            let signature = help.signatures.get(0).unwrap();
+            let signature = help.signatures.first().unwrap();
             assert_eq!(
                 signature.label,
                 String::from(

--- a/crates/ark/src/lsp/statement_range.rs
+++ b/crates/ark/src/lsp/statement_range.rs
@@ -869,17 +869,17 @@ mod tests {
         let mut in_end = false;
 
         for (line_row, line) in lines.into_iter().enumerate() {
-            for (char_column, char) in line.as_bytes().into_iter().enumerate() {
+            for (char_column, char) in line.as_bytes().iter().enumerate() {
                 if in_start {
                     // We are in a `<`. Whatever happens next, we will exit the "in start" state.
                     in_start = false;
 
                     // Found a `<<`
                     if char == &mark_start {
-                        if !sel_end.is_none() {
+                        if sel_end.is_some() {
                             panic!("`<<` must be used before `>>`.");
                         }
-                        if !sel_start.is_none() {
+                        if sel_start.is_some() {
                             panic!("`<<` must only be used once.");
                         }
 
@@ -911,7 +911,7 @@ mod tests {
                         if sel_start.is_none() {
                             panic!("`<<` must be used before `>>`.");
                         }
-                        if !sel_end.is_none() {
+                        if sel_end.is_some() {
                             panic!("`>>` must only be used once.");
                         }
 
@@ -954,7 +954,7 @@ mod tests {
                 }
 
                 if char == &mark_cursor {
-                    if !cursor.is_none() {
+                    if cursor.is_some() {
                         panic!("`@` must only be used once.");
                     }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -1153,9 +1153,8 @@ outer <- 4
                 ..Default::default()
             };
             let result = super::symbols(&params, &state).unwrap();
-            let out = result.into_iter().map(|s| s.name).collect();
 
-            out
+            result.into_iter().map(|s| s.name).collect()
         }
 
         // Should include section when true

--- a/crates/ark/src/variables/variable.rs
+++ b/crates/ark/src/variables/variable.rs
@@ -1781,12 +1781,12 @@ mod tests {
 
             assert_eq!(variable.display_type, String::from("foo (3)"));
 
-            assert_eq!(variable.has_children, true);
+            assert!(variable.has_children);
 
             assert_eq!(variable.kind, VariableKind::Other);
 
             // The has_viewer method returns TRUE, so the object has a viewer
-            assert_eq!(variable.has_viewer, true);
+            assert!(variable.has_viewer);
 
             // Now inspect `x`
             let path = vec![String::from("x")];
@@ -2063,7 +2063,7 @@ mod tests {
             let vars = inspect_from_expr("matrix(0, ncol = 10000, nrow = 10000)");
             assert_eq!(vars.len(), MAX_DISPLAY_VALUE_ENTRIES);
             assert_eq!(vars[0].display_value.len(), MAX_DISPLAY_VALUE_LENGTH);
-            assert_eq!(vars[0].is_truncated, true);
+            assert!(vars[0].is_truncated);
 
             let vars = inspect_from_expr("new.env(parent=emptyenv())");
             assert_eq!(vars.len(), 0);
@@ -2079,7 +2079,7 @@ mod tests {
             );
             assert_eq!(vars.len(), 10);
             assert_eq!(vars[0].display_value.len(), MAX_DISPLAY_VALUE_LENGTH);
-            assert_eq!(vars[0].is_truncated, true);
+            assert!(vars[0].is_truncated);
 
             let vars = inspect_from_expr(
                 "structure(1:10, names = rep(paste(rep(letters, length.out = 10000), collapse = ''), 10))",
@@ -2101,12 +2101,12 @@ mod tests {
 
             let vars = inspect_from_expr("list(x = x ~ {y + z + a})");
             assert_eq!(vars[0].display_value, "x ~ { ...");
-            assert_eq!(vars[0].is_truncated, true);
+            assert!(vars[0].is_truncated);
 
             let formula: String = (0..100).map(|i| format!("x{i}")).collect_vec().join(" + ");
             let vars = inspect_from_expr(format!("list(x = x ~ {formula})").as_str());
 
-            assert_eq!(vars[0].is_truncated, true);
+            assert!(vars[0].is_truncated);
             // The deparser truncates the formula at 70 characters so we don't expect to get to
             // MAX_DISPLAY_VALUE_LENGTH. We do have protections if this behavior changes, though.
             assert_eq!(vars[0].display_value.len(), 70);
@@ -2144,7 +2144,7 @@ mod tests {
             let vars = PositronVariable::inspect(env.into(), &path).unwrap();
             assert_eq!(vars.len(), 1);
             assert_eq!(vars[0].display_value.len(), MAX_DISPLAY_VALUE_LENGTH);
-            assert_eq!(vars[0].is_truncated, true);
+            assert!(vars[0].is_truncated);
 
             // Test for the empty string
             let env = Environment::new_empty();

--- a/crates/ark/tests/connections.rs
+++ b/crates/ark/tests/connections.rs
@@ -23,7 +23,7 @@ use harp::object::RObject;
 use stdext::assert_match;
 
 fn open_dummy_connection() -> (socket::comm::CommSocket, Receiver<IOPubMessage>) {
-    print!("testing!\n");
+    println!("testing!");
 
     let (comm_event_tx, comm_event_rx) = bounded::<CommEvent>(0);
     // Create a dummy iopub channel to receive responses.
@@ -91,7 +91,7 @@ fn socket_rpc(
     iopub_rx: &Receiver<IOPubMessage>,
     req: ConnectionsBackendRequest,
 ) -> ConnectionsBackendReply {
-    socket_rpc_request::<ConnectionsBackendRequest, ConnectionsBackendReply>(&socket, iopub_rx, req)
+    socket_rpc_request::<ConnectionsBackendRequest, ConnectionsBackendReply>(socket, iopub_rx, req)
 }
 
 #[test]

--- a/crates/ark/tests/dap.rs
+++ b/crates/ark/tests/dap.rs
@@ -218,7 +218,7 @@ fn test_dap_error_during_debug() {
 
     // We're at browser(), stack should have 1 frame
     let stack = dap.stack_trace();
-    assert!(stack.len() >= 1, "Should have at least 1 frame");
+    assert!(!stack.is_empty(), "Should have at least 1 frame");
 
     // Step to execute the error
     frontend.debug_send_step_command("n");

--- a/crates/ark/tests/dap_step.rs
+++ b/crates/ark/tests/dap_step.rs
@@ -29,7 +29,7 @@ fn test_dap_source_and_step() {
 
     // Check stack at browser() - line 4, end_column 10 for `browser()`
     let stack = dap.stack_trace();
-    assert!(stack.len() >= 1, "Expected at least 1 frame");
+    assert!(!stack.is_empty(), "Expected at least 1 frame");
     assert_file_frame(&stack[0], &file.filename, 5, 12);
 
     frontend.debug_send_step_command("n");
@@ -38,7 +38,7 @@ fn test_dap_source_and_step() {
 
     // After stepping, we should be at line 5 (the `3` expression after browser())
     let stack = dap.stack_trace();
-    assert!(stack.len() >= 1, "Expected at least 1 frame after step");
+    assert!(!stack.is_empty(), "Expected at least 1 frame after step");
     assert_file_frame(&stack[0], &file.filename, 6, 4);
 
     // Exit with Q via Jupyter

--- a/crates/ark/tests/dap_variables.rs
+++ b/crates/ark/tests/dap_variables.rs
@@ -25,7 +25,7 @@ local({
 
     // Get the stack trace to get frame_id
     let stack = dap.stack_trace();
-    assert!(stack.len() >= 1, "Expected at least 1 frame");
+    assert!(!stack.is_empty(), "Expected at least 1 frame");
     let frame_id = stack[0].id;
 
     // Get scopes for the frame

--- a/crates/ark/tests/data_explorer.rs
+++ b/crates/ark/tests/data_explorer.rs
@@ -127,13 +127,10 @@ fn open_data_explorer_from_expression(expr: &str, bind: Option<&str>) -> anyhow:
     let inner = r_task(|| -> anyhow::Result<TestInner> {
         let object = harp::parse_eval_global(expr)?;
 
-        let binding = match bind {
-            Some(name) => Some(DataObjectEnvInfo {
-                name: name.to_string(),
-                env: RObject::view(R_ENVS.global),
-            }),
-            None => None,
-        };
+        let binding = bind.map(|name| DataObjectEnvInfo {
+            name: name.to_string(),
+            env: RObject::view(R_ENVS.global),
+        });
         let handler = RDataExplorer::new(String::from("obj"), object, binding)?;
         Ok(TestInner(handler, ctx))
     })?;
@@ -804,8 +801,8 @@ fn expect_column_profile_results(
     let reply: DataExplorerBackendReply = match msg {
         CommMsg::Rpc { data: value, .. } => {
             println!("<-- {:?}", value);
-            let reply = serde_json::from_value(value).unwrap();
-            reply
+
+            serde_json::from_value(value).unwrap()
         },
         _ => panic!("Unexpected Comm Message"),
     };
@@ -1058,7 +1055,7 @@ fn test_summary_stats() {
     // Request summary stats for all 3 columns
     let req = RequestBuilder::get_column_profiles(
         String::from("id"),
-        (0..3).map(|i| ProfileBuilder::summary_stats(i)).collect(),
+        (0..3).map(ProfileBuilder::summary_stats).collect(),
     );
 
     expect_column_profile_results(&setup, req, |data| {
@@ -2010,7 +2007,7 @@ fn test_row_names_matrix() {
     });
     assert_match!(setup.rpc(DataExplorerBackendRequest::GetState),
         DataExplorerBackendReply::GetStateReply(state) => {
-            assert_eq!(state.has_row_labels, true)
+            assert!(state.has_row_labels)
         }
     );
 
@@ -2029,7 +2026,7 @@ fn test_row_names_matrix() {
             .unwrap();
     assert_match!(setup2.rpc(DataExplorerBackendRequest::GetState),
         DataExplorerBackendReply::GetStateReply(state) => {
-            assert_eq!(state.has_row_labels, false)
+            assert!(!state.has_row_labels)
         }
     );
 }
@@ -2057,14 +2054,12 @@ fn test_schema_identification() {
         DataExplorerBackendReply::GetSchemaReply(schema) => {
             assert_eq!(schema.columns.len(), 6);
 
-            let expected_types = vec![
-                (ColumnDisplayType::Floating, "dbl"),
+            let expected_types = [(ColumnDisplayType::Floating, "dbl"),
                 (ColumnDisplayType::String, "str"),
                 (ColumnDisplayType::Boolean, "lgl"),
                 (ColumnDisplayType::String, "fct(3)"),
                 (ColumnDisplayType::Date, "Date"),
-                (ColumnDisplayType::Datetime, "POSIXct"),
-            ];
+                (ColumnDisplayType::Datetime, "POSIXct")];
 
             for (i, (expected_display, expected_name)) in expected_types.iter().enumerate() {
                 assert_eq!(schema.columns[i].type_display, *expected_display);
@@ -2886,14 +2881,12 @@ fn test_empty_data_frame_schema() {
         DataExplorerBackendReply::GetSchemaReply(schema) => {
             assert_eq!(schema.columns.len(), 6);
 
-            let expected_types = vec![
-                (ColumnDisplayType::Floating, "dbl"),
+            let expected_types = [(ColumnDisplayType::Floating, "dbl"),
                 (ColumnDisplayType::String, "str"),
                 (ColumnDisplayType::Boolean, "lgl"),
                 (ColumnDisplayType::String, "fct(0)"),
                 (ColumnDisplayType::Date, "Date"),
-                (ColumnDisplayType::Datetime, "POSIXct"),
-            ];
+                (ColumnDisplayType::Datetime, "POSIXct")];
 
             for (i, (expected_display, expected_name)) in expected_types.iter().enumerate() {
                 assert_eq!(schema.columns[i].type_display, *expected_display);

--- a/crates/ark/tests/help.rs
+++ b/crates/ark/tests/help.rs
@@ -150,8 +150,5 @@ fn test_custom_help_handlers() {
     });
 
     r_help.test_topic("obj$hello", "help-test-id-4");
-    assert_eq!(
-        r_task(|| unsafe { harp::parse_eval_global("called").unwrap().to::<bool>() }).unwrap(),
-        true,
-    );
+    assert!(r_task(|| unsafe { harp::parse_eval_global("called").unwrap().to::<bool>() }).unwrap());
 }

--- a/crates/ark/tests/kernel-hooks-source.rs
+++ b/crates/ark/tests/kernel-hooks-source.rs
@@ -9,7 +9,7 @@ fn test_source_local() {
     let frontend = DummyArkFrontend::lock();
 
     let mut file = tempfile::NamedTempFile::new().unwrap();
-    write!(file, "foobar\n").unwrap();
+    writeln!(file, "foobar").unwrap();
 
     let path = file.path().to_str().unwrap().replace("\\", "/");
 
@@ -43,7 +43,7 @@ fn test_source_global() {
     let frontend = DummyArkFrontend::lock();
 
     let mut file = tempfile::NamedTempFile::new().unwrap();
-    write!(file, "foo\n").unwrap();
+    writeln!(file, "foo").unwrap();
 
     let path = file.path().to_str().unwrap().replace("\\", "/");
 

--- a/crates/ark/tests/kernel-shutdown.rs
+++ b/crates/ark/tests/kernel-shutdown.rs
@@ -30,7 +30,7 @@ fn test_shutdown_request() {
 
     let reply = frontend.recv_control_shutdown_reply();
     assert_eq!(reply.status, Status::Ok);
-    assert_eq!(reply.restart, false);
+    assert!(!reply.restart);
 
     frontend.recv_iopub_idle();
 
@@ -48,7 +48,7 @@ fn test_shutdown_request_with_restart() {
 
     let reply = frontend.recv_control_shutdown_reply();
     assert_eq!(reply.status, Status::Ok);
-    assert_eq!(reply.restart, true);
+    assert!(reply.restart);
 
     frontend.recv_iopub_idle();
 
@@ -85,7 +85,7 @@ fn test_shutdown_request_browser() {
     // messages concurrently instead of sequentially.
     let reply = frontend.recv_control_shutdown_reply();
     assert_eq!(reply.status, Status::Ok);
-    assert_eq!(reply.restart, true);
+    assert!(reply.restart);
 
     frontend.recv_iopub_idle();
 
@@ -114,7 +114,7 @@ fn test_shutdown_request_while_busy() {
 
     let reply = frontend.recv_control_shutdown_reply();
     assert_eq!(reply.status, Status::Ok);
-    assert_eq!(reply.restart, false);
+    assert!(!reply.restart);
 
     // Drain any streams from the interrupted Sys.sleep execution. The stream
     // could arrive before or after the shutdown idle (race condition), so we

--- a/crates/ark/tests/variables.rs
+++ b/crates/ark/tests/variables.rs
@@ -89,7 +89,7 @@ fn test_variables_list() {
     let evt: VariablesFrontendEvent = serde_json::from_value(data).unwrap();
     match evt {
         VariablesFrontendEvent::Refresh(params) => {
-            assert!(params.variables.len() == 0);
+            assert!(params.variables.is_empty());
             assert_eq!(params.version, 1);
         },
         _ => panic!("Expected refresh event"),

--- a/crates/harp/src/environment.rs
+++ b/crates/harp/src/environment.rs
@@ -316,7 +316,7 @@ mod tests {
             assert_eq!(names, vec!["a", "b", "c"]);
 
             // Also assert that `.iter()` will be sorted
-            let expected = vec!["a", "b", "c"];
+            let expected = ["a", "b", "c"];
             for (i, binding) in Environment::new(env).iter().enumerate() {
                 assert_eq!(binding.unwrap().name, expected[i]);
             }
@@ -345,7 +345,7 @@ mod tests {
             let env: Environment = Environment::new(env);
 
             assert_eq!(env.names().len(), 0);
-            assert_eq!(env.is_empty(), true);
+            assert!(env.is_empty());
             assert_eq!(env.length(), 0);
 
             // Make sure that it would actually dispatch to the s3 methods we implemented

--- a/crates/harp/src/environment_iter.rs
+++ b/crates/harp/src/environment_iter.rs
@@ -196,8 +196,8 @@ mod tests {
             let b = iter.next().unwrap().unwrap();
 
             // same object bound to different symbols
-            assert_eq!(a.id() == b.id(), false);
-            assert_eq!(a.value.id() == b.value.id(), true);
+            assert!(!(a.id() == b.id()));
+            assert!(a.value.id() == b.value.id());
 
             // now bind a different object to b
             let b = harp::parse_eval_base("1").unwrap();
@@ -207,7 +207,7 @@ mod tests {
             let a = iter.next().unwrap().unwrap();
             let b = iter.next().unwrap().unwrap();
             // Even though they are equal by value, their id() is different
-            assert_eq!(a.value.id() == b.value.id(), false);
+            assert!(!(a.value.id() == b.value.id()));
         })
     }
 }

--- a/crates/harp/src/exec.rs
+++ b/crates/harp/src/exec.rs
@@ -689,7 +689,7 @@ mod tests {
             // ok SEXP
             let ok: harp::Result<RObject> = try_catch(|| Rf_ScalarInteger(42).into());
             assert_match!(ok, Ok(value) => {
-                assert_eq!(r_typeof(value.sexp), INTSXP as u32);
+                assert_eq!(r_typeof(value.sexp), INTSXP);
                 assert_eq!(INTEGER_ELT(value.sexp, 0), 42);
             });
 
@@ -775,8 +775,7 @@ mod tests {
             let result = exec_with_cleanup(
                 || {
                     // Create a simple R object and return it directly (T = RObject)
-                    let obj = RObject::from(unsafe { Rf_ScalarInteger(42) });
-                    obj
+                    RObject::from(unsafe { Rf_ScalarInteger(42) })
                 },
                 || {
                     *cleanup_called_clone.lock().unwrap() = true;

--- a/crates/harp/src/object.rs
+++ b/crates/harp/src/object.rs
@@ -1618,7 +1618,7 @@ mod tests {
         crate::r_task(|| {
             // Create a map of pizza toppings to their acceptability.
             let v = harp::parse_eval_global("list(x = 1L, y = 2L, x = 3L)").unwrap();
-            assert_eq!(v.length(), 3 as isize);
+            assert_eq!(v.length(), 3_isize);
 
             // Ensure we created an object of the same size as the map.
             let out: HashMap<String, i32> = v.try_into().unwrap();
@@ -1640,7 +1640,7 @@ mod tests {
         crate::r_task(|| {
             // Create a map of pizza toppings to their acceptability.
             let v = harp::parse_eval_global("list(x = c(1L, 2L), y = c('a', 'b'))").unwrap();
-            assert_eq!(v.length(), 2 as isize);
+            assert_eq!(v.length(), 2_isize);
 
             // Ensure we can convert the object back into a map with the same values.
             let out: HashMap<String, RObject> = v.try_into().unwrap();

--- a/crates/harp/src/parse.rs
+++ b/crates/harp/src/parse.rs
@@ -189,7 +189,7 @@ mod tests {
             assert_match!(
                 parse_status(&ParseInput::Text("")),
                 Ok(ParseResult::Complete(out)) => {
-                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP as u32);
+                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP);
                     assert_eq!(r_length(out.sexp), 0);
                 }
             );
@@ -198,15 +198,15 @@ mod tests {
             assert_match!(
                 parse_status(&ParseInput::Text("force(42)")),
                 Ok(ParseResult::Complete(out)) => {
-                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP as u32);
+                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP);
 
                     let call = libr::VECTOR_ELT(out.sexp, 0);
-                    assert_eq!(r_typeof(call), libr::LANGSXP as u32);
+                    assert_eq!(r_typeof(call), libr::LANGSXP);
                     assert_eq!(libr::Rf_xlength(call), 2);
                     assert_eq!(libr::CAR(call), r_symbol!("force"));
 
                     let arg = libr::CADR(call);
-                    assert_eq!(r_typeof(arg), libr::REALSXP as u32);
+                    assert_eq!(r_typeof(arg), libr::REALSXP);
                     assert_eq!(*libr::REAL(arg), 42.0);
                 }
             );
@@ -237,7 +237,7 @@ mod tests {
             assert_match!(
                 parse_status(&ParseInput::Text("x<-\r\n1\r\npi")),
                 Ok(ParseResult::Complete(out)) => {
-                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP as u32);
+                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP);
                     assert_eq!(r_stringify(out.sexp, "").unwrap(), "expression(x <- 1, pi)");
                 }
             );
@@ -246,7 +246,7 @@ mod tests {
             assert_match!(
                 parse_status(&ParseInput::Text(r#"'a\r\nb'"#)),
                 Ok(ParseResult::Complete(out)) => {
-                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP as u32);
+                    assert_eq!(r_typeof(out.sexp), libr::EXPRSXP);
                     assert_eq!(r_stringify(out.sexp, "").unwrap(), r#"expression("a\r\nb")"#);
                 }
             );
@@ -261,7 +261,7 @@ mod tests {
                 "foo\nbar"
             );
 
-            let input = srcref::SrcFile::try_from("foo\nbar").unwrap();
+            let input = srcref::SrcFile::from("foo\nbar");
             assert_eq!(
                 parse_input_as_string(&ParseInput::SrcFile(&input)).unwrap(),
                 "foo\nbar"

--- a/crates/harp/src/parser/parse_data.rs
+++ b/crates/harp/src/parser/parse_data.rs
@@ -146,16 +146,16 @@ mod tests {
     #[test]
     fn test_parse_data() {
         crate::r_task(|| {
-            let srcfile = srcref::SrcFile::try_from("foo\nbar").unwrap();
+            let srcfile = srcref::SrcFile::from("foo\nbar");
             let exprs = parse::parse_exprs_ext(&parse::ParseInput::SrcFile(&srcfile)).unwrap();
             let srcrefs: Vec<harp::srcref::SrcRef> = exprs.srcrefs().unwrap();
 
             let parse_data = ParseData::from_srcfile(&srcfile).unwrap();
             let top_level = parse_data.filter_top_level();
 
-            let parse_first = top_level.nodes.get(0).unwrap();
+            let parse_first = top_level.nodes.first().unwrap();
             let parse_second = top_level.nodes.get(1).unwrap();
-            let srcref_first = srcrefs.get(0).unwrap();
+            let srcref_first = srcrefs.first().unwrap();
             let srcref_second = srcrefs.get(1).unwrap();
 
             assert_eq!(parse_first.line, srcref_first.line);

--- a/crates/harp/src/raii.rs
+++ b/crates/harp/src/raii.rs
@@ -189,14 +189,14 @@ mod tests {
 
             {
                 let _guard = RLocalShowErrorMessageOption::new(true);
-                assert_eq!(get(), true);
+                assert!(get());
 
                 {
                     let _guard = RLocalShowErrorMessageOption::new(false);
-                    assert_eq!(get(), false);
+                    assert!(!get());
                 }
 
-                assert_eq!(get(), true);
+                assert!(get());
             }
 
             assert_eq!(get(), old);

--- a/crates/harp/src/traits/slice.rs
+++ b/crates/harp/src/traits/slice.rs
@@ -59,6 +59,6 @@ mod test {
         let value = ["hello"];
         let slice = value.as_slice();
         assert!(slice.len() == 1);
-        assert!(*slice.get(0).unwrap() == "hello");
+        assert!(*slice.first().unwrap() == "hello");
     }
 }

--- a/crates/harp/src/vector/character_vector.rs
+++ b/crates/harp/src/vector/character_vector.rs
@@ -152,7 +152,7 @@ mod test {
         crate::r_task(|| {
             let vector = CharacterVector::create(&["hello", "world"]);
             assert!(vector == ["hello", "world"]);
-            assert!(vector == &["hello", "world"]);
+            assert!(vector == ["hello", "world"]);
 
             let mut it = vector.iter();
 
@@ -162,7 +162,7 @@ mod test {
 
             let vector = CharacterVector::create(["hello".to_string(), "world".to_string()]);
             assert!(vector == ["hello", "world"]);
-            assert!(vector == &["hello", "world"]);
+            assert!(vector == ["hello", "world"]);
 
             assert!(vector.get_unchecked(0) == Some(String::from("hello")));
             assert!(vector.get_unchecked(1) == Some(String::from("world")));

--- a/crates/harp/src/vector/list.rs
+++ b/crates/harp/src/vector/list.rs
@@ -139,6 +139,20 @@ impl std::iter::Iterator for ListIter {
     }
 }
 
+impl TryFrom<SEXP> for List {
+    type Error = harp::Error;
+    fn try_from(value: SEXP) -> harp::Result<Self> {
+        super::try_r_vector_from_r_sexp(value)
+    }
+}
+
+impl TryFrom<&List> for Vec<RObject> {
+    type Error = harp::Error;
+    fn try_from(value: &List) -> harp::Result<Self> {
+        super::try_vec_from_r_vector(value)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::fixtures::r_task;
@@ -165,19 +179,5 @@ mod test {
             ));
             assert!(it.next().is_none());
         })
-    }
-}
-
-impl TryFrom<SEXP> for List {
-    type Error = harp::Error;
-    fn try_from(value: SEXP) -> harp::Result<Self> {
-        super::try_r_vector_from_r_sexp(value)
-    }
-}
-
-impl TryFrom<&List> for Vec<RObject> {
-    type Error = harp::Error;
-    fn try_from(value: &List) -> harp::Result<Self> {
-        super::try_vec_from_r_vector(value)
     }
 }

--- a/crates/stdext/src/all.rs
+++ b/crates/stdext/src/all.rs
@@ -19,9 +19,9 @@ mod tests {
 
     #[test]
     fn test_all() {
-        assert!(all!() == true);
-        assert!(all!(false, false true) == false);
-        assert!(all!(true, false) == false);
-        assert!(all!(true true) == true);
+        assert!(all!());
+        assert!(!all!(false, false true));
+        assert!(!all!(true, false));
+        assert!(all!(true true));
     }
 }

--- a/crates/stdext/src/any.rs
+++ b/crates/stdext/src/any.rs
@@ -19,9 +19,9 @@ mod tests {
 
     #[test]
     fn test_any() {
-        assert!(any!() == false);
-        assert!(any!(false false) == false);
-        assert!(any!(true false) == true);
-        assert!(any!(true true) == true);
+        assert!(!any!());
+        assert!(!any!(false false));
+        assert!(any!(true false));
+        assert!(any!(true true));
     }
 }


### PR DESCRIPTION
Branched on #1111 
Progress towards #1104 

After turning on clippy in Zed, I learned the default is to use `--all-targets`

This is another round of auto-fixing for all targets.