### PR TITLE
Add `PackageCache` for populating a package source cache

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
+          # Putting Rtools related tooling on the PATH causes Rust crate
+          # compilation to pick up Rtools's `link.exe` and mingw32 related
+          # tooling, in particular it can cause aws-lc-sys compilation to fail
+          # on ARM Windows, where it uses clang-cl and has to compile in a bunch
+          # of C code.
+          # https://github.com/aws/aws-lc-rs/blob/main/book/src/requirements/windows.md
+          windows-path-include-rtools: false
 
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,8 @@ If changes are needed in these files, that must happen in the separate Positron 
 
 - Always prefer importing with `use` instead of qualifying with `::`, unless specifically requested in these instructions or by the user, or you see existing `::` usages in the file you're editing.
 
+- Prefer file level or `mod tests` level `use` statements over function level `use` statements.
+
 - When two code paths do analogous things, make them structurally parallel so the symmetry is visible.
 
 - Don't let comments drift from the code. If behaviour changes, update nearby comments. If a file is renamed, update its header comment.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,6 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "threadpool",
 ]
 
 [[package]]
@@ -3853,15 +3852,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
+ "threadpool",
 ]
 
 [[package]]
@@ -3852,6 +3853,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
  "actix-utils",
  "ahash",
  "base64 0.22.1",
- "bitflags 2.4.0",
+ "bitflags 2.11.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -169,7 +169,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.5.4",
- "time 0.3.36",
+ "time",
  "url",
 ]
 
@@ -193,12 +193,6 @@ checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -483,6 +477,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +507,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-link",
@@ -638,9 +654,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
@@ -711,7 +727,7 @@ checksum = "34701d821c19736317bc716b8eb6153a78b431b06fbd3950716cedc705a6c811"
 dependencies = [
  "crossbeam-channel",
  "num_cpus",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -722,9 +738,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"
@@ -737,14 +753,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-expr"
@@ -763,19 +786,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.24"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-link",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -809,15 +855,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.36",
+ "time",
  "version_check",
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
+name = "core-foundation"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -947,7 +1003,7 @@ source = "git+https://github.com/sztomi/dap-rs?branch=main#913a2a520416a2a81a1f0
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -995,7 +1051,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1102,6 +1158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "echo"
 version = "0.1.0"
 dependencies = [
@@ -1201,7 +1263,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1223,13 +1295,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.27"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1246,6 +1324,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1408,6 +1492,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,7 +1543,7 @@ dependencies = [
  "libr",
  "log",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "regex",
  "rust-embed",
  "semver",
@@ -1595,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1613,9 +1709,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1625,26 +1721,47 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
  "want",
 ]
 
 [[package]]
-name = "hyper-util"
-version = "0.1.3"
+name = "hyper-rustls"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
+ "http 1.1.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.1.0",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.6.3",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -1840,22 +1957,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
+name = "ipnet"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "ipnet"
-version = "2.8.0"
+name = "iri-string"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1865,7 +1980,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1893,6 +2008,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.40",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,10 +2062,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2125,20 +2285,12 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2214,16 +2366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2392,16 @@ dependencies = [
  "air_r_syntax",
  "assert_matches",
  "biome_rowan",
+]
+
+[[package]]
+name = "oak_fs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "log",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2286,6 +2438,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_r_process"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "log",
+]
+
+[[package]]
+name = "oak_sources"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "etcetera",
+ "flate2",
+ "hex",
+ "log",
+ "oak_fs",
+ "oak_package",
+ "oak_r_process",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tempfile",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,21 +2482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2324,21 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2584,6 +2746,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.2.9",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2806,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -2618,6 +2839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2869,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.9",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2712,7 +2962,7 @@ checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.9",
  "redox_syscall",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -2767,59 +3017,62 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.1.0",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
 dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
  "reqwest",
- "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "tower-service",
 ]
 
 [[package]]
 name = "reqwest-retry"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83df1aaec00176d0fabb65dea13f832d2a446ca99107afc17c5d2d4981221d0"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2827,22 +3080,36 @@ dependencies = [
  "getrandom 0.2.9",
  "http 1.1.0",
  "hyper",
- "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
- "wasm-timer",
+ "wasmtimer",
 ]
 
 [[package]]
 name = "retry-policies"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom 0.2.9",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2906,7 +3173,7 @@ version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -2919,11 +3186,86 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2948,6 +3290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,6 +3318,29 @@ dependencies = [
  "selectors",
  "smallvec",
  "tendril",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3082,7 +3456,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.36",
+ "time",
 ]
 
 [[package]]
@@ -3159,6 +3533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3590,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,7 +3639,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -3348,6 +3744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,7 +3809,16 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.40",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3417,6 +3833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,17 +3851,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -3479,6 +3895,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,7 +3920,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.4.9",
@@ -3506,6 +3937,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3591,17 +4032,48 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-lsp"
@@ -3620,7 +4092,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-lsp-macros",
  "tracing",
 ]
@@ -3637,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3660,8 +4132,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
- "time 0.3.36",
+ "thiserror 1.0.40",
+ "time",
  "tracing-subscriber",
 ]
 
@@ -3808,6 +4280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,38 +4385,29 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.86"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.86"
+name = "wasm-bindgen"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
- "bumpalo",
- "log",
+ "cfg-if",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
@@ -3956,9 +4425,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3966,36 +4435,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
+name = "wasmtimer"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-utils",
+ "slab",
  "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -4006,6 +4477,25 @@ checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4055,36 +4545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4407,10 +4876,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
+]
 
 [[package]]
 name = "xdg"
@@ -4490,6 +4975,12 @@ dependencies = [
  "syn 2.0.111",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zeromq-src"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ blake3 = "1.8.2"
 bus = "2.3.0"
 cc = "1.1.22"
 cfg-if = "1.0.0"
-chrono = "0.4.23"
+chrono = "0.4.44"
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 crypto-common = "0.1.6"
 ctor = "0.1.26"
@@ -52,6 +52,8 @@ dirs = "4.0.0"
 ego-tree = "0.6.2"
 embed-resource = "2.5.0"
 env_logger = "0.10.0"
+etcetera = "0.11.0"
+flate2 = "1.1.1"
 futures = "0.3.30"
 generic-array = "0.14.6"
 harp = { path = "crates/harp" }
@@ -70,17 +72,20 @@ mime_guess = "2.0.4"
 nix = { version = "0.26.2", features = ["signal"] }
 notify = "6.0.0"
 oak_core = { path = "crates/oak_core" }
+oak_fs = { path = "crates/oak_fs" }
 oak_index = { path = "crates/oak_index" }
 oak_package = { path = "crates/oak_package" }
+oak_r_process = { path = "crates/oak_r_process" }
+oak_sources = { path = "crates/oak_sources" }
 once_cell = "1.17.1"
 parking_lot = "0.12.3"
 paste = "1.0.14"
 quote = "1.0.42"
 rand = "0.8.5"
 regex = "1.10.0"
-reqwest = { version = "0.12.5", default-features = false, features = ["json"] }
-reqwest-middleware = "0.3.3"
-reqwest-retry = "0.6.1"
+reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
+reqwest-middleware = "0.5.1"
+reqwest-retry = "0.9.1"
 rust-embed = "8.2.0"
 rustc-hash = "2.1.1"
 scraper = "0.15.0"
@@ -96,6 +101,7 @@ streaming-iterator = "0.1.9"
 strum = "0.26.2"
 strum_macros = "0.26.2"
 syn = { version = "2.0.111", features = ["full"] }
+tar = "0.4.44"
 tempfile = "3.13.0"
 tokio = { version = "1.26.0", features = ["full"] }
 # For https://github.com/ebkalderon/tower-lsp/pull/428
@@ -109,6 +115,7 @@ tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "95aff09
 url = "2.5.7"
 uuid = { version = "1.3.0", features = ["v4"] }
 walkdir = "2"
+windows-sys ="0.61.2"
 winsafe = { version = "0.0.19", features = ["kernel"] }
 xdg = "2.5.2"
 yaml-rust = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ strum_macros = "0.26.2"
 syn = { version = "2.0.111", features = ["full"] }
 tar = "0.4.44"
 tempfile = "3.13.0"
-threadpool = "1"
 tokio = { version = "1.26.0", features = ["full"] }
 # For https://github.com/ebkalderon/tower-lsp/pull/428
 tower-lsp = { branch = "bugfix/patches", git = "https://github.com/lionel-/tower-lsp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ strum_macros = "0.26.2"
 syn = { version = "2.0.111", features = ["full"] }
 tar = "0.4.44"
 tempfile = "3.13.0"
+threadpool = "1"
 tokio = { version = "1.26.0", features = ["full"] }
 # For https://github.com/ebkalderon/tower-lsp/pull/428
 tower-lsp = { branch = "bugfix/patches", git = "https://github.com/lionel-/tower-lsp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,7 @@
 resolver = "2"
 
 members = [
-    "crates/amalthea",
-    "crates/ark",
-    "crates/echo",
-    "crates/harp",
-    "crates/libr",
-    "crates/oak_core",
-    "crates/oak_index",
-    "crates/oak_package",
-    "crates/stdext",
+    "crates/*"
 ]
 
 [workspace.package]

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1646,6 +1646,7 @@ foo
                 name: "mockpkg".to_string(),
                 version: "1.0.0".to_string(),
                 depends: vec![],
+                repository: None,
                 fields: Dcf::new(),
             };
             let package = Package::from_parts(PathBuf::from("/mock/path"), description, namespace);
@@ -1742,6 +1743,7 @@ foo
                 name: "pkg1".to_string(),
                 version: "1.0.0".to_string(),
                 depends: vec![],
+                repository: None,
                 fields: Dcf::new(),
             };
             let package1 =
@@ -1757,6 +1759,7 @@ foo
                 name: "pkg2".to_string(),
                 version: "1.0.0".to_string(),
                 depends: vec![],
+                repository: None,
                 fields: Dcf::new(),
             };
             let package2 =
@@ -1814,6 +1817,7 @@ foo
                 name: "pkg".to_string(),
                 version: "1.0.0".to_string(),
                 depends: vec![],
+                repository: None,
                 fields: Dcf::new(),
             };
             let package = Package::from_parts(PathBuf::from("/mock/path"), description, namespace);

--- a/crates/oak_fs/Cargo.toml
+++ b/crates/oak_fs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "oak_fs"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+libc.workspace = true
+log.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation"] }
+
+[lints]
+workspace = true

--- a/crates/oak_fs/src/file_lock.rs
+++ b/crates/oak_fs/src/file_lock.rs
@@ -1,0 +1,456 @@
+//! File-locking support.
+//!
+//! This module defines the [`Filesystem`] type which is an abstraction over a
+//! filesystem, ensuring that access to the filesystem is only done through
+//! coordinated locks.
+//!
+//! The [`FileLock`] type represents a locked file, and provides access to the
+//! file.
+//!
+//! Brought in with modifications from MIT licensed cargo, which faces similar
+//! challenges where multiple cargo processes may modify the same cache.
+//! https://github.com/rust-lang/cargo/blob/edf7ff01434287519767f9cd50b2b49beba5aee5/src/cargo/util/flock.rs
+
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::fs::TryLockError;
+use std::io;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::path::Display;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+
+/// A locked file.
+///
+/// This provides access to file while holding a lock on the file. This type
+/// implements the [`Read`], [`Write`], and [`Seek`] traits to provide access
+/// to the underlying file.
+///
+/// Locks are either shared (multiple processes can access the file) or
+/// exclusive (only one process can access the file).
+///
+/// This type is created via methods on the [`Filesystem`] type.
+///
+/// When this value is dropped, the lock will be released.
+#[derive(Debug)]
+pub struct FileLock {
+    f: Option<File>,
+    path: PathBuf,
+}
+
+impl FileLock {
+    /// Returns the underlying file handle of this lock.
+    pub fn file(&self) -> &File {
+        self.f.as_ref().unwrap()
+    }
+
+    /// Returns the underlying path that this lock points to.
+    ///
+    /// Note that special care must be taken to ensure that the path is not
+    /// referenced outside the lifetime of this lock.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the parent path containing this file
+    pub fn parent(&self) -> &Path {
+        self.path.parent().unwrap()
+    }
+
+    /// Removes all sibling files to this locked file.
+    ///
+    /// This can be useful if a directory is locked with a sentinel file but it
+    /// needs to be cleared out as it may be corrupt.
+    pub fn remove_siblings(&self) -> anyhow::Result<()> {
+        let path = self.path();
+        for entry in path.parent().unwrap().read_dir()? {
+            let entry = entry?;
+            if Some(&entry.file_name()[..]) == path.file_name() {
+                continue;
+            }
+            let kind = entry.file_type()?;
+            if kind.is_dir() {
+                std::fs::remove_dir_all(entry.path())?;
+            } else {
+                std::fs::remove_file(entry.path())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Renames the file and updates the internal path.
+    ///
+    /// This method performs a filesystem rename operation using [`std::fs::rename`]
+    /// while keeping the FileLock's internal path synchronized with the actual
+    /// file location.
+    ///
+    /// ## Difference from `std::fs::rename`
+    ///
+    /// - `std::fs::rename(old, new)` only moves the file on the filesystem
+    /// - `FileLock::rename(new)` moves the file AND updates `self.path` to point to the new location
+    pub fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> anyhow::Result<()> {
+        let new_path = new_path.as_ref();
+        std::fs::rename(&self.path, new_path).with_context(|| {
+            format!(
+                "Failed to rename {} to {}",
+                self.path.display(),
+                new_path.display()
+            )
+        })?;
+        self.path = new_path.to_path_buf();
+        Ok(())
+    }
+}
+
+impl Read for FileLock {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.file().read(buf)
+    }
+}
+
+impl Seek for FileLock {
+    fn seek(&mut self, to: SeekFrom) -> io::Result<u64> {
+        self.file().seek(to)
+    }
+}
+
+impl Write for FileLock {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.file().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file().flush()
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        if let Some(f) = self.f.take() {
+            if let Err(e) = f.unlock() {
+                log::warn!("Failed to release lock: {e:?}");
+            }
+        }
+    }
+}
+
+/// A "filesystem" is intended to be a globally shared, hence locked, resource
+/// in Aether.
+///
+/// The `Path` of a filesystem cannot be learned unless it's done in a locked
+/// fashion, and otherwise functions on this structure are prepared to handle
+/// concurrent invocations across multiple instances of Aether.
+///
+/// The methods on `Filesystem` that open files return a [`FileLock`] which
+/// holds the lock, and that type provides methods for accessing the
+/// underlying file.
+///
+/// If the blocking methods (like [`Filesystem::open_ro_shared`]) detect that
+/// they will block, then they will log that it is blocked. There are
+/// non-blocking variants starting with the `try_` prefix like
+/// [`Filesystem::try_open_ro_shared_create`].
+///
+/// The behavior of locks acquired by the `Filesystem` depend on the operating
+/// system. On unix-like system, they are advisory using [`flock`], and thus
+/// not enforced against processes which do not try to acquire the lock. On
+/// Windows, they are mandatory using [`LockFileEx`], enforced against all
+/// processes.
+///
+/// This **does not** guarantee that a lock is acquired. In some cases, for
+/// example on filesystems that don't support locking, it will return a
+/// [`FileLock`] even though the filesystem lock was not acquired. This is
+/// intended to provide a graceful fallback instead of refusing to work.
+/// Usually there aren't multiple processes accessing the same resource. In
+/// that case, it is the user's responsibility to not run concurrent
+/// processes.
+///
+/// [`flock`]: https://linux.die.net/man/2/flock
+/// [`LockFileEx`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Filesystem {
+    root: PathBuf,
+}
+
+impl Filesystem {
+    /// Creates a new filesystem to be rooted at the given path.
+    pub fn new(path: PathBuf) -> Filesystem {
+        Filesystem { root: path }
+    }
+
+    /// Like `Path::join`, creates a new filesystem rooted at this filesystem
+    /// joined with the given path.
+    pub fn join<T: AsRef<Path>>(&self, other: T) -> Filesystem {
+        Filesystem::new(self.root.join(other))
+    }
+
+    /// Like `Path::push`, pushes a new path component onto this filesystem.
+    pub fn push<T: AsRef<Path>>(&mut self, other: T) {
+        self.root.push(other);
+    }
+
+    /// Consumes this filesystem and returns the underlying `PathBuf`.
+    ///
+    /// Note that this is a relatively dangerous operation and should be used
+    /// with great caution!.
+    pub fn into_path_unlocked(self) -> PathBuf {
+        self.root
+    }
+
+    /// Returns the underlying `Path`.
+    ///
+    /// Note that this is a relatively dangerous operation and should be used
+    /// with great caution!.
+    pub fn as_path_unlocked(&self) -> &Path {
+        &self.root
+    }
+
+    /// Creates the directory pointed to by this filesystem.
+    ///
+    /// Naturally handles errors where other Aether processes are also attempting to
+    /// concurrently create this directory via [std::fs::create_dir_all()].
+    pub fn create_dir(&self) -> anyhow::Result<()> {
+        Ok(std::fs::create_dir_all(&self.root)?)
+    }
+
+    /// Returns an adaptor that can be used to print the path of this
+    /// filesystem.
+    pub fn display(&self) -> Display<'_> {
+        self.root.display()
+    }
+
+    /// Opens read-write exclusive access to a file, returning the locked
+    /// version of a file.
+    ///
+    /// This function will create a file at `path` if it doesn't already exist
+    /// (including intermediate directories), and then it will acquire an
+    /// exclusive lock on `path`. If the process must block waiting for the
+    /// lock, then a message is logged.
+    ///
+    /// The returned file can be accessed to look at the path and also has
+    /// read/write access to the underlying file.
+    pub fn open_rw_exclusive_create<P>(&self, path: P) -> anyhow::Result<FileLock>
+    where
+        P: AsRef<Path>,
+    {
+        let mut opts = OpenOptions::new();
+        opts.read(true).write(true).create(true);
+        let (path, f) = self.open(path.as_ref(), &opts, true)?;
+        acquire(&path, &|| f.try_lock(), &|| f.lock())?;
+        Ok(FileLock { f: Some(f), path })
+    }
+
+    /// A non-blocking version of [`Filesystem::open_rw_exclusive_create`].
+    ///
+    /// Returns `None` if the operation would block due to another process
+    /// holding the lock.
+    pub fn try_open_rw_exclusive_create<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> anyhow::Result<Option<FileLock>> {
+        let mut opts = OpenOptions::new();
+        opts.read(true).write(true).create(true);
+        let (path, f) = self.open(path.as_ref(), &opts, true)?;
+        if try_acquire(&path, &|| f.try_lock())? {
+            Ok(Some(FileLock { f: Some(f), path }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Opens read-only shared access to a file, returning the locked version of a file.
+    ///
+    /// This function will fail if `path` doesn't already exist, but if it does
+    /// then it will acquire a shared lock on `path`. If the process must block
+    /// waiting for the lock, then a message is logged.
+    ///
+    /// The returned file can be accessed to look at the path and also has read
+    /// access to the underlying file. Any writes to the file will return an
+    /// error.
+    pub fn open_ro_shared<P>(&self, path: P) -> anyhow::Result<FileLock>
+    where
+        P: AsRef<Path>,
+    {
+        let mut opts = OpenOptions::new();
+        opts.read(true);
+        let (path, f) = self.open(path.as_ref(), &opts, false)?;
+        acquire(&path, &|| f.try_lock_shared(), &|| f.lock_shared())?;
+        Ok(FileLock { f: Some(f), path })
+    }
+
+    /// Opens read-only shared access to a file, returning the locked version of a file.
+    ///
+    /// Compared to [`Filesystem::open_ro_shared`], this will create the file
+    /// (and any directories in the parent) if the file does not already
+    /// exist.
+    pub fn open_ro_shared_create<P: AsRef<Path>>(&self, path: P) -> anyhow::Result<FileLock> {
+        let mut opts = OpenOptions::new();
+        opts.read(true).write(true).create(true);
+        let (path, f) = self.open(path.as_ref(), &opts, true)?;
+        acquire(&path, &|| f.try_lock_shared(), &|| f.lock_shared())?;
+        Ok(FileLock { f: Some(f), path })
+    }
+
+    /// A non-blocking version of [`Filesystem::open_ro_shared_create`].
+    ///
+    /// Returns `None` if the operation would block due to another process
+    /// holding the lock.
+    pub fn try_open_ro_shared_create<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> anyhow::Result<Option<FileLock>> {
+        let mut opts = OpenOptions::new();
+        opts.read(true).write(true).create(true);
+        let (path, f) = self.open(path.as_ref(), &opts, true)?;
+        if try_acquire(&path, &|| f.try_lock_shared())? {
+            Ok(Some(FileLock { f: Some(f), path }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn open(
+        &self,
+        path: &Path,
+        opts: &OpenOptions,
+        create: bool,
+    ) -> anyhow::Result<(PathBuf, File)> {
+        let path = self.root.join(path);
+        let f = opts
+            .open(&path)
+            .or_else(|e| {
+                // If we were requested to create this file, and there was a
+                // NotFound error, then that was likely due to missing
+                // intermediate directories. Try creating them and try again.
+                if e.kind() == io::ErrorKind::NotFound && create {
+                    std::fs::create_dir_all(path.parent().unwrap())?;
+                    Ok(opts.open(&path)?)
+                } else {
+                    Err(anyhow::Error::from(e))
+                }
+            })
+            .with_context(|| format!("Failed to open: {}", path.display()))?;
+        Ok((path, f))
+    }
+}
+
+impl PartialEq<Path> for Filesystem {
+    fn eq(&self, other: &Path) -> bool {
+        self.root == other
+    }
+}
+
+impl PartialEq<Filesystem> for Path {
+    fn eq(&self, other: &Filesystem) -> bool {
+        self == other.root
+    }
+}
+
+fn try_acquire(
+    path: &Path,
+    lock_try: &dyn Fn() -> Result<(), TryLockError>,
+) -> anyhow::Result<bool> {
+    // File locking on Unix is currently implemented via `flock`, which is known
+    // to be broken on NFS. We could in theory just ignore errors that happen on
+    // NFS, but apparently the failure mode [1] for `flock` on NFS is **blocking
+    // forever**, even if the "non-blocking" flag is passed!
+    //
+    // As a result, we just skip all file locks entirely on NFS mounts. That
+    // should avoid calling any `flock` functions at all, and it wouldn't work
+    // there anyway.
+    //
+    // [1]: https://github.com/rust-lang/cargo/issues/2615
+    if is_on_nfs_mount(path) {
+        log::debug!("{path:?} appears to be an NFS mount, not trying to lock");
+        return Ok(true);
+    }
+
+    match lock_try() {
+        Ok(()) => Ok(true),
+
+        // In addition to ignoring NFS which is commonly not working we also
+        // just ignore locking on filesystems that look like they don't
+        // implement file locking.
+        Err(TryLockError::Error(e)) if error_unsupported(&e) => Ok(true),
+
+        Err(TryLockError::Error(e)) => {
+            let e = anyhow::Error::from(e);
+            let cx = format!("failed to lock file: {}", path.display());
+            Err(e.context(cx))
+        },
+
+        Err(TryLockError::WouldBlock) => Ok(false),
+    }
+}
+
+/// Acquires a lock on a file in a "nice" manner.
+///
+/// This function will acquire the lock on a `path`, logging if we have to wait for it. It
+/// will first attempt to use `try` to acquire a lock on the crate, and in the case of
+/// contention it will emit a log message, and then use `block` to block waiting to
+/// acquire a lock.
+///
+/// Returns an error if the lock could not be acquired or if any error other
+/// than a contention error happens.
+fn acquire(
+    path: &Path,
+    lock_try: &dyn Fn() -> Result<(), TryLockError>,
+    lock_block: &dyn Fn() -> io::Result<()>,
+) -> anyhow::Result<()> {
+    if try_acquire(path, lock_try)? {
+        return Ok(());
+    }
+
+    log::trace!("Waiting for file lock on {}", path.display());
+
+    lock_block().with_context(|| format!("Failed to lock file: {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+fn is_on_nfs_mount(path: &Path) -> bool {
+    use std::ffi::CString;
+    use std::mem;
+    use std::os::unix::prelude::*;
+
+    let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+
+    unsafe {
+        let mut buf: libc::statfs = mem::zeroed();
+        let r = libc::statfs(path.as_ptr(), &mut buf);
+
+        r == 0 && buf.f_type as u32 == libc::NFS_SUPER_MAGIC as u32
+    }
+}
+
+#[cfg(any(not(target_os = "linux"), target_env = "musl"))]
+fn is_on_nfs_mount(_path: &Path) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn error_unsupported(err: &std::io::Error) -> bool {
+    match err.raw_os_error() {
+        // Unfortunately, depending on the target, these may or may not be the same.
+        // For targets in which they are the same, the duplicate pattern causes a warning.
+        #[allow(unreachable_patterns)]
+        Some(libc::ENOTSUP | libc::EOPNOTSUPP) => true,
+        Some(libc::ENOSYS) => true,
+        _ => err.kind() == std::io::ErrorKind::Unsupported,
+    }
+}
+
+#[cfg(windows)]
+fn error_unsupported(err: &std::io::Error) -> bool {
+    use windows_sys::Win32::Foundation::ERROR_INVALID_FUNCTION;
+    match err.raw_os_error() {
+        Some(code) if code == ERROR_INVALID_FUNCTION as i32 => true,
+        _ => err.kind() == std::io::ErrorKind::Unsupported,
+    }
+}

--- a/crates/oak_fs/src/lib.rs
+++ b/crates/oak_fs/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod file_lock;

--- a/crates/oak_package/src/package_description.rs
+++ b/crates/oak_package/src/package_description.rs
@@ -38,8 +38,15 @@ pub struct Description {
     /// `Depends` field. Currently doesn't contain versions.
     pub depends: Vec<String>,
 
+    pub repository: Option<Repository>,
+
     /// Raw DCF fields
     pub fields: Dcf,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Repository {
+    CRAN,
 }
 
 impl Description {
@@ -70,10 +77,18 @@ impl Description {
             })
             .unwrap_or_default();
 
+        let repository = fields.get("Repository").and_then(|repository| {
+            if repository == "CRAN" {
+                return Some(Repository::CRAN);
+            }
+            None
+        });
+
         Ok(Description {
             name,
             version,
             depends,
+            repository,
             fields,
         })
     }
@@ -180,6 +195,26 @@ Description: This is a long description
         let parsed = Description::parse(desc).unwrap();
         assert_eq!(parsed.name, "mypackage");
         assert_eq!(parsed.version, "1.0.0");
+    }
+
+    #[test]
+    fn parses_description_with_known_repository() {
+        let desc = r#"Package: mypackage
+Version: 1.0.0
+Title: My Package
+Repository: CRAN"#;
+        let parsed = Description::parse(desc).unwrap();
+        assert_eq!(parsed.repository, Some(Repository::CRAN));
+    }
+
+    #[test]
+    fn parses_description_with_unknown_repository() {
+        let desc = r#"Package: mypackage
+Version: 1.0.0
+Title: My Package
+Repository: notCRAN"#;
+        let parsed = Description::parse(desc).unwrap();
+        assert_eq!(parsed.repository, None);
     }
 
     #[test]

--- a/crates/oak_r_process/Cargo.toml
+++ b/crates/oak_r_process/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "oak_r_process"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+log.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oak_r_process/Cargo.toml
+++ b/crates/oak_r_process/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 log.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/oak_r_process/src/lib.rs
+++ b/crates/oak_r_process/src/lib.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+use std::process::Command;
+use std::process::Output;
+use std::process::Stdio;
+
+/// Runs an R script in a subprocess via `Rscript` and returns its output.
+pub fn run_script(
+    rscript: &Path,
+    script: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> anyhow::Result<Output> {
+    let mut command = Command::new(rscript);
+
+    command
+        .arg("--vanilla")
+        .arg(script)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    let child = command.spawn()?;
+    let output = child.wait_with_output()?;
+
+    Ok(output)
+}

--- a/crates/oak_r_process/src/lib.rs
+++ b/crates/oak_r_process/src/lib.rs
@@ -3,21 +3,29 @@ use std::process::Command;
 use std::process::Output;
 use std::process::Stdio;
 
-/// Runs an R script in a subprocess via `Rscript` and returns its output.
-pub fn run_script(
-    rscript: &Path,
-    script: &Path,
+/// Runs an R file in a subprocess via `R` and returns its output.
+pub fn run_file(
+    r: &Path,
+    file: &Path,
     args: &[&str],
     env: &[(&str, &str)],
 ) -> anyhow::Result<Output> {
-    let mut command = Command::new(rscript);
+    let mut command = Command::new(r);
 
-    command
-        .arg("--vanilla")
-        .arg(script)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    command.arg("-f").arg(file);
+
+    // `--no-save`, `--no-restore`, `--no-site-file`, `--no-init-file`, `--no-environ`
+    command.arg("--vanilla");
+    // In addition to `--vanilla`, run as quietly as possible
+    command.arg("--no-echo");
+
+    // Optional arguments retrievable via `commandArgs(trailingOnly = TRUE)`
+    if !args.is_empty() {
+        command.arg("--args").args(args);
+    }
+
+    // We collect stdout/stderr into `output`
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     for (key, value) in env {
         command.env(key, value);
@@ -27,4 +35,32 @@ pub fn run_script(
     let output = child.wait_with_output()?;
 
     Ok(output)
+}
+
+/// Runs a snippet of R code in a subprocess via `R` and returns its output.
+///
+/// Writes the snippet to a temp file, because using `-e` is very unreliable regarding
+/// how things are quoted, particularly on Windows
+pub fn run_text(
+    r: &Path,
+    text: &str,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> anyhow::Result<Output> {
+    let file = write_tempfile(text)?;
+    run_file(r, file.path(), args, env)
+}
+
+fn write_tempfile(text: &str) -> anyhow::Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+
+    let mut file = tempfile::Builder::new()
+        .suffix(".R")
+        .tempfile()
+        .map_err(|err| anyhow::anyhow!("Failed to create temporary file: {err}"))?;
+
+    file.write_all(text.as_bytes())
+        .map_err(|err| anyhow::anyhow!("Failed to write temporary file: {err}"))?;
+
+    Ok(file)
 }

--- a/crates/oak_r_process/src/lib.rs
+++ b/crates/oak_r_process/src/lib.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 use std::process::Output;
@@ -52,8 +53,6 @@ pub fn run_text(
 }
 
 fn write_tempfile(text: &str) -> anyhow::Result<tempfile::NamedTempFile> {
-    use std::io::Write;
-
     let mut file = tempfile::Builder::new()
         .suffix(".R")
         .tempfile()

--- a/crates/oak_sources/Cargo.toml
+++ b/crates/oak_sources/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "oak_sources"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+etcetera.workspace = true
+flate2.workspace = true
+hex.workspace = true
+log.workspace = true
+oak_fs.workspace = true
+oak_package.workspace = true
+oak_r_process.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oak_sources/Cargo.toml
+++ b/crates/oak_sources/Cargo.toml
@@ -22,7 +22,6 @@ serde_json.workspace = true
 sha2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
-threadpool.workspace = true
 
 [lints]
 workspace = true

--- a/crates/oak_sources/Cargo.toml
+++ b/crates/oak_sources/Cargo.toml
@@ -22,6 +22,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+threadpool.workspace = true
 
 [lints]
 workspace = true

--- a/crates/oak_sources/scripts/srcrefs.R
+++ b/crates/oak_sources/scripts/srcrefs.R
@@ -1,5 +1,8 @@
 # Extract source code from an installed R package using srcref metadata.
 #
+# See also `lobstr::src()`:
+# https://github.com/r-lib/lobstr/blob/85dd18d43e4612f98b05bb93019a7b12fb0bbf6b/R/src.R#L205
+#
 # Arguments (via commandArgs):
 #   1. package - Package name
 #   2. version - Expected package version

--- a/crates/oak_sources/scripts/srcrefs.R
+++ b/crates/oak_sources/scripts/srcrefs.R
@@ -1,0 +1,99 @@
+# Extract source code from an installed R package using srcref metadata.
+#
+# Arguments (via commandArgs):
+#   1. package - Package name
+#   2. version - Expected package version
+#
+# Library paths have been set ahead of time via the `R_LIBS` environment
+# variable.
+#
+# On success: prints the concatenated source lines (with `#line` directives) to
+# stdout.
+#
+# On failure: exits with code 1 (package unexpectedly not installed, version
+# mismatch) or 2 (no srcrefs).
+
+args <- commandArgs(trailingOnly = TRUE)
+
+if (length(args) != 2L) {
+    message("'package' and 'version' are required arguments.")
+    quit(status = 1L)
+}
+
+package <- args[[1L]]
+version <- args[[2L]]
+
+# Make sure package is installed
+path <- find.package(package, quiet = TRUE)
+if (length(path) == 0L) {
+    message(paste0("Package '", package, "' is not installed"))
+    quit(status = 1L)
+}
+
+# Make sure installed version matches the requested version
+installed_version <- as.character(packageVersion(package))
+if (installed_version != version) {
+    message(paste0(
+        "Version mismatch for '",
+        package,
+        "': ",
+        "installed ",
+        installed_version,
+        ", requested ",
+        version
+    ))
+    quit(status = 1L)
+}
+
+# Get the package namespace and find a function object.
+# Functions will contain the srcrefs if srcrefs have been kept, and are what we
+# can back out the full file structure from.
+ns <- asNamespace(package)
+exports <- getNamespaceExports(ns)
+
+fn <- NULL
+for (name in exports) {
+    candidate <- get0(name, envir = ns, mode = "function")
+    if (!is.null(candidate)) {
+        fn <- candidate
+        break
+    }
+}
+
+if (is.null(fn)) {
+    message(paste0("No functions found for package '", package, "'"))
+    quit(status = 2L)
+}
+
+extract_lines <- function(fn) {
+    srcref <- attr(fn, "srcref")
+    if (is.null(srcref)) {
+        return(NULL)
+    }
+
+    srcfile <- attr(srcref, "srcfile")
+    if (is.null(srcfile)) {
+        return(NULL)
+    }
+
+    original <- srcfile$original
+    if (is.null(original)) {
+        return(NULL)
+    }
+
+    lines <- original$lines
+    if (is.null(lines)) {
+        return(NULL)
+    }
+
+    lines
+}
+
+lines <- extract_lines(fn)
+
+if (is.null(lines)) {
+    message(paste0("No srcrefs found for package '", package, "'"))
+    quit(status = 2L)
+}
+
+cat(lines, sep = "\n")

--- a/crates/oak_sources/src/cran.rs
+++ b/crates/oak_sources/src/cran.rs
@@ -2,9 +2,15 @@ use std::io::Cursor;
 use std::path::Path;
 
 use flate2::read::GzDecoder;
+use oak_fs::file_lock::FileLock;
 
-/// Assumes `destination` exists and is file locked by the caller
-pub(crate) fn cache_cran(package: &str, version: &str, destination: &Path) -> anyhow::Result<bool> {
+/// Downloads an R package's source files from CRAN if possible and adds them to the cache
+/// at the parent folder containing `destination_lock`
+pub(crate) fn cache_cran(
+    package: &str,
+    version: &str,
+    destination_lock: &FileLock,
+) -> anyhow::Result<bool> {
     let response = download(package, version)?;
 
     // "Not on CRAN" isn't an error
@@ -20,7 +26,7 @@ pub(crate) fn cache_cran(package: &str, version: &str, destination: &Path) -> an
         ));
     }
 
-    let destination = destination.join("R");
+    let destination = destination_lock.parent().join("R");
     std::fs::create_dir(&destination)?;
 
     extract(package, response, destination.as_path())?;
@@ -126,6 +132,7 @@ fn extract(
 
 #[cfg(test)]
 mod tests {
+    use oak_fs::file_lock::Filesystem;
     use tempfile::TempDir;
 
     use crate::cran::cache_cran;
@@ -133,12 +140,14 @@ mod tests {
     /// Requires internet access
     #[test]
     fn test_cran_r_files_exist_and_are_readonly() {
-        let destination = TempDir::new().unwrap();
+        let destination_tempdir = TempDir::new().unwrap();
+        let destination = Filesystem::new(destination_tempdir.path().to_path_buf());
+        let destination_lock = destination.open_rw_exclusive_create(".lock").unwrap();
 
-        let ok = cache_cran("vctrs", "0.7.2", destination.path()).unwrap();
+        let ok = cache_cran("vctrs", "0.7.2", &destination_lock).unwrap();
         assert!(ok);
 
-        let r_dir = destination.path().join("R");
+        let r_dir = destination_lock.parent().join("R");
         assert!(r_dir.exists());
 
         for entry in std::fs::read_dir(&r_dir).unwrap() {
@@ -150,9 +159,11 @@ mod tests {
 
     #[test]
     fn test_cache_cran_not_found() {
-        let destination = TempDir::new().unwrap();
+        let destination_tempdir = TempDir::new().unwrap();
+        let destination = Filesystem::new(destination_tempdir.path().to_path_buf());
+        let destination_lock = destination.open_rw_exclusive_create(".lock").unwrap();
 
-        let ok = cache_cran("definitely_not_a_package", "0.0.0", destination.path()).unwrap();
+        let ok = cache_cran("definitely_not_a_package", "0.0.0", &destination_lock).unwrap();
         assert!(!ok);
     }
 }

--- a/crates/oak_sources/src/cran.rs
+++ b/crates/oak_sources/src/cran.rs
@@ -1,0 +1,124 @@
+use std::io::Cursor;
+use std::path::Path;
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+/// Assumes `destination` exists and is file locked by the caller
+pub(crate) fn cache_cran(package: &str, version: &str, destination: &Path) -> anyhow::Result<bool> {
+    let response = download(package, version)?;
+
+    // "Not on CRAN" isn't an error
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(false);
+    }
+
+    // But anything else is
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Failed to download {package} {version}: HTTP {status}",
+            status = response.status()
+        ));
+    }
+
+    let destination = destination.join("R");
+    std::fs::create_dir(&destination)?;
+
+    extract(package, response, destination.as_path())?;
+
+    Ok(true)
+}
+
+fn download(package: &str, version: &str) -> anyhow::Result<reqwest::blocking::Response> {
+    // Try released version
+    let url = format!("https://cran.r-project.org/src/contrib/{package}_{version}.tar.gz");
+    let response = reqwest::blocking::get(&url)?;
+
+    if response.status() != reqwest::StatusCode::NOT_FOUND {
+        // Found it
+        return Ok(response);
+    }
+
+    // Try archive
+    let url = format!(
+        "https://cran.r-project.org/src/contrib/Archive/{package}/{package}_{version}.tar.gz"
+    );
+    let response = reqwest::blocking::get(&url)?;
+
+    // Return `response` whether or not we found something
+    Ok(response)
+}
+
+fn extract(
+    package: &str,
+    response: reqwest::blocking::Response,
+    destination: &Path,
+) -> anyhow::Result<()> {
+    let bytes = response.bytes()?;
+    let cursor = Cursor::new(bytes);
+    let gz = GzDecoder::new(cursor);
+    let mut archive = Archive::new(gz);
+
+    // Looking for files under `R/`
+    let prefix = format!("{package}/R/");
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+
+        let path = entry.path()?;
+        let path = path.to_string_lossy();
+
+        if !path.starts_with(&prefix) {
+            continue;
+        }
+
+        let Some(relative) = path.strip_prefix(&prefix) else {
+            continue;
+        };
+
+        if !relative.ends_with(".R") && !relative.ends_with(".r") {
+            continue;
+        }
+
+        let absolute = destination.join(relative);
+
+        // Write to disk
+        entry.unpack(&absolute)?;
+        crate::fs::set_readonly(&absolute)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use crate::cran::cache_cran;
+
+    /// Requires internet access
+    #[test]
+    fn test_cran_r_files_exist_and_are_readonly() {
+        let destination = TempDir::new().unwrap();
+
+        let ok = cache_cran("vctrs", "0.7.2", destination.path()).unwrap();
+        assert!(ok);
+
+        let r_dir = destination.path().join("R");
+        assert!(r_dir.exists());
+
+        for entry in std::fs::read_dir(&r_dir).unwrap() {
+            let entry = entry.unwrap();
+            let metadata = entry.metadata().unwrap();
+            assert!(metadata.permissions().readonly());
+        }
+    }
+
+    #[test]
+    fn test_cache_cran_not_found() {
+        let destination = TempDir::new().unwrap();
+
+        let ok = cache_cran("definitely_not_a_package", "0.0.0", destination.path()).unwrap();
+        assert!(!ok);
+    }
+}

--- a/crates/oak_sources/src/cran.rs
+++ b/crates/oak_sources/src/cran.rs
@@ -2,7 +2,6 @@ use std::io::Cursor;
 use std::path::Path;
 
 use flate2::read::GzDecoder;
-use tar::Archive;
 
 /// Assumes `destination` exists and is file locked by the caller
 pub(crate) fn cache_cran(package: &str, version: &str, destination: &Path) -> anyhow::Result<bool> {
@@ -86,10 +85,13 @@ fn extract(
     response: reqwest::blocking::Response,
     destination: &Path,
 ) -> anyhow::Result<()> {
+    // Pass response bytes of the `.tar.gz` into a gzip decoder, wrapped in a tar archive
+    // reader, this abstracts away all the details, so we can just iterate over the
+    // entries
     let bytes = response.bytes()?;
     let cursor = Cursor::new(bytes);
     let gz = GzDecoder::new(cursor);
-    let mut archive = Archive::new(gz);
+    let mut archive = tar::Archive::new(gz);
 
     // Looking for files under `R/`
     let prefix = format!("{package}/R/");

--- a/crates/oak_sources/src/cran.rs
+++ b/crates/oak_sources/src/cran.rs
@@ -30,9 +30,11 @@ pub(crate) fn cache_cran(package: &str, version: &str, destination: &Path) -> an
 }
 
 fn download(package: &str, version: &str) -> anyhow::Result<reqwest::blocking::Response> {
+    let mirrors = ["https://cran.r-project.org", "https://cran.rstudio.com"];
+
     // Try released version
-    let url = format!("https://cran.r-project.org/src/contrib/{package}_{version}.tar.gz");
-    let response = reqwest::blocking::get(&url)?;
+    let response =
+        download_with_mirrors(&format!("src/contrib/{package}_{version}.tar.gz"), &mirrors)?;
 
     if response.status() != reqwest::StatusCode::NOT_FOUND {
         // Found it
@@ -40,13 +42,43 @@ fn download(package: &str, version: &str) -> anyhow::Result<reqwest::blocking::R
     }
 
     // Try archive
-    let url = format!(
-        "https://cran.r-project.org/src/contrib/Archive/{package}/{package}_{version}.tar.gz"
-    );
-    let response = reqwest::blocking::get(&url)?;
+    let response = download_with_mirrors(
+        &format!("src/contrib/Archive/{package}/{package}_{version}.tar.gz"),
+        &mirrors,
+    )?;
 
     // Return `response` whether or not we found something
     Ok(response)
+}
+
+fn download_with_mirrors(
+    suffix: &str,
+    mirrors: &[&str],
+) -> anyhow::Result<reqwest::blocking::Response> {
+    if mirrors.is_empty() {
+        panic!("`mirrors` can't be empty.");
+    }
+
+    let mut out = None;
+
+    for mirror in mirrors {
+        let url = format!("{mirror}/{suffix}");
+        let response = reqwest::blocking::get(&url)?;
+        let status = response.status();
+
+        out = Some(response);
+
+        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            // Try next mirror, this one is temporarily unavailable
+            continue;
+        } else {
+            // We got an actual response of some kind from this mirror, return it
+            break;
+        }
+    }
+
+    // Safety: We guarantee that there is at least 1 mirror
+    Ok(out.unwrap())
 }
 
 fn extract(

--- a/crates/oak_sources/src/fs.rs
+++ b/crates/oak_sources/src/fs.rs
@@ -1,0 +1,33 @@
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use etcetera::BaseStrategy;
+
+fn cache_dir() -> anyhow::Result<PathBuf> {
+    // Can fail if the home directory can't be found
+    Ok(etcetera::choose_base_strategy()?.cache_dir().join("oak"))
+}
+
+pub(crate) fn sources_dir() -> anyhow::Result<PathBuf> {
+    Ok(cache_dir()?.join("sources").join("v1"))
+}
+
+/// Set a file's on disk permissions to read only
+pub(crate) fn set_readonly<P>(path: P) -> io::Result<()>
+where
+    P: AsRef<Path>,
+{
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_readonly(true);
+    std::fs::set_permissions(path, permissions)
+}
+
+pub(crate) fn remove_dir_all_or_warn(path: &Path) {
+    if let Err(err) = std::fs::remove_dir_all(path) {
+        log::warn!(
+            "Failed to remove directory {path}: {err:?}",
+            path = path.display()
+        );
+    }
+}

--- a/crates/oak_sources/src/fs.rs
+++ b/crates/oak_sources/src/fs.rs
@@ -14,13 +14,19 @@ pub(crate) fn sources_dir() -> anyhow::Result<PathBuf> {
 }
 
 /// Set a file's on disk permissions to read only
-pub(crate) fn set_readonly<P>(path: P) -> io::Result<()>
-where
-    P: AsRef<Path>,
-{
+pub(crate) fn set_readonly<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let mut permissions = std::fs::metadata(&path)?.permissions();
     permissions.set_readonly(true);
     std::fs::set_permissions(path, permissions)
+}
+
+pub(crate) fn copy_as_readonly<P: AsRef<Path>, Q: AsRef<Path>>(
+    from: P,
+    to: Q,
+) -> anyhow::Result<()> {
+    std::fs::copy(from.as_ref(), to.as_ref())?;
+    crate::fs::set_readonly(to.as_ref())?;
+    Ok(())
 }
 
 pub(crate) fn remove_dir_all_or_warn(path: &Path) {

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -69,11 +69,11 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 ///
 /// The cache root `.lock` can be locked as shared or exclusive:
 ///
-/// - **Shared root lock** is held for the lifetime of this `PackageSourcesCache`. The
-///   invariant is that if you hold a shared root lock, you can read from or append new
-///   entries to the cache, but never delete from it. Multiple sessions can hold this
-///   simultaneously. The main purpose is to prevent cleanup from running so that any
-///   PathBuf handed out by [`get`] stays valid while this lock is held.
+/// - **Shared root lock** is held for the lifetime of this `PackageCache`. The invariant
+///   is that if you hold a shared root lock, you can read from or append new entries to
+///   the cache, but never delete from it. Multiple sessions can hold this simultaneously.
+///   The main purpose is to prevent cleanup from running so that any PathBuf handed out
+///   by [`get`] stays valid while this lock is held.
 ///
 /// - **Exclusive root lock** is only attempted to be taken at startup to run [`clean`].
 ///   Skipped if any other session already holds a shared root lock, which is fine, we
@@ -104,9 +104,9 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// - Deleting if the package it originated from no longer exists
 /// - Deleting if the DESCRIPTION it originated from has changed
 ///
-/// [`get`]: PackageSourcesCache::get
-/// [`clean`]: PackageSourcesCache::clean
-pub struct PackageSourcesCache {
+/// [`get`]: PackageCache::get
+/// [`clean`]: PackageCache::clean
+pub struct PackageCache {
     /// Path to `R` binary
     r: PathBuf,
 
@@ -118,10 +118,9 @@ pub struct PackageSourcesCache {
 
     /// Shared lock on the root `.lock`, held for the life of this cache.
     ///
-    /// Blocks any other process from acquiring the root exclusive lock (the only
-    /// thing that can delete entries). That way, any `PathBuf` we hand out remains
-    /// valid for the life of this cache (as long as `PackageSourcesCache` itself
-    /// is not dropped!).
+    /// Blocks any other process from acquiring the root exclusive lock (the only thing
+    /// that can delete entries). That way, any `PathBuf` we hand out remains valid for
+    /// the life of this cache (as long as `PackageCache` itself is not dropped!).
     _root_lock: FileLock,
 
     /// Set of packages which are installed, but we failed to populate their sources (from
@@ -140,7 +139,7 @@ struct Metadata {
     generated_at: DateTime<Utc>,
 }
 
-impl PackageSourcesCache {
+impl PackageCache {
     pub fn new(r: PathBuf, r_libpaths: Vec<PathBuf>) -> anyhow::Result<Self> {
         let cache_root = file_lock::Filesystem::new(crate::fs::sources_dir()?);
         cache_root.create_dir()?;

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -284,16 +284,12 @@ impl PackageSourcesCache {
             return Ok(false);
         }
 
-        let namespace_destination_path = destination_path.join("NAMESPACE");
-        std::fs::copy(namespace_path, &namespace_destination_path)?;
-        crate::fs::set_readonly(&namespace_destination_path)?;
-
-        let description_destination_path = destination_path.join("DESCRIPTION");
-        std::fs::copy(description_path, &description_destination_path)?;
-        crate::fs::set_readonly(&description_destination_path)?;
+        crate::fs::copy_as_readonly(description_path, destination_path.join("DESCRIPTION"))?;
+        crate::fs::copy_as_readonly(namespace_path, destination_path.join("NAMESPACE"))?;
 
         // Last! Only write `.metadata` if all other writes succeed. It is our completion sentinal.
         self.write_metadata(package, libpath, description_hash, destination_path)?;
+
         Ok(true)
     }
 

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -6,7 +6,6 @@ use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::RwLock;
 
 use chrono::DateTime;
@@ -26,9 +25,6 @@ const LOCK_FILENAME: &str = ".lock";
 
 /// Name of the completion sentinel written last in each cache entry.
 const METADATA_FILENAME: &str = ".metadata";
-
-/// Number of threads used for the prefetch pool
-const NUMBER_OF_PREFETCH_THREADS: usize = 4;
 
 /// Minimum age before `clean()` will evict a stale entry.
 ///
@@ -110,23 +106,8 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// - Deleting if the DESCRIPTION it originated from has changed
 ///
 /// [`get`]: PackageCache::get
-/// [`clean`]: PackageCacheInner::clean
+/// [`clean`]: PackageCache::clean
 pub struct PackageCache {
-    inner: Arc<PackageCacheInner>,
-
-    /// Small threadpool used for background prefetching
-    pool: threadpool::ThreadPool,
-
-    /// Shared lock on the root `.lock`, held for the life of this cache.
-    ///
-    /// Blocks any other process from acquiring the root exclusive lock (the only thing
-    /// that can delete entries). That way, any `PathBuf` we hand out remains valid for
-    /// the life of this cache (as long as `PackageCache` itself is not dropped!).
-    _root_lock: FileLock,
-}
-
-/// Data shared across prefetch threads
-struct PackageCacheInner {
     /// Path to `R` binary
     r: PathBuf,
 
@@ -135,6 +116,13 @@ struct PackageCacheInner {
 
     /// On disk cache directory root
     cache_root: file_lock::Filesystem,
+
+    /// Shared lock on the root `.lock`, held for the life of this cache.
+    ///
+    /// Blocks any other process from acquiring the root exclusive lock (the only thing
+    /// that can delete entries). That way, any `PathBuf` we hand out remains valid for
+    /// the life of this cache (as long as `PackageCache` itself is not dropped!).
+    _root_lock: FileLock,
 
     /// Set of packages which are installed, but we failed to populate their sources (from
     /// CRAN or srcrefs). If we request sources for one of these packages a second time,
@@ -159,7 +147,7 @@ impl PackageCache {
 
         // Try to clean the cache. Only works if no other processes hold a shared root lock.
         if let Some(root_lock) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
-            if let Err(err) = PackageCacheInner::clean(root_lock.parent()) {
+            if let Err(err) = Self::clean(&root_lock) {
                 log::warn!("Failed to clean sources cache: {err:?}");
             }
             drop(root_lock);
@@ -169,46 +157,19 @@ impl PackageCache {
         let root_lock = cache_root.open_ro_shared_create(LOCK_FILENAME)?;
 
         Ok(Self {
-            inner: Arc::new(PackageCacheInner {
-                r,
-                r_libpaths,
-                cache_root,
-                source_unavailable: RwLock::new(HashSet::new()),
-            }),
-            pool: threadpool::ThreadPool::new(NUMBER_OF_PREFETCH_THREADS),
+            r,
+            r_libpaths,
+            cache_root,
             _root_lock: root_lock,
+            source_unavailable: RwLock::new(HashSet::new()),
         })
-    }
-
-    /// Populate the cache for `package` in the background
-    ///
-    /// This method is fire-and-forget. Callers anticipate that at some time in the future
-    /// they are likely to require sources for this package, but don't gain access to
-    /// them now.
-    ///
-    /// It is perfectly safe to call this followed by a `get()` at some time shortly
-    /// after, even if the prefetch hasn't finished yet.
-    pub fn prefetch(&self, package: &str) {
-        self.pool.execute({
-            let inner = Arc::clone(&self.inner);
-            let package = package.to_string();
-            move || {
-                inner.get(&package);
-            }
-        });
     }
 
     /// Get a package's cached source folder
     ///
-    /// Blocks and may spawn an R subprocess or download from CRAN (in a blocking manner)
-    /// to generate the sources.
+    /// May spawn an R subprocess or download from CRAN (in a blocking manner) to
+    /// generate the sources, so keep that in mind when calling this.
     pub fn get(&self, package: &str) -> Option<PathBuf> {
-        self.inner.get(package)
-    }
-}
-
-impl PackageCacheInner {
-    fn get(&self, package: &str) -> Option<PathBuf> {
         match self.get_impl(package) {
             Ok(Some(sources)) => Some(sources),
             Ok(None) => None,
@@ -410,7 +371,8 @@ impl PackageCacheInner {
     /// Walks all cache entries and evicts ones that are provably stale.
     ///
     /// Caller must hold the root exclusive lock.
-    fn clean(root: &Path) -> anyhow::Result<()> {
+    fn clean(root_lock: &file_lock::FileLock) -> anyhow::Result<()> {
+        let root = root_lock.parent();
         let now = Utc::now();
 
         for entry in std::fs::read_dir(root)? {

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -252,16 +252,6 @@ impl PackageCacheInner {
         let key =
             format!("{package}_{version}_libpath-{libpath_hash}_description-{description_hash}");
 
-        // If we've already tried to generate sources for this installed package but
-        // failed, then refuse to attempt expensive source generation again
-        if self
-            .source_unavailable
-            .read()
-            .is_ok_and(|set| set.contains(&key))
-        {
-            return Ok(None);
-        }
-
         let destination = self.cache_root.join(&key);
         // Safety: We hold the root lock
         let destination_path = destination.as_path_unlocked();
@@ -271,7 +261,18 @@ impl PackageCacheInner {
             return Ok(Some(destination_path.to_path_buf()));
         }
 
-        // Write path: take per-key exclusive lock
+        // Write path: before generating sources, check if we've already tried to generate
+        // sources for this installed package but failed. If so, refuse to attempt
+        // expensive source generation again
+        if self
+            .source_unavailable
+            .read()
+            .is_ok_and(|set| set.contains(&key))
+        {
+            return Ok(None);
+        }
+
+        // Take per-key exclusive lock
         destination.create_dir()?;
         let destination_lock = destination.open_rw_exclusive_create(LOCK_FILENAME)?;
 

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -1,0 +1,457 @@
+mod cran;
+mod fs;
+mod srcref;
+
+use std::collections::HashMap;
+use std::fs::read_to_string;
+use std::path::Path;
+use std::path::PathBuf;
+
+use chrono::DateTime;
+use chrono::TimeDelta;
+use chrono::Utc;
+use oak_fs::file_lock;
+use oak_fs::file_lock::FileLock;
+use oak_package::package_description::Description;
+use oak_package::package_description::Repository;
+use serde::Deserialize;
+use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
+
+/// Name of the root lock file and the per-key lock file.
+const LOCK_FILENAME: &str = ".lock";
+
+/// Name of the completion sentinel written last in each cache entry.
+const METADATA_FILENAME: &str = ".metadata";
+
+/// Minimum age before `clean()` will evict a stale entry.
+///
+/// Gives users a window to revert CRAN <-> dev swaps (or similar) without losing the
+/// cached CRAN build they had before the swap (dev builds will always be dropped due to
+/// the DESCRIPTION `Build:` timestamp being different).
+const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
+
+/// A two-level cache (on disk + in memory) of extracted R package sources.
+///
+/// # On disk layout
+///
+/// The on disk cache at `<cache_dir>/oak/sources/v1/` is the source of truth
+/// across all sessions. Each entry is a flat folder:
+///
+/// ```text
+/// <cache_dir>/oak/sources/v1/
+///     .lock
+///     {package}_{version}_libpath-{hash}_description-{hash}/
+///         .lock
+///         .metadata
+///         DESCRIPTION
+///         NAMESPACE
+///         R/
+/// ```
+///
+/// Files other than `.lock` and `.metadata` are marked read only. `.metadata`
+/// is written last and is the sole completion sentinel. An entry without it
+/// is considered garbage and will be wiped by the next writer for that key.
+///
+/// # Locking
+///
+/// The cache root `.lock` can be locked as shared or exclusive:
+///
+/// - **Shared root lock** is held for the lifetime of this `PackageSourcesCache`. The
+///   invariant is that if you hold a shared root lock, you can read from or append new
+///   entries to the cache, but never delete from it. Multiple sessions can hold this
+///   simultaneously. The main purpose is to prevent cleanup from running so that any
+///   PathBuf handed out by [`get`] stays valid while this lock is held.
+///
+/// - **Exclusive root lock** is only attempted to be taken at startup to run [`clean`].
+///   Skipped if any other session already holds a shared root lock, which is fine, we
+///   will just attempt to clean next time.
+///
+/// There are also per-key exclusive locks at
+/// `{package}_{version}_libpath-{hash}_description-{hash}/.lock`. When appending a new
+/// entry to the cache, a per-key exclusive lock must be taken first to ensure that two
+/// sessions don't write to the same directory simultaneously.
+///
+/// This setup allows multiple sessions (or even one session) to add to the cache in
+/// parallel, while guaranteeing that they cannot interfere with each other or a cleanup
+/// run.
+///
+/// # In memory cache
+///
+/// [`get`] resolves the key and caches the resulting `Sources(PathBuf)` or `NoSources` in
+/// memory. This is mostly to avoid re-attempting to generate sources for packages that we
+/// know already have `NoSources`. Results for packages that weren't installed at all are
+/// not cached, so later installs within the same session can still attempt a source
+/// generation.
+///
+/// # Cleanup
+///
+/// Cache cleanup is attempted once per session but is only possible if there are no other
+/// sessions active (i.e. we can take an exclusive lock on the cache root). If we can,
+/// then we check the `.metadata` file and use various strategies to see if the cache
+/// folder is stale, including:
+///
+/// - Doing nothing if it is younger than 1 week old (to avoid churn when switching
+///   between CRAN and dev versions repeatedly)
+/// - Deleting if the libpath it originated from no longer exists
+/// - Deleting if the package it originated from no longer exists
+/// - Deleting if the DESCRIPTION it originated from has changed
+///
+/// [`get`]: PackageSourcesCache::get
+/// [`clean`]: PackageSourcesCache::clean
+pub struct PackageSourcesCache {
+    /// Path to `Rscript`
+    r_script_path: PathBuf,
+
+    /// Set of R library paths
+    r_libpaths: Vec<PathBuf>,
+
+    /// On disk cache directory root
+    cache_root: file_lock::Filesystem,
+
+    /// Shared lock on the root `.lock`, held for the life of this cache.
+    ///
+    /// Blocks any other process from acquiring the root exclusive lock (the only
+    /// thing that can delete entries). That way, any PathBuf we hand out remains
+    /// valid for the life of this cache (as long as `PackageSourcesCache` itself
+    /// is not dropped!).
+    _root_lock: FileLock,
+
+    /// In memory cache to avoid repeated lookups, particularly for packages we've already
+    /// determined have no sources.
+    cache: HashMap<String, Status>,
+}
+
+enum Status {
+    NoSources,
+    Sources(PathBuf),
+}
+
+/// Completion sentinel for a cache entry, written last. Also used to determine if we can
+/// clean the cache folder out.
+#[derive(Serialize, Deserialize)]
+struct Metadata {
+    package: String,
+    libpath: PathBuf,
+    description_hash: String,
+    generated_at: DateTime<Utc>,
+}
+
+impl PackageSourcesCache {
+    pub fn new(r_script_path: PathBuf, r_libpaths: Vec<PathBuf>) -> anyhow::Result<Self> {
+        let cache_root = file_lock::Filesystem::new(crate::fs::sources_dir()?);
+        cache_root.create_dir()?;
+
+        // Try to clean the cache. Only works if no other processes hold a shared root lock.
+        if let Some(cache_root_lockfile) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
+            if let Err(err) = Self::clean(&cache_root_lockfile) {
+                log::warn!("Failed to clean sources cache: {err:?}");
+            }
+            drop(cache_root_lockfile);
+        }
+
+        // Take shared lock for the lifetime of the cache so any paths we hand out stay valid
+        let root_lock = cache_root.open_ro_shared_create(LOCK_FILENAME)?;
+
+        Ok(Self {
+            r_script_path,
+            r_libpaths,
+            cache_root,
+            _root_lock: root_lock,
+            cache: HashMap::new(),
+        })
+    }
+
+    /// Get a package's cached source folder
+    ///
+    /// May spawn an R subprocess or download from CRAN (in a blocking manner) to
+    /// generate the sources, so keep that in mind when calling this.
+    pub fn get(&mut self, package: &str) -> Option<PathBuf> {
+        match self.get_impl(package) {
+            Ok(Some(sources)) => Some(sources),
+            Ok(None) => None,
+            Err(err) => {
+                log::error!("Failed to get sources for {package}: {err:?}");
+                None
+            },
+        }
+    }
+
+    fn get_impl(&mut self, package: &str) -> anyhow::Result<Option<PathBuf>> {
+        // Find install path of the package
+        let mut libpath = None;
+        for r_libpath in &self.r_libpaths {
+            if r_libpath.join(package).exists() {
+                libpath = Some(r_libpath);
+                break;
+            }
+        }
+        let Some(libpath) = libpath else {
+            // Not even installed. We don't record anything about this package in
+            // the in memory cache in case the user installs it later in the session.
+            return Ok(None);
+        };
+
+        let package_path = libpath.join(package);
+        let namespace_path = package_path.join("NAMESPACE");
+        let description_path = package_path.join("DESCRIPTION");
+
+        let description_contents = read_to_string(&description_path)?;
+        let description = Description::parse(&description_contents)?;
+
+        let version = description.version.as_str();
+
+        let libpath_hash = hash(libpath.to_string_lossy().as_ref());
+        let description_hash = hash(&description_contents);
+
+        // Flat key unique enough to handle:
+        // - The same R package across multiple libpaths
+        // - Reinstalling a dev R package without changing the version (0.1.0.9000)
+        let key =
+            format!("{package}_{version}_libpath-{libpath_hash}_description-{description_hash}");
+
+        // In memory cache check
+        if let Some(status) = self.cache.get(&key) {
+            match status {
+                Status::NoSources => return Ok(None),
+                Status::Sources(sources) => return Ok(Some(sources.clone())),
+            }
+        }
+
+        let destination = self.cache_root.join(&key);
+        // Safety: We hold the root lock
+        let destination_path = destination.as_path_unlocked();
+
+        // Read path: completion sentinel present, already exists on disk
+        if destination_path.join(METADATA_FILENAME).exists() {
+            self.cache
+                .insert(key.clone(), Status::Sources(destination_path.to_path_buf()));
+            return Ok(Some(destination_path.to_path_buf()));
+        }
+
+        // Write path: take per-key exclusive lock
+        destination.create_dir()?;
+        let destination_lock = destination.open_rw_exclusive_create(LOCK_FILENAME)?;
+
+        // Re-check: another writer may have populated the key while we waited for an
+        // exclusive lock
+        if destination_path.join(METADATA_FILENAME).exists() {
+            self.cache
+                .insert(key.clone(), Status::Sources(destination_path.to_path_buf()));
+            return Ok(Some(destination_path.to_path_buf()));
+        }
+
+        // Wipe any partial content from a prior writer that may have crashed before
+        // writing `.metadata`.
+        destination_lock.remove_siblings()?;
+
+        if self.try_populate(
+            package,
+            version,
+            libpath,
+            &namespace_path,
+            &description_path,
+            &description,
+            &description_hash,
+            destination_path,
+        )? {
+            self.cache
+                .insert(key.clone(), Status::Sources(destination_path.to_path_buf()));
+            Ok(Some(destination_path.to_path_buf()))
+        } else {
+            self.cache.insert(key, Status::NoSources);
+            Ok(None)
+        }
+    }
+
+    /// Writes `DESCRIPTION`, `NAMESPACE`, and `R/` to the cache entry, if possible
+    ///
+    /// Can assume that `destination_path` exists and we have exclusive access to via the
+    /// lock.
+    fn try_populate(
+        &self,
+        package: &str,
+        version: &str,
+        libpath: &Path,
+        namespace_path: &Path,
+        description_path: &Path,
+        description: &Description,
+        description_hash: &str,
+        destination_path: &Path,
+    ) -> anyhow::Result<bool> {
+        if !self.write_r_files(package, version, description, destination_path)? {
+            return Ok(false);
+        }
+
+        let namespace_destination_path = destination_path.join("NAMESPACE");
+        std::fs::copy(namespace_path, &namespace_destination_path)?;
+        crate::fs::set_readonly(&namespace_destination_path)?;
+
+        let description_destination_path = destination_path.join("DESCRIPTION");
+        std::fs::copy(description_path, &description_destination_path)?;
+        crate::fs::set_readonly(&description_destination_path)?;
+
+        // Last! Only write `.metadata` if all other writes succeed. It is our completion sentinal.
+        self.write_metadata(package, libpath, description_hash, destination_path)?;
+        Ok(true)
+    }
+
+    fn write_r_files(
+        &self,
+        package: &str,
+        version: &str,
+        description: &Description,
+        destination_path: &Path,
+    ) -> anyhow::Result<bool> {
+        // Try caching from srcref
+        match crate::srcref::cache_srcref(
+            package,
+            version,
+            destination_path,
+            &self.r_script_path,
+            &self.r_libpaths,
+        ) {
+            Ok(true) => {
+                log::trace!("Cached {package} {version} from srcrefs.");
+                return Ok(true);
+            },
+            Ok(false) => {
+                // Fall through
+            },
+            Err(err) => {
+                // Fall through with log
+                log::warn!("Failed to cache {package} {version} from srcrefs: {err:?}");
+            },
+        }
+
+        // Try caching from CRAN
+        if matches!(description.repository, Some(Repository::CRAN)) {
+            match crate::cran::cache_cran(package, version, destination_path) {
+                Ok(true) => {
+                    log::trace!("Cached {package} {version} from CRAN download.");
+                    return Ok(true);
+                },
+                Ok(false) => {
+                    // Fall through
+                },
+                Err(err) => {
+                    // Fall through with log
+                    log::warn!("Failed to cache {package} {version} from CRAN download: {err:?}");
+                },
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Writes the `.metadata` completion sentinel last.
+    ///
+    /// A reader that sees `.metadata` can trust the rest of the entry is complete
+    /// and stable (Other files are read only. Only `clean()` could remove them,
+    /// and `clean()` needs the root exclusive lock which no one can take while we
+    /// hold a shared lock).
+    fn write_metadata(
+        &self,
+        package: &str,
+        libpath: &Path,
+        description_hash: &str,
+        destination_path: &Path,
+    ) -> anyhow::Result<()> {
+        let metadata = Metadata {
+            package: package.to_string(),
+            libpath: libpath.to_path_buf(),
+            description_hash: description_hash.to_string(),
+            generated_at: Utc::now(),
+        };
+        let contents = serde_json::to_vec_pretty(&metadata)?;
+        std::fs::write(destination_path.join(METADATA_FILENAME), contents)?;
+        Ok(())
+    }
+
+    /// Walks all cache entries and evicts ones that are provably stale.
+    ///
+    /// Caller must hold the root exclusive lock.
+    fn clean(cache_root_lockfile: &file_lock::FileLock) -> anyhow::Result<()> {
+        let root = cache_root_lockfile.parent();
+        let now = Utc::now();
+
+        for entry in std::fs::read_dir(root)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if !entry.file_type()?.is_dir() {
+                // i.e. `.lock` itself
+                continue;
+            }
+
+            let metadata_path = path.join(METADATA_FILENAME);
+
+            let Ok(metadata_contents) = std::fs::read_to_string(&metadata_path) else {
+                log::warn!(
+                    "Cleaning {} due to missing or unreadable metadata",
+                    path.display()
+                );
+                crate::fs::remove_dir_all_or_warn(&path);
+                continue;
+            };
+
+            let metadata: Metadata = match serde_json::from_str(&metadata_contents) {
+                Ok(m) => m,
+                Err(err) => {
+                    log::warn!(
+                        "Cleaning {} due to unreadable metadata: {err:?}",
+                        path.display()
+                    );
+                    crate::fs::remove_dir_all_or_warn(&path);
+                    continue;
+                },
+            };
+
+            // Refuse to do anything if younger than 1 week. The user may be switching
+            // between CRAN and dev, and we want to keep the cache for the CRAN version
+            // around.
+            let age = now.signed_duration_since(metadata.generated_at);
+            if age < ONE_WEEK {
+                continue;
+            }
+
+            if !metadata.libpath.exists() {
+                log::trace!("Cleaning {} due to nonexistent libpath", path.display());
+                crate::fs::remove_dir_all_or_warn(&path);
+                continue;
+            }
+
+            let package_path = metadata.libpath.join(&metadata.package);
+
+            if !package_path.exists() {
+                log::trace!("Cleaning {} due to nonexistent package", path.display());
+                crate::fs::remove_dir_all_or_warn(&path);
+                continue;
+            }
+
+            let Ok(description_contents) =
+                std::fs::read_to_string(package_path.join("DESCRIPTION"))
+            else {
+                log::trace!("Cleaning {} due to missing DESCRIPTION", path.display());
+                crate::fs::remove_dir_all_or_warn(&path);
+                continue;
+            };
+
+            if hash(&description_contents) != metadata.description_hash {
+                log::trace!("Cleaning {} due to changed DESCRIPTION", path.display());
+                crate::fs::remove_dir_all_or_warn(&path);
+                continue;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Retain 8 ASCII characters for each hash fragment
+fn hash(contents: &str) -> String {
+    let mut hash = hex::encode(Sha256::digest(contents));
+    hash.truncate(8);
+    hash
+}

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -346,6 +346,13 @@ impl PackageCache {
             }
         }
 
+        // TODO: Also consider Bioconductor as a source, which seem to have a `biocViews`
+        // field in their DESCRIPTION according to some renv docs. We will also need a
+        // Bioconductor version to download for. pkgcache has some R code that helps
+        // with this kind of thing.
+        // https://github.com/rstudio/renv/blob/c689571a0a6ce83a2f82a93b396f3a1ba87b0282/vignettes/package-sources.Rmd#L34-L50
+        // https://github.com/r-lib/pkgcache/blob/05d430e907064c5dea822ff82d4257f0b5668070/R/bioc.R
+
         Ok(false)
     }
 

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -84,6 +84,9 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// parallel, while guaranteeing that they cannot interfere with each other or a cleanup
 /// run.
 ///
+/// This cache design is somewhat similar to cargo's model, except cargo doesn't hold
+/// long running shared locks since each cargo command is pretty short lived.
+///
 /// # In memory cache
 ///
 /// [`get`] resolves the key and caches the resulting `Sources(PathBuf)` or `NoSources` in

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -2,7 +2,7 @@ mod cran;
 mod fs;
 mod srcref;
 
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::path::PathBuf;
@@ -32,7 +32,7 @@ const METADATA_FILENAME: &str = ".metadata";
 /// the DESCRIPTION `Build:` timestamp being different).
 const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 
-/// A two-level cache (on disk + in memory) of extracted R package sources.
+/// A cache of extracted R package sources
 ///
 /// # On disk layout
 ///
@@ -87,14 +87,6 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// This cache design is somewhat similar to cargo's model, except cargo doesn't hold
 /// long running shared locks since each cargo command is pretty short lived.
 ///
-/// # In memory cache
-///
-/// [`get`] resolves the key and caches the resulting `Sources(PathBuf)` or `NoSources` in
-/// memory. This is mostly to avoid re-attempting to generate sources for packages that we
-/// know already have `NoSources`. Results for packages that weren't installed at all are
-/// not cached, so later installs within the same session can still attempt a source
-/// generation.
-///
 /// # Cleanup
 ///
 /// Cache cleanup is attempted once per session but is only possible if there are no other
@@ -123,19 +115,15 @@ pub struct PackageSourcesCache {
     /// Shared lock on the root `.lock`, held for the life of this cache.
     ///
     /// Blocks any other process from acquiring the root exclusive lock (the only
-    /// thing that can delete entries). That way, any PathBuf we hand out remains
+    /// thing that can delete entries). That way, any `PathBuf` we hand out remains
     /// valid for the life of this cache (as long as `PackageSourcesCache` itself
     /// is not dropped!).
     _root_lock: FileLock,
 
-    /// In memory cache to avoid repeated lookups, particularly for packages we've already
-    /// determined have no sources.
-    cache: HashMap<String, Status>,
-}
-
-enum Status {
-    NoSources,
-    Sources(PathBuf),
+    /// Set of packages which are installed, but we failed to populate their sources (from
+    /// CRAN or srcrefs). If we request sources for one of these packages a second time,
+    /// we don't attempt expensive source generation again.
+    source_unavailable: HashSet<String>,
 }
 
 /// Completion sentinel for a cache entry, written last. Also used to determine if we can
@@ -154,11 +142,11 @@ impl PackageSourcesCache {
         cache_root.create_dir()?;
 
         // Try to clean the cache. Only works if no other processes hold a shared root lock.
-        if let Some(cache_root_lockfile) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
-            if let Err(err) = Self::clean(&cache_root_lockfile) {
+        if let Some(root_lock) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
+            if let Err(err) = Self::clean(&root_lock) {
                 log::warn!("Failed to clean sources cache: {err:?}");
             }
-            drop(cache_root_lockfile);
+            drop(root_lock);
         }
 
         // Take shared lock for the lifetime of the cache so any paths we hand out stay valid
@@ -169,7 +157,7 @@ impl PackageSourcesCache {
             r_libpaths,
             cache_root,
             _root_lock: root_lock,
-            cache: HashMap::new(),
+            source_unavailable: HashSet::new(),
         })
     }
 
@@ -198,8 +186,8 @@ impl PackageSourcesCache {
             }
         }
         let Some(libpath) = libpath else {
-            // Not even installed. We don't record anything about this package in
-            // the in memory cache in case the user installs it later in the session.
+            // Not even installed. We don't record this package in `source_unavailable` in
+            // case the user installs it later in the session.
             return Ok(None);
         };
 
@@ -221,12 +209,10 @@ impl PackageSourcesCache {
         let key =
             format!("{package}_{version}_libpath-{libpath_hash}_description-{description_hash}");
 
-        // In memory cache check
-        if let Some(status) = self.cache.get(&key) {
-            match status {
-                Status::NoSources => return Ok(None),
-                Status::Sources(sources) => return Ok(Some(sources.clone())),
-            }
+        // If we've already tried to generate sources for this installed package but
+        // failed, then refuse to attempt expensive source generation again
+        if self.source_unavailable.contains(&key) {
+            return Ok(None);
         }
 
         let destination = self.cache_root.join(&key);
@@ -235,8 +221,6 @@ impl PackageSourcesCache {
 
         // Read path: completion sentinel present, already exists on disk
         if destination_path.join(METADATA_FILENAME).exists() {
-            self.cache
-                .insert(key.clone(), Status::Sources(destination_path.to_path_buf()));
             return Ok(Some(destination_path.to_path_buf()));
         }
 
@@ -247,8 +231,6 @@ impl PackageSourcesCache {
         // Re-check: another writer may have populated the key while we waited for an
         // exclusive lock
         if destination_path.join(METADATA_FILENAME).exists() {
-            self.cache
-                .insert(key.clone(), Status::Sources(destination_path.to_path_buf()));
             return Ok(Some(destination_path.to_path_buf()));
         }
 
@@ -266,11 +248,10 @@ impl PackageSourcesCache {
             &description_hash,
             destination_path,
         )? {
-            self.cache
-                .insert(key.clone(), Status::Sources(destination_path.to_path_buf()));
             Ok(Some(destination_path.to_path_buf()))
         } else {
-            self.cache.insert(key, Status::NoSources);
+            // Never try source generation for this key again
+            self.source_unavailable.insert(key);
             Ok(None)
         }
     }
@@ -378,8 +359,8 @@ impl PackageSourcesCache {
     /// Walks all cache entries and evicts ones that are provably stale.
     ///
     /// Caller must hold the root exclusive lock.
-    fn clean(cache_root_lockfile: &file_lock::FileLock) -> anyhow::Result<()> {
-        let root = cache_root_lockfile.parent();
+    fn clean(root_lock: &file_lock::FileLock) -> anyhow::Result<()> {
+        let root = root_lock.parent();
         let now = Utc::now();
 
         for entry in std::fs::read_dir(root)? {

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::RwLock;
 
 use chrono::DateTime;
 use chrono::TimeDelta;
@@ -126,7 +127,7 @@ pub struct PackageCache {
     /// Set of packages which are installed, but we failed to populate their sources (from
     /// CRAN or srcrefs). If we request sources for one of these packages a second time,
     /// we don't attempt expensive source generation again.
-    source_unavailable: HashSet<String>,
+    source_unavailable: RwLock<HashSet<String>>,
 }
 
 /// Completion sentinel for a cache entry, written last. Also used to determine if we can
@@ -160,7 +161,7 @@ impl PackageCache {
             r_libpaths,
             cache_root,
             _root_lock: root_lock,
-            source_unavailable: HashSet::new(),
+            source_unavailable: RwLock::new(HashSet::new()),
         })
     }
 
@@ -168,7 +169,7 @@ impl PackageCache {
     ///
     /// May spawn an R subprocess or download from CRAN (in a blocking manner) to
     /// generate the sources, so keep that in mind when calling this.
-    pub fn get(&mut self, package: &str) -> Option<PathBuf> {
+    pub fn get(&self, package: &str) -> Option<PathBuf> {
         match self.get_impl(package) {
             Ok(Some(sources)) => Some(sources),
             Ok(None) => None,
@@ -179,7 +180,7 @@ impl PackageCache {
         }
     }
 
-    fn get_impl(&mut self, package: &str) -> anyhow::Result<Option<PathBuf>> {
+    fn get_impl(&self, package: &str) -> anyhow::Result<Option<PathBuf>> {
         // Find install path of the package
         let mut libpath = None;
         for r_libpath in &self.r_libpaths {
@@ -214,7 +215,11 @@ impl PackageCache {
 
         // If we've already tried to generate sources for this installed package but
         // failed, then refuse to attempt expensive source generation again
-        if self.source_unavailable.contains(&key) {
+        if self
+            .source_unavailable
+            .read()
+            .is_ok_and(|set| set.contains(&key))
+        {
             return Ok(None);
         }
 
@@ -254,7 +259,10 @@ impl PackageCache {
             Ok(Some(destination_path.to_path_buf()))
         } else {
             // Never try source generation for this key again
-            self.source_unavailable.insert(key);
+            self.source_unavailable
+                .write()
+                .ok()
+                .map(|mut set| set.insert(key));
             Ok(None)
         }
     }

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -127,6 +127,11 @@ pub struct PackageCache {
     /// Set of packages which are installed, but we failed to populate their sources (from
     /// CRAN or srcrefs). If we request sources for one of these packages a second time,
     /// we don't attempt expensive source generation again.
+    ///
+    /// Inside an [RwLock] so that [PackageCache::get()] avoids being `mut`, allowing a
+    /// caller to wrap a [PackageCache] in an [std::sync::Arc] and call
+    /// [PackageCache::get()] in the background on a thread, acting as a form of
+    /// "prefetching".
     source_unavailable: RwLock<HashSet<String>>,
 }
 

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -175,7 +175,7 @@ impl PackageCache {
     /// May spawn an R subprocess or download from CRAN (in a blocking manner) to
     /// generate the sources, so keep that in mind when calling this.
     pub fn get(&self, package: &str) -> Option<PathBuf> {
-        match self.get_impl(package) {
+        match self.get_result(package) {
             Ok(Some(sources)) => Some(sources),
             Ok(None) => None,
             Err(err) => {
@@ -185,7 +185,7 @@ impl PackageCache {
         }
     }
 
-    fn get_impl(&self, package: &str) -> anyhow::Result<Option<PathBuf>> {
+    fn get_result(&self, package: &str) -> anyhow::Result<Option<PathBuf>> {
         // Find install path of the package
         let mut libpath = None;
         for r_libpath in &self.r_libpaths {

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -122,7 +122,7 @@ pub struct PackageCache {
     /// Blocks any other process from acquiring the root exclusive lock (the only thing
     /// that can delete entries). That way, any `PathBuf` we hand out remains valid for
     /// the life of this cache (as long as `PackageCache` itself is not dropped!).
-    _root_lock: FileLock,
+    cache_root_lock: FileLock,
 
     /// Set of packages which are installed, but we failed to populate their sources (from
     /// CRAN or srcrefs). If we request sources for one of these packages a second time,
@@ -151,21 +151,21 @@ impl PackageCache {
         cache_root.create_dir()?;
 
         // Try to clean the cache. Only works if no other processes hold a shared root lock.
-        if let Some(root_lock) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
-            if let Err(err) = Self::clean(&root_lock) {
+        if let Some(cache_root_lock) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
+            if let Err(err) = Self::clean(&cache_root_lock) {
                 log::warn!("Failed to clean sources cache: {err:?}");
             }
-            drop(root_lock);
+            drop(cache_root_lock);
         }
 
         // Take shared lock for the lifetime of the cache so any paths we hand out stay valid
-        let root_lock = cache_root.open_ro_shared_create(LOCK_FILENAME)?;
+        let cache_root_lock = cache_root.open_ro_shared_create(LOCK_FILENAME)?;
 
         Ok(Self {
             r,
             r_libpaths,
             cache_root,
-            _root_lock: root_lock,
+            cache_root_lock,
             source_unavailable: RwLock::new(HashSet::new()),
         })
     }
@@ -218,18 +218,14 @@ impl PackageCache {
         let key =
             format!("{package}_{version}_libpath-{libpath_hash}_description-{description_hash}");
 
-        let destination = self.cache_root.join(&key);
-        // Safety: We hold the root lock
-        let destination_path = destination.as_path_unlocked();
-
         // Read path: completion sentinel present, already exists on disk
-        if destination_path.join(METADATA_FILENAME).exists() {
-            return Ok(Some(destination_path.to_path_buf()));
+        let destination = self.cache_root_lock.parent().join(&key);
+        if destination.join(METADATA_FILENAME).exists() {
+            return Ok(Some(destination));
         }
 
-        // Write path: before generating sources, check if we've already tried to generate
-        // sources for this installed package but failed. If so, refuse to attempt
-        // expensive source generation again
+        // Check if we've already tried to generate sources for this installed package but
+        // failed. If so, refuse to attempt expensive source generation again.
         if self
             .source_unavailable
             .read()
@@ -238,14 +234,15 @@ impl PackageCache {
             return Ok(None);
         }
 
-        // Take per-key exclusive lock
+        // Write path: take per-key exclusive lock
+        let destination = self.cache_root.join(&key);
         destination.create_dir()?;
         let destination_lock = destination.open_rw_exclusive_create(LOCK_FILENAME)?;
 
         // Re-check: another writer may have populated the key while we waited for an
         // exclusive lock
-        if destination_path.join(METADATA_FILENAME).exists() {
-            return Ok(Some(destination_path.to_path_buf()));
+        if destination_lock.parent().join(METADATA_FILENAME).exists() {
+            return Ok(Some(destination_lock.parent().to_path_buf()));
         }
 
         // Wipe any partial content from a prior writer that may have crashed before
@@ -260,9 +257,9 @@ impl PackageCache {
             &description_path,
             &description,
             &description_hash,
-            destination_path,
+            &destination_lock,
         )? {
-            Ok(Some(destination_path.to_path_buf()))
+            Ok(Some(destination_lock.parent().to_path_buf()))
         } else {
             // Never try source generation for this key again
             self.source_unavailable
@@ -274,9 +271,6 @@ impl PackageCache {
     }
 
     /// Writes `DESCRIPTION`, `NAMESPACE`, and `R/` to the cache entry, if possible
-    ///
-    /// Can assume that `destination_path` exists and we have exclusive access to via the
-    /// lock.
     fn try_populate(
         &self,
         package: &str,
@@ -286,17 +280,20 @@ impl PackageCache {
         description_path: &Path,
         description: &Description,
         description_hash: &str,
-        destination_path: &Path,
+        destination_lock: &FileLock,
     ) -> anyhow::Result<bool> {
-        if !self.write_r_files(package, version, description, destination_path)? {
+        if !self.write_r_files(package, version, description, destination_lock)? {
             return Ok(false);
         }
 
-        crate::fs::copy_as_readonly(description_path, destination_path.join("DESCRIPTION"))?;
-        crate::fs::copy_as_readonly(namespace_path, destination_path.join("NAMESPACE"))?;
+        crate::fs::copy_as_readonly(
+            description_path,
+            destination_lock.parent().join("DESCRIPTION"),
+        )?;
+        crate::fs::copy_as_readonly(namespace_path, destination_lock.parent().join("NAMESPACE"))?;
 
         // Last! Only write `.metadata` if all other writes succeed. It is our completion sentinal.
-        self.write_metadata(package, libpath, description_hash, destination_path)?;
+        self.write_metadata(package, libpath, description_hash, destination_lock)?;
 
         Ok(true)
     }
@@ -306,13 +303,13 @@ impl PackageCache {
         package: &str,
         version: &str,
         description: &Description,
-        destination_path: &Path,
+        destination_lock: &FileLock,
     ) -> anyhow::Result<bool> {
         // Try caching from srcref
         match crate::srcref::cache_srcref(
             package,
             version,
-            destination_path,
+            destination_lock,
             &self.r,
             &self.r_libpaths,
         ) {
@@ -331,7 +328,7 @@ impl PackageCache {
 
         // Try caching from CRAN
         if matches!(description.repository, Some(Repository::CRAN)) {
-            match crate::cran::cache_cran(package, version, destination_path) {
+            match crate::cran::cache_cran(package, version, destination_lock) {
                 Ok(true) => {
                     log::trace!("Cached {package} {version} from CRAN download.");
                     return Ok(true);
@@ -367,7 +364,7 @@ impl PackageCache {
         package: &str,
         libpath: &Path,
         description_hash: &str,
-        destination_path: &Path,
+        destination_lock: &FileLock,
     ) -> anyhow::Result<()> {
         let metadata = Metadata {
             package: package.to_string(),
@@ -376,18 +373,18 @@ impl PackageCache {
             generated_at: Utc::now(),
         };
         let contents = serde_json::to_vec_pretty(&metadata)?;
-        std::fs::write(destination_path.join(METADATA_FILENAME), contents)?;
+        std::fs::write(destination_lock.parent().join(METADATA_FILENAME), contents)?;
         Ok(())
     }
 
     /// Walks all cache entries and evicts ones that are provably stale.
     ///
     /// Caller must hold the root exclusive lock.
-    fn clean(root_lock: &file_lock::FileLock) -> anyhow::Result<()> {
-        let root = root_lock.parent();
+    fn clean(cache_root_lock: &file_lock::FileLock) -> anyhow::Result<()> {
+        let cache_root = cache_root_lock.parent();
         let now = Utc::now();
 
-        for entry in std::fs::read_dir(root)? {
+        for entry in std::fs::read_dir(cache_root)? {
             let entry = entry?;
             let path = entry.path();
 

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -61,6 +61,10 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// unique due to the `Built` field, which includes a timestamp of when the package was
 /// built (either by CRAN or the user).
 ///
+/// The `{package}` and `{version}` components of the key are not required to make it
+/// unique, but make for a nicer reading experience when goto-definition opens one of
+/// these files in your editor.
+///
 /// # Locking
 ///
 /// The cache root `.lock` can be locked as shared or exclusive:

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::RwLock;
 
 use chrono::DateTime;
@@ -25,6 +26,9 @@ const LOCK_FILENAME: &str = ".lock";
 
 /// Name of the completion sentinel written last in each cache entry.
 const METADATA_FILENAME: &str = ".metadata";
+
+/// Number of threads used for the prefetch pool
+const NUMBER_OF_PREFETCH_THREADS: usize = 4;
 
 /// Minimum age before `clean()` will evict a stale entry.
 ///
@@ -106,8 +110,23 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// - Deleting if the DESCRIPTION it originated from has changed
 ///
 /// [`get`]: PackageCache::get
-/// [`clean`]: PackageCache::clean
+/// [`clean`]: PackageCacheInner::clean
 pub struct PackageCache {
+    inner: Arc<PackageCacheInner>,
+
+    /// Small threadpool used for background prefetching
+    pool: threadpool::ThreadPool,
+
+    /// Shared lock on the root `.lock`, held for the life of this cache.
+    ///
+    /// Blocks any other process from acquiring the root exclusive lock (the only thing
+    /// that can delete entries). That way, any `PathBuf` we hand out remains valid for
+    /// the life of this cache (as long as `PackageCache` itself is not dropped!).
+    _root_lock: FileLock,
+}
+
+/// Data shared across prefetch threads
+struct PackageCacheInner {
     /// Path to `R` binary
     r: PathBuf,
 
@@ -116,13 +135,6 @@ pub struct PackageCache {
 
     /// On disk cache directory root
     cache_root: file_lock::Filesystem,
-
-    /// Shared lock on the root `.lock`, held for the life of this cache.
-    ///
-    /// Blocks any other process from acquiring the root exclusive lock (the only thing
-    /// that can delete entries). That way, any `PathBuf` we hand out remains valid for
-    /// the life of this cache (as long as `PackageCache` itself is not dropped!).
-    _root_lock: FileLock,
 
     /// Set of packages which are installed, but we failed to populate their sources (from
     /// CRAN or srcrefs). If we request sources for one of these packages a second time,
@@ -147,7 +159,7 @@ impl PackageCache {
 
         // Try to clean the cache. Only works if no other processes hold a shared root lock.
         if let Some(root_lock) = cache_root.try_open_rw_exclusive_create(LOCK_FILENAME)? {
-            if let Err(err) = Self::clean(&root_lock) {
+            if let Err(err) = PackageCacheInner::clean(root_lock.parent()) {
                 log::warn!("Failed to clean sources cache: {err:?}");
             }
             drop(root_lock);
@@ -157,19 +169,46 @@ impl PackageCache {
         let root_lock = cache_root.open_ro_shared_create(LOCK_FILENAME)?;
 
         Ok(Self {
-            r,
-            r_libpaths,
-            cache_root,
+            inner: Arc::new(PackageCacheInner {
+                r,
+                r_libpaths,
+                cache_root,
+                source_unavailable: RwLock::new(HashSet::new()),
+            }),
+            pool: threadpool::ThreadPool::new(NUMBER_OF_PREFETCH_THREADS),
             _root_lock: root_lock,
-            source_unavailable: RwLock::new(HashSet::new()),
         })
+    }
+
+    /// Populate the cache for `package` in the background
+    ///
+    /// This method is fire-and-forget. Callers anticipate that at some time in the future
+    /// they are likely to require sources for this package, but don't gain access to
+    /// them now.
+    ///
+    /// It is perfectly safe to call this followed by a `get()` at some time shortly
+    /// after, even if the prefetch hasn't finished yet.
+    pub fn prefetch(&self, package: &str) {
+        self.pool.execute({
+            let inner = Arc::clone(&self.inner);
+            let package = package.to_string();
+            move || {
+                inner.get(&package);
+            }
+        });
     }
 
     /// Get a package's cached source folder
     ///
-    /// May spawn an R subprocess or download from CRAN (in a blocking manner) to
-    /// generate the sources, so keep that in mind when calling this.
+    /// Blocks and may spawn an R subprocess or download from CRAN (in a blocking manner)
+    /// to generate the sources.
     pub fn get(&self, package: &str) -> Option<PathBuf> {
+        self.inner.get(package)
+    }
+}
+
+impl PackageCacheInner {
+    fn get(&self, package: &str) -> Option<PathBuf> {
         match self.get_impl(package) {
             Ok(Some(sources)) => Some(sources),
             Ok(None) => None,
@@ -370,8 +409,7 @@ impl PackageCache {
     /// Walks all cache entries and evicts ones that are provably stale.
     ///
     /// Caller must hold the root exclusive lock.
-    fn clean(root_lock: &file_lock::FileLock) -> anyhow::Result<()> {
-        let root = root_lock.parent();
+    fn clean(root: &Path) -> anyhow::Result<()> {
         let now = Utc::now();
 
         for entry in std::fs::read_dir(root)? {

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -54,6 +54,13 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// is written last and is the sole completion sentinel. An entry without it
 /// is considered garbage and will be wiped by the next writer for that key.
 ///
+/// The combination of `libpath-{hash}` and `description-{hash}` are enough to make a
+/// unique key. The same R package could be installed in multiple libraries (even for the
+/// same R version), so libpath matters and is also recorded in `.metadata` as one of the
+/// signals that allows us to clean up a stale source folder. And the DESCRIPTION hash is
+/// unique due to the `Built` field, which includes a timestamp of when the package was
+/// built (either by CRAN or the user).
+///
 /// # Locking
 ///
 /// The cache root `.lock` can be locked as shared or exclusive:

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -107,8 +107,8 @@ const ONE_WEEK: TimeDelta = TimeDelta::weeks(1);
 /// [`get`]: PackageSourcesCache::get
 /// [`clean`]: PackageSourcesCache::clean
 pub struct PackageSourcesCache {
-    /// Path to `Rscript`
-    r_script_path: PathBuf,
+    /// Path to `R` binary
+    r: PathBuf,
 
     /// Set of R library paths
     r_libpaths: Vec<PathBuf>,
@@ -141,7 +141,7 @@ struct Metadata {
 }
 
 impl PackageSourcesCache {
-    pub fn new(r_script_path: PathBuf, r_libpaths: Vec<PathBuf>) -> anyhow::Result<Self> {
+    pub fn new(r: PathBuf, r_libpaths: Vec<PathBuf>) -> anyhow::Result<Self> {
         let cache_root = file_lock::Filesystem::new(crate::fs::sources_dir()?);
         cache_root.create_dir()?;
 
@@ -157,7 +157,7 @@ impl PackageSourcesCache {
         let root_lock = cache_root.open_ro_shared_create(LOCK_FILENAME)?;
 
         Ok(Self {
-            r_script_path,
+            r,
             r_libpaths,
             cache_root,
             _root_lock: root_lock,
@@ -300,7 +300,7 @@ impl PackageSourcesCache {
             package,
             version,
             destination_path,
-            &self.r_script_path,
+            &self.r,
             &self.r_libpaths,
         ) {
             Ok(true) => {

--- a/crates/oak_sources/src/srcref.rs
+++ b/crates/oak_sources/src/srcref.rs
@@ -11,7 +11,7 @@ pub(crate) fn cache_srcref(
     package: &str,
     version: &str,
     destination: &Path,
-    r_script_path: &Path,
+    r: &Path,
     r_libpaths: &[PathBuf],
 ) -> anyhow::Result<bool> {
     let args = &[package, version];
@@ -25,8 +25,7 @@ pub(crate) fn cache_srcref(
         .join(if cfg!(windows) { ";" } else { ":" });
     let env = &[("R_LIBS", libpaths.as_str())];
 
-    let script = write_script(SCRIPT)?;
-    let output = oak_r_process::run_script(r_script_path, script.path(), args, env)?;
+    let output = oak_r_process::run_text(r, SCRIPT, args, env)?;
 
     let code = output.status.code().unwrap_or(1);
 
@@ -61,18 +60,6 @@ pub(crate) fn cache_srcref(
     }
 
     Ok(true)
-}
-
-/// Writes a script string to a temporary file for execution by `Rscript`.
-fn write_script(script: &str) -> anyhow::Result<tempfile::NamedTempFile> {
-    use std::io::Write;
-    let mut file = tempfile::Builder::new()
-        .suffix(".R")
-        .tempfile()
-        .map_err(|err| anyhow::anyhow!("Failed to create temporary script file: {err}"))?;
-    file.write_all(script.as_bytes())
-        .map_err(|err| anyhow::anyhow!("Failed to write temporary script file: {err}"))?;
-    Ok(file)
 }
 
 /// Parses the concatenated srcref output into individual files.
@@ -198,7 +185,7 @@ fn_a <- function() {
         assert_eq!(parse_line_directive("#line 1 missing-quotes"), None);
     }
 
-    /// Requires Rscript on PATH and internet access
+    /// Requires R on the PATH and internet access
     ///
     /// Installs source version of {generics} from CRAN into a temporary library, then
     /// extracts the R source files via srcref metadata. We use {generics} because it
@@ -207,34 +194,33 @@ fn_a <- function() {
     fn test_srcref_extraction() {
         use std::process::Command;
 
-        // Find Rscript on PATH.
+        // Find R on PATH.
         // On Windows, `which` (from Git) returns POSIX paths that `Command::new()` can't
         // resolve. Use `where` which returns native paths.
         let output = Command::new(if cfg!(windows) { "where" } else { "which" })
-            .arg("Rscript")
+            .arg("R")
             .output()
-            .unwrap_or_else(|err| panic!("Failed to find Rscript: {err}"));
+            .unwrap_or_else(|err| panic!("Failed to find R: {err}"));
         assert!(output.status.success());
 
         // Parse (`where` on Windows can return multiple matches, take the first)
-        let r_script_path = PathBuf::from(
+        let r = PathBuf::from(
             String::from_utf8(output.stdout)
-                .expect("Non-UTF8 Rscript path")
+                .expect("Non-UTF8 R path")
                 .trim()
                 .lines()
                 .next()
-                .expect("Rscript should exist"),
+                .expect("R should exist"),
         );
 
-        // Get base libpaths from this Rscript
-        let output = Command::new(&r_script_path)
-            .args([
-                "--vanilla",
-                "-e",
-                r#"cat(normalizePath(.libPaths()), sep = "\n")"#,
-            ])
-            .output()
-            .expect("Failed to get .libPaths()");
+        // Get base libpaths from R
+        let output = oak_r_process::run_text(
+            &r,
+            r#"cat(normalizePath(.libPaths()), sep = "\n")"#,
+            &[],
+            &[],
+        )
+        .expect("Failed to get .libPaths()");
         assert!(output.status.success(), "Failed to query .libPaths()");
 
         let r_libpaths_original: Vec<PathBuf> = String::from_utf8(output.stdout)
@@ -253,29 +239,27 @@ fn_a <- function() {
             r_libpaths.path().display().to_string().replace('\\', "/");
 
         // Install generics from CRAN source with srcrefs preserved
-        let status = Command::new(&r_script_path)
-            .args([
-                "--vanilla",
-                "-e",
-                &format!(
+        let output = oak_r_process::run_text(
+            &r,
+            &format!(
                     r#"install.packages("generics", lib = "{r_libpaths_for_interpolation}", repos = "https://cran.r-project.org", type = "source", INSTALL_opts = "--with-keep.source")"#,
                 ),
-            ])
-            .output()
-            .expect("Failed to run install.packages()");
-        assert!(status.status.success());
+            &[],
+            &[],
+        )
+        .expect("Failed to run install.packages()");
+        assert!(output.status.success());
 
         // Query the installed generics version
-        let output = Command::new(&r_script_path)
-            .args([
-                "--vanilla",
-                "-e",
-                &format!(
+        let output = oak_r_process::run_text(
+            &r,
+            &format!(
                     r#"cat(as.character(packageVersion("generics", lib.loc = "{r_libpaths_for_interpolation}")))"#,
                 ),
-            ])
-            .output()
-            .expect("Failed to get generics version");
+            &[],
+            &[],
+        )
+        .expect("Failed to get generics version");
         assert!(output.status.success());
 
         let version = String::from_utf8(output.stdout)
@@ -290,14 +274,7 @@ fn_a <- function() {
         // Cache destination
         let destination = tempfile::TempDir::new().unwrap();
 
-        let ok = cache_srcref(
-            "generics",
-            &version,
-            destination.path(),
-            &r_script_path,
-            &all_libpaths,
-        )
-        .unwrap();
+        let ok = cache_srcref("generics", &version, destination.path(), &r, &all_libpaths).unwrap();
         assert!(ok);
 
         // Verify R source files were written

--- a/crates/oak_sources/src/srcref.rs
+++ b/crates/oak_sources/src/srcref.rs
@@ -1,0 +1,319 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+const SCRIPT: &str = include_str!("../scripts/srcrefs.R");
+
+/// Extracts an R package's source files from srcref metadata if possible and adds
+/// them to the cache at `destination`
+///
+/// Launches a sidecar R session to read the srcrefs from the installed package.
+pub(crate) fn cache_srcref(
+    package: &str,
+    version: &str,
+    destination: &Path,
+    r_script_path: &Path,
+    r_libpaths: &[PathBuf],
+) -> anyhow::Result<bool> {
+    let args = &[package, version];
+
+    // Set `R_LIBS` to ensure the correct R package libraries are checked
+    // `:` on Unix, `;` on Windows, see `?R_LIBS`
+    let libpaths = r_libpaths
+        .iter()
+        .map(|libpath| libpath.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(if cfg!(windows) { ";" } else { ":" });
+    let env = &[("R_LIBS", libpaths.as_str())];
+
+    let script = write_script(SCRIPT)?;
+    let output = oak_r_process::run_script(r_script_path, script.path(), args, env)?;
+
+    let code = output.status.code().unwrap_or(1);
+
+    // Exit code 2 means no srcrefs
+    if code == 2 {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::trace!("R script returned with exit code {code} for {package} {version}: {stderr}");
+        return Ok(false);
+    }
+
+    // Any other unexpected failure (unexpectedly not installed or wrong version)
+    if code != 0 {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!(
+            "R script failed with exit code {code} for {package} {version}: {stderr}"
+        ));
+    }
+
+    let stdout = String::from_utf8(output.stdout).map_err(|err| {
+        anyhow::anyhow!("R script output was not valid UTF-8 for {package} {version}: {err}")
+    })?;
+
+    let files = parse_output(&stdout);
+
+    let destination = destination.join("R");
+    std::fs::create_dir(&destination)?;
+
+    for (name, contents) in files {
+        let path = destination.join(name);
+        std::fs::write(&path, contents)?;
+        crate::fs::set_readonly(&path)?;
+    }
+
+    Ok(true)
+}
+
+/// Writes a script string to a temporary file for execution by `Rscript`.
+fn write_script(script: &str) -> anyhow::Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+    let mut file = tempfile::Builder::new()
+        .suffix(".R")
+        .tempfile()
+        .map_err(|err| anyhow::anyhow!("Failed to create temporary script file: {err}"))?;
+    file.write_all(script.as_bytes())
+        .map_err(|err| anyhow::anyhow!("Failed to write temporary script file: {err}"))?;
+    Ok(file)
+}
+
+/// Parses the concatenated srcref output into individual files.
+///
+/// The output format uses `#line 1 "<path>"` directives to separate files:
+///
+/// ```text
+/// #line 1 "</install/path>/pkg/R/aaa.R"
+/// <contents of aaa.R>
+/// #line 1 "</install/path>/pkg/R/bbb.R"
+/// <contents of bbb.R>
+/// ```
+fn parse_output(output: &str) -> Vec<(String, String)> {
+    let mut files: Vec<(String, String)> = Vec::new();
+    let mut current_name: Option<String> = None;
+    let mut current_lines: Vec<&str> = Vec::new();
+
+    // This discards any lines before the first line directive, like this line, which
+    // isn't part of the package sources `.packageName <- "vctrs"`
+    for line in output.lines() {
+        if let Some(name) = parse_line_directive(line) {
+            // Flush the previous file
+            if let Some(current_name) = current_name.take() {
+                files.push((current_name, current_lines.join("\n")));
+                current_lines.clear();
+            }
+            current_name = Some(name);
+        } else {
+            if current_name.is_some() {
+                current_lines.push(line);
+            }
+        }
+    }
+
+    // Flush the last file
+    if let Some(name) = current_name.take() {
+        files.push((name, current_lines.join("\n")));
+    }
+
+    files
+}
+
+/// Extracts the filename from a line directive, keeping just the basename.
+///
+/// For example, `line 1 "</install/path>/pkg/R/aaa.R"` becomes `aaa.R`.
+///
+/// Does not have a way to fail on malformed line directives. If for some reason one is
+/// malformed and doesn't have our expected prefix/suffix, then we would end up treating
+/// it like a comment within a file.
+fn parse_line_directive(line: &str) -> Option<String> {
+    let path = line.strip_prefix("#line 1 \"")?;
+    let path = path.strip_suffix('"')?;
+    let file_name = Path::new(path).file_name()?;
+    Some(file_name.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_output_single_file() {
+        let output = "\
+#line 1 \"/path/to/pkg/R/aaa.R\"
+fn_a <- function() {
+  1 + 1
+}";
+        let files = parse_output(output);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "aaa.R");
+        assert_eq!(files[0].1, "fn_a <- function() {\n  1 + 1\n}");
+    }
+
+    #[test]
+    fn test_parse_output_multiple_files() {
+        let output = "\
+#line 1 \"/path/to/pkg/R/aaa.R\"
+fn_a <- function() { }
+#line 1 \"/path/to/pkg/R/bbb.R\"
+fn_b <- function() { }";
+        let files = parse_output(output);
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].0, "aaa.R");
+        assert_eq!(files[0].1, "fn_a <- function() { }");
+        assert_eq!(files[1].0, "bbb.R");
+        assert_eq!(files[1].1, "fn_b <- function() { }");
+    }
+
+    #[test]
+    fn test_parse_output_leading_text() {
+        let output = "\
+packageName <- \"vctrs\"
+#line 1 \"/path/to/pkg/R/aaa.R\"
+fn_a <- function() {
+  1 + 1
+}";
+        let files = parse_output(output);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "aaa.R");
+        assert_eq!(files[0].1, "fn_a <- function() {\n  1 + 1\n}");
+    }
+
+    #[test]
+    fn test_parse_output_empty() {
+        let files = parse_output("");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_output_no_directives() {
+        let files = parse_output("just some text\nwith no directives");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_line_directive() {
+        assert_eq!(
+            parse_line_directive("#line 1 \"/path/to/file.R\""),
+            Some(String::from("file.R"))
+        );
+        assert_eq!(parse_line_directive("not a directive"), None);
+        assert_eq!(parse_line_directive("#line 2 \"/path/to/file.R\""), None);
+        assert_eq!(parse_line_directive("#line 1 missing-quotes"), None);
+    }
+
+    /// Requires Rscript on PATH and internet access
+    ///
+    /// Installs source version of {generics} from CRAN into a temporary library, then
+    /// extracts the R source files via srcref metadata. We use {generics} because it
+    /// is very easy to install from source and lightweight.
+    #[test]
+    fn test_srcref_extraction() {
+        use std::process::Command;
+
+        // Find Rscript on PATH.
+        // On Windows, `which` (from Git) returns POSIX paths that `Command::new()` can't
+        // resolve. Use `where` which returns native paths.
+        let output = Command::new(if cfg!(windows) { "where" } else { "which" })
+            .arg("Rscript")
+            .output()
+            .unwrap_or_else(|err| panic!("Failed to find Rscript: {err}"));
+        assert!(output.status.success());
+
+        // Parse (`where` on Windows can return multiple matches, take the first)
+        let r_script_path = PathBuf::from(
+            String::from_utf8(output.stdout)
+                .expect("Non-UTF8 Rscript path")
+                .trim()
+                .lines()
+                .next()
+                .expect("Rscript should exist"),
+        );
+
+        // Get base libpaths from this Rscript
+        let output = Command::new(&r_script_path)
+            .args([
+                "--vanilla",
+                "-e",
+                r#"cat(normalizePath(.libPaths()), sep = "\n")"#,
+            ])
+            .output()
+            .expect("Failed to get .libPaths()");
+        assert!(output.status.success(), "Failed to query .libPaths()");
+
+        let r_libpaths_original: Vec<PathBuf> = String::from_utf8(output.stdout)
+            .expect("Non-UTF8 libpaths")
+            .trim()
+            .lines()
+            .map(PathBuf::from)
+            .collect();
+
+        // Temporary library for installing generics
+        let r_libpaths = tempfile::TempDir::new().unwrap();
+
+        // Use forward slashes so the path is safe inside R string literals on Windows
+        // (backslashes would be interpreted as escape sequences).
+        let r_libpaths_for_interpolation =
+            r_libpaths.path().display().to_string().replace('\\', "/");
+
+        // Install generics from CRAN source with srcrefs preserved
+        let status = Command::new(&r_script_path)
+            .args([
+                "--vanilla",
+                "-e",
+                &format!(
+                    r#"install.packages("generics", lib = "{r_libpaths_for_interpolation}", repos = "https://cran.r-project.org", type = "source", INSTALL_opts = "--with-keep.source")"#,
+                ),
+            ])
+            .output()
+            .expect("Failed to run install.packages()");
+        assert!(status.status.success());
+
+        // Query the installed generics version
+        let output = Command::new(&r_script_path)
+            .args([
+                "--vanilla",
+                "-e",
+                &format!(
+                    r#"cat(as.character(packageVersion("generics", lib.loc = "{r_libpaths_for_interpolation}")))"#,
+                ),
+            ])
+            .output()
+            .expect("Failed to get generics version");
+        assert!(output.status.success());
+
+        let version = String::from_utf8(output.stdout)
+            .expect("Non-UTF8 version")
+            .trim()
+            .to_string();
+
+        // Prepend our temp library so generics is found there first
+        let mut all_libpaths = vec![r_libpaths.path().to_path_buf()];
+        all_libpaths.extend(r_libpaths_original);
+
+        // Cache destination
+        let destination = tempfile::TempDir::new().unwrap();
+
+        let ok = cache_srcref(
+            "generics",
+            &version,
+            destination.path(),
+            &r_script_path,
+            &all_libpaths,
+        )
+        .unwrap();
+        assert!(ok);
+
+        // Verify R source files were written
+        let r_dir = destination.path().join("R");
+        assert!(r_dir.exists());
+
+        let entries: Vec<_> = std::fs::read_dir(&r_dir)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(!entries.is_empty());
+
+        // Verify files are readonly
+        for entry in &entries {
+            let metadata = entry.metadata().unwrap();
+            assert!(metadata.permissions().readonly());
+        }
+    }
+}

--- a/crates/oak_sources/src/srcref.rs
+++ b/crates/oak_sources/src/srcref.rs
@@ -1,16 +1,18 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use oak_fs::file_lock::FileLock;
+
 const SCRIPT: &str = include_str!("../scripts/srcrefs.R");
 
 /// Extracts an R package's source files from srcref metadata if possible and adds
-/// them to the cache at `destination`
+/// them to the cache at the parent folder containing `destination_lock`
 ///
 /// Launches a sidecar R session to read the srcrefs from the installed package.
 pub(crate) fn cache_srcref(
     package: &str,
     version: &str,
-    destination: &Path,
+    destination_lock: &FileLock,
     r: &Path,
     r_libpaths: &[PathBuf],
 ) -> anyhow::Result<bool> {
@@ -50,7 +52,7 @@ pub(crate) fn cache_srcref(
 
     let files = parse_output(&stdout);
 
-    let destination = destination.join("R");
+    let destination = destination_lock.parent().join("R");
     std::fs::create_dir(&destination)?;
 
     for (name, contents) in files {
@@ -118,6 +120,8 @@ fn parse_line_directive(line: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use oak_fs::file_lock::Filesystem;
+
     use super::*;
 
     #[test]
@@ -272,13 +276,15 @@ fn_a <- function() {
         all_libpaths.extend(r_libpaths_original);
 
         // Cache destination
-        let destination = tempfile::TempDir::new().unwrap();
+        let destination_tempdir = tempfile::TempDir::new().unwrap();
+        let destination = Filesystem::new(destination_tempdir.path().to_path_buf());
+        let destination_lock = destination.open_rw_exclusive_create(".lock").unwrap();
 
-        let ok = cache_srcref("generics", &version, destination.path(), &r, &all_libpaths).unwrap();
+        let ok = cache_srcref("generics", &version, &destination_lock, &r, &all_libpaths).unwrap();
         assert!(ok);
 
         // Verify R source files were written
-        let r_dir = destination.path().join("R");
+        let r_dir = destination_lock.parent().join("R");
         assert!(r_dir.exists());
 
         let entries: Vec<_> = std::fs::read_dir(&r_dir)


### PR DESCRIPTION
https://github.com/posit-dev/positron/issues/2286
Progress towards https://github.com/posit-dev/positron/issues/2749

Two tiered approach to caching R package sources, in the following priority order:
- Source references on already installed package (requires sidecar R session)
- CRAN download (requires internet)
    - Future Bioconductor download (not yet, but Gabor has code for this in pkgdepends)

## API

```
PackageCache::new(r_script_path: PathBuf, r_libpaths: Vec<PathBuf>)
PackageCache::get(&mut self, package: &str) -> Option<PathBuf>
```

## Source references

When a package is installed with source references, `attr(attr(pkg::fn, "srcref"), "srcfile")$original$lines` contains something like this:

```
[1] ".packageName <- \"vctrs\""
[2] "#line 1 \"/private/var/folders/by/4wf2qrmn4_j93s5k5k5fzrx00000gp/T/Rtmp5mAZjD/R.INSTALL164782a40400c/vctrs/R/aaa.R\""                  
   [3] "replace_from <- function(what, pkg, to = topenv(caller_env())) {"                                                                      
   [4] "  if (what %in% getNamespaceExports(pkg)) {"                                                                                           
   [5] "    env <- ns_env(pkg)"                                                                                                                
   [6] "  } else {"                                                                                                                            
   [7] "    env <- to"                                                                                                                         
   [8] "  }"                                                                                                                                   
   [9] "  env_get(env, what, inherit = TRUE)"                                                                                                  
  [10] "}"                                                                                                                                     
  [11] ""                                                                                                                                      
  [12] "# nocov start"                                                                                                                         
  [13] ""                                                                                                                                      
  [14] "# Useful for micro-optimising default arguments requiring evaluation,"                                                                 
  [15] "# such as `param = c(\"foo\", \"bar\")`. Buys about 0.6us on my desktop."                                                              
  [16] "fn_inline_formals <- function(fn, names) {"                                                                                            
  [17] "  stopifnot(typeof(fn) == \"closure\")"                                                                                                
  [18] ""                                                                                                                                      
  [19] "  fmls <- formals(fn)"                                                                                                                 
  [20] "  fmls[names] <- lapply(fmls[names], eval)"                                                                                            
  [21] ""                                                                                                                                      
  [22] "  formals(fn) <- fmls"                                                                                                                 
  [23] "  fn"                                                                                                                                  
  [24] "}"                                                                                                                                     
  [25] ""                                                                                                                                      
  [26] "# nocov end"                                                                                                                           
  [27] "#line 1 \"/private/var/folders/by/4wf2qrmn4_j93s5k5k5fzrx00000gp/T/Rtmp5mAZjD/R.INSTALL164782a40400c/vctrs/R/altrep-lazy-character.R\""
  [28] "#' Lazy character vector"                                                                                                              
  [29] "#'"                                                                                                                                    
  [30] "#' `new_lazy_character()` takes a function with no arguments which must return"                                                        
  [31] "#' a character vector of arbitrary length. The function will be evaluated"
```

These source references are generated from a number of sources:

- `devtools::install(build = FALSE, keep_source = TRUE)`
    - Absolute file paths will point to the user's local package folder
- `devtools::install(build = TRUE, keep_source = TRUE)`
    - Absolute file paths will point to a nonexistent temp directory
- `pak::pak(<github source>)`
    - Only with `KeepSource: true` or envvar `R_KEEP_PKG_SOURCE=yes`
    - Absolute file paths will point to a nonexistent temp directory
- CRAN binary download
    - From package bundle generated with `KeepSource: true`
    - Absolute file paths will point to a nonexistent CRAN machine directory

For the most part, the absolute paths are useless to us. But the _relative package structure_ is incredibly useful. i.e. with `<install-path>/vctrs/R/altrep-lazy-character.R` we can rebuild `altrep-lazy-character.R` - comments and all!

This unfortunately requires R to yank out this srcref information.

## CRAN download

Given a package name and version, we can go out and download its sources from CRAN. They retain historical archives for all package versions.

## What does this get us?

We can `get("vctrs")` and be returned a `PathBuf` that points to a directory that is guaranteed to contain:
- `DESCRIPTION`
- `NAMESPACE`
- `R/` with full comments and file structure

We can use this for further static analysis.