### PR TITLE
Draft semantic index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,18 @@ The codebase is organized as a Rust workspace containing multiple crates:
 - **harp**: Rust wrappers for R objects and interfaces
 - **libr**: Bindings to R (dynamically loaded using `dlopen`/`LoadLibrary`)
 - **amalthea**: A Rust framework for building Jupyter and Positron kernels
+- **oak_index**: Per-file semantic index for R (scopes, symbols, definitions, uses)
 - **echo**: A toy kernel for testing the kernel framework
 - **stdext**: Extensions to Rust's standard library used by the other projects
+
+### External dependencies (R parser)
+
+The `oak_index` and `ark` crates depend on the R parser from [posit-dev/air](https://github.com/posit-dev/air), pinned by git revision in the workspace `Cargo.toml`. The relevant crates are re-exported under `aether_` prefixes:
+
+- **`aether_syntax`** (`air_r_syntax`): Typed CST nodes (`RIdentifier`, `RBinaryExpression`, `RFunctionDefinition`, etc.), `RSyntaxKind`, `RSyntaxNode`, `RSyntaxToken`.
+- **`aether_parser`** (`air_r_parser`): `parse()` function that produces an `RRoot` CST.
+
+Source code for these crates lives in `posit-dev/air` under `crates/air_r_syntax/` and `crates/air_r_parser/`. When looking up type definitions, AST node variants, or syntax kinds, consult that repository.
 
 ## Common Development Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,6 +2242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_index"
+version = "0.1.0"
+dependencies = [
+ "air_r_parser",
+ "air_r_syntax",
+ "biome_rowan",
+ "rustc-hash",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/echo",
     "crates/harp",
     "crates/libr",
+    "crates/oak_index",
     "crates/stdext",
 ]
 
@@ -74,6 +75,7 @@ log = "0.4.18"
 mime_guess = "2.0.4"
 nix = { version = "0.26.2", features = ["signal"] }
 notify = "6.0.0"
+oak_index = { path = "crates/oak_index" }
 once_cell = "1.17.1"
 parking_lot = "0.12.3"
 paste = "1.0.14"

--- a/crates/oak_index/Cargo.toml
+++ b/crates/oak_index/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oak_index"
+version = "0.1.0"
+description = """
+Per-file semantic index for R: scopes, symbols, bindings, and uses.
+"""
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aether_syntax.workspace = true
+biome_rowan.workspace = true
+rustc-hash.workspace = true
+
+[dev-dependencies]
+aether_parser.workspace = true

--- a/crates/oak_index/src/arena.rs
+++ b/crates/oak_index/src/arena.rs
@@ -2,7 +2,8 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::ops;
 
-pub trait Idx: Copy + fmt::Debug + Eq + From<u32> {
+pub trait Idx: Copy + fmt::Debug + Eq {
+    fn new(value: usize) -> Self;
     fn index(self) -> usize;
 }
 
@@ -22,7 +23,7 @@ impl<I: Idx, V> IndexVec<I, V> {
     }
 
     pub fn push(&mut self, value: V) -> I {
-        let id = I::from(self.raw.len() as u32);
+        let id = self.next_id();
         self.raw.push(value);
         id
     }
@@ -36,14 +37,11 @@ impl<I: Idx, V> IndexVec<I, V> {
     }
 
     pub fn next_id(&self) -> I {
-        I::from(self.raw.len() as u32)
+        I::new(self.raw.len())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (I, &V)> {
-        self.raw
-            .iter()
-            .enumerate()
-            .map(|(i, v)| (I::from(i as u32), v))
+        self.raw.iter().enumerate().map(|(i, v)| (I::new(i), v))
     }
 }
 
@@ -96,6 +94,10 @@ macro_rules! define_index {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $name(u32);
 
+        impl $name {
+            const MAX: usize = u32::MAX as usize - 1;
+        }
+
         impl From<u32> for $name {
             fn from(raw: u32) -> Self {
                 Self(raw)
@@ -103,6 +105,11 @@ macro_rules! define_index {
         }
 
         impl $crate::arena::Idx for $name {
+            fn new(value: usize) -> Self {
+                assert!(value <= Self::MAX);
+                Self(value as u32)
+            }
+
             fn index(self) -> usize {
                 self.0 as usize
             }

--- a/crates/oak_index/src/arena.rs
+++ b/crates/oak_index/src/arena.rs
@@ -1,0 +1,113 @@
+use std::fmt;
+use std::marker::PhantomData;
+use std::ops;
+
+pub trait Idx: Copy + fmt::Debug + Eq + From<u32> {
+    fn index(self) -> usize;
+}
+
+/// A typed arena: a `Vec<V>` indexed by a strongly-typed newtype `I` instead
+/// of `usize`, so that indices from different arenas can't be mixed up.
+pub struct IndexVec<I: Idx, V> {
+    raw: Vec<V>,
+    _phantom: PhantomData<I>,
+}
+
+impl<I: Idx, V> IndexVec<I, V> {
+    pub fn new() -> Self {
+        Self {
+            raw: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn push(&mut self, value: V) -> I {
+        let id = I::from(self.raw.len() as u32);
+        self.raw.push(value);
+        id
+    }
+
+    pub fn len(&self) -> usize {
+        self.raw.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.raw.is_empty()
+    }
+
+    pub fn next_id(&self) -> I {
+        I::from(self.raw.len() as u32)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (I, &V)> {
+        self.raw
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (I::from(i as u32), v))
+    }
+}
+
+impl<I: Idx, V> IntoIterator for IndexVec<I, V> {
+    type Item = V;
+    type IntoIter = std::vec::IntoIter<V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.raw.into_iter()
+    }
+}
+
+impl<I: Idx, V> FromIterator<V> for IndexVec<I, V> {
+    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+        Self {
+            raw: iter.into_iter().collect(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I: Idx, V> Default for IndexVec<I, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<I: Idx, V: fmt::Debug> fmt::Debug for IndexVec<I, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.raw.iter()).finish()
+    }
+}
+
+impl<I: Idx, V> ops::Index<I> for IndexVec<I, V> {
+    type Output = V;
+
+    fn index(&self, id: I) -> &V {
+        &self.raw[id.index()]
+    }
+}
+
+impl<I: Idx, V> ops::IndexMut<I> for IndexVec<I, V> {
+    fn index_mut(&mut self, id: I) -> &mut V {
+        &mut self.raw[id.index()]
+    }
+}
+
+macro_rules! define_index {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(u32);
+
+        impl From<u32> for $name {
+            fn from(raw: u32) -> Self {
+                Self(raw)
+            }
+        }
+
+        impl $crate::arena::Idx for $name {
+            fn index(self) -> usize {
+                self.0 as usize
+            }
+        }
+    };
+}
+
+pub(crate) use define_index;

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -112,8 +112,35 @@ impl SemanticIndexBuilder {
     }
 
     fn add_binding(&mut self, name: &str, flags: SymbolFlags, range: TextRange) {
-        let symbol = self.symbol_tables[self.current_scope].intern(name, flags);
-        self.bindings[self.current_scope].push(Binding { symbol, range });
+        self.add_binding_in_scope(self.current_scope, name, flags, range);
+    }
+
+    fn add_binding_in_scope(
+        &mut self,
+        scope: ScopeId,
+        name: &str,
+        flags: SymbolFlags,
+        range: TextRange,
+    ) {
+        let symbol = self.symbol_tables[scope].intern(name, flags);
+        self.bindings[scope].push(Binding { symbol, range });
+    }
+
+    /// Walk from `current_scope` up through ancestors looking for a scope
+    /// that already has a binding for `name`. Returns the file scope if
+    /// no existing binding is found (matching R's runtime `<<-` semantics).
+    fn resolve_super_target(&self, name: &str) -> ScopeId {
+        let file = ScopeId::from(0);
+        let mut scope = self.scopes[self.current_scope].parent;
+        while let Some(id) = scope {
+            if let Some(sym) = self.symbol_tables[id].get(name) {
+                if sym.flags().contains(SymbolFlags::IS_BOUND) {
+                    return id;
+                }
+            }
+            scope = self.scopes[id].parent;
+        }
+        file
     }
 
     fn add_use(&mut self, name: &str, range: TextRange) {
@@ -155,7 +182,7 @@ impl SemanticIndexBuilder {
             },
 
             AnyRExpression::RBinaryExpression(bin) => {
-                // `<-`, `=`, and `->` are assignments when they appear as
+                // `<-`, `=`, `->`, `<<-`, and `->>` are assignments when they appear as
                 // `RBinaryExpression`. In call arguments, `=` is consumed by
                 // the parser into `RArgumentNameClause` instead, so it never
                 // reaches here.
@@ -316,6 +343,12 @@ impl SemanticIndexBuilder {
 
     fn collect_assignment(&mut self, op: &RBinaryExpression) {
         let right = is_right_assignment(op);
+        let super_assign = is_super_assignment(op);
+        let flags = if super_assign {
+            SymbolFlags::IS_SUPER_BOUND
+        } else {
+            SymbolFlags::IS_BOUND
+        };
 
         // Value side first to record uses before the binding. The uses
         // might refer to the same symbol as the new binding, but refer
@@ -329,11 +362,15 @@ impl SemanticIndexBuilder {
         let Ok(target) = target else { return };
         match target {
             AnyRExpression::RIdentifier(ident) => {
-                self.add_binding(
-                    &ident.syntax().text_trimmed().to_string(),
-                    SymbolFlags::IS_BOUND,
-                    ident.syntax().text_trimmed_range(),
-                );
+                let name = ident.syntax().text_trimmed().to_string();
+                let range = ident.syntax().text_trimmed_range();
+
+                if super_assign {
+                    let target_scope = self.resolve_super_target(&name);
+                    self.add_binding_in_scope(target_scope, &name, flags, range);
+                } else {
+                    self.add_binding(&name, flags, range);
+                }
             },
 
             // Complex target (`x$foo <- rhs`, `x[1] <- rhs`, etc.) does
@@ -364,7 +401,11 @@ fn is_assignment(bin: &RBinaryExpression) -> bool {
     };
     matches!(
         op.kind(),
-        RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL | RSyntaxKind::ASSIGN_RIGHT
+        RSyntaxKind::ASSIGN |
+            RSyntaxKind::EQUAL |
+            RSyntaxKind::ASSIGN_RIGHT |
+            RSyntaxKind::SUPER_ASSIGN |
+            RSyntaxKind::SUPER_ASSIGN_RIGHT
     )
 }
 
@@ -372,5 +413,18 @@ fn is_right_assignment(bin: &RBinaryExpression) -> bool {
     let Ok(op) = bin.operator() else {
         return false;
     };
-    matches!(op.kind(), RSyntaxKind::ASSIGN_RIGHT)
+    matches!(
+        op.kind(),
+        RSyntaxKind::ASSIGN_RIGHT | RSyntaxKind::SUPER_ASSIGN_RIGHT
+    )
+}
+
+fn is_super_assignment(bin: &RBinaryExpression) -> bool {
+    let Ok(op) = bin.operator() else {
+        return false;
+    };
+    matches!(
+        op.kind(),
+        RSyntaxKind::SUPER_ASSIGN | RSyntaxKind::SUPER_ASSIGN_RIGHT
+    )
 }

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -262,6 +262,11 @@ impl SemanticIndexBuilder {
             // `RWhileStatement`, `RRepeatStatement`, `RUnaryExpression`,
             // `RParenthesizedExpression`, `RReturnExpression`, literals, and
             // any future expression types without needing explicit arms.
+            //
+            // NOTE: This also means that identifiers and assignments inside
+            // quoting constructs (`~`, `quote()`, `bquote()`) are recorded as
+            // uses and bindings. Refining this requires special-casing these
+            // forms, which we defer as future work.
             _ => {
                 self.collect_descendants(expr.syntax());
             },

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -155,7 +155,7 @@ impl SemanticIndexBuilder {
             },
 
             AnyRExpression::RBinaryExpression(bin) => {
-                // Both `<-` and `=` are assignments when they appear as
+                // `<-`, `=`, and `->` are assignments when they appear as
                 // `RBinaryExpression`. In call arguments, `=` is consumed by
                 // the parser into `RArgumentNameClause` instead, so it never
                 // reaches here.
@@ -315,15 +315,19 @@ impl SemanticIndexBuilder {
     }
 
     fn collect_assignment(&mut self, op: &RBinaryExpression) {
-        // RHS first to record uses before the binding. The uses might refer to
-        // the same symbol as the new binding, but refer to a different place
-        // (previous binding).
-        if let Ok(rhs) = op.right() {
-            self.collect_expression(&rhs);
+        let right = is_right_assignment(op);
+
+        // Value side first to record uses before the binding. The uses
+        // might refer to the same symbol as the new binding, but refer
+        // to a different place (previous binding).
+        let value = if right { op.left() } else { op.right() };
+        if let Ok(value) = value {
+            self.collect_expression(&value);
         }
 
-        let Ok(lhs) = op.left() else { return };
-        match lhs {
+        let target = if right { op.right() } else { op.left() };
+        let Ok(target) = target else { return };
+        match target {
             AnyRExpression::RIdentifier(ident) => {
                 self.add_binding(
                     &ident.syntax().text_trimmed().to_string(),
@@ -332,8 +336,8 @@ impl SemanticIndexBuilder {
                 );
             },
 
-            // Complex LHS (`x$foo <- rhs`, `x[1] <- rhs`, etc.) do not
-            // represent a binding. We recurse for uses.
+            // Complex target (`x$foo <- rhs`, `x[1] <- rhs`, etc.) does
+            // not represent a binding. We recurse for uses.
             other => self.collect_expression(&other),
         }
     }
@@ -358,5 +362,15 @@ fn is_assignment(bin: &RBinaryExpression) -> bool {
     let Ok(op) = bin.operator() else {
         return false;
     };
-    matches!(op.kind(), RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL)
+    matches!(
+        op.kind(),
+        RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL | RSyntaxKind::ASSIGN_RIGHT
+    )
+}
+
+fn is_right_assignment(bin: &RBinaryExpression) -> bool {
+    let Ok(op) = bin.operator() else {
+        return false;
+    };
+    matches!(op.kind(), RSyntaxKind::ASSIGN_RIGHT)
 }

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -1,0 +1,362 @@
+use aether_syntax::AnyRExpression;
+use aether_syntax::AnyRParameterName;
+use aether_syntax::RArgumentList;
+use aether_syntax::RBinaryExpression;
+use aether_syntax::RExpressionList;
+use aether_syntax::RFunctionDefinition;
+use aether_syntax::RParameter;
+use aether_syntax::RParameters;
+use aether_syntax::RRoot;
+use aether_syntax::RSyntaxKind;
+use aether_syntax::RSyntaxNode;
+use biome_rowan::AstNode;
+use biome_rowan::AstNodeList;
+use biome_rowan::AstSeparatedList;
+use biome_rowan::SyntaxNodeCast;
+use biome_rowan::TextRange;
+use biome_rowan::WalkEvent;
+
+use crate::arena::Idx;
+use crate::arena::IndexVec;
+use crate::semantic_index::Binding;
+use crate::semantic_index::BindingId;
+use crate::semantic_index::Scope;
+use crate::semantic_index::ScopeId;
+use crate::semantic_index::ScopeKind;
+use crate::semantic_index::SemanticIndex;
+use crate::semantic_index::SymbolFlags;
+use crate::semantic_index::SymbolTableBuilder;
+use crate::semantic_index::Use;
+use crate::semantic_index::UseId;
+
+/// Build a [`SemanticIndex`] from a parsed R file.
+pub fn build(root: &RRoot) -> SemanticIndex {
+    let range = root.syntax().text_trimmed_range();
+    let mut builder = SemanticIndexBuilder::new(range);
+    builder.collect_expression_list(&root.expressions());
+    builder.finish()
+}
+
+// Maintains the preorder allocation invariant on `Scope::descendants`. The
+// parallel arrays are pushed in lockstep so they stay indexed by the same
+// `ScopeId`.
+struct SemanticIndexBuilder {
+    scopes: IndexVec<ScopeId, Scope>,
+    symbol_tables: IndexVec<ScopeId, SymbolTableBuilder>,
+    bindings: IndexVec<ScopeId, IndexVec<BindingId, Binding>>,
+    uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
+    current_scope: ScopeId,
+}
+
+impl SemanticIndexBuilder {
+    fn new(range: TextRange) -> Self {
+        let mut scopes = IndexVec::new();
+        let mut symbol_tables = IndexVec::new();
+        let mut bindings = IndexVec::new();
+        let mut uses = IndexVec::new();
+
+        // The descendants range starts empty (`n+1..n+1`). `pop_scope` later
+        // fills in `descendants.end` with the current arena length. Everything
+        // allocated between push and pop is a descendant.
+        let file = scopes.push(Scope {
+            parent: None,
+            kind: ScopeKind::File,
+            range,
+            descendants: ScopeId::from(1)..ScopeId::from(1),
+        });
+
+        symbol_tables.push(SymbolTableBuilder::new());
+        bindings.push(IndexVec::new());
+        uses.push(IndexVec::new());
+
+        Self {
+            scopes,
+            symbol_tables,
+            bindings,
+            uses,
+            current_scope: file,
+        }
+    }
+
+    fn push_scope(&mut self, kind: ScopeKind, range: TextRange) -> ScopeId {
+        let parent = Some(self.current_scope);
+        let next_raw = self.scopes.next_id().index() as u32;
+
+        // Descendants start right after this scope. `end` is later filled in by
+        // `pop_scope`.
+        let descendants = ScopeId::from(next_raw + 1)..ScopeId::from(next_raw + 1);
+
+        let id = self.scopes.push(Scope {
+            parent,
+            kind,
+            range,
+            descendants,
+        });
+        self.current_scope = id;
+
+        self.symbol_tables.push(SymbolTableBuilder::new());
+        self.bindings.push(IndexVec::new());
+        self.uses.push(IndexVec::new());
+
+        id
+    }
+
+    fn pop_scope(&mut self, id: ScopeId) {
+        // Close the descendants range: everything allocated from `push_scope()`
+        // to here is a descendant.
+        self.scopes[id].descendants.end = self.scopes.next_id();
+        self.current_scope = match self.scopes[id].parent {
+            Some(parent) => parent,
+            None => panic!("`pop_scope()` called on the file scope"),
+        };
+    }
+
+    fn add_binding(&mut self, name: &str, flags: SymbolFlags, range: TextRange) {
+        let symbol = self.symbol_tables[self.current_scope].intern(name, flags);
+        self.bindings[self.current_scope].push(Binding { symbol, range });
+    }
+
+    fn add_use(&mut self, name: &str, range: TextRange) {
+        let symbol = self.symbol_tables[self.current_scope].intern(name, SymbolFlags::IS_USED);
+        self.uses[self.current_scope].push(Use { symbol, range });
+    }
+
+    // --- Recursive descent ---
+
+    fn collect_expression_list(&mut self, list: &RExpressionList) {
+        for expr in list.iter() {
+            self.collect_expression(&expr);
+        }
+    }
+
+    fn collect_expression(&mut self, expr: &AnyRExpression) {
+        match expr {
+            AnyRExpression::RIdentifier(ident) => {
+                let name = ident.syntax().text_trimmed().to_string();
+                let range = ident.syntax().text_trimmed_range();
+                self.add_use(&name, range);
+            },
+
+            AnyRExpression::RDots(dots) => {
+                self.add_use("...", dots.syntax().text_trimmed_range());
+            },
+
+            AnyRExpression::RDotDotI(ddi) => {
+                let name = ddi.syntax().text_trimmed().to_string();
+                self.add_use(&name, ddi.syntax().text_trimmed_range());
+            },
+
+            AnyRExpression::RFunctionDefinition(func) => {
+                self.collect_function(func);
+            },
+
+            AnyRExpression::RBracedExpressions(braced) => {
+                self.collect_expression_list(&braced.expressions());
+            },
+
+            AnyRExpression::RBinaryExpression(bin) => {
+                // Both `<-` and `=` are assignments when they appear as
+                // `RBinaryExpression`. In call arguments, `=` is consumed by
+                // the parser into `RArgumentNameClause` instead, so it never
+                // reaches here.
+                if is_assignment(bin) {
+                    self.collect_assignment(bin);
+                } else {
+                    if let Ok(lhs) = bin.left() {
+                        self.collect_expression(&lhs);
+                    }
+                    if let Ok(rhs) = bin.right() {
+                        self.collect_expression(&rhs);
+                    }
+                }
+            },
+
+            // Calls and subsets need explicit handling because argument name
+            // clauses contain `RIdentifier` nodes that should not be recorded
+            // as uses.
+            AnyRExpression::RCall(call) => {
+                if let Ok(func) = call.function() {
+                    self.collect_expression(&func);
+                }
+                if let Ok(args) = call.arguments() {
+                    self.collect_arguments(&args.items());
+                }
+            },
+            AnyRExpression::RSubset(subset) => {
+                if let Ok(object) = subset.function() {
+                    self.collect_expression(&object);
+                }
+                if let Ok(args) = subset.arguments() {
+                    self.collect_arguments(&args.items());
+                }
+            },
+            AnyRExpression::RSubset2(subset) => {
+                if let Ok(object) = subset.function() {
+                    self.collect_expression(&object);
+                }
+                if let Ok(args) = subset.arguments() {
+                    self.collect_arguments(&args.items());
+                }
+            },
+
+            AnyRExpression::RExtractExpression(extract) => {
+                // For `x$name` or `x@slot`, collect the object and skip the member
+                if let Ok(object) = extract.left() {
+                    self.collect_expression(&object);
+                }
+            },
+
+            AnyRExpression::RNamespaceExpression(_) => {
+                // In `pkg::fn` or `pkg:::fn`, both sides are selectors, not
+                // variable references in the current scope
+            },
+
+            AnyRExpression::RForStatement(stmt) => {
+                if let Ok(variable) = stmt.variable() {
+                    self.add_binding(
+                        &variable.syntax().text_trimmed().to_string(),
+                        SymbolFlags::IS_BOUND,
+                        variable.syntax().text_trimmed_range(),
+                    );
+                }
+                if let Ok(sequence) = stmt.sequence() {
+                    self.collect_expression(&sequence);
+                }
+                if let Ok(body) = stmt.body() {
+                    self.collect_expression(&body);
+                }
+            },
+
+            AnyRExpression::RBogusExpression(_) => {},
+
+            // Generic fallback: walk over descendant nodes and collect their
+            // `AnyRExpression` children, letting `collect_expression`
+            // handle their contents. This covers `RIfStatement`,
+            // `RWhileStatement`, `RRepeatStatement`, `RUnaryExpression`,
+            // `RParenthesizedExpression`, `RReturnExpression`, literals, and
+            // any future expression types without needing explicit arms.
+            _ => {
+                self.collect_descendants(expr.syntax());
+            },
+        }
+    }
+
+    // Walk descendant nodes of `expr`, collecting the outermost
+    // `AnyRExpression` nodes and recursing into them via `collect_expression`.
+    // This skips intermediate wrapper nodes (e.g. `RElseClause`) while
+    // correctly stopping at expression boundaries.
+    fn collect_descendants(&mut self, node: &RSyntaxNode) {
+        let mut preorder = node.preorder();
+
+        // Skip the root node itself
+        preorder.next();
+
+        while let Some(event) = preorder.next() {
+            let WalkEvent::Enter(node) = event else {
+                continue;
+            };
+            if let Some(expr) = node.cast::<AnyRExpression>() {
+                self.collect_expression(&expr);
+                preorder.skip_subtree();
+            }
+        }
+    }
+
+    fn collect_function(&mut self, fun: &RFunctionDefinition) {
+        let scope = self.push_scope(ScopeKind::Function, fun.syntax().text_trimmed_range());
+
+        if let Ok(params) = fun.parameters() {
+            self.collect_parameters(&params);
+        }
+        if let Ok(body) = fun.body() {
+            self.collect_expression(&body);
+        }
+
+        self.pop_scope(scope);
+    }
+
+    fn collect_parameters(&mut self, params: &RParameters) {
+        for param in params.items().iter() {
+            let Ok(param) = param else { continue };
+            self.collect_parameter(&param);
+        }
+    }
+
+    fn collect_parameter(&mut self, param: &RParameter) {
+        let flags = SymbolFlags::IS_BOUND.union(SymbolFlags::IS_PARAMETER);
+
+        if let Ok(name) = param.name() {
+            match &name {
+                AnyRParameterName::RIdentifier(ident) => {
+                    self.add_binding(
+                        &ident.syntax().text_trimmed().to_string(),
+                        flags,
+                        ident.syntax().text_trimmed_range(),
+                    );
+                },
+                AnyRParameterName::RDots(dots) => {
+                    self.add_binding("...", flags, dots.syntax().text_trimmed_range());
+                },
+                AnyRParameterName::RDotDotI(ddi) => {
+                    self.add_binding(
+                        &ddi.syntax().text_trimmed().to_string(),
+                        flags,
+                        ddi.syntax().text_trimmed_range(),
+                    );
+                },
+            }
+        }
+
+        if let Some(default) = param.default() {
+            if let Ok(value) = default.value() {
+                self.collect_expression(&value);
+            }
+        }
+    }
+
+    fn collect_assignment(&mut self, op: &RBinaryExpression) {
+        // RHS first to record uses before the binding. The uses might refer to
+        // the same symbol as the new binding, but refer to a different place
+        // (previous binding).
+        if let Ok(rhs) = op.right() {
+            self.collect_expression(&rhs);
+        }
+
+        let Ok(lhs) = op.left() else { return };
+        match lhs {
+            AnyRExpression::RIdentifier(ident) => {
+                self.add_binding(
+                    &ident.syntax().text_trimmed().to_string(),
+                    SymbolFlags::IS_BOUND,
+                    ident.syntax().text_trimmed_range(),
+                );
+            },
+
+            // Complex LHS (`x$foo <- rhs`, `x[1] <- rhs`, etc.) do not
+            // represent a binding. We recurse for uses.
+            other => self.collect_expression(&other),
+        }
+    }
+
+    fn collect_arguments(&mut self, args: &RArgumentList) {
+        for item in args.iter() {
+            let Ok(arg) = item else { continue };
+            if let Some(value) = arg.value() {
+                self.collect_expression(&value);
+            }
+        }
+    }
+
+    fn finish(mut self) -> SemanticIndex {
+        self.scopes[ScopeId::from(0)].descendants.end = self.scopes.next_id();
+        let symbol_tables = self.symbol_tables.into_iter().map(|b| b.build()).collect();
+        SemanticIndex::new(self.scopes, symbol_tables, self.bindings, self.uses)
+    }
+}
+
+fn is_assignment(bin: &RBinaryExpression) -> bool {
+    let Ok(op) = bin.operator() else {
+        return false;
+    };
+    matches!(op.kind(), RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL)
+}

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -1,5 +1,6 @@
 use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRParameterName;
+use aether_syntax::AnyRValue;
 use aether_syntax::RArgumentList;
 use aether_syntax::RBinaryExpression;
 use aether_syntax::RExpressionList;
@@ -171,7 +172,7 @@ impl SemanticIndexBuilder {
     fn collect_expression(&mut self, expr: &AnyRExpression) {
         match expr {
             AnyRExpression::RIdentifier(ident) => {
-                let name = ident.syntax().text_trimmed().to_string();
+                let name = identifier_text(ident);
                 let range = ident.syntax().text_trimmed_range();
                 self.add_use(&name, range);
             },
@@ -253,7 +254,7 @@ impl SemanticIndexBuilder {
             AnyRExpression::RForStatement(stmt) => {
                 if let Ok(variable) = stmt.variable() {
                     self.add_definition(
-                        &variable.syntax().text_trimmed().to_string(),
+                        &identifier_text(&variable),
                         SymbolFlags::IS_BOUND,
                         DefinitionKind::ForVariable(stmt.syntax().clone()),
                         variable.syntax().text_trimmed_range(),
@@ -334,7 +335,7 @@ impl SemanticIndexBuilder {
             match &name {
                 AnyRParameterName::RIdentifier(ident) => {
                     self.add_definition(
-                        &ident.syntax().text_trimmed().to_string(),
+                        &identifier_text(ident),
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         ident.syntax().text_trimmed_range(),
@@ -380,33 +381,47 @@ impl SemanticIndexBuilder {
 
         let target = if right { op.right() } else { op.left() };
         let Ok(target) = target else { return };
-        match target {
-            AnyRExpression::RIdentifier(ident) => {
-                let name = ident.syntax().text_trimmed().to_string();
-                let range = ident.syntax().text_trimmed_range();
 
-                if super_assign {
-                    let target_scope = self.resolve_super_target(&name);
-                    self.add_definition_in_scope(
-                        target_scope,
-                        &name,
-                        SymbolFlags::IS_BOUND,
-                        DefinitionKind::SuperAssignment(op.syntax().clone()),
-                        range,
-                    );
-                } else {
-                    self.add_definition(
-                        &name,
-                        SymbolFlags::IS_BOUND,
-                        DefinitionKind::Assignment(op.syntax().clone()),
-                        range,
-                    );
-                }
+        let (name, range) = match &target {
+            AnyRExpression::RIdentifier(ident) => {
+                let name = identifier_text(ident);
+                let range = ident.syntax().text_trimmed_range();
+                (name, range)
+            },
+
+            // `"x" <- 1` is equivalent to `x <- 1` in R
+            AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => {
+                let Some(name) = string_value_text(s) else {
+                    return;
+                };
+                let range = s.syntax().text_trimmed_range();
+                (name, range)
             },
 
             // Complex target (`x$foo <- rhs`, `x[1] <- rhs`, etc.) does
             // not represent a binding. We recurse for uses.
-            other => self.collect_expression(&other),
+            other => {
+                self.collect_expression(other);
+                return;
+            },
+        };
+
+        if super_assign {
+            let target_scope = self.resolve_super_target(&name);
+            self.add_definition_in_scope(
+                target_scope,
+                &name,
+                SymbolFlags::IS_BOUND,
+                DefinitionKind::SuperAssignment(op.syntax().clone()),
+                range,
+            );
+        } else {
+            self.add_definition(
+                &name,
+                SymbolFlags::IS_BOUND,
+                DefinitionKind::Assignment(op.syntax().clone()),
+                range,
+            );
         }
     }
 
@@ -448,6 +463,31 @@ fn is_right_assignment(bin: &RBinaryExpression) -> bool {
         op.kind(),
         RSyntaxKind::ASSIGN_RIGHT | RSyntaxKind::SUPER_ASSIGN_RIGHT
     )
+}
+
+/// Extract the name of an `RIdentifier`, stripping backticks if present.
+///
+/// Backtick-quoted identifiers like `` `my var` `` are parsed as `RIdentifier`
+/// nodes whose `text_trimmed()` includes the backticks. The backticks are a
+/// quoting mechanism, not part of the symbol name.
+fn identifier_text(ident: &aether_syntax::RIdentifier) -> String {
+    let text = ident.syntax().text_trimmed().to_string();
+    match text.strip_prefix('`').and_then(|s| s.strip_suffix('`')) {
+        Some(inner) => inner.to_string(),
+        None => text,
+    }
+}
+
+/// Extract the unquoted text of an `RStringValue`.
+///
+/// Note: `RStringValue::inner_string_text()` from aether_syntax would be the
+/// idiomatic API for this, but it delegates to the free `inner_string_text()`
+/// which checks for node kind `R_STRING_VALUE` instead of token kind
+/// `R_STRING_LITERAL`, so it never actually strips the delimiters.
+fn string_value_text(s: &aether_syntax::RStringValue) -> Option<String> {
+    let token = s.value_token().ok()?;
+    let text = token.text_trimmed();
+    Some(text[1..text.len() - 1].to_string())
 }
 
 fn is_super_assignment(bin: &RBinaryExpression) -> bool {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -18,8 +18,9 @@ use biome_rowan::WalkEvent;
 
 use crate::arena::Idx;
 use crate::arena::IndexVec;
-use crate::semantic_index::Binding;
-use crate::semantic_index::BindingId;
+use crate::semantic_index::Definition;
+use crate::semantic_index::DefinitionId;
+use crate::semantic_index::DefinitionKind;
 use crate::semantic_index::Scope;
 use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
@@ -43,7 +44,7 @@ pub fn build(root: &RRoot) -> SemanticIndex {
 struct SemanticIndexBuilder {
     scopes: IndexVec<ScopeId, Scope>,
     symbol_tables: IndexVec<ScopeId, SymbolTableBuilder>,
-    bindings: IndexVec<ScopeId, IndexVec<BindingId, Binding>>,
+    definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
     uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
     current_scope: ScopeId,
 }
@@ -52,7 +53,7 @@ impl SemanticIndexBuilder {
     fn new(range: TextRange) -> Self {
         let mut scopes = IndexVec::new();
         let mut symbol_tables = IndexVec::new();
-        let mut bindings = IndexVec::new();
+        let mut definitions = IndexVec::new();
         let mut uses = IndexVec::new();
 
         // The descendants range starts empty (`n+1..n+1`). `pop_scope` later
@@ -66,13 +67,13 @@ impl SemanticIndexBuilder {
         });
 
         symbol_tables.push(SymbolTableBuilder::new());
-        bindings.push(IndexVec::new());
+        definitions.push(IndexVec::new());
         uses.push(IndexVec::new());
 
         Self {
             scopes,
             symbol_tables,
-            bindings,
+            definitions,
             uses,
             current_scope: file,
         }
@@ -95,7 +96,7 @@ impl SemanticIndexBuilder {
         self.current_scope = id;
 
         self.symbol_tables.push(SymbolTableBuilder::new());
-        self.bindings.push(IndexVec::new());
+        self.definitions.push(IndexVec::new());
         self.uses.push(IndexVec::new());
 
         id
@@ -111,42 +112,47 @@ impl SemanticIndexBuilder {
         };
     }
 
-    fn add_binding(&mut self, name: &str, flags: SymbolFlags, range: TextRange) {
-        self.add_binding_in_scope(self.current_scope, name, flags, range);
+    fn add_definition(
+        &mut self,
+        name: &str,
+        flags: SymbolFlags,
+        kind: DefinitionKind,
+        range: TextRange,
+    ) {
+        self.add_definition_in_scope(self.current_scope, name, flags, kind, range);
     }
 
-    fn add_binding_in_scope(
+    fn add_definition_in_scope(
         &mut self,
         scope: ScopeId,
         name: &str,
         flags: SymbolFlags,
+        kind: DefinitionKind,
         range: TextRange,
     ) {
         let symbol = self.symbol_tables[scope].intern(name, flags);
-        self.bindings[scope].push(Binding { symbol, range });
+        self.definitions[scope].push(Definition {
+            symbol,
+            kind,
+            range,
+        });
     }
 
     /// Walk from `current_scope` up through ancestors looking for a scope
     /// that already has a binding for `name`. Returns the file scope if
     /// no existing binding is found (matching R's runtime `<<-` semantics).
-    ///
-    /// When an existing binding is found, returns `IS_BOUND` (it's a
-    /// regular binding in that scope). `IS_SUPER_BOUND` is only used
-    /// when no ancestor has a binding, meaning the `<<-` creates a new
-    /// name at file scope as a side effect. Typically we'll issue a
-    /// diagnostic in that case.
-    fn resolve_super_target(&self, name: &str) -> (ScopeId, SymbolFlags) {
+    fn resolve_super_target(&self, name: &str) -> ScopeId {
         let file = ScopeId::from(0);
         let mut scope = self.scopes[self.current_scope].parent;
         while let Some(id) = scope {
             if let Some(sym) = self.symbol_tables[id].get(name) {
                 if sym.flags().contains(SymbolFlags::IS_BOUND) {
-                    return (id, SymbolFlags::IS_BOUND);
+                    return id;
                 }
             }
             scope = self.scopes[id].parent;
         }
-        (file, SymbolFlags::IS_SUPER_BOUND)
+        file
     }
 
     fn add_use(&mut self, name: &str, range: TextRange) {
@@ -246,9 +252,10 @@ impl SemanticIndexBuilder {
 
             AnyRExpression::RForStatement(stmt) => {
                 if let Ok(variable) = stmt.variable() {
-                    self.add_binding(
+                    self.add_definition(
                         &variable.syntax().text_trimmed().to_string(),
                         SymbolFlags::IS_BOUND,
+                        DefinitionKind::ForVariable,
                         variable.syntax().text_trimmed_range(),
                     );
                 }
@@ -326,19 +333,26 @@ impl SemanticIndexBuilder {
         if let Ok(name) = param.name() {
             match &name {
                 AnyRParameterName::RIdentifier(ident) => {
-                    self.add_binding(
+                    self.add_definition(
                         &ident.syntax().text_trimmed().to_string(),
                         flags,
+                        DefinitionKind::Parameter,
                         ident.syntax().text_trimmed_range(),
                     );
                 },
                 AnyRParameterName::RDots(dots) => {
-                    self.add_binding("...", flags, dots.syntax().text_trimmed_range());
+                    self.add_definition(
+                        "...",
+                        flags,
+                        DefinitionKind::Parameter,
+                        dots.syntax().text_trimmed_range(),
+                    );
                 },
                 AnyRParameterName::RDotDotI(ddi) => {
-                    self.add_binding(
+                    self.add_definition(
                         &ddi.syntax().text_trimmed().to_string(),
                         flags,
+                        DefinitionKind::Parameter,
                         ddi.syntax().text_trimmed_range(),
                     );
                 },
@@ -372,10 +386,21 @@ impl SemanticIndexBuilder {
                 let range = ident.syntax().text_trimmed_range();
 
                 if super_assign {
-                    let (target_scope, flags) = self.resolve_super_target(&name);
-                    self.add_binding_in_scope(target_scope, &name, flags, range);
+                    let target_scope = self.resolve_super_target(&name);
+                    self.add_definition_in_scope(
+                        target_scope,
+                        &name,
+                        SymbolFlags::IS_BOUND,
+                        DefinitionKind::SuperAssignment,
+                        range,
+                    );
                 } else {
-                    self.add_binding(&name, SymbolFlags::IS_BOUND, range);
+                    self.add_definition(
+                        &name,
+                        SymbolFlags::IS_BOUND,
+                        DefinitionKind::Assignment,
+                        range,
+                    );
                 }
             },
 
@@ -397,7 +422,7 @@ impl SemanticIndexBuilder {
     fn finish(mut self) -> SemanticIndex {
         self.scopes[ScopeId::from(0)].descendants.end = self.scopes.next_id();
         let symbol_tables = self.symbol_tables.into_iter().map(|b| b.build()).collect();
-        SemanticIndex::new(self.scopes, symbol_tables, self.bindings, self.uses)
+        SemanticIndex::new(self.scopes, symbol_tables, self.definitions, self.uses)
     }
 }
 

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -255,7 +255,7 @@ impl SemanticIndexBuilder {
                     self.add_definition(
                         &variable.syntax().text_trimmed().to_string(),
                         SymbolFlags::IS_BOUND,
-                        DefinitionKind::ForVariable,
+                        DefinitionKind::ForVariable(stmt.syntax().clone()),
                         variable.syntax().text_trimmed_range(),
                     );
                 }
@@ -336,7 +336,7 @@ impl SemanticIndexBuilder {
                     self.add_definition(
                         &ident.syntax().text_trimmed().to_string(),
                         flags,
-                        DefinitionKind::Parameter,
+                        DefinitionKind::Parameter(param.syntax().clone()),
                         ident.syntax().text_trimmed_range(),
                     );
                 },
@@ -344,7 +344,7 @@ impl SemanticIndexBuilder {
                     self.add_definition(
                         "...",
                         flags,
-                        DefinitionKind::Parameter,
+                        DefinitionKind::Parameter(param.syntax().clone()),
                         dots.syntax().text_trimmed_range(),
                     );
                 },
@@ -352,7 +352,7 @@ impl SemanticIndexBuilder {
                     self.add_definition(
                         &ddi.syntax().text_trimmed().to_string(),
                         flags,
-                        DefinitionKind::Parameter,
+                        DefinitionKind::Parameter(param.syntax().clone()),
                         ddi.syntax().text_trimmed_range(),
                     );
                 },
@@ -391,14 +391,14 @@ impl SemanticIndexBuilder {
                         target_scope,
                         &name,
                         SymbolFlags::IS_BOUND,
-                        DefinitionKind::SuperAssignment,
+                        DefinitionKind::SuperAssignment(op.syntax().clone()),
                         range,
                     );
                 } else {
                     self.add_definition(
                         &name,
                         SymbolFlags::IS_BOUND,
-                        DefinitionKind::Assignment,
+                        DefinitionKind::Assignment(op.syntax().clone()),
                         range,
                     );
                 }

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -17,8 +17,8 @@ use biome_rowan::SyntaxNodeCast;
 use biome_rowan::TextRange;
 use biome_rowan::WalkEvent;
 
-use crate::arena::Idx;
-use crate::arena::IndexVec;
+use crate::index_vec::Idx;
+use crate::index_vec::IndexVec;
 use crate::semantic_index::Definition;
 use crate::semantic_index::DefinitionId;
 use crate::semantic_index::DefinitionKind;

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -120,40 +120,12 @@ impl SemanticIndexBuilder {
         kind: DefinitionKind,
         range: TextRange,
     ) {
-        self.add_definition_in_scope(self.current_scope, name, flags, kind, range);
-    }
-
-    fn add_definition_in_scope(
-        &mut self,
-        scope: ScopeId,
-        name: &str,
-        flags: SymbolFlags,
-        kind: DefinitionKind,
-        range: TextRange,
-    ) {
-        let symbol = self.symbol_tables[scope].intern(name, flags);
-        self.definitions[scope].push(Definition {
+        let symbol = self.symbol_tables[self.current_scope].intern(name, flags);
+        self.definitions[self.current_scope].push(Definition {
             symbol,
             kind,
             range,
         });
-    }
-
-    /// Walk from `current_scope` up through ancestors looking for a scope
-    /// that already has a binding for `name`. Returns the file scope if
-    /// no existing binding is found (matching R's runtime `<<-` semantics).
-    fn resolve_super_target(&self, name: &str) -> ScopeId {
-        let file = ScopeId::from(0);
-        let mut scope = self.scopes[self.current_scope].parent;
-        while let Some(id) = scope {
-            if let Some(sym) = self.symbol_tables[id].get(name) {
-                if sym.flags().contains(SymbolFlags::IS_BOUND) {
-                    return id;
-                }
-            }
-            scope = self.scopes[id].parent;
-        }
-        file
     }
 
     fn add_use(&mut self, name: &str, range: TextRange) {
@@ -407,11 +379,9 @@ impl SemanticIndexBuilder {
         };
 
         if super_assign {
-            let target_scope = self.resolve_super_target(&name);
-            self.add_definition_in_scope(
-                target_scope,
+            self.add_definition(
                 &name,
-                SymbolFlags::IS_BOUND,
+                SymbolFlags::IS_SUPER_BOUND,
                 DefinitionKind::SuperAssignment(op.syntax().clone()),
                 range,
             );

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -129,18 +129,24 @@ impl SemanticIndexBuilder {
     /// Walk from `current_scope` up through ancestors looking for a scope
     /// that already has a binding for `name`. Returns the file scope if
     /// no existing binding is found (matching R's runtime `<<-` semantics).
-    fn resolve_super_target(&self, name: &str) -> ScopeId {
+    ///
+    /// When an existing binding is found, returns `IS_BOUND` (it's a
+    /// regular binding in that scope). `IS_SUPER_BOUND` is only used
+    /// when no ancestor has a binding, meaning the `<<-` creates a new
+    /// name at file scope as a side effect. Typically we'll issue a
+    /// diagnostic in that case.
+    fn resolve_super_target(&self, name: &str) -> (ScopeId, SymbolFlags) {
         let file = ScopeId::from(0);
         let mut scope = self.scopes[self.current_scope].parent;
         while let Some(id) = scope {
             if let Some(sym) = self.symbol_tables[id].get(name) {
                 if sym.flags().contains(SymbolFlags::IS_BOUND) {
-                    return id;
+                    return (id, SymbolFlags::IS_BOUND);
                 }
             }
             scope = self.scopes[id].parent;
         }
-        file
+        (file, SymbolFlags::IS_SUPER_BOUND)
     }
 
     fn add_use(&mut self, name: &str, range: TextRange) {
@@ -349,11 +355,6 @@ impl SemanticIndexBuilder {
     fn collect_assignment(&mut self, op: &RBinaryExpression) {
         let right = is_right_assignment(op);
         let super_assign = is_super_assignment(op);
-        let flags = if super_assign {
-            SymbolFlags::IS_SUPER_BOUND
-        } else {
-            SymbolFlags::IS_BOUND
-        };
 
         // Value side first to record uses before the binding. The uses
         // might refer to the same symbol as the new binding, but refer
@@ -371,10 +372,10 @@ impl SemanticIndexBuilder {
                 let range = ident.syntax().text_trimmed_range();
 
                 if super_assign {
-                    let target_scope = self.resolve_super_target(&name);
+                    let (target_scope, flags) = self.resolve_super_target(&name);
                     self.add_binding_in_scope(target_scope, &name, flags, range);
                 } else {
-                    self.add_binding(&name, flags, range);
+                    self.add_binding(&name, SymbolFlags::IS_BOUND, range);
                 }
             },
 

--- a/crates/oak_index/src/index_vec.rs
+++ b/crates/oak_index/src/index_vec.rs
@@ -7,8 +7,8 @@ pub trait Idx: Copy + fmt::Debug + Eq {
     fn index(self) -> usize;
 }
 
-/// A typed arena: a `Vec<V>` indexed by a strongly-typed newtype `I` instead
-/// of `usize`, so that indices from different arenas can't be mixed up.
+/// A `Vec<V>` indexed by a strongly-typed newtype `I` instead of `usize`,
+/// so that indices from different vectors can't be mixed up.
 pub struct IndexVec<I: Idx, V> {
     raw: Vec<V>,
     _phantom: PhantomData<I>,
@@ -104,7 +104,7 @@ macro_rules! define_index {
             }
         }
 
-        impl $crate::arena::Idx for $name {
+        impl $crate::index_vec::Idx for $name {
             fn new(value: usize) -> Self {
                 assert!(value <= Self::MAX);
                 Self(value as u32)

--- a/crates/oak_index/src/lib.rs
+++ b/crates/oak_index/src/lib.rs
@@ -1,0 +1,3 @@
+pub(crate) mod arena;
+pub mod builder;
+pub mod semantic_index;

--- a/crates/oak_index/src/lib.rs
+++ b/crates/oak_index/src/lib.rs
@@ -1,3 +1,3 @@
-pub(crate) mod arena;
 pub mod builder;
+pub(crate) mod index_vec;
 pub mod semantic_index;

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -183,9 +183,10 @@ impl SymbolFlags {
     pub const IS_BOUND: Self = Self(1 << 1);
     // Appears in a function's formal parameter list.
     pub const IS_PARAMETER: Self = Self(1 << 2);
-    // Given a value via superassignment (`<<-`, `->>`). The binding is
-    // recorded in the nearest ancestor scope that already binds the name,
-    // or the file scope if none does (matching R's runtime semantics).
+    // A name introduced at file scope purely by `<<-` or `->>`, with no
+    // prior local binding. This only appears at file scope. When `<<-`
+    // targets an ancestor that already has a binding, `IS_SUPER_BOUND`
+    // is not added.
     pub const IS_SUPER_BOUND: Self = Self(1 << 3);
 
     pub const fn empty() -> Self {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -12,8 +12,8 @@ define_index!(ScopeId);
 // Scope-local symbol identifier
 define_index!(SymbolId);
 
-// Binding site identifier
-define_index!(BindingId);
+// Definition site identifier
+define_index!(DefinitionId);
 
 // Use site identifier
 define_index!(UseId);
@@ -23,7 +23,7 @@ define_index!(UseId);
 // scripts) is a separate concern handled by layers above this.
 // Consequently, `ScopeId(0)` is always the top-level scope of a file.
 //
-// Scopes, symbol tables, bindings, and uses are stored in parallel arrays
+// Scopes, symbol tables, definitions, and uses are stored in parallel arrays
 // (all indexed by `ScopeId`) rather than bundled into a single struct, so
 // that each can be cached and invalidated independently (when salsa is
 // introduced).
@@ -38,18 +38,18 @@ pub struct SemanticIndex {
     // We defer that until salsa is introduced.
     symbol_tables: IndexVec<ScopeId, SymbolTable>,
 
-    // Flat per-scope lists of binding and use sites. These support rename and
-    // go-to-definition by letting us find all sites for a given symbol without
-    // control-flow analysis.
+    // Flat per-scope lists of definition and use sites. These support rename
+    // and go-to-definition by letting us find all sites for a given symbol
+    // without control-flow analysis.
     //
     // In ty, this role is filled by salsa-tracked `Definition<'db>` structs
     // and `AstIds`. When we introduce salsa, these lists may be restructured
     // to match.
     //
     // Use-def maps will layer on top of these lists, not replace them. A
-    // use-def map tracks which bindings reach each use through control flow,
-    // referencing `BindingId` and `UseId` indices into these arenas.
-    bindings: IndexVec<ScopeId, IndexVec<BindingId, Binding>>,
+    // use-def map tracks which definitions reach each use through control flow,
+    // referencing `DefinitionId` and `UseId` indices into these arenas.
+    definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
     uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
 }
 
@@ -57,13 +57,13 @@ impl SemanticIndex {
     pub(crate) fn new(
         scopes: IndexVec<ScopeId, Scope>,
         symbol_tables: IndexVec<ScopeId, SymbolTable>,
-        bindings: IndexVec<ScopeId, IndexVec<BindingId, Binding>>,
+        definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
         uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
     ) -> Self {
         Self {
             scopes,
             symbol_tables,
-            bindings,
+            definitions,
             uses,
         }
     }
@@ -76,8 +76,8 @@ impl SemanticIndex {
         &self.symbol_tables[scope]
     }
 
-    pub fn bindings(&self, scope: ScopeId) -> &IndexVec<BindingId, Binding> {
-        &self.bindings[scope]
+    pub fn definitions(&self, scope: ScopeId) -> &IndexVec<DefinitionId, Definition> {
+        &self.definitions[scope]
     }
 
     pub fn uses(&self, scope: ScopeId) -> &IndexVec<UseId, Use> {
@@ -125,7 +125,7 @@ impl SemanticIndex {
                 if self.symbol_tables[ancestor]
                     .symbol(id)
                     .flags
-                    .intersects(SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND))
+                    .contains(SymbolFlags::IS_BOUND)
                 {
                     return Some((ancestor, id));
                 }
@@ -183,11 +183,6 @@ impl SymbolFlags {
     pub const IS_BOUND: Self = Self(1 << 1);
     // Appears in a function's formal parameter list.
     pub const IS_PARAMETER: Self = Self(1 << 2);
-    // A name introduced at file scope purely by `<<-` or `->>`, with no
-    // prior local binding. This only appears at file scope. When `<<-`
-    // targets an ancestor that already has a binding, `IS_SUPER_BOUND`
-    // is not added.
-    pub const IS_SUPER_BOUND: Self = Self(1 << 3);
 
     pub const fn empty() -> Self {
         Self(0)
@@ -301,17 +296,30 @@ impl std::ops::Deref for SymbolTableBuilder {
     }
 }
 
-// --- Binding and Use sites ---
+// --- Definition and Use sites ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefinitionKind {
+    Assignment,
+    SuperAssignment,
+    Parameter,
+    ForVariable,
+}
 
 #[derive(Debug)]
-pub struct Binding {
+pub struct Definition {
     pub(crate) symbol: SymbolId,
+    pub(crate) kind: DefinitionKind,
     pub(crate) range: TextRange,
 }
 
-impl Binding {
+impl Definition {
     pub fn symbol(&self) -> SymbolId {
         self.symbol
+    }
+
+    pub fn kind(&self) -> DefinitionKind {
+        self.kind
     }
 
     pub fn range(&self) -> TextRange {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use aether_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
 
@@ -359,12 +360,12 @@ pub struct Definition {
     pub(crate) range: TextRange,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum DefinitionKind {
-    Assignment,
-    SuperAssignment,
-    Parameter,
-    ForVariable,
+    Assignment(RSyntaxNode),
+    SuperAssignment(RSyntaxNode),
+    Parameter(RSyntaxNode),
+    ForVariable(RSyntaxNode),
 }
 
 impl Definition {
@@ -372,8 +373,8 @@ impl Definition {
         self.symbol
     }
 
-    pub fn kind(&self) -> DefinitionKind {
-        self.kind
+    pub fn kind(&self) -> &DefinitionKind {
+        &self.kind
     }
 
     pub fn range(&self) -> TextRange {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -4,8 +4,8 @@ use aether_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
 
-use crate::arena::define_index;
-use crate::arena::IndexVec;
+use crate::index_vec::define_index;
+use crate::index_vec::IndexVec;
 
 // File-local scope identifier
 define_index!(ScopeId);

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -1,0 +1,363 @@
+use std::ops::Range;
+
+use biome_rowan::TextRange;
+use rustc_hash::FxHashMap;
+
+use crate::arena::define_index;
+use crate::arena::IndexVec;
+
+// File-local scope identifier
+define_index!(ScopeId);
+
+// Scope-local symbol identifier
+define_index!(SymbolId);
+
+// Binding site identifier
+define_index!(BindingId);
+
+// Use site identifier
+define_index!(UseId);
+
+// One `SemanticIndex` per R source file. This reflects the physical reality of
+// a single file. Cross-file resolution (e.g. package namespaces, sourced
+// scripts) is a separate concern handled by layers above this.
+// Consequently, `ScopeId(0)` is always the top-level scope of a file.
+//
+// Scopes, symbol tables, bindings, and uses are stored in parallel arrays
+// (all indexed by `ScopeId`) rather than bundled into a single struct, so
+// that each can be cached and invalidated independently (when salsa is
+// introduced).
+#[derive(Debug)]
+pub struct SemanticIndex {
+    scopes: IndexVec<ScopeId, Scope>,
+
+    // ty wraps per-scope tables in `Arc` so they can be returned from
+    // individual salsa tracked queries (e.g. `place_table(db, scope) ->
+    // Arc<PlaceTable>`). Salsa compares the returned `Arc` by `Eq` to skip
+    // re-running downstream queries when a scope's table hasn't changed.
+    // We defer that until salsa is introduced.
+    symbol_tables: IndexVec<ScopeId, SymbolTable>,
+
+    // Flat per-scope lists of binding and use sites. These support rename and
+    // go-to-definition by letting us find all sites for a given symbol without
+    // control-flow analysis.
+    //
+    // In ty, this role is filled by salsa-tracked `Definition<'db>` structs
+    // and `AstIds`. When we introduce salsa, these lists may be restructured
+    // to match.
+    //
+    // Use-def maps will layer on top of these lists, not replace them. A
+    // use-def map tracks which bindings reach each use through control flow,
+    // referencing `BindingId` and `UseId` indices into these arenas.
+    bindings: IndexVec<ScopeId, IndexVec<BindingId, Binding>>,
+    uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
+}
+
+impl SemanticIndex {
+    pub(crate) fn new(
+        scopes: IndexVec<ScopeId, Scope>,
+        symbol_tables: IndexVec<ScopeId, SymbolTable>,
+        bindings: IndexVec<ScopeId, IndexVec<BindingId, Binding>>,
+        uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
+    ) -> Self {
+        Self {
+            scopes,
+            symbol_tables,
+            bindings,
+            uses,
+        }
+    }
+
+    pub fn scope(&self, id: ScopeId) -> &Scope {
+        &self.scopes[id]
+    }
+
+    pub fn symbols(&self, scope: ScopeId) -> &SymbolTable {
+        &self.symbol_tables[scope]
+    }
+
+    pub fn bindings(&self, scope: ScopeId) -> &IndexVec<BindingId, Binding> {
+        &self.bindings[scope]
+    }
+
+    pub fn uses(&self, scope: ScopeId) -> &IndexVec<UseId, Use> {
+        &self.uses[scope]
+    }
+
+    /// Find the innermost scope containing `offset`.
+    pub fn scope_at(&self, offset: biome_rowan::TextSize) -> ScopeId {
+        // Start at the file scope
+        let mut current = ScopeId::from(0);
+        'outer: loop {
+            for child_id in self.child_scopes(current) {
+                if self.scopes[child_id].range.contains(offset) {
+                    current = child_id;
+                    continue 'outer;
+                }
+            }
+            return current;
+        }
+    }
+
+    /// Iterate direct child scopes of `scope`.
+    pub fn child_scopes(&self, scope: ScopeId) -> ChildScopesIter<'_> {
+        let descendants = &self.scopes[scope].descendants;
+        ChildScopesIter {
+            index: self,
+            current: descendants.start,
+            end: descendants.end,
+        }
+    }
+
+    /// Walk from `scope` up through ancestors to the file root. Note that
+    /// `scope` itself is included in the ancestors.
+    pub fn ancestor_scopes(&self, scope: ScopeId) -> AncestorsIter<'_> {
+        AncestorsIter {
+            index: self,
+            current: Some(scope),
+        }
+    }
+
+    /// Resolve a name starting from `scope`, walking up the scope chain.
+    pub fn resolve_symbol(&self, name: &str, scope: ScopeId) -> Option<(ScopeId, SymbolId)> {
+        for ancestor in self.ancestor_scopes(scope) {
+            if let Some(id) = self.symbol_tables[ancestor].id(name) {
+                if self.symbol_tables[ancestor]
+                    .symbol(id)
+                    .flags
+                    .contains(SymbolFlags::IS_BOUND)
+                {
+                    return Some((ancestor, id));
+                }
+            }
+        }
+        None
+    }
+}
+
+// --- Scope ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeKind {
+    File,
+    Function,
+}
+
+#[derive(Debug)]
+pub struct Scope {
+    pub(crate) parent: Option<ScopeId>,
+    pub(crate) kind: ScopeKind,
+    pub(crate) range: TextRange,
+    // Scopes are allocated in preorder, so a scope's descendants always
+    // occupy a contiguous range of IDs. This lets `child_scopes` and
+    // `scope_at` work by range arithmetic instead of pointer chasing.
+    pub(crate) descendants: Range<ScopeId>,
+}
+
+impl Scope {
+    pub fn parent(&self) -> Option<ScopeId> {
+        self.parent
+    }
+
+    pub fn kind(&self) -> ScopeKind {
+        self.kind
+    }
+
+    pub fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+// --- Symbol ---
+
+// Summary bits accumulated during the tree walk, so queries like "is this
+// symbol bound in this scope?" are O(1) without scanning binding/use lists.
+// Bitflags rather than a struct of bools for compact storage and composability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SymbolFlags(u8);
+
+impl SymbolFlags {
+    // Referenced by name in this scope.
+    pub const IS_USED: Self = Self(1 << 0);
+    // Given a value: assignment (`<-`, `=`) or parameter definition.
+    pub const IS_BOUND: Self = Self(1 << 1);
+    // Appears in a function's formal parameter list.
+    pub const IS_PARAMETER: Self = Self(1 << 2);
+
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub fn insert(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+}
+
+#[derive(Debug)]
+pub struct Symbol {
+    pub(crate) name: String,
+    pub(crate) flags: SymbolFlags,
+}
+
+impl Symbol {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn flags(&self) -> SymbolFlags {
+        self.flags
+    }
+}
+
+// --- Symbol table (per scope) ---
+
+// Read-only after construction. The builder uses `SymbolTableBuilder`.
+#[derive(Debug, Default)]
+pub struct SymbolTable {
+    symbols: IndexVec<SymbolId, Symbol>,
+
+    // Note that ty uses `hashbrown::HashTable` to provide lookup by name
+    // without storing the name twice
+    by_name: FxHashMap<String, SymbolId>,
+}
+
+impl SymbolTable {
+    pub fn get(&self, name: &str) -> Option<&Symbol> {
+        self.by_name.get(name).map(|&id| &self.symbols[id])
+    }
+
+    pub fn id(&self, name: &str) -> Option<SymbolId> {
+        self.by_name.get(name).copied()
+    }
+
+    pub fn symbol(&self, id: SymbolId) -> &Symbol {
+        &self.symbols[id]
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (SymbolId, &Symbol)> {
+        self.symbols.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.symbols.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SymbolTableBuilder {
+    table: SymbolTable,
+}
+
+impl SymbolTableBuilder {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn intern(&mut self, name: &str, flags: SymbolFlags) -> SymbolId {
+        if let Some(&id) = self.table.by_name.get(name) {
+            self.table.symbols[id].flags.insert(flags);
+            return id;
+        }
+        let id = self.table.symbols.push(Symbol {
+            name: name.to_owned(),
+            flags,
+        });
+        self.table.by_name.insert(name.to_owned(), id);
+        id
+    }
+
+    pub(crate) fn build(self) -> SymbolTable {
+        self.table
+    }
+}
+
+impl std::ops::Deref for SymbolTableBuilder {
+    type Target = SymbolTable;
+
+    fn deref(&self) -> &SymbolTable {
+        &self.table
+    }
+}
+
+// --- Binding and Use sites ---
+
+#[derive(Debug)]
+pub struct Binding {
+    pub(crate) symbol: SymbolId,
+    pub(crate) range: TextRange,
+}
+
+impl Binding {
+    pub fn symbol(&self) -> SymbolId {
+        self.symbol
+    }
+
+    pub fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+#[derive(Debug)]
+pub struct Use {
+    pub(crate) symbol: SymbolId,
+    pub(crate) range: TextRange,
+}
+
+impl Use {
+    pub fn symbol(&self) -> SymbolId {
+        self.symbol
+    }
+
+    pub fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+// --- Iterators ---
+
+pub struct ChildScopesIter<'a> {
+    index: &'a SemanticIndex,
+    current: ScopeId,
+    end: ScopeId,
+}
+
+impl<'a> Iterator for ChildScopesIter<'a> {
+    type Item = ScopeId;
+
+    fn next(&mut self) -> Option<ScopeId> {
+        if self.current >= self.end {
+            return None;
+        }
+        let id = self.current;
+        // Skip over this child's descendants to get to the next sibling
+        self.current = self.index.scopes[id].descendants.end;
+        Some(id)
+    }
+}
+
+pub struct AncestorsIter<'a> {
+    index: &'a SemanticIndex,
+    current: Option<ScopeId>,
+}
+
+impl<'a> Iterator for AncestorsIter<'a> {
+    type Item = ScopeId;
+
+    fn next(&mut self) -> Option<ScopeId> {
+        let id = self.current?;
+        self.current = self.index.scopes[id].parent;
+        Some(id)
+    }
+}

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -309,6 +309,10 @@ impl SymbolFlags {
     pub const IS_BOUND: Self = Self(1 << 1);
     // Appears in a function's formal parameter list.
     pub const IS_PARAMETER: Self = Self(1 << 2);
+    // Target of a super-assignment (`<<-`, `->>`). Recorded in the scope
+    // where the expression lexically appears, not in the target ancestor
+    // scope. Not visible to `resolve_symbol` (which checks `IS_BOUND`).
+    pub const IS_SUPER_BOUND: Self = Self(1 << 3);
 
     pub const fn empty() -> Self {
         Self(0)

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -125,7 +125,7 @@ impl SemanticIndex {
                 if self.symbol_tables[ancestor]
                     .symbol(id)
                     .flags
-                    .contains(SymbolFlags::IS_BOUND)
+                    .intersects(SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND))
                 {
                     return Some((ancestor, id));
                 }
@@ -179,10 +179,14 @@ pub struct SymbolFlags(u8);
 impl SymbolFlags {
     // Referenced by name in this scope.
     pub const IS_USED: Self = Self(1 << 0);
-    // Given a value: assignment (`<-`, `=`) or parameter definition.
+    // Given a value: assignment (`<-`, `=`, `->`) or parameter definition.
     pub const IS_BOUND: Self = Self(1 << 1);
     // Appears in a function's formal parameter list.
     pub const IS_PARAMETER: Self = Self(1 << 2);
+    // Given a value via superassignment (`<<-`, `->>`). The binding is
+    // recorded in the nearest ancestor scope that already binds the name,
+    // or the file scope if none does (matching R's runtime semantics).
+    pub const IS_SUPER_BOUND: Self = Self(1 << 3);
 
     pub const fn empty() -> Self {
         Self(0)
@@ -190,6 +194,11 @@ impl SymbolFlags {
 
     pub const fn contains(self, other: Self) -> bool {
         self.0 & other.0 == other.0
+    }
+
+    /// Returns `true` if `self` and `other` share at least one flag.
+    pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
     }
 
     pub const fn union(self, other: Self) -> Self {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -12,10 +12,10 @@ define_index!(ScopeId);
 // Scope-local symbol identifier
 define_index!(SymbolId);
 
-// Definition site identifier
+// Scope-local definition site identifier
 define_index!(DefinitionId);
 
-// Use site identifier
+// Scope-local use site identifier
 define_index!(UseId);
 
 // One `SemanticIndex` per R source file. This reflects the physical reality of
@@ -42,9 +42,10 @@ pub struct SemanticIndex {
     // and go-to-definition by letting us find all sites for a given symbol
     // without control-flow analysis.
     //
-    // In ty, this role is filled by salsa-tracked `Definition<'db>` structs
-    // and `AstIds`. When we introduce salsa, these lists may be restructured
-    // to match.
+    // In ty, definitions are salsa-tracked `Definition<'db>` structs (stored
+    // in `definitions_by_node`), and use sites are tracked via `AstIds`
+    // (a per-scope map from AST node positions to `ScopedUseId`). When we
+    // introduce salsa, these lists may be restructured to match.
     //
     // Use-def maps will layer on top of these lists, not replace them. A
     // use-def map tracks which definitions reach each use through control flow,
@@ -137,6 +138,14 @@ impl SemanticIndex {
 
 // --- Scope ---
 
+// A lexical scope within a file. Each scope has its own symbol table,
+// definitions, and uses. The scope chain (via `parent`) is always bounded
+// by the file: walking `parent` from any scope eventually reaches the
+// `File` scope which itself has `parent: None`.
+//
+// Currently only `function()` creates a new scope. In the future, constructs
+// like `local()`, `with()`, `within()` may also create scopes (determined
+// by function declarations resolved via salsa queries).
 #[derive(Debug)]
 pub struct Scope {
     pub(crate) parent: Option<ScopeId>,
@@ -150,6 +159,9 @@ pub struct Scope {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScopeKind {
+    // The file's top-level scope. Every file has exactly one, always at
+    // `ScopeId(0)`. Unresolved names fall through to this scope, where
+    // cross-file resolution (package namespace, session, etc.) takes over.
     File,
     Function,
 }
@@ -244,6 +256,20 @@ impl std::ops::Deref for SymbolTableBuilder {
 
 // --- Symbol ---
 
+// The unique identity of a name within a scope. A symbol is created the first
+// time a name is encountered (as a binding or a use), and subsequent
+// occurrences of the same name in that scope merge their flags into the
+// existing symbol.
+//
+// Definitions and uses reference symbols via `SymbolId`. The symbol itself
+// doesn't track where it's defined or used, that's the job of the `Definition`
+// and `Use` lists. The symbol just records the name and summary flags (bound?
+// used? parameter?).
+//
+// In ty, symbols live in a `PlaceTable` (which generalizes to include member
+// access like `x.y`). `resolve_symbol()` walks the scope chain looking for a
+// symbol with `IS_BOUND`. Future type inference will look up the symbol's
+// definitions and infer a type from them.
 #[derive(Debug)]
 pub struct Symbol {
     pub(crate) name: String,
@@ -298,19 +324,47 @@ impl SymbolFlags {
 
 // --- Definition and Use sites ---
 
+// A site where a symbol is bound (given a value) or declared (given a type
+// constraint). Bridges the scope/symbol layer (which symbol, which scope)
+// and the syntax layer (what construct created it, via `DefinitionKind`).
+//
+// A symbol can have multiple definitions in the same scope (e.g. `x <- 1`
+// then `x <- 2`). In ty, `DefinitionKind` classifies the construct
+// (assignment, parameter, for-variable) and carries a reference to the
+// syntax node. This split matters for salsa: the kind is marked `#[no_eq]`
+// so that editing the RHS of an assignment re-runs type inference for that
+// definition without invalidating the definition's identity (file + scope +
+// place) or the UseDefMap.
+//
+// Our definitions don't carry file or scope because they live inside the
+// `SemanticIndex` at a known position (`definitions[scope_id][def_id]`).
+// In ty, `Definition<'db>` is a self-contained salsa tracked struct that
+// carries file + scope + place, because it gets passed around independently
+// to type inference queries and cross-file lookups. We'll add those fields
+// when salsa is introduced.
+//
+// Type inference will eventually take a definition as input and inspect
+// the syntax node (via the kind) to determine the type.
+//
+// ty also classifies definitions into categories: `Binding` (gives a value),
+// `Declaration` (constrains a type), or `DeclarationAndBinding` (both).
+// For R, most definitions are bindings today, but function definitions are
+// implicitly declarations (they declare a name as a function with a specific
+// signature). Future `declare()` annotations will also produce pure
+// declarations.
+#[derive(Debug)]
+pub struct Definition {
+    pub(crate) symbol: SymbolId,
+    pub(crate) kind: DefinitionKind,
+    pub(crate) range: TextRange,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefinitionKind {
     Assignment,
     SuperAssignment,
     Parameter,
     ForVariable,
-}
-
-#[derive(Debug)]
-pub struct Definition {
-    pub(crate) symbol: SymbolId,
-    pub(crate) kind: DefinitionKind,
-    pub(crate) range: TextRange,
 }
 
 impl Definition {
@@ -327,6 +381,11 @@ impl Definition {
     }
 }
 
+// A site where a symbol is referenced by name. In ty, use sites are tracked
+// via `ScopedUseId` indices in a per-scope `AstIds` structure (mapping AST
+// node positions to use IDs). Our flat list serves the same purpose: the
+// `UseDefMap` will reference `UseId` indices into this list to connect each
+// use to its reaching definitions.
 #[derive(Debug)]
 pub struct Use {
     pub(crate) symbol: SymbolId,

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -290,6 +290,15 @@ impl Symbol {
 // Summary bits accumulated during the tree walk, so queries like "is this
 // symbol bound in this scope?" are O(1) without scanning binding/use lists.
 // Bitflags rather than a struct of bools for compact storage and composability.
+//
+// These flags are scope-level summaries, not fine-grained enough to
+// implement LSP features directly. For example, `IS_BOUND` says "x is
+// bound somewhere in this scope" but can't answer "which definition of x
+// reaches this point?" or "is x defined before this use?". Use-def maps
+// provide that precision. The flags remain useful for scope-level queries
+// like `resolve_symbol` and `resolve_super_target` (which walk the scope
+// chain checking `IS_BOUND`). They can also be useful as filters for
+// short-circuiting unneeded expensive operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SymbolFlags(u8);
 

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -137,12 +137,6 @@ impl SemanticIndex {
 
 // --- Scope ---
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ScopeKind {
-    File,
-    Function,
-}
-
 #[derive(Debug)]
 pub struct Scope {
     pub(crate) parent: Option<ScopeId>,
@@ -152,6 +146,12 @@ pub struct Scope {
     // occupy a contiguous range of IDs. This lets `child_scopes` and
     // `scope_at` work by range arithmetic instead of pointer chasing.
     pub(crate) descendants: Range<ScopeId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeKind {
+    File,
+    Function,
 }
 
 impl Scope {
@@ -165,60 +165,6 @@ impl Scope {
 
     pub fn range(&self) -> TextRange {
         self.range
-    }
-}
-
-// --- Symbol ---
-
-// Summary bits accumulated during the tree walk, so queries like "is this
-// symbol bound in this scope?" are O(1) without scanning binding/use lists.
-// Bitflags rather than a struct of bools for compact storage and composability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SymbolFlags(u8);
-
-impl SymbolFlags {
-    // Referenced by name in this scope.
-    pub const IS_USED: Self = Self(1 << 0);
-    // Given a value: assignment (`<-`, `=`, `->`) or parameter definition.
-    pub const IS_BOUND: Self = Self(1 << 1);
-    // Appears in a function's formal parameter list.
-    pub const IS_PARAMETER: Self = Self(1 << 2);
-
-    pub const fn empty() -> Self {
-        Self(0)
-    }
-
-    pub const fn contains(self, other: Self) -> bool {
-        self.0 & other.0 == other.0
-    }
-
-    /// Returns `true` if `self` and `other` share at least one flag.
-    pub const fn intersects(self, other: Self) -> bool {
-        self.0 & other.0 != 0
-    }
-
-    pub const fn union(self, other: Self) -> Self {
-        Self(self.0 | other.0)
-    }
-
-    pub fn insert(&mut self, other: Self) {
-        self.0 |= other.0;
-    }
-}
-
-#[derive(Debug)]
-pub struct Symbol {
-    pub(crate) name: String,
-    pub(crate) flags: SymbolFlags,
-}
-
-impl Symbol {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn flags(&self) -> SymbolFlags {
-        self.flags
     }
 }
 
@@ -293,6 +239,60 @@ impl std::ops::Deref for SymbolTableBuilder {
 
     fn deref(&self) -> &SymbolTable {
         &self.table
+    }
+}
+
+// --- Symbol ---
+
+#[derive(Debug)]
+pub struct Symbol {
+    pub(crate) name: String,
+    pub(crate) flags: SymbolFlags,
+}
+
+impl Symbol {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn flags(&self) -> SymbolFlags {
+        self.flags
+    }
+}
+
+// Summary bits accumulated during the tree walk, so queries like "is this
+// symbol bound in this scope?" are O(1) without scanning binding/use lists.
+// Bitflags rather than a struct of bools for compact storage and composability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SymbolFlags(u8);
+
+impl SymbolFlags {
+    // Referenced by name in this scope.
+    pub const IS_USED: Self = Self(1 << 0);
+    // Given a value: assignment (`<-`, `=`, `->`) or parameter definition.
+    pub const IS_BOUND: Self = Self(1 << 1);
+    // Appears in a function's formal parameter list.
+    pub const IS_PARAMETER: Self = Self(1 << 2);
+
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns `true` if `self` and `other` share at least one flag.
+    pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub fn insert(&mut self, other: Self) {
+        self.0 |= other.0;
     }
 }
 

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -444,3 +444,158 @@ fn test_right_assignment_complex_target() {
 
     assert_eq!(index.bindings(file).len(), 0);
 }
+
+#[test]
+fn test_super_assignment_at_file_scope() {
+    // At file scope there's no parent, so `<<-` lands in the file scope itself
+    let index = index("x <<- 1");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+
+    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.uses(file).len(), 0);
+}
+
+#[test]
+fn test_super_assignment_right_at_file_scope() {
+    let index = index("1 ->> x");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+
+    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.uses(file).len(), 0);
+}
+
+#[test]
+fn test_super_assignment_lands_in_file_scope() {
+    // No ancestor has a binding for `x`, so `<<-` lands in the file scope
+    let index = index("f <- function() { x <<- 1 }");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(index.bindings(file).len(), 2); // `f` + `x`
+
+    assert!(index.symbols(fun).get("x").is_none());
+    assert_eq!(index.bindings(fun).len(), 0);
+}
+
+#[test]
+fn test_super_assignment_right_lands_in_file_scope() {
+    let index = index("f <- function() { 1 ->> x }");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+
+    assert!(index.symbols(fun).get("x").is_none());
+}
+
+#[test]
+fn test_super_assignment_finds_existing_binding() {
+    // `x` is bound in the file scope, so `x <<- 2` inside the function
+    // lands there rather than creating a new binding
+    let index = index("x <- 1\nf <- function() { x <<- 2 }");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(
+        x.flags(),
+        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND)
+    );
+
+    // Two binding sites in file scope: the `<-` and the `<<-`
+    let x_bindings: Vec<_> = index
+        .bindings(file)
+        .iter()
+        .filter(|(_, b)| index.symbols(file).symbol(b.symbol()).name() == "x")
+        .collect();
+    assert_eq!(x_bindings.len(), 2);
+
+    assert!(index.symbols(fun).get("x").is_none());
+}
+
+#[test]
+fn test_super_assignment_finds_nearest_ancestor() {
+    // `x` is bound in both file and outer function; `<<-` should target the
+    // nearest ancestor (outer function), not the file scope.
+    let index = index("x <- 0\nf <- function() { x <- 1; g <- function() { x <<- 2 } }");
+    let file = ScopeId::from(0);
+    let outer = ScopeId::from(1);
+    let inner = ScopeId::from(2);
+
+    // Outer function gets both `IS_BOUND` (from `x <- 1`) and
+    // `IS_SUPER_BOUND` (from `x <<- 2` in the inner function)
+    let x_outer = index.symbols(outer).get("x").unwrap();
+    assert_eq!(
+        x_outer.flags(),
+        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND)
+    );
+
+    // File scope `x` is untouched by the inner `<<-`
+    let x_file = index.symbols(file).get("x").unwrap();
+    assert_eq!(x_file.flags(), SymbolFlags::IS_BOUND);
+
+    // Inner function has no binding for `x`
+    assert!(index.symbols(inner).get("x").is_none());
+}
+
+#[test]
+fn test_super_assignment_skips_use_only_ancestor() {
+    // Outer function uses `x` but doesn't bind it. `<<-` should skip it
+    // and land in the file scope where `x` is bound.
+    let index = index("x <- 1\nf <- function() { print(x); g <- function() { x <<- 2 } }");
+    let file = ScopeId::from(0);
+    let outer = ScopeId::from(1);
+    let inner = ScopeId::from(2);
+
+    let x_file = index.symbols(file).get("x").unwrap();
+    assert_eq!(
+        x_file.flags(),
+        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND)
+    );
+
+    // Outer function has `x` as `IS_USED` only (from `print(x)`)
+    let x_outer = index.symbols(outer).get("x").unwrap();
+    assert_eq!(x_outer.flags(), SymbolFlags::IS_USED);
+
+    assert!(index.symbols(inner).get("x").is_none());
+}
+
+#[test]
+fn test_super_assignment_resolvable() {
+    // `resolve_symbol` from inner scope finds the superassignment binding
+    // in the file scope
+    let index = index("f <- function() { x <<- 1 }");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    let (scope, _) = index.resolve_symbol("x", fun).unwrap();
+    assert_eq!(scope, file);
+}
+
+#[test]
+fn test_super_assignment_is_not_is_bound() {
+    let index = index("f <- function() { x <<- 1 }");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+}
+
+#[test]
+fn test_super_assignment_with_use_on_value_side() {
+    let index = index("f <- function() { x <<- y }");
+    let fun = ScopeId::from(1);
+
+    // `y` is a use in the function scope (where the expression lives)
+    let y = index.symbols(fun).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_USED);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -599,3 +599,82 @@ fn test_super_assignment_with_use_on_value_side() {
     let y = index.symbols(fun).get("y").unwrap();
     assert_eq!(y.flags(), SymbolFlags::IS_USED);
 }
+
+// --- NSE / quoting constructs ---
+//
+// Identifiers inside `~`, `quote()`, and `bquote()` are currently recorded
+// as uses. This is a known simplification; refining it is deferred as
+// future work. These tests document the current behaviour.
+
+#[test]
+fn test_fixme_formula_records_uses() {
+    let index = index("y ~ x + z");
+    let file = ScopeId::from(0);
+
+    assert_eq!(
+        index.symbols(file).get("y").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+    assert_eq!(
+        index.symbols(file).get("x").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+    assert_eq!(
+        index.symbols(file).get("z").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+}
+
+#[test]
+fn test_fixme_one_sided_formula_records_uses() {
+    let index = index("~ x + y");
+    let file = ScopeId::from(0);
+
+    assert_eq!(
+        index.symbols(file).get("x").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+    assert_eq!(
+        index.symbols(file).get("y").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+}
+
+#[test]
+fn test_fixme_quote_records_uses() {
+    let index = index("quote(x + y)");
+    let file = ScopeId::from(0);
+
+    assert_eq!(
+        index.symbols(file).get("quote").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+    assert_eq!(
+        index.symbols(file).get("x").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+    assert_eq!(
+        index.symbols(file).get("y").unwrap().flags(),
+        SymbolFlags::IS_USED
+    );
+}
+
+#[test]
+fn test_fixme_quote_records_assignment() {
+    let index = index("quote(x <- 1)");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.bindings(file).len(), 1);
+}
+
+#[test]
+fn test_fixme_formula_records_assignment() {
+    let index = index("~ (x <- 1)");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.bindings(file).len(), 1);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1039,44 +1039,84 @@ fn test_subset_named_argument_not_use() {
 }
 
 // --- Backticked identifiers ---
-//
-// Backticks are a quoting mechanism: `my var` and my_var both refer to
-// symbols. Currently the builder stores the raw text including backticks,
-// so lookup requires the backticks. This should be fixed so that the
-// canonical name strips backticks (they are not part of the symbol identity).
 
 #[test]
-fn test_fixme_backticked_identifier_includes_backticks() {
+fn test_backticked_identifier_assignment() {
     let index = index("`my var` <- 1");
     let file = ScopeId::from(0);
 
-    // Current behaviour: name includes backticks
-    assert!(index.symbols(file).get("`my var`").is_some());
-    assert!(index.symbols(file).get("my var").is_none());
+    let sym = index.symbols(file).get("my var").unwrap();
+    assert_eq!(sym.flags(), SymbolFlags::IS_BOUND);
     assert_eq!(index.definitions(file).len(), 1);
 }
 
 #[test]
-fn test_fixme_backticked_identifier_use_includes_backticks() {
+fn test_backticked_identifier_use() {
     let index = index("x <- `my var`");
     let file = ScopeId::from(0);
 
-    // Current behaviour: name includes backticks
-    assert!(index.symbols(file).get("`my var`").is_some());
-    assert!(index.symbols(file).get("my var").is_none());
+    let sym = index.symbols(file).get("my var").unwrap();
+    assert_eq!(sym.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_backticked_identifier_parameter() {
+    let index = index("function(`a b`) `a b`");
+    let fun = ScopeId::from(1);
+
+    let sym = index.symbols(fun).get("a b").unwrap();
+    assert_eq!(
+        sym.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+}
+
+#[test]
+fn test_backticked_for_variable() {
+    let index = index("for (`i j` in xs) `i j`");
+    let file = ScopeId::from(0);
+
+    let sym = index.symbols(file).get("i j").unwrap();
+    assert_eq!(
+        sym.flags(),
+        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED)
+    );
 }
 
 // --- String as assignment target ---
 
 #[test]
-fn test_fixme_string_assignment_target_no_binding() {
-    // `"x" <- 1` is equivalent to `x <- 1` in R, but the parser sees a
-    // string literal on the LHS, not an identifier. No binding is created.
+fn test_string_assignment_target() {
+    // `"x" <- 1` is equivalent to `x <- 1` in R
     let index = index("\"x\" <- 1");
     let file = ScopeId::from(0);
 
-    assert_eq!(index.definitions(file).len(), 0);
-    assert_eq!(index.symbols(file).len(), 0);
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.definitions(file).len(), 1);
+}
+
+#[test]
+fn test_string_assignment_right() {
+    let index = index("1 -> \"x\"");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.definitions(file).len(), 1);
+}
+
+#[test]
+fn test_string_super_assignment() {
+    let index = index("f <- function() { \"x\" <<- 1 }");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert!(index.symbols(fun).get("x").is_none());
 }
 
 // --- Multiple expressions (semicolons) ---

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -392,3 +392,55 @@ fn test_parenthesized_equals_is_assignment() {
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
     assert_eq!(index.bindings(file).len(), 1);
 }
+
+#[test]
+fn test_right_assignment() {
+    let index = index("1 -> x");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.symbols(file).len(), 1);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.uses(file).len(), 0);
+}
+
+#[test]
+fn test_right_assignment_with_use() {
+    let index = index("y -> x");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    let y = index.symbols(file).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_right_assignment_rhs_collected_before_lhs() {
+    let index = index("y -> x");
+    let file = ScopeId::from(0);
+
+    let use_site = &index.uses(file)[UseId::from(0)];
+    let use_sym = index.symbols(file).symbol(use_site.symbol());
+    assert_eq!(use_sym.name(), "y");
+
+    let bind_site = &index.bindings(file)[BindingId::from(0)];
+    let bind_sym = index.symbols(file).symbol(bind_site.symbol());
+    assert_eq!(bind_sym.name(), "x");
+}
+
+#[test]
+fn test_right_assignment_complex_target() {
+    // `1 -> x$foo` -- `x` is a use, not a binding
+    let index = index("1 -> x$foo");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    assert_eq!(index.bindings(file).len(), 0);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1,7 +1,8 @@
 use aether_parser::parse;
 use aether_parser::RParserOptions;
 use oak_index::builder::build;
-use oak_index::semantic_index::BindingId;
+use oak_index::semantic_index::DefinitionId;
+use oak_index::semantic_index::DefinitionKind;
 use oak_index::semantic_index::ScopeId;
 use oak_index::semantic_index::ScopeKind;
 use oak_index::semantic_index::SemanticIndex;
@@ -31,7 +32,11 @@ fn test_simple_assignment() {
     let sym = index.symbols(file).get("x").unwrap();
     assert_eq!(sym.flags(), SymbolFlags::IS_BOUND);
 
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
+    assert_eq!(
+        index.definitions(file)[DefinitionId::from(0)].kind(),
+        DefinitionKind::Assignment
+    );
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -57,13 +62,13 @@ fn test_assignment_with_use() {
     let y = index.symbols(file).get("y").unwrap();
     assert_eq!(y.flags(), SymbolFlags::IS_USED);
 
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
     assert_eq!(index.uses(file).len(), 1);
 }
 
 #[test]
 fn test_rhs_collected_before_lhs() {
-    // The first use site should be `y` (RHS) and the first binding site should be `x` (LHS).
+    // The first use site should be `y` (RHS) and the first definition site should be `x` (LHS).
     let index = index("x <- y");
     let file = ScopeId::from(0);
 
@@ -71,9 +76,9 @@ fn test_rhs_collected_before_lhs() {
     let use_sym = index.symbols(file).symbol(use_site.symbol());
     assert_eq!(use_sym.name(), "y");
 
-    let bind_site = &index.bindings(file)[BindingId::from(0)];
-    let bind_sym = index.symbols(file).symbol(bind_site.symbol());
-    assert_eq!(bind_sym.name(), "x");
+    let def_site = &index.definitions(file)[DefinitionId::from(0)];
+    let def_sym = index.symbols(file).symbol(def_site.symbol());
+    assert_eq!(def_sym.name(), "x");
 }
 
 #[test]
@@ -81,9 +86,9 @@ fn test_multiple_assignments_same_symbol() {
     let index = index("x <- 1\nx <- 2");
     let file = ScopeId::from(0);
 
-    // One symbol, two binding sites
+    // One symbol, two definition sites
     assert_eq!(index.symbols(file).len(), 1);
-    assert_eq!(index.bindings(file).len(), 2);
+    assert_eq!(index.definitions(file).len(), 2);
 }
 
 #[test]
@@ -112,7 +117,11 @@ fn test_function_creates_scope() {
             .union(SymbolFlags::IS_USED)
     );
 
-    assert_eq!(index.bindings(fun_scope).len(), 1);
+    assert_eq!(index.definitions(fun_scope).len(), 1);
+    assert_eq!(
+        index.definitions(fun_scope)[DefinitionId::from(0)].kind(),
+        DefinitionKind::Parameter
+    );
     assert_eq!(index.uses(fun_scope).len(), 1);
 }
 
@@ -167,7 +176,7 @@ fn test_call_argument_equals_not_assignment() {
     let index = index("f(x = 1)");
     let file = ScopeId::from(0);
 
-    // Only `f` is recorded (as a use), `x` is an argument name, not a binding
+    // Only `f` is recorded (as a use), `x` is an argument name, not a definition
     assert_eq!(index.symbols(file).len(), 1);
     assert!(index.symbols(file).get("f").is_some());
     assert!(index.symbols(file).get("x").is_none());
@@ -183,7 +192,7 @@ fn test_complex_lhs_not_binding() {
     assert_eq!(x.flags(), SymbolFlags::IS_USED);
 
     assert!(index.symbols(file).get("foo").is_none());
-    assert_eq!(index.bindings(file).len(), 0);
+    assert_eq!(index.definitions(file).len(), 0);
 }
 
 #[test]
@@ -270,6 +279,11 @@ fn test_for_loop_body() {
 
     let i = idx.symbols(file).get("i").unwrap();
     assert_eq!(i.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+
+    assert_eq!(
+        idx.definitions(file)[DefinitionId::from(0)].kind(),
+        DefinitionKind::ForVariable
+    );
 }
 
 #[test]
@@ -293,7 +307,7 @@ fn test_braced_expression_assignments() {
     let index = index("f <- function() {\n  x <- 1\n  y <- x\n}");
     let fun = ScopeId::from(1);
 
-    assert_eq!(index.bindings(fun).len(), 2);
+    assert_eq!(index.definitions(fun).len(), 2);
     assert!(index.symbols(fun).get("x").is_some());
     assert!(index.symbols(fun).get("y").is_some());
 
@@ -345,19 +359,19 @@ fn test_arrow_assignment_in_if_condition() {
 
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
 }
 
 #[test]
 fn test_arrow_assignment_in_call_argument() {
-    // `<-` in a call argument still creates a binding in the enclosing scope
+    // `<-` in a call argument still creates a definition in the enclosing scope
     let index = index("f(x <- 1)");
     let file = ScopeId::from(0);
 
     assert!(index.symbols(file).get("x").is_some());
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
 }
 
 #[test]
@@ -367,7 +381,7 @@ fn test_equals_in_call_argument_still_not_assignment() {
     let file = ScopeId::from(0);
 
     assert!(index.symbols(file).get("x").is_none());
-    assert_eq!(index.bindings(file).len(), 0);
+    assert_eq!(index.definitions(file).len(), 0);
 }
 
 #[test]
@@ -378,7 +392,7 @@ fn test_parenthesized_arrow_assignment() {
 
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
 }
 
 #[test]
@@ -391,7 +405,7 @@ fn test_parenthesized_equals_is_assignment() {
 
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
 }
 
 #[test]
@@ -404,7 +418,7 @@ fn test_right_assignment() {
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -429,9 +443,9 @@ fn test_right_assignment_rhs_collected_before_lhs() {
     let use_sym = index.symbols(file).symbol(use_site.symbol());
     assert_eq!(use_sym.name(), "y");
 
-    let bind_site = &index.bindings(file)[BindingId::from(0)];
-    let bind_sym = index.symbols(file).symbol(bind_site.symbol());
-    assert_eq!(bind_sym.name(), "x");
+    let def_site = &index.definitions(file)[DefinitionId::from(0)];
+    let def_sym = index.symbols(file).symbol(def_site.symbol());
+    assert_eq!(def_sym.name(), "x");
 }
 
 #[test]
@@ -443,7 +457,7 @@ fn test_right_assignment_complex_target() {
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_USED);
 
-    assert_eq!(index.bindings(file).len(), 0);
+    assert_eq!(index.definitions(file).len(), 0);
 }
 
 #[test]
@@ -457,7 +471,7 @@ fn test_subset_assignment_complex_lhs() {
     let value = index.symbols(file).get("value").unwrap();
     assert_eq!(value.flags(), SymbolFlags::IS_USED);
 
-    assert_eq!(index.bindings(file).len(), 0);
+    assert_eq!(index.definitions(file).len(), 0);
 }
 
 #[test]
@@ -468,7 +482,7 @@ fn test_double_bracket_assignment_complex_lhs() {
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_USED);
 
-    assert_eq!(index.bindings(file).len(), 0);
+    assert_eq!(index.definitions(file).len(), 0);
 }
 
 #[test]
@@ -530,9 +544,13 @@ fn test_super_assignment_at_file_scope() {
     let file = ScopeId::from(0);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
+    assert_eq!(
+        index.definitions(file)[DefinitionId::from(0)].kind(),
+        DefinitionKind::SuperAssignment
+    );
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -542,25 +560,40 @@ fn test_super_assignment_right_at_file_scope() {
     let file = ScopeId::from(0);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
+    assert_eq!(
+        index.definitions(file)[DefinitionId::from(0)].kind(),
+        DefinitionKind::SuperAssignment
+    );
     assert_eq!(index.uses(file).len(), 0);
 }
 
 #[test]
 fn test_super_assignment_lands_in_file_scope() {
-    // No ancestor has a binding for `x`, so `<<-` lands in the file scope
+    // No ancestor has a definition for `x`, so `<<-` lands in the file scope
     let index = index("f <- function() { x <<- 1 }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
-    assert_eq!(index.bindings(file).len(), 2); // `f` + `x`
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.definitions(file).len(), 2); // `f` + `x`
+
+    // `x <<- 1` is visited during the function body (value side) before
+    // `f` gets its binding (target side)
+    assert_eq!(
+        index.definitions(file)[DefinitionId::from(0)].kind(),
+        DefinitionKind::SuperAssignment
+    );
+    assert_eq!(
+        index.definitions(file)[DefinitionId::from(1)].kind(),
+        DefinitionKind::Assignment
+    );
 
     assert!(index.symbols(fun).get("x").is_none());
-    assert_eq!(index.bindings(fun).len(), 0);
+    assert_eq!(index.definitions(fun).len(), 0);
 }
 
 #[test]
@@ -570,7 +603,7 @@ fn test_super_assignment_right_lands_in_file_scope() {
     let fun = ScopeId::from(1);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
     assert!(index.symbols(fun).get("x").is_none());
 }
@@ -578,7 +611,7 @@ fn test_super_assignment_right_lands_in_file_scope() {
 #[test]
 fn test_super_assignment_finds_existing_binding() {
     // `x` is bound in the file scope, so `x <<- 2` inside the function
-    // lands there rather than creating a new binding
+    // lands there rather than creating a new definition
     let index = index("x <- 1\nf <- function() { x <<- 2 }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
@@ -586,13 +619,17 @@ fn test_super_assignment_finds_existing_binding() {
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
-    // Two binding sites in file scope: the `<-` and the `<<-`
-    let x_bindings: Vec<_> = index
-        .bindings(file)
+    // Two definition sites in file scope: the `<-` and the `<<-`
+    let x_defs: Vec<_> = index
+        .definitions(file)
         .iter()
-        .filter(|(_, b)| index.symbols(file).symbol(b.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
         .collect();
-    assert_eq!(x_bindings.len(), 2);
+    assert_eq!(x_defs.len(), 2);
+
+    // First is Assignment, second is SuperAssignment
+    assert_eq!(x_defs[0].1.kind(), DefinitionKind::Assignment);
+    assert_eq!(x_defs[1].1.kind(), DefinitionKind::SuperAssignment);
 
     assert!(index.symbols(fun).get("x").is_none());
 }
@@ -606,15 +643,24 @@ fn test_super_assignment_finds_nearest_ancestor() {
     let outer = ScopeId::from(1);
     let inner = ScopeId::from(2);
 
-    // `<<-` targeting an existing binding uses `IS_BOUND`, not `IS_SUPER_BOUND`
+    // Outer function has both Assignment and SuperAssignment definitions for `x`
     let x_outer = index.symbols(outer).get("x").unwrap();
     assert_eq!(x_outer.flags(), SymbolFlags::IS_BOUND);
+
+    let x_outer_defs: Vec<_> = index
+        .definitions(outer)
+        .iter()
+        .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
+        .collect();
+    assert_eq!(x_outer_defs.len(), 2);
+    assert_eq!(x_outer_defs[0].1.kind(), DefinitionKind::Assignment);
+    assert_eq!(x_outer_defs[1].1.kind(), DefinitionKind::SuperAssignment);
 
     // File scope `x` is untouched by the inner `<<-`
     let x_file = index.symbols(file).get("x").unwrap();
     assert_eq!(x_file.flags(), SymbolFlags::IS_BOUND);
 
-    // Inner function has no binding for `x`
+    // Inner function has no definition for `x`
     assert!(index.symbols(inner).get("x").is_none());
 }
 
@@ -644,7 +690,16 @@ fn test_super_assignment_creates_file_scope_binding() {
     let fun = ScopeId::from(1);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    // The definition is a SuperAssignment
+    let x_defs: Vec<_> = index
+        .definitions(file)
+        .iter()
+        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
+        .collect();
+    assert_eq!(x_defs.len(), 1);
+    assert_eq!(x_defs[0].1.kind(), DefinitionKind::SuperAssignment);
 
     let (scope, _) = index.resolve_symbol("x", fun).unwrap();
     assert_eq!(scope, file);
@@ -726,7 +781,7 @@ fn test_fixme_quote_records_assignment() {
 
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
 }
 
 #[test]
@@ -736,5 +791,5 @@ fn test_fixme_formula_records_assignment() {
 
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.definitions(file).len(), 1);
 }

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -182,6 +182,7 @@ fn test_complex_lhs_not_binding() {
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_USED);
 
+    assert!(index.symbols(file).get("foo").is_none());
     assert_eq!(index.bindings(file).len(), 0);
 }
 
@@ -443,6 +444,83 @@ fn test_right_assignment_complex_target() {
     assert_eq!(x.flags(), SymbolFlags::IS_USED);
 
     assert_eq!(index.bindings(file).len(), 0);
+}
+
+#[test]
+fn test_subset_assignment_complex_lhs() {
+    let index = index("x[1] <- value");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    let value = index.symbols(file).get("value").unwrap();
+    assert_eq!(value.flags(), SymbolFlags::IS_USED);
+
+    assert_eq!(index.bindings(file).len(), 0);
+}
+
+#[test]
+fn test_double_bracket_assignment_complex_lhs() {
+    let index = index("x[[1]] <- value");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    assert_eq!(index.bindings(file).len(), 0);
+}
+
+#[test]
+fn test_at_extraction() {
+    let index = index("x@slot");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    // `slot` is not recorded as a use
+    assert!(index.symbols(file).get("slot").is_none());
+    assert_eq!(index.symbols(file).len(), 1);
+}
+
+#[test]
+fn test_namespace_expression_no_uses() {
+    let index = index("dplyr::filter");
+    let file = ScopeId::from(0);
+
+    assert!(index.symbols(file).get("dplyr").is_none());
+    assert!(index.symbols(file).get("filter").is_none());
+    assert_eq!(index.symbols(file).len(), 0);
+}
+
+#[test]
+fn test_triple_colon_namespace_no_uses() {
+    let index = index("pkg:::internal_fn");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.symbols(file).len(), 0);
+}
+
+#[test]
+fn test_while_loop() {
+    let index = index("while (cond) x");
+    let file = ScopeId::from(0);
+
+    let cond = index.symbols(file).get("cond").unwrap();
+    assert_eq!(cond.flags(), SymbolFlags::IS_USED);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_repeat_loop() {
+    let index = index("repeat x");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
 }
 
 #[test]

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -812,3 +812,317 @@ fn test_fixme_formula_records_assignment() {
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
     assert_eq!(index.definitions(file).len(), 1);
 }
+
+// --- Lambda syntax ---
+
+#[test]
+fn test_lambda_creates_scope() {
+    let index = index(r"f <- \(x) x");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    assert_eq!(
+        index.symbols(file).get("f").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+
+    assert_eq!(index.scope(fun).kind(), ScopeKind::Function);
+    assert_eq!(index.scope(fun).parent(), Some(file));
+
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(
+        x.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+}
+
+#[test]
+fn test_lambda_nested() {
+    let index = index(r"\(x) \(y) x + y");
+    let outer = ScopeId::from(1);
+    let inner = ScopeId::from(2);
+
+    let x = index.symbols(outer).get("x").unwrap();
+    assert_eq!(
+        x.flags(),
+        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_PARAMETER)
+    );
+
+    let x_inner = index.symbols(inner).get("x").unwrap();
+    assert_eq!(x_inner.flags(), SymbolFlags::IS_USED);
+
+    let y = index.symbols(inner).get("y").unwrap();
+    assert_eq!(
+        y.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+}
+
+// --- Unary expressions ---
+
+#[test]
+fn test_unary_not() {
+    let index = index("!x");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_unary_minus() {
+    let index = index("-x");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+}
+
+// --- Return, break, next ---
+
+#[test]
+fn test_return_expression() {
+    let index = index("function() return(x)");
+    let fun = ScopeId::from(1);
+
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_break_no_uses() {
+    let index = index("while (TRUE) break");
+    let file = ScopeId::from(0);
+
+    // Only `TRUE` is in the tree, `break` has no identifier children
+    assert_eq!(index.symbols(file).len(), 0);
+    assert_eq!(index.uses(file).len(), 0);
+}
+
+#[test]
+fn test_next_no_uses() {
+    let index = index("while (TRUE) next");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.symbols(file).len(), 0);
+    assert_eq!(index.uses(file).len(), 0);
+}
+
+// --- Pipe operator ---
+
+#[test]
+fn test_pipe_operator() {
+    let index = index("x |> f()");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    let f = index.symbols(file).get("f").unwrap();
+    assert_eq!(f.flags(), SymbolFlags::IS_USED);
+}
+
+// --- Chained / nested assignments ---
+
+#[test]
+fn test_chained_assignment() {
+    let index = index("x <- y <- 1");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    let y = index.symbols(file).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_BOUND);
+
+    assert_eq!(index.definitions(file).len(), 2);
+}
+
+// --- Call arguments ---
+
+#[test]
+fn test_positional_call_arguments_are_uses() {
+    let index = index("f(a, b)");
+    let file = ScopeId::from(0);
+
+    let f = index.symbols(file).get("f").unwrap();
+    assert_eq!(f.flags(), SymbolFlags::IS_USED);
+
+    let a = index.symbols(file).get("a").unwrap();
+    assert_eq!(a.flags(), SymbolFlags::IS_USED);
+
+    let b = index.symbols(file).get("b").unwrap();
+    assert_eq!(b.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_named_call_argument_value_is_use() {
+    // For `f(x = y)`, `y` should be a use but `x` should not.
+    let index = index("f(x = y)");
+    let file = ScopeId::from(0);
+
+    assert!(index.symbols(file).get("x").is_none());
+
+    let y = index.symbols(file).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_function_as_call_argument() {
+    let index = index("lapply(xs, function(x) x + 1)");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    let lapply = index.symbols(file).get("lapply").unwrap();
+    assert_eq!(lapply.flags(), SymbolFlags::IS_USED);
+
+    let xs = index.symbols(file).get("xs").unwrap();
+    assert_eq!(xs.flags(), SymbolFlags::IS_USED);
+
+    assert_eq!(index.scope(fun).kind(), ScopeKind::Function);
+    assert_eq!(index.scope(fun).parent(), Some(file));
+
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(
+        x.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+}
+
+#[test]
+fn test_nested_calls() {
+    let index = index("f(g(x))");
+    let file = ScopeId::from(0);
+
+    let f = index.symbols(file).get("f").unwrap();
+    assert_eq!(f.flags(), SymbolFlags::IS_USED);
+
+    let g = index.symbols(file).get("g").unwrap();
+    assert_eq!(g.flags(), SymbolFlags::IS_USED);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+}
+
+// --- Chained extraction ---
+
+#[test]
+fn test_chained_dollar_extraction() {
+    // `x$a$b` — only `x` should be a use
+    let index = index("x$a$b");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.symbols(file).len(), 1);
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+}
+
+// --- Subset with named argument ---
+
+#[test]
+fn test_subset_named_argument_not_use() {
+    // `x[drop = FALSE]` — `drop` is an argument name, not a use
+    let index = index("x[drop = FALSE]");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    assert!(index.symbols(file).get("drop").is_none());
+    assert_eq!(index.symbols(file).len(), 1);
+}
+
+// --- Backticked identifiers ---
+//
+// Backticks are a quoting mechanism: `my var` and my_var both refer to
+// symbols. Currently the builder stores the raw text including backticks,
+// so lookup requires the backticks. This should be fixed so that the
+// canonical name strips backticks (they are not part of the symbol identity).
+
+#[test]
+fn test_fixme_backticked_identifier_includes_backticks() {
+    let index = index("`my var` <- 1");
+    let file = ScopeId::from(0);
+
+    // Current behaviour: name includes backticks
+    assert!(index.symbols(file).get("`my var`").is_some());
+    assert!(index.symbols(file).get("my var").is_none());
+    assert_eq!(index.definitions(file).len(), 1);
+}
+
+#[test]
+fn test_fixme_backticked_identifier_use_includes_backticks() {
+    let index = index("x <- `my var`");
+    let file = ScopeId::from(0);
+
+    // Current behaviour: name includes backticks
+    assert!(index.symbols(file).get("`my var`").is_some());
+    assert!(index.symbols(file).get("my var").is_none());
+}
+
+// --- String as assignment target ---
+
+#[test]
+fn test_fixme_string_assignment_target_no_binding() {
+    // `"x" <- 1` is equivalent to `x <- 1` in R, but the parser sees a
+    // string literal on the LHS, not an identifier. No binding is created.
+    let index = index("\"x\" <- 1");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.definitions(file).len(), 0);
+    assert_eq!(index.symbols(file).len(), 0);
+}
+
+// --- Multiple expressions (semicolons) ---
+
+#[test]
+fn test_semicolons_multiple_expressions() {
+    let index = index("x <- 1; y <- 2");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    let y = index.symbols(file).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_BOUND);
+
+    assert_eq!(index.definitions(file).len(), 2);
+}
+
+// --- Nested for loops ---
+
+#[test]
+fn test_nested_for_loops() {
+    let index = index("for (i in xs) for (j in ys) f(i, j)");
+    let file = ScopeId::from(0);
+
+    let i = index.symbols(file).get("i").unwrap();
+    assert_eq!(i.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+
+    let j = index.symbols(file).get("j").unwrap();
+    assert_eq!(j.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+
+    assert_eq!(index.definitions(file).len(), 2);
+}
+
+// --- Assignment in loop body ---
+
+#[test]
+fn test_assignment_in_for_body() {
+    let index = index("for (i in xs) x <- i");
+    let file = ScopeId::from(0);
+
+    let i = index.symbols(file).get("i").unwrap();
+    assert_eq!(i.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    assert_eq!(index.definitions(file).len(), 2);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -12,6 +12,11 @@ use oak_index::semantic_index::UseId;
 
 fn index(source: &str) -> SemanticIndex {
     let parsed = parse(source, RParserOptions::default());
+
+    if parsed.has_error() {
+        panic!("source has syntax errors: {source}");
+    }
+
     build(&parsed.tree())
 }
 

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1,0 +1,394 @@
+use aether_parser::parse;
+use aether_parser::RParserOptions;
+use oak_index::builder::build;
+use oak_index::semantic_index::BindingId;
+use oak_index::semantic_index::ScopeId;
+use oak_index::semantic_index::ScopeKind;
+use oak_index::semantic_index::SemanticIndex;
+use oak_index::semantic_index::SymbolFlags;
+use oak_index::semantic_index::UseId;
+
+fn index(source: &str) -> SemanticIndex {
+    let parsed = parse(source, RParserOptions::default());
+    build(&parsed.tree())
+}
+
+#[test]
+fn test_empty_file() {
+    let index = index("");
+    let file = ScopeId::from(0);
+    assert_eq!(index.scope(file).kind(), ScopeKind::File);
+    assert_eq!(index.symbols(file).len(), 0);
+}
+
+#[test]
+fn test_simple_assignment() {
+    let index = index("x <- 1");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.symbols(file).len(), 1);
+
+    let sym = index.symbols(file).get("x").unwrap();
+    assert_eq!(sym.flags(), SymbolFlags::IS_BOUND);
+
+    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.uses(file).len(), 0);
+}
+
+#[test]
+fn test_equals_assignment() {
+    let index = index("x = 1");
+    let file = ScopeId::from(0);
+
+    let sym = index.symbols(file).get("x").unwrap();
+    assert_eq!(sym.flags(), SymbolFlags::IS_BOUND);
+}
+
+#[test]
+fn test_assignment_with_use() {
+    let index = index("x <- y");
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.symbols(file).len(), 2);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+
+    let y = index.symbols(file).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_USED);
+
+    assert_eq!(index.bindings(file).len(), 1);
+    assert_eq!(index.uses(file).len(), 1);
+}
+
+#[test]
+fn test_rhs_collected_before_lhs() {
+    // The first use site should be `y` (RHS) and the first binding site should be `x` (LHS).
+    let index = index("x <- y");
+    let file = ScopeId::from(0);
+
+    let use_site = &index.uses(file)[UseId::from(0)];
+    let use_sym = index.symbols(file).symbol(use_site.symbol());
+    assert_eq!(use_sym.name(), "y");
+
+    let bind_site = &index.bindings(file)[BindingId::from(0)];
+    let bind_sym = index.symbols(file).symbol(bind_site.symbol());
+    assert_eq!(bind_sym.name(), "x");
+}
+
+#[test]
+fn test_multiple_assignments_same_symbol() {
+    let index = index("x <- 1\nx <- 2");
+    let file = ScopeId::from(0);
+
+    // One symbol, two binding sites
+    assert_eq!(index.symbols(file).len(), 1);
+    assert_eq!(index.bindings(file).len(), 2);
+}
+
+#[test]
+fn test_function_creates_scope() {
+    let index = index("f <- function(x) x");
+    let file = ScopeId::from(0);
+    let fun_scope = ScopeId::from(1);
+
+    // File scope has `f`
+    assert_eq!(index.symbols(file).len(), 1);
+    assert_eq!(
+        index.symbols(file).get("f").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+
+    // Function scope
+    assert_eq!(index.scope(fun_scope).kind(), ScopeKind::Function);
+    assert_eq!(index.scope(fun_scope).parent(), Some(file));
+
+    // Function scope has `x` as parameter and use
+    let x = index.symbols(fun_scope).get("x").unwrap();
+    assert_eq!(
+        x.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+
+    assert_eq!(index.bindings(fun_scope).len(), 1);
+    assert_eq!(index.uses(fun_scope).len(), 1);
+}
+
+#[test]
+fn test_nested_functions() {
+    let index = index("f <- function(x) function(y) x + y");
+    let file = ScopeId::from(0);
+    let outer = ScopeId::from(1);
+    let inner = ScopeId::from(2);
+
+    // File scope: `f`
+    assert_eq!(index.symbols(file).len(), 1);
+
+    // Outer function: `x` as parameter (no use in this scope)
+    assert_eq!(index.scope(outer).kind(), ScopeKind::Function);
+    let x = index.symbols(outer).get("x").unwrap();
+    assert_eq!(
+        x.flags(),
+        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_PARAMETER)
+    );
+
+    // Inner function: `y` as parameter+use, `x` as use
+    assert_eq!(index.scope(inner).kind(), ScopeKind::Function);
+    assert_eq!(index.scope(inner).parent(), Some(outer));
+
+    let y = index.symbols(inner).get("y").unwrap();
+    assert_eq!(
+        y.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+
+    let x_inner = index.symbols(inner).get("x").unwrap();
+    assert_eq!(x_inner.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_parameter_default_uses() {
+    let index = index("function(x = y) x");
+    let fun_scope = ScopeId::from(1);
+
+    // `y` in the default is a use in the function scope
+    assert!(index.symbols(fun_scope).get("y").is_some());
+    let y = index.symbols(fun_scope).get("y").unwrap();
+    assert_eq!(y.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_call_argument_equals_not_assignment() {
+    // `x = 1` inside a call argument is NOT an assignment
+    let index = index("f(x = 1)");
+    let file = ScopeId::from(0);
+
+    // Only `f` is recorded (as a use), `x` is an argument name, not a binding
+    assert_eq!(index.symbols(file).len(), 1);
+    assert!(index.symbols(file).get("f").is_some());
+    assert!(index.symbols(file).get("x").is_none());
+}
+
+#[test]
+fn test_complex_lhs_not_binding() {
+    // `x$foo <- 1` -- `x` is a use, not a binding
+    let index = index("x$foo <- 1");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_USED);
+
+    assert_eq!(index.bindings(file).len(), 0);
+}
+
+#[test]
+fn test_resolve_symbol_in_scope() {
+    let index = index("x <- 1\nf <- function(y) x + y");
+    let inner = ScopeId::from(1);
+
+    // `y` resolves in the function scope
+    let (scope, _) = index.resolve_symbol("y", inner).unwrap();
+    assert_eq!(scope, inner);
+
+    // `x` resolves in the file scope
+    let file = ScopeId::from(0);
+    let (scope, _) = index.resolve_symbol("x", inner).unwrap();
+    assert_eq!(scope, file);
+
+    // `z` doesn't resolve
+    assert!(index.resolve_symbol("z", inner).is_none());
+}
+
+#[test]
+fn test_resolve_prefers_inner_scope() {
+    let index = index("x <- 1\nf <- function(x) x");
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    // From function scope, `x` resolves to the function's own `x`
+    let (scope, _) = index.resolve_symbol("x", fun).unwrap();
+    assert_eq!(scope, fun);
+
+    // From file scope, `x` resolves to file's `x`
+    let (scope, _) = index.resolve_symbol("x", file).unwrap();
+    assert_eq!(scope, file);
+}
+
+#[test]
+fn test_scope_at() {
+    let source = "x <- 1\nf <- function(y) y";
+    let idx = index(source);
+    let file = ScopeId::from(0);
+    let fun = ScopeId::from(1);
+
+    // Offset 0 is in `x` -- file scope
+    assert_eq!(idx.scope_at(biome_rowan::TextSize::from(0)), file);
+
+    // Offset inside the function body
+    let body_offset = source.find(") y").unwrap() + 2;
+    assert_eq!(
+        idx.scope_at(biome_rowan::TextSize::from(body_offset as u32)),
+        fun
+    );
+}
+
+#[test]
+fn test_child_scopes() {
+    let index = index("f <- function(x) x\ng <- function(y) y");
+    let file = ScopeId::from(0);
+
+    let children: Vec<_> = index.child_scopes(file).collect();
+    assert_eq!(children.len(), 2);
+}
+
+#[test]
+fn test_ancestor_scopes() {
+    let index = index("f <- function(x) function(y) y");
+    let inner = ScopeId::from(2);
+    let outer = ScopeId::from(1);
+    let file = ScopeId::from(0);
+
+    let ancestors: Vec<_> = index.ancestor_scopes(inner).collect();
+    assert_eq!(ancestors, vec![inner, outer, file]);
+}
+
+#[test]
+fn test_for_loop_body() {
+    let idx = index("for (i in xs) print(i)");
+    let file = ScopeId::from(0);
+
+    let xs = idx.symbols(file).get("xs").unwrap();
+    assert_eq!(xs.flags(), SymbolFlags::IS_USED);
+
+    let print = idx.symbols(file).get("print").unwrap();
+    assert_eq!(print.flags(), SymbolFlags::IS_USED);
+
+    let i = idx.symbols(file).get("i").unwrap();
+    assert_eq!(i.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+}
+
+#[test]
+fn test_if_else() {
+    let index = index("if (cond) a else b");
+    let file = ScopeId::from(0);
+
+    let cond = index.symbols(file).get("cond").unwrap();
+    assert_eq!(cond.flags(), SymbolFlags::IS_USED);
+
+    let a = index.symbols(file).get("a").unwrap();
+    assert_eq!(a.flags(), SymbolFlags::IS_USED);
+
+    let b = index.symbols(file).get("b").unwrap();
+    assert_eq!(b.flags(), SymbolFlags::IS_USED);
+}
+
+#[test]
+fn test_braced_expression_assignments() {
+    // Assignments inside `{}` are in the same scope (no new scope for braces)
+    let index = index("f <- function() {\n  x <- 1\n  y <- x\n}");
+    let fun = ScopeId::from(1);
+
+    assert_eq!(index.bindings(fun).len(), 2);
+    assert!(index.symbols(fun).get("x").is_some());
+    assert!(index.symbols(fun).get("y").is_some());
+
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+}
+
+#[test]
+fn test_dots_parameter() {
+    let index = index("function(...) list(...)");
+    let fun = ScopeId::from(1);
+
+    let dots = index.symbols(fun).get("...").unwrap();
+    assert_eq!(
+        dots.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+}
+
+#[test]
+fn test_dot_dot_i_parameter() {
+    let index = index("function(..1, ..2) list(..1, ..2)");
+    let fun = ScopeId::from(1);
+
+    let dot1 = index.symbols(fun).get("..1").unwrap();
+    assert_eq!(
+        dot1.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+
+    let dot2 = index.symbols(fun).get("..2").unwrap();
+    assert_eq!(
+        dot2.flags(),
+        SymbolFlags::IS_BOUND
+            .union(SymbolFlags::IS_PARAMETER)
+            .union(SymbolFlags::IS_USED)
+    );
+}
+
+#[test]
+fn test_arrow_assignment_in_if_condition() {
+    // `<-` is always an assignment, even inside `if()`
+    let index = index("if (x <- f()) x");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
+    assert_eq!(index.bindings(file).len(), 1);
+}
+
+#[test]
+fn test_arrow_assignment_in_call_argument() {
+    // `<-` in a call argument still creates a binding in the enclosing scope
+    let index = index("f(x <- 1)");
+    let file = ScopeId::from(0);
+
+    assert!(index.symbols(file).get("x").is_some());
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.bindings(file).len(), 1);
+}
+
+#[test]
+fn test_equals_in_call_argument_still_not_assignment() {
+    // `=` in a call argument is NOT an assignment (unchanged)
+    let index = index("f(x = 1)");
+    let file = ScopeId::from(0);
+
+    assert!(index.symbols(file).get("x").is_none());
+    assert_eq!(index.bindings(file).len(), 0);
+}
+
+#[test]
+fn test_parenthesized_arrow_assignment() {
+    // `<-` is always an assignment, even inside parentheses
+    let index = index("(x <- 1)");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.bindings(file).len(), 1);
+}
+
+#[test]
+fn test_parenthesized_equals_is_assignment() {
+    // `(x = 1)` -- `=` as a `RBinaryExpression` is always an assignment.
+    // In call arguments, `=` is consumed by the parser into
+    // `RArgumentNameClause` and never appears as a binary expression.
+    let index = index("(x = 1)");
+    let file = ScopeId::from(0);
+
+    let x = index.symbols(file).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(index.bindings(file).len(), 1);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -584,10 +584,7 @@ fn test_super_assignment_finds_existing_binding() {
     let fun = ScopeId::from(1);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(
-        x.flags(),
-        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND)
-    );
+    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
     // Two binding sites in file scope: the `<-` and the `<<-`
     let x_bindings: Vec<_> = index
@@ -609,13 +606,9 @@ fn test_super_assignment_finds_nearest_ancestor() {
     let outer = ScopeId::from(1);
     let inner = ScopeId::from(2);
 
-    // Outer function gets both `IS_BOUND` (from `x <- 1`) and
-    // `IS_SUPER_BOUND` (from `x <<- 2` in the inner function)
+    // `<<-` targeting an existing binding uses `IS_BOUND`, not `IS_SUPER_BOUND`
     let x_outer = index.symbols(outer).get("x").unwrap();
-    assert_eq!(
-        x_outer.flags(),
-        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND)
-    );
+    assert_eq!(x_outer.flags(), SymbolFlags::IS_BOUND);
 
     // File scope `x` is untouched by the inner `<<-`
     let x_file = index.symbols(file).get("x").unwrap();
@@ -635,10 +628,7 @@ fn test_super_assignment_skips_use_only_ancestor() {
     let inner = ScopeId::from(2);
 
     let x_file = index.symbols(file).get("x").unwrap();
-    assert_eq!(
-        x_file.flags(),
-        SymbolFlags::IS_BOUND.union(SymbolFlags::IS_SUPER_BOUND)
-    );
+    assert_eq!(x_file.flags(), SymbolFlags::IS_BOUND);
 
     // Outer function has `x` as `IS_USED` only (from `print(x)`)
     let x_outer = index.symbols(outer).get("x").unwrap();
@@ -648,24 +638,16 @@ fn test_super_assignment_skips_use_only_ancestor() {
 }
 
 #[test]
-fn test_super_assignment_resolvable() {
-    // `resolve_symbol` from inner scope finds the superassignment binding
-    // in the file scope
+fn test_super_assignment_creates_file_scope_binding() {
     let index = index("f <- function() { x <<- 1 }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
-    let (scope, _) = index.resolve_symbol("x", fun).unwrap();
-    assert_eq!(scope, file);
-}
-
-#[test]
-fn test_super_assignment_is_not_is_bound() {
-    let index = index("f <- function() { x <<- 1 }");
-    let file = ScopeId::from(0);
-
     let x = index.symbols(file).get("x").unwrap();
     assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+
+    let (scope, _) = index.resolve_symbol("x", fun).unwrap();
+    assert_eq!(scope, file);
 }
 
 #[test]

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1,5 +1,6 @@
 use aether_parser::parse;
 use aether_parser::RParserOptions;
+use aether_syntax::RSyntaxKind;
 use oak_index::builder::build;
 use oak_index::semantic_index::DefinitionId;
 use oak_index::semantic_index::DefinitionKind;
@@ -33,10 +34,11 @@ fn test_simple_assignment() {
     assert_eq!(sym.flags(), SymbolFlags::IS_BOUND);
 
     assert_eq!(index.definitions(file).len(), 1);
-    assert_eq!(
-        index.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::Assignment
-    );
+    let DefinitionKind::Assignment(node) = index.definitions(file)[DefinitionId::from(0)].kind()
+    else {
+        panic!("expected Assignment");
+    };
+    assert_eq!(node.kind(), RSyntaxKind::R_BINARY_EXPRESSION);
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -118,10 +120,12 @@ fn test_function_creates_scope() {
     );
 
     assert_eq!(index.definitions(fun_scope).len(), 1);
-    assert_eq!(
-        index.definitions(fun_scope)[DefinitionId::from(0)].kind(),
-        DefinitionKind::Parameter
-    );
+    let DefinitionKind::Parameter(node) =
+        index.definitions(fun_scope)[DefinitionId::from(0)].kind()
+    else {
+        panic!("expected Parameter");
+    };
+    assert_eq!(node.kind(), RSyntaxKind::R_PARAMETER);
     assert_eq!(index.uses(fun_scope).len(), 1);
 }
 
@@ -280,10 +284,11 @@ fn test_for_loop_body() {
     let i = idx.symbols(file).get("i").unwrap();
     assert_eq!(i.flags(), SymbolFlags::IS_BOUND.union(SymbolFlags::IS_USED));
 
-    assert_eq!(
-        idx.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::ForVariable
-    );
+    let DefinitionKind::ForVariable(node) = idx.definitions(file)[DefinitionId::from(0)].kind()
+    else {
+        panic!("expected ForVariable");
+    };
+    assert_eq!(node.kind(), RSyntaxKind::R_FOR_STATEMENT);
 }
 
 #[test]
@@ -547,10 +552,12 @@ fn test_super_assignment_at_file_scope() {
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
     assert_eq!(index.definitions(file).len(), 1);
-    assert_eq!(
-        index.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::SuperAssignment
-    );
+    let DefinitionKind::SuperAssignment(node) =
+        index.definitions(file)[DefinitionId::from(0)].kind()
+    else {
+        panic!("expected SuperAssignment");
+    };
+    assert_eq!(node.kind(), RSyntaxKind::R_BINARY_EXPRESSION);
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -563,10 +570,10 @@ fn test_super_assignment_right_at_file_scope() {
     assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
 
     assert_eq!(index.definitions(file).len(), 1);
-    assert_eq!(
+    assert!(matches!(
         index.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::SuperAssignment
-    );
+        DefinitionKind::SuperAssignment(_)
+    ));
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -583,14 +590,14 @@ fn test_super_assignment_lands_in_file_scope() {
 
     // `x <<- 1` is visited during the function body (value side) before
     // `f` gets its binding (target side)
-    assert_eq!(
+    assert!(matches!(
         index.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::SuperAssignment
-    );
-    assert_eq!(
+        DefinitionKind::SuperAssignment(_)
+    ));
+    assert!(matches!(
         index.definitions(file)[DefinitionId::from(1)].kind(),
-        DefinitionKind::Assignment
-    );
+        DefinitionKind::Assignment(_)
+    ));
 
     assert!(index.symbols(fun).get("x").is_none());
     assert_eq!(index.definitions(fun).len(), 0);
@@ -628,8 +635,11 @@ fn test_super_assignment_finds_existing_binding() {
     assert_eq!(x_defs.len(), 2);
 
     // First is Assignment, second is SuperAssignment
-    assert_eq!(x_defs[0].1.kind(), DefinitionKind::Assignment);
-    assert_eq!(x_defs[1].1.kind(), DefinitionKind::SuperAssignment);
+    assert!(matches!(x_defs[0].1.kind(), DefinitionKind::Assignment(_)));
+    assert!(matches!(
+        x_defs[1].1.kind(),
+        DefinitionKind::SuperAssignment(_)
+    ));
 
     assert!(index.symbols(fun).get("x").is_none());
 }
@@ -653,8 +663,14 @@ fn test_super_assignment_finds_nearest_ancestor() {
         .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_outer_defs.len(), 2);
-    assert_eq!(x_outer_defs[0].1.kind(), DefinitionKind::Assignment);
-    assert_eq!(x_outer_defs[1].1.kind(), DefinitionKind::SuperAssignment);
+    assert!(matches!(
+        x_outer_defs[0].1.kind(),
+        DefinitionKind::Assignment(_)
+    ));
+    assert!(matches!(
+        x_outer_defs[1].1.kind(),
+        DefinitionKind::SuperAssignment(_)
+    ));
 
     // File scope `x` is untouched by the inner `<<-`
     let x_file = index.symbols(file).get("x").unwrap();
@@ -699,7 +715,10 @@ fn test_super_assignment_creates_file_scope_binding() {
         .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_defs.len(), 1);
-    assert_eq!(x_defs[0].1.kind(), DefinitionKind::SuperAssignment);
+    assert!(matches!(
+        x_defs[0].1.kind(),
+        DefinitionKind::SuperAssignment(_)
+    ));
 
     let (scope, _) = index.resolve_symbol("x", fun).unwrap();
     assert_eq!(scope, file);

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -544,12 +544,12 @@ fn test_repeat_loop() {
 
 #[test]
 fn test_super_assignment_at_file_scope() {
-    // At file scope there's no parent, so `<<-` lands in the file scope itself
+    // At file scope, `<<-` records in file scope with IS_SUPER_BOUND
     let index = index("x <<- 1");
     let file = ScopeId::from(0);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
 
     assert_eq!(index.definitions(file).len(), 1);
     let DefinitionKind::SuperAssignment(node) =
@@ -567,7 +567,7 @@ fn test_super_assignment_right_at_file_scope() {
     let file = ScopeId::from(0);
 
     let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
 
     assert_eq!(index.definitions(file).len(), 1);
     assert!(matches!(
@@ -578,82 +578,90 @@ fn test_super_assignment_right_at_file_scope() {
 }
 
 #[test]
-fn test_super_assignment_lands_in_file_scope() {
-    // No ancestor has a definition for `x`, so `<<-` lands in the file scope
+fn test_super_assignment_recorded_in_current_scope() {
+    // `<<-` records the definition in the function scope where it lexically
+    // appears, not in an ancestor scope.
     let index = index("f <- function() { x <<- 1 }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
-    let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert_eq!(index.definitions(file).len(), 2); // `f` + `x`
-
-    // `x <<- 1` is visited during the function body (value side) before
-    // `f` gets its binding (target side)
+    // File scope only has `f`
+    assert!(index.symbols(file).get("x").is_none());
+    assert_eq!(index.definitions(file).len(), 1);
     assert!(matches!(
         index.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::SuperAssignment(_)
-    ));
-    assert!(matches!(
-        index.definitions(file)[DefinitionId::from(1)].kind(),
         DefinitionKind::Assignment(_)
     ));
 
-    assert!(index.symbols(fun).get("x").is_none());
-    assert_eq!(index.definitions(fun).len(), 0);
+    // Function scope has `x` with IS_SUPER_BOUND
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(index.definitions(fun).len(), 1);
+    assert!(matches!(
+        index.definitions(fun)[DefinitionId::from(0)].kind(),
+        DefinitionKind::SuperAssignment(_)
+    ));
 }
 
 #[test]
-fn test_super_assignment_right_lands_in_file_scope() {
+fn test_super_assignment_right_recorded_in_current_scope() {
     let index = index("f <- function() { 1 ->> x }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
-    let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    assert!(index.symbols(file).get("x").is_none());
 
-    assert!(index.symbols(fun).get("x").is_none());
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
 }
 
 #[test]
-fn test_super_assignment_finds_existing_binding() {
-    // `x` is bound in the file scope, so `x <<- 2` inside the function
-    // lands there rather than creating a new definition
+fn test_super_assignment_does_not_pollute_ancestor() {
+    // `x <- 1` is in file scope, `x <<- 2` is in the function. The `<<-`
+    // does NOT add a definition to the file scope.
     let index = index("x <- 1\nf <- function() { x <<- 2 }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
-    let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    // File scope: `x` has IS_BOUND from the `<-`, `f` has IS_BOUND
+    let x_file = index.symbols(file).get("x").unwrap();
+    assert_eq!(x_file.flags(), SymbolFlags::IS_BOUND);
 
-    // Two definition sites in file scope: the `<-` and the `<<-`
-    let x_defs: Vec<_> = index
+    let x_file_defs: Vec<_> = index
         .definitions(file)
         .iter()
         .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
         .collect();
-    assert_eq!(x_defs.len(), 2);
-
-    // First is Assignment, second is SuperAssignment
-    assert!(matches!(x_defs[0].1.kind(), DefinitionKind::Assignment(_)));
+    assert_eq!(x_file_defs.len(), 1);
     assert!(matches!(
-        x_defs[1].1.kind(),
-        DefinitionKind::SuperAssignment(_)
+        x_file_defs[0].1.kind(),
+        DefinitionKind::Assignment(_)
     ));
 
-    assert!(index.symbols(fun).get("x").is_none());
+    // Function scope: `x` has IS_SUPER_BOUND from the `<<-`
+    let x_fun = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x_fun.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(index.definitions(fun).len(), 1);
+    assert!(matches!(
+        index.definitions(fun)[DefinitionId::from(0)].kind(),
+        DefinitionKind::SuperAssignment(_)
+    ));
 }
 
 #[test]
-fn test_super_assignment_finds_nearest_ancestor() {
-    // `x` is bound in both file and outer function; `<<-` should target the
-    // nearest ancestor (outer function), not the file scope.
+fn test_super_assignment_nested_recorded_in_inner_scope() {
+    // `x` is bound in both file and outer function. `<<-` in the inner
+    // function records the definition in the inner scope, not in any ancestor.
     let index = index("x <- 0\nf <- function() { x <- 1; g <- function() { x <<- 2 } }");
     let file = ScopeId::from(0);
     let outer = ScopeId::from(1);
     let inner = ScopeId::from(2);
 
-    // Outer function has both Assignment and SuperAssignment definitions for `x`
+    // File scope: `x` has IS_BOUND (from `<-`), untouched by inner `<<-`
+    let x_file = index.symbols(file).get("x").unwrap();
+    assert_eq!(x_file.flags(), SymbolFlags::IS_BOUND);
+
+    // Outer function: `x` has IS_BOUND (from `<-`), no super-assignment here
     let x_outer = index.symbols(outer).get("x").unwrap();
     assert_eq!(x_outer.flags(), SymbolFlags::IS_BOUND);
 
@@ -662,28 +670,26 @@ fn test_super_assignment_finds_nearest_ancestor() {
         .iter()
         .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
         .collect();
-    assert_eq!(x_outer_defs.len(), 2);
+    assert_eq!(x_outer_defs.len(), 1);
     assert!(matches!(
         x_outer_defs[0].1.kind(),
         DefinitionKind::Assignment(_)
     ));
+
+    // Inner function: `x` has IS_SUPER_BOUND (from `<<-`)
+    let x_inner = index.symbols(inner).get("x").unwrap();
+    assert_eq!(x_inner.flags(), SymbolFlags::IS_SUPER_BOUND);
+    assert_eq!(index.definitions(inner).len(), 1);
     assert!(matches!(
-        x_outer_defs[1].1.kind(),
+        index.definitions(inner)[DefinitionId::from(0)].kind(),
         DefinitionKind::SuperAssignment(_)
     ));
-
-    // File scope `x` is untouched by the inner `<<-`
-    let x_file = index.symbols(file).get("x").unwrap();
-    assert_eq!(x_file.flags(), SymbolFlags::IS_BOUND);
-
-    // Inner function has no definition for `x`
-    assert!(index.symbols(inner).get("x").is_none());
 }
 
 #[test]
-fn test_super_assignment_skips_use_only_ancestor() {
-    // Outer function uses `x` but doesn't bind it. `<<-` should skip it
-    // and land in the file scope where `x` is bound.
+fn test_super_assignment_coexists_with_use_in_ancestors() {
+    // Outer function uses `x` but doesn't bind it. `<<-` in the inner
+    // function records in the inner scope. Ancestors are unaffected.
     let index = index("x <- 1\nf <- function() { print(x); g <- function() { x <<- 2 } }");
     let file = ScopeId::from(0);
     let outer = ScopeId::from(1);
@@ -696,32 +702,29 @@ fn test_super_assignment_skips_use_only_ancestor() {
     let x_outer = index.symbols(outer).get("x").unwrap();
     assert_eq!(x_outer.flags(), SymbolFlags::IS_USED);
 
-    assert!(index.symbols(inner).get("x").is_none());
+    // Inner function has `x` as IS_SUPER_BOUND
+    let x_inner = index.symbols(inner).get("x").unwrap();
+    assert_eq!(x_inner.flags(), SymbolFlags::IS_SUPER_BOUND);
 }
 
 #[test]
-fn test_super_assignment_creates_file_scope_binding() {
+fn test_super_assignment_not_visible_to_resolve_symbol() {
+    // `<<-` does not create a binding visible to `resolve_symbol` (which
+    // checks IS_BOUND, not IS_SUPER_BOUND). Cross-scope effects of `<<-`
+    // are a runtime concern, not statically modelled.
     let index = index("f <- function() { x <<- 1 }");
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
-    let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
+    // File scope has no `x`
+    assert!(index.symbols(file).get("x").is_none());
 
-    // The definition is a SuperAssignment
-    let x_defs: Vec<_> = index
-        .definitions(file)
-        .iter()
-        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
-        .collect();
-    assert_eq!(x_defs.len(), 1);
-    assert!(matches!(
-        x_defs[0].1.kind(),
-        DefinitionKind::SuperAssignment(_)
-    ));
+    // Function scope has `x` with IS_SUPER_BOUND
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
 
-    let (scope, _) = index.resolve_symbol("x", fun).unwrap();
-    assert_eq!(scope, file);
+    // resolve_symbol does not find `x` because no scope has IS_BOUND for it
+    assert!(index.resolve_symbol("x", fun).is_none());
 }
 
 #[test]
@@ -1114,9 +1117,10 @@ fn test_string_super_assignment() {
     let file = ScopeId::from(0);
     let fun = ScopeId::from(1);
 
-    let x = index.symbols(file).get("x").unwrap();
-    assert_eq!(x.flags(), SymbolFlags::IS_BOUND);
-    assert!(index.symbols(fun).get("x").is_none());
+    assert!(index.symbols(file).get("x").is_none());
+
+    let x = index.symbols(fun).get("x").unwrap();
+    assert_eq!(x.flags(), SymbolFlags::IS_SUPER_BOUND);
 }
 
 // --- Multiple expressions (semicolons) ---


### PR DESCRIPTION
Part of #1141 

Implements scopes and symbol tables. Prelude to implementing use-def maps.

To get oriented:
- See comments documenting the new data structures in `src/semantic_index.rs`
- See `tests/builder.rs` documenting the behaviour of the recursive descent in `src/builder.rs`.
