### PR TITLE
Support notifications from frontend

### DIFF
--- a/crates/amalthea/src/comm/plot_comm.rs
+++ b/crates/amalthea/src/comm/plot_comm.rs
@@ -167,6 +167,13 @@ pub struct UpdateParams {
 	pub pre_render: Option<PlotResult>,
 }
 
+/// Parameters for the Show method.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ShowParams {
+	/// Optional pre-rendering data for immediate display
+	pub pre_render: Option<PlotResult>,
+}
+
 /**
  * Backend RPC request types for the plot comm
  */
@@ -238,7 +245,7 @@ pub enum PlotFrontendEvent {
 	Update(UpdateParams),
 
 	#[serde(rename = "show")]
-	Show,
+	Show(ShowParams),
 
 }
 

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -411,15 +411,6 @@ pub struct OpenWithSystemParams {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "params")]
 pub enum UiBackendRequest {
-	/// Notification that the settings to render a plot (i.e. the plot size)
-	/// have changed.
-	///
-	/// Typically fired when the plot component has been resized by the user.
-	/// This notification is useful to produce accurate pre-renderings of
-	/// plots.
-	#[serde(rename = "did_change_plots_render_settings")]
-	DidChangePlotsRenderSettings(DidChangePlotsRenderSettingsParams),
-
 	/// Notification that the frontend is ready
 	///
 	/// This notification is sent by the frontend after the UI comm has been
@@ -451,9 +442,6 @@ pub enum UiBackendRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "result")]
 pub enum UiBackendReply {
-	/// Unused response to notification
-	DidChangePlotsRenderSettingsReply(),
-
 	/// Unused response to notification
 	FrontendReadyReply(),
 
@@ -590,6 +578,20 @@ pub enum UiFrontendReply {
 
 	/// Editor metadata
 	LastActiveEditorContextReply(Option<EditorContext>),
+
+}
+
+/**
+ * Backend events for the ui comm
+ */
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "method", content = "params")]
+pub enum UiBackendEvent {
+	/// Typically fired when the plot component has been resized by the user.
+	/// This notification is useful to produce accurate pre-renderings of
+	/// plots.
+	#[serde(rename = "did_change_plots_render_settings")]
+	DidChangePlotsRenderSettings(DidChangePlotsRenderSettingsParams),
 
 }
 

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -411,15 +411,6 @@ pub struct OpenWithSystemParams {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "params")]
 pub enum UiBackendRequest {
-	/// Notification that the frontend is ready
-	///
-	/// This notification is sent by the frontend after the UI comm has been
-	/// established. The backend uses this signal to run session
-	/// initialization hooks that may need to communicate with the frontend
-	/// via RPCs (e.g. rstudioapi calls).
-	#[serde(rename = "frontend_ready")]
-	FrontendReady(FrontendReadyParams),
-
 	/// Run a method in the interpreter and return the result to the frontend
 	///
 	/// Unlike other RPC methods, `call_method` calls into methods implemented
@@ -442,9 +433,6 @@ pub enum UiBackendRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "result")]
 pub enum UiBackendReply {
-	/// Unused response to notification
-	FrontendReadyReply(),
-
 	/// The method result
 	CallMethodReply(CallMethodResult),
 
@@ -592,6 +580,13 @@ pub enum UiBackendEvent {
 	/// plots.
 	#[serde(rename = "did_change_plots_render_settings")]
 	DidChangePlotsRenderSettings(DidChangePlotsRenderSettingsParams),
+
+	/// This notification is sent by the frontend after the UI comm has been
+	/// established. The backend uses this signal to run session
+	/// initialization hooks that may need to communicate with the frontend
+	/// via RPCs (e.g. rstudioapi calls).
+	#[serde(rename = "frontend_ready")]
+	FrontendReady(FrontendReadyParams),
 
 }
 

--- a/crates/ark/src/comm_handler.rs
+++ b/crates/ark/src/comm_handler.rs
@@ -105,6 +105,51 @@ pub(crate) struct ConsoleComm {
     pub(crate) ctx: CommHandlerContext,
 }
 
+/// Handle an incoming comm message, dispatching RPCs and events to their
+/// respective handlers. Serialization and error handling are managed here
+/// so individual comms only deal with typed values.
+pub fn handle_comm_message<Reqs, Reps, Evts>(
+    outgoing_tx: &CommOutgoingTx,
+    comm_name: &str,
+    message: CommMsg,
+    rpc_handler: impl FnOnce(Reqs) -> anyhow::Result<Reps>,
+    event_handler: impl FnOnce(Evts) -> anyhow::Result<()>,
+) where
+    Reqs: DeserializeOwned + Debug,
+    Reps: Serialize,
+    Evts: DeserializeOwned + Debug,
+{
+    match message {
+        CommMsg::Rpc {
+            id,
+            parent_header,
+            data,
+        } => {
+            let json = dispatch_rpc(comm_name, &data, |req| {
+                let _span = tracing::trace_span!("comm handler", name = comm_name, request = ?req)
+                    .entered();
+                rpc_handler(req)
+            });
+            let response = CommMsg::Rpc {
+                id,
+                parent_header,
+                data: json,
+            };
+            outgoing_tx.send(response).log_err();
+        },
+        CommMsg::Data(data) => {
+            dispatch_event(comm_name, &data, |evt| {
+                let _span =
+                    tracing::trace_span!("comm handler", name = comm_name, event = ?evt).entered();
+                event_handler(evt)
+            });
+        },
+        other => {
+            log::warn!("Unexpected message for {comm_name}: {other:?}");
+        },
+    }
+}
+
 /// Handle an RPC request from a `CommMsg`.
 ///
 /// Non-RPC messages are logged and ignored. Requests that could not be
@@ -130,28 +175,47 @@ pub fn handle_rpc_request<Reqs, Reps>(
         },
     };
 
-    let json = match serde_json::from_value::<Reqs>(data.clone()) {
-        Ok(m) => {
-            let _span =
-                tracing::trace_span!("comm handler", name = comm_name, request = ?m).entered();
-            match request_handler(m) {
-                Ok(reply) => match serde_json::to_value(reply) {
-                    Ok(value) => value,
-                    Err(err) => {
-                        let message = format!(
+    let json = dispatch_rpc(comm_name, &data, |req| {
+        let _span =
+            tracing::trace_span!("comm handler", name = comm_name, request = ?req).entered();
+        request_handler(req)
+    });
+
+    let response = CommMsg::Rpc {
+        id,
+        parent_header,
+        data: json,
+    };
+    outgoing_tx.send(response).log_err();
+}
+
+fn dispatch_rpc<Reqs, Reps>(
+    comm_name: &str,
+    data: &serde_json::Value,
+    handler: impl FnOnce(Reqs) -> anyhow::Result<Reps>,
+) -> serde_json::Value
+where
+    Reqs: DeserializeOwned + Debug,
+    Reps: Serialize,
+{
+    match serde_json::from_value::<Reqs>(data.clone()) {
+        Ok(m) => match handler(m) {
+            Ok(reply) => match serde_json::to_value(reply) {
+                Ok(value) => value,
+                Err(err) => {
+                    let message = format!(
                             "Failed to serialise reply for {comm_name} request: {err} (request: {data})"
                         );
-                        log::warn!("{message}");
-                        json_rpc_error(JsonRpcErrorCode::InternalError, message)
-                    },
-                },
-                Err(err) => {
-                    let message =
-                        format!("Failed to process {comm_name} request: {err} (request: {data})");
                     log::warn!("{message}");
                     json_rpc_error(JsonRpcErrorCode::InternalError, message)
                 },
-            }
+            },
+            Err(err) => {
+                let message =
+                    format!("Failed to process {comm_name} request: {err} (request: {data})");
+                log::warn!("{message}");
+                json_rpc_error(JsonRpcErrorCode::InternalError, message)
+            },
         },
         Err(err) => {
             let message = format!(
@@ -160,12 +224,22 @@ pub fn handle_rpc_request<Reqs, Reps>(
             log::warn!("{message}");
             json_rpc_error(JsonRpcErrorCode::MethodNotFound, message)
         },
-    };
+    }
+}
 
-    let response = CommMsg::Rpc {
-        id,
-        parent_header,
-        data: json,
-    };
-    outgoing_tx.send(response).log_err();
+fn dispatch_event<Evts>(
+    comm_name: &str,
+    data: &serde_json::Value,
+    handler: impl FnOnce(Evts) -> anyhow::Result<()>,
+) where
+    Evts: DeserializeOwned + Debug,
+{
+    match serde_json::from_value::<Evts>(data.clone()) {
+        Ok(event) => {
+            handler(event).log_err();
+        },
+        Err(err) => {
+            log::warn!("Failed to parse {comm_name} event: {err} (data: {data})");
+        },
+    }
 }

--- a/crates/ark/src/ui/ui_comm.rs
+++ b/crates/ark/src/ui/ui_comm.rs
@@ -14,6 +14,7 @@ use amalthea::comm::ui_comm::EvalResult;
 use amalthea::comm::ui_comm::EvaluateCodeParams;
 use amalthea::comm::ui_comm::FrontendReadyParams;
 use amalthea::comm::ui_comm::PromptStateParams;
+use amalthea::comm::ui_comm::UiBackendEvent;
 use amalthea::comm::ui_comm::UiBackendReply;
 use amalthea::comm::ui_comm::UiBackendRequest;
 use amalthea::comm::ui_comm::UiFrontendEvent;
@@ -73,9 +74,19 @@ impl CommHandler for UiComm {
     }
 
     fn handle_msg(&mut self, msg: CommMsg, ctx: &CommHandlerContext) {
-        handle_rpc_request(&ctx.outgoing_tx, UI_COMM_NAME, msg, |req| {
-            self.handle_rpc(req)
-        });
+        match msg {
+            CommMsg::Rpc { .. } => {
+                handle_rpc_request(&ctx.outgoing_tx, UI_COMM_NAME, msg, |req| {
+                    self.handle_rpc(req)
+                });
+            },
+            CommMsg::Data(data) => {
+                self.handle_event(data);
+            },
+            other => {
+                log::warn!("Unexpected message for {UI_COMM_NAME}: {other:?}");
+            },
+        }
     }
 
     fn handle_environment(&mut self, event: &EnvironmentChanged, ctx: &CommHandlerContext) {
@@ -113,11 +124,22 @@ impl UiComm {
     fn handle_rpc(&mut self, request: UiBackendRequest) -> anyhow::Result<UiBackendReply> {
         match request {
             UiBackendRequest::CallMethod(params) => self.handle_call_method(params),
-            UiBackendRequest::DidChangePlotsRenderSettings(params) => {
-                self.handle_did_change_plot_render_settings(params)
-            },
             UiBackendRequest::FrontendReady(params) => self.handle_frontend_ready(params),
             UiBackendRequest::EvaluateCode(params) => self.handle_evaluate_code(params),
+        }
+    }
+
+    fn handle_event(&mut self, data: Value) {
+        match serde_json::from_value::<UiBackendEvent>(data) {
+            Ok(event) => match event {
+                UiBackendEvent::DidChangePlotsRenderSettings(params) => {
+                    self.handle_did_change_plot_render_settings(params)
+                        .log_err();
+                },
+            },
+            Err(err) => {
+                log::warn!("Failed to parse {UI_COMM_NAME} event: {err}");
+            },
         }
     }
 
@@ -157,7 +179,7 @@ impl UiComm {
     fn handle_did_change_plot_render_settings(
         &self,
         params: DidChangePlotsRenderSettingsParams,
-    ) -> anyhow::Result<UiBackendReply> {
+    ) -> anyhow::Result<()> {
         // The frontend shouldn't send invalid sizes but be defensive. Sometimes
         // the plot container is in a strange state when it's hidden.
         if params.settings.size.height <= 0 || params.settings.size.width <= 0 {
@@ -173,7 +195,7 @@ impl UiComm {
             ))
             .map_err(|err| anyhow::anyhow!("Failed to send plot render settings: {err}"))?;
 
-        Ok(UiBackendReply::DidChangePlotsRenderSettingsReply())
+        Ok(())
     }
 
     fn handle_frontend_ready(&self, params: FrontendReadyParams) -> anyhow::Result<UiBackendReply> {

--- a/crates/ark/src/ui/ui_comm.rs
+++ b/crates/ark/src/ui/ui_comm.rs
@@ -124,7 +124,6 @@ impl UiComm {
     fn handle_rpc(&mut self, request: UiBackendRequest) -> anyhow::Result<UiBackendReply> {
         match request {
             UiBackendRequest::CallMethod(params) => self.handle_call_method(params),
-            UiBackendRequest::FrontendReady(params) => self.handle_frontend_ready(params),
             UiBackendRequest::EvaluateCode(params) => self.handle_evaluate_code(params),
         }
     }
@@ -135,6 +134,9 @@ impl UiComm {
                 UiBackendEvent::DidChangePlotsRenderSettings(params) => {
                     self.handle_did_change_plot_render_settings(params)
                         .log_err();
+                },
+                UiBackendEvent::FrontendReady(params) => {
+                    self.handle_frontend_ready(params).log_err();
                 },
             },
             Err(err) => {
@@ -198,7 +200,7 @@ impl UiComm {
         Ok(())
     }
 
-    fn handle_frontend_ready(&self, params: FrontendReadyParams) -> anyhow::Result<UiBackendReply> {
+    fn handle_frontend_ready(&self, params: FrontendReadyParams) -> anyhow::Result<()> {
         log::info!("Frontend ready (start_type = {})", params.start_type);
 
         if params.start_type == "reconnect" {
@@ -212,7 +214,7 @@ impl UiComm {
                 .warn_on_err();
         }
 
-        Ok(UiBackendReply::FrontendReadyReply())
+        Ok(())
     }
 
     fn handle_evaluate_code(&self, params: EvaluateCodeParams) -> anyhow::Result<UiBackendReply> {

--- a/crates/ark/src/ui/ui_comm.rs
+++ b/crates/ark/src/ui/ui_comm.rs
@@ -27,7 +27,7 @@ use serde_json::Value;
 use stdext::result::ResultExt;
 use tokio::sync::mpsc::UnboundedSender as AsyncUnboundedSender;
 
-use crate::comm_handler::handle_rpc_request;
+use crate::comm_handler::handle_comm_message;
 use crate::comm_handler::CommHandler;
 use crate::comm_handler::CommHandlerContext;
 use crate::comm_handler::EnvironmentChanged;
@@ -74,19 +74,14 @@ impl CommHandler for UiComm {
     }
 
     fn handle_msg(&mut self, msg: CommMsg, ctx: &CommHandlerContext) {
-        match msg {
-            CommMsg::Rpc { .. } => {
-                handle_rpc_request(&ctx.outgoing_tx, UI_COMM_NAME, msg, |req| {
-                    self.handle_rpc(req)
-                });
-            },
-            CommMsg::Data(data) => {
-                self.handle_event(data);
-            },
-            other => {
-                log::warn!("Unexpected message for {UI_COMM_NAME}: {other:?}");
-            },
-        }
+        let this = &*self;
+        handle_comm_message(
+            &ctx.outgoing_tx,
+            UI_COMM_NAME,
+            msg,
+            |req| this.handle_rpc(req),
+            |evt| this.handle_event(evt),
+        );
     }
 
     fn handle_environment(&mut self, event: &EnvironmentChanged, ctx: &CommHandlerContext) {
@@ -121,27 +116,19 @@ impl UiComm {
         }
     }
 
-    fn handle_rpc(&mut self, request: UiBackendRequest) -> anyhow::Result<UiBackendReply> {
+    fn handle_rpc(&self, request: UiBackendRequest) -> anyhow::Result<UiBackendReply> {
         match request {
             UiBackendRequest::CallMethod(params) => self.handle_call_method(params),
             UiBackendRequest::EvaluateCode(params) => self.handle_evaluate_code(params),
         }
     }
 
-    fn handle_event(&mut self, data: Value) {
-        match serde_json::from_value::<UiBackendEvent>(data) {
-            Ok(event) => match event {
-                UiBackendEvent::DidChangePlotsRenderSettings(params) => {
-                    self.handle_did_change_plot_render_settings(params)
-                        .log_err();
-                },
-                UiBackendEvent::FrontendReady(params) => {
-                    self.handle_frontend_ready(params).log_err();
-                },
+    fn handle_event(&self, event: UiBackendEvent) -> anyhow::Result<()> {
+        match event {
+            UiBackendEvent::DidChangePlotsRenderSettings(params) => {
+                self.handle_did_change_plot_render_settings(params)
             },
-            Err(err) => {
-                log::warn!("Failed to parse {UI_COMM_NAME} event: {err}");
-            },
+            UiBackendEvent::FrontendReady(params) => self.handle_frontend_ready(params),
         }
     }
 

--- a/crates/ark/tests/kernel-hooks-session.rs
+++ b/crates/ark/tests/kernel-hooks-session.rs
@@ -5,7 +5,6 @@
 //
 //
 
-use amalthea::comm::ui_comm::UiBackendReply;
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
 use ark_test::DummyArkFrontend;
 
@@ -47,7 +46,6 @@ fn test_session_init_hook_new() {
     let data = serde_json::json!({
         "method": "frontend_ready",
         "params": { "start_type": "new" },
-        "id": "frontend-ready-rpc"
     });
     frontend.send_shell_comm_msg(String::from(&comm_id), data);
     frontend.recv_iopub_busy();
@@ -60,10 +58,6 @@ fn test_session_init_hook_new() {
         Some("open_editor")
     );
 
-    let reply = frontend.recv_iopub_comm_msg();
-    assert_eq!(reply.comm_id, comm_id);
-    let reply = serde_json::from_value::<UiBackendReply>(reply.data).unwrap();
-    assert_eq!(reply, UiBackendReply::FrontendReadyReply());
     frontend.recv_iopub_idle();
 }
 
@@ -82,15 +76,10 @@ fn test_session_init_hook_restart() {
     let data = serde_json::json!({
         "method": "frontend_ready",
         "params": { "start_type": "restart" },
-        "id": "frontend-ready-rpc"
     });
     frontend.send_shell_comm_msg(String::from(&comm_id), data);
     frontend.recv_iopub_busy();
     frontend.assert_stream_stdout_contains("restart");
-    let reply = frontend.recv_iopub_comm_msg();
-    assert_eq!(reply.comm_id, comm_id);
-    let reply = serde_json::from_value::<UiBackendReply>(reply.data).unwrap();
-    assert_eq!(reply, UiBackendReply::FrontendReadyReply());
     frontend.recv_iopub_idle();
 }
 
@@ -114,14 +103,9 @@ fn test_session_reconnect_hook() {
     let data = serde_json::json!({
         "method": "frontend_ready",
         "params": { "start_type": "reconnect" },
-        "id": "frontend-ready-rpc"
     });
     frontend.send_shell_comm_msg(String::from(&comm_id), data);
     frontend.recv_iopub_busy();
     frontend.assert_stream_stdout_contains("reconnect ran");
-    let reply = frontend.recv_iopub_comm_msg();
-    assert_eq!(reply.comm_id, comm_id);
-    let reply = serde_json::from_value::<UiBackendReply>(reply.data).unwrap();
-    assert_eq!(reply, UiBackendReply::FrontendReadyReply());
     frontend.recv_iopub_idle();
 }


### PR DESCRIPTION
Part of https://github.com/posit-dev/positron/issues/7448
Backend side of https://github.com/posit-dev/positron/pull/12859

- "Plot render settings" and "frontend ready" are now notifications instead of RPCs with ignored results.
- New `handle_comm_message()` helper that takes care of unserialisation and dispatch to RPC and event paths.