### PR TITLE
Rename `positron.error_entrace` to `ark.error_entrace`

### DIFF
--- a/crates/ark/src/modules/positron/errors.R
+++ b/crates/ark/src/modules/positron/errors.R
@@ -44,7 +44,7 @@
         return(handle_error_base(cnd))
     }
 
-    if (!inherits(cnd, "rlang_error") && !positron_option_error_entrace()) {
+    if (!inherits(cnd, "rlang_error") && !option_ark_error_entrace()) {
         # We have a non-rlang error, but the user requested we dont entrace it
         return(handle_error_base(cnd))
     }
@@ -192,9 +192,9 @@ handle_error_rlang <- function(cnd) {
     .ps.Call("ps_record_error", evalue, traceback)
 }
 
-positron_option_error_entrace <- function() {
-    # TODO: Wire this up to a Positron option for easy toggling?
-    isTRUE(getOption("positron.error_entrace", default = TRUE))
+option_ark_error_entrace <- function() {
+    # TODO: Wire this up to a Positron setting for easy toggling?
+    isTRUE(getOption("ark.error_entrace", default = TRUE))
 }
 
 rust_backtrace <- function() {

--- a/crates/ark/tests/kernel-execute.rs
+++ b/crates/ark/tests/kernel-execute.rs
@@ -33,7 +33,7 @@ fn test_execute_request_incomplete() {
 
     let frontend = DummyArkFrontend::lock();
 
-    frontend.execute_request_invisibly("options(positron.error_entrace = FALSE)");
+    frontend.execute_request_invisibly("options(ark.error_entrace = FALSE)");
 
     frontend.execute_request_error("1 +", |error_msg| {
         assert_eq!(error_msg, "Error:\nCan't parse incomplete input");

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -4,6 +4,12 @@ This guide details Ark's configuration.
 
 # Ark options
 
+## `ark.error_entrace`
+
+A boolean, with a default value of `TRUE`.
+
+If `TRUE`, errors will be entraced by `rlang::entrace()` if rlang is installed. This often results in more informative backtraces.
+
 ## `ark.ragg`
 
 A boolean, with a default of `TRUE`.
@@ -41,12 +47,6 @@ If `TRUE`, virtual documents will be generated for packages without source refer
 A boolean, with a default value of `FALSE`.
 
 If `TRUE`, the special `.Last.value` will be shown in Positron's Variables pane.
-
-## `positron.error_entrace`
-
-A boolean, with a default value of `TRUE`.
-
-If `TRUE`, errors will be entraced by `rlang::entrace()` if rlang is installed. This often results in more informative backtraces.
 
 # R options
 


### PR DESCRIPTION
Breaking change, but for a niche option so I'm not too worried.

This option is relevant in Jupyter apps too so the right prefix is `ark`.