### PR TITLE
Implement enclosing snapshots

### DIFF
--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -16,17 +16,22 @@ use biome_rowan::AstSeparatedList;
 use biome_rowan::SyntaxNodeCast;
 use biome_rowan::TextRange;
 use biome_rowan::WalkEvent;
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use crate::index_vec::Idx;
 use crate::index_vec::IndexVec;
 use crate::semantic_index::Definition;
 use crate::semantic_index::DefinitionId;
 use crate::semantic_index::DefinitionKind;
+use crate::semantic_index::EnclosingSnapshotId;
+use crate::semantic_index::EnclosingSnapshotKey;
 use crate::semantic_index::Scope;
 use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
 use crate::semantic_index::SemanticIndex;
 use crate::semantic_index::SymbolFlags;
+use crate::semantic_index::SymbolId;
 use crate::semantic_index::SymbolTableBuilder;
 use crate::semantic_index::Use;
 use crate::semantic_index::UseId;
@@ -36,6 +41,7 @@ use crate::use_def_map::UseDefMapBuilder;
 pub fn build(root: &RRoot) -> SemanticIndex {
     let range = root.syntax().text_trimmed_range();
     let mut builder = SemanticIndexBuilder::new(range);
+    builder.pre_scan_scope(root.syntax());
     builder.collect_expression_list(&root.expressions());
     builder.finish()
 }
@@ -50,6 +56,9 @@ struct SemanticIndexBuilder {
     uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
     use_def_maps: IndexVec<ScopeId, UseDefMapBuilder>,
     current_scope: ScopeId,
+    current_pre_scan: PreScanScope,
+    pre_scan_stack: Vec<PreScanScope>,
+    enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
 }
 
 impl SemanticIndexBuilder {
@@ -85,6 +94,9 @@ impl SemanticIndexBuilder {
             uses,
             use_def_maps,
             current_scope: file,
+            current_pre_scan: PreScanScope::new(),
+            pre_scan_stack: Vec::new(),
+            enclosing_snapshots: FxHashMap::default(),
         }
     }
 
@@ -109,6 +121,9 @@ impl SemanticIndexBuilder {
         self.uses.push(IndexVec::new());
         self.use_def_maps.push(UseDefMapBuilder::new());
 
+        let parent_pre_scan = std::mem::replace(&mut self.current_pre_scan, PreScanScope::new());
+        self.pre_scan_stack.push(parent_pre_scan);
+
         id
     }
 
@@ -119,6 +134,11 @@ impl SemanticIndexBuilder {
         self.current_scope = match self.scopes[id].parent {
             Some(parent) => parent,
             None => panic!("`pop_scope()` called on the file scope"),
+        };
+
+        self.current_pre_scan = match self.pre_scan_stack.pop() {
+            Some(pre_scan) => pre_scan,
+            None => panic!("`pop_scope()` called with empty pre-scan stack"),
         };
     }
 
@@ -202,6 +222,71 @@ impl SemanticIndexBuilder {
         });
         self.use_def_maps[self.current_scope].ensure_symbol(symbol_id);
         self.use_def_maps[self.current_scope].record_use(symbol_id, use_id);
+
+        // Associate free variables with the enclosing snapshot where the
+        // variable is defined
+        if self.use_def_maps[self.current_scope].is_may_be_unbound(symbol_id) {
+            self.register_enclosing_snapshot(name, symbol_id);
+        }
+    }
+
+    fn register_enclosing_snapshot(&mut self, name: &str, nested_symbol_id: SymbolId) {
+        // We're looking for a parent definition for this scope's free variable
+        // so start from parent
+        let Some(mut current_scope) = self.scopes[self.current_scope].parent else {
+            return;
+        };
+        let Some(mut stack_idx) = self.pre_scan_stack.len().checked_sub(1) else {
+            return;
+        };
+
+        loop {
+            let found_by_flag = self.symbol_tables[current_scope]
+                .id(name)
+                .is_some_and(|sym_id| {
+                    self.symbol_tables[current_scope]
+                        .symbol(sym_id)
+                        .flags()
+                        .contains(SymbolFlags::IS_BOUND)
+                });
+
+            let found_by_prescan = self.pre_scan_stack[stack_idx].has_name(name);
+
+            if found_by_flag || found_by_prescan {
+                // Intern with empty flags: we just need a stable `SymbolId` for
+                // the lookup key. If found via `found_by_flag`, the symbol
+                // already exists with `IS_BOUND`. If found via pre-scan only,
+                // the later `add_definition` call during the full walk will set
+                // `IS_BOUND`.
+                let enclosing_symbol_id =
+                    self.symbol_tables[current_scope].intern(name, SymbolFlags::empty());
+
+                let key = EnclosingSnapshotKey {
+                    nested_scope: self.current_scope,
+                    nested_symbol: nested_symbol_id,
+                };
+                if self.enclosing_snapshots.contains_key(&key) {
+                    return;
+                }
+
+                self.use_def_maps[current_scope].ensure_symbol(enclosing_symbol_id);
+                let snapshot_id = self.use_def_maps[current_scope]
+                    .register_enclosing_snapshot(enclosing_symbol_id);
+                self.enclosing_snapshots
+                    .insert(key, (current_scope, snapshot_id));
+
+                return;
+            }
+
+            let Some(parent) = self.scopes[current_scope].parent else {
+                return;
+            };
+            let Some(next_idx) = stack_idx.checked_sub(1) else {
+                return;
+            };
+            current_scope = parent;
+            stack_idx = next_idx;
+        }
     }
 
     // --- Recursive descent ---
@@ -316,7 +401,11 @@ impl SemanticIndexBuilder {
                 if let Ok(body) = stmt.body() {
                     let first_use = self.uses[self.current_scope].next_id();
                     self.collect_expression(&body);
-                    self.use_def_maps[self.current_scope].finish_loop_defs(&pre_loop, first_use);
+                    self.use_def_maps[self.current_scope].finish_loop_defs(
+                        &pre_loop,
+                        first_use,
+                        &self.uses[self.current_scope],
+                    );
                 }
 
                 self.use_def_maps[self.current_scope].merge(pre_loop);
@@ -360,7 +449,11 @@ impl SemanticIndexBuilder {
                 if let Ok(body) = stmt.body() {
                     let first_use = self.uses[self.current_scope].next_id();
                     self.collect_expression(&body);
-                    self.use_def_maps[self.current_scope].finish_loop_defs(&pre_loop, first_use);
+                    self.use_def_maps[self.current_scope].finish_loop_defs(
+                        &pre_loop,
+                        first_use,
+                        &self.uses[self.current_scope],
+                    );
                 }
 
                 // Body may not execute
@@ -368,12 +461,16 @@ impl SemanticIndexBuilder {
             },
 
             AnyRExpression::RRepeatStatement(stmt) => {
-                // Body always executes at least once, no snapshot needed
+                // Body always executes at least once, so no merge with pre-loop state.
                 if let Ok(body) = stmt.body() {
                     let pre_loop = self.use_def_maps[self.current_scope].snapshot();
                     let first_use = self.uses[self.current_scope].next_id();
                     self.collect_expression(&body);
-                    self.use_def_maps[self.current_scope].finish_loop_defs(&pre_loop, first_use);
+                    self.use_def_maps[self.current_scope].finish_loop_defs(
+                        &pre_loop,
+                        first_use,
+                        &self.uses[self.current_scope],
+                    );
                 }
             },
 
@@ -423,10 +520,58 @@ impl SemanticIndexBuilder {
             self.collect_parameters(&params);
         }
         if let Ok(body) = fun.body() {
+            self.pre_scan_scope(body.syntax());
             self.collect_expression(&body);
         }
 
         self.pop_scope(scope);
+    }
+
+    /// Pre-scan a scope to collect all definition names (skipping nested
+    /// function bodies). Runs before the full walk so that enclosing
+    /// snapshot registration can find where free variables are bound,
+    /// even when the walk in the parent scope hasn't reached the
+    /// definition yet. Must stay in sync with the full walk's definition
+    /// handling: any construct that calls `add_definition` should have a
+    /// corresponding entry here.
+    fn pre_scan_scope(&mut self, node: &RSyntaxNode) {
+        let mut preorder = node.preorder();
+        while let Some(event) = preorder.next() {
+            let WalkEvent::Enter(node) = event else {
+                continue;
+            };
+            let Some(expr) = AnyRExpression::cast(node) else {
+                continue;
+            };
+            match &expr {
+                // NSE scopes (e.g. `local({...})`) will also need to
+                // be skipped here once recognized, since their
+                // definitions belong to a child scope.
+                AnyRExpression::RFunctionDefinition(_) => {
+                    preorder.skip_subtree();
+                },
+                AnyRExpression::RBinaryExpression(bin) if is_assignment(bin) => {
+                    if !is_super_assignment(bin) {
+                        let right = is_right_assignment(bin);
+                        let target = if right { bin.right() } else { bin.left() };
+                        if let Ok(target) = target {
+                            if let Some((name, range)) = assignment_target_name(&target) {
+                                self.current_pre_scan.add(name, range);
+                            }
+                        }
+                    }
+                },
+                AnyRExpression::RForStatement(stmt) => {
+                    if let Ok(variable) = stmt.variable() {
+                        self.current_pre_scan.add(
+                            identifier_text(&variable),
+                            variable.syntax().text_trimmed_range(),
+                        );
+                    }
+                },
+                _ => {},
+            }
+        }
     }
 
     fn collect_parameters(&mut self, params: &RParameters) {
@@ -526,7 +671,12 @@ impl SemanticIndexBuilder {
         self.scopes[ScopeId::from(0)].descendants.end = self.scopes.next_id();
 
         let symbol_tables = self.symbol_tables.into_iter().map(|b| b.build()).collect();
-        let use_def_maps = self.use_def_maps.into_iter().map(|b| b.finish()).collect();
+        let use_def_maps: IndexVec<ScopeId, _> = self
+            .use_def_maps
+            .into_iter()
+            .zip(self.uses.iter())
+            .map(|(b, (_, uses))| b.finish(uses))
+            .collect();
 
         SemanticIndex::new(
             self.scopes,
@@ -534,7 +684,56 @@ impl SemanticIndexBuilder {
             self.definitions,
             self.uses,
             use_def_maps,
+            self.enclosing_snapshots,
         )
+    }
+}
+
+/// All definitions in a scope, collected before the full walk. Skips nested
+/// function bodies (those belong to child scopes). Two consumers:
+///
+/// - Enclosing snapshots: `has_name()` checks whether a symbol will be
+///   defined in an ancestor scope (even when the ancestor's walk hasn't reached
+///   that definition yet), so that `register_enclosing_snapshot()` can find the
+///   right ancestor for free variables.
+/// - NSE resolution: With NSE, each function call potentially pushes a scope
+///   (which can be lazy or eager). We need to resolve the called function's
+///   semantic during the walk. Inside lazy scopes (e.g. function bodies),
+///   `by_name` provides the complete set of parent definitions so that the
+///   function can be resolved against all the parent scope's definitions (if NSE
+///   semantics don't match across definitions, we pick one and lint). Intra-scope
+///   resolution is linear and uses the current `symbol_states` directly instead.
+struct PreScanScope {
+    _defs: Vec<PreScanDef>,
+    by_name: FxHashMap<String, SmallVec<[usize; 2]>>,
+}
+
+/// A single definition site found during the pre-scan. Fields are not
+/// read yet but will be used for NSE lookup.
+struct PreScanDef {
+    _name: String,
+    _range: TextRange,
+}
+
+impl PreScanScope {
+    fn new() -> Self {
+        Self {
+            _defs: Vec::new(),
+            by_name: FxHashMap::default(),
+        }
+    }
+
+    fn add(&mut self, name: String, range: TextRange) {
+        let idx = self._defs.len();
+        self.by_name.entry(name.clone()).or_default().push(idx);
+        self._defs.push(PreScanDef {
+            _name: name,
+            _range: range,
+        });
+    }
+
+    fn has_name(&self, name: &str) -> bool {
+        self.by_name.contains_key(name)
     }
 }
 

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -31,7 +31,6 @@ use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
 use crate::semantic_index::SemanticIndex;
 use crate::semantic_index::SymbolFlags;
-use crate::semantic_index::SymbolId;
 use crate::semantic_index::SymbolTableBuilder;
 use crate::semantic_index::Use;
 use crate::semantic_index::UseId;
@@ -226,11 +225,15 @@ impl SemanticIndexBuilder {
         // Associate free variables with the enclosing snapshot where the
         // variable is defined
         if self.use_def_maps[self.current_scope].is_may_be_unbound(symbol_id) {
-            self.register_enclosing_snapshot(name, symbol_id);
+            let use_key = EnclosingSnapshotKey {
+                nested_scope: self.current_scope,
+                nested_symbol: symbol_id,
+            };
+            self.register_enclosing_snapshot(name, use_key);
         }
     }
 
-    fn register_enclosing_snapshot(&mut self, name: &str, nested_symbol_id: SymbolId) {
+    fn register_enclosing_snapshot(&mut self, name: &str, use_key: EnclosingSnapshotKey) {
         // We're looking for a parent definition for this scope's free variable
         // so start from parent
         let Some(mut current_scope) = self.scopes[self.current_scope].parent else {
@@ -261,11 +264,7 @@ impl SemanticIndexBuilder {
                 let enclosing_symbol_id =
                     self.symbol_tables[current_scope].intern(name, SymbolFlags::empty());
 
-                let key = EnclosingSnapshotKey {
-                    nested_scope: self.current_scope,
-                    nested_symbol: nested_symbol_id,
-                };
-                if self.enclosing_snapshots.contains_key(&key) {
+                if self.enclosing_snapshots.contains_key(&use_key) {
                     return;
                 }
 
@@ -273,7 +272,7 @@ impl SemanticIndexBuilder {
                 let snapshot_id = self.use_def_maps[current_scope]
                     .register_enclosing_snapshot(enclosing_symbol_id);
                 self.enclosing_snapshots
-                    .insert(key, (current_scope, snapshot_id));
+                    .insert(use_key, (current_scope, snapshot_id));
 
                 return;
             }

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -55,8 +55,7 @@ struct SemanticIndexBuilder {
     uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
     use_def_maps: IndexVec<ScopeId, UseDefMapBuilder>,
     current_scope: ScopeId,
-    current_pre_scan: PreScanScope,
-    pre_scan_stack: Vec<PreScanScope>,
+    pre_scans: IndexVec<ScopeId, PreScanScope>,
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
 }
 
@@ -67,6 +66,7 @@ impl SemanticIndexBuilder {
         let mut definitions = IndexVec::new();
         let mut uses = IndexVec::new();
         let mut use_def_maps = IndexVec::new();
+        let mut pre_scans = IndexVec::new();
 
         // The descendants range starts empty (`n+1..n+1`). `pop_scope` later
         // fills in `descendants.end` with the current arena length. Everything
@@ -85,6 +85,7 @@ impl SemanticIndexBuilder {
         definitions.push(IndexVec::new());
         uses.push(IndexVec::new());
         use_def_maps.push(UseDefMapBuilder::new());
+        pre_scans.push(PreScanScope::new());
 
         Self {
             scopes,
@@ -93,8 +94,7 @@ impl SemanticIndexBuilder {
             uses,
             use_def_maps,
             current_scope: file,
-            current_pre_scan: PreScanScope::new(),
-            pre_scan_stack: Vec::new(),
+            pre_scans,
             enclosing_snapshots: FxHashMap::default(),
         }
     }
@@ -119,9 +119,7 @@ impl SemanticIndexBuilder {
         self.definitions.push(IndexVec::new());
         self.uses.push(IndexVec::new());
         self.use_def_maps.push(UseDefMapBuilder::new());
-
-        let parent_pre_scan = std::mem::replace(&mut self.current_pre_scan, PreScanScope::new());
-        self.pre_scan_stack.push(parent_pre_scan);
+        self.pre_scans.push(PreScanScope::new());
 
         id
     }
@@ -133,11 +131,6 @@ impl SemanticIndexBuilder {
         self.current_scope = match self.scopes[id].parent {
             Some(parent) => parent,
             None => panic!("`pop_scope()` called on the file scope"),
-        };
-
-        self.current_pre_scan = match self.pre_scan_stack.pop() {
-            Some(pre_scan) => pre_scan,
-            None => panic!("`pop_scope()` called with empty pre-scan stack"),
         };
     }
 
@@ -239,9 +232,6 @@ impl SemanticIndexBuilder {
         let Some(mut current_scope) = self.scopes[self.current_scope].parent else {
             return;
         };
-        let Some(mut stack_idx) = self.pre_scan_stack.len().checked_sub(1) else {
-            return;
-        };
 
         loop {
             let found_by_flag = self.symbol_tables[current_scope]
@@ -253,7 +243,7 @@ impl SemanticIndexBuilder {
                         .contains(SymbolFlags::IS_BOUND)
                 });
 
-            let found_by_prescan = self.pre_scan_stack[stack_idx].has_name(name);
+            let found_by_prescan = self.pre_scans[current_scope].has_name(name);
 
             if found_by_flag || found_by_prescan {
                 // Intern with empty flags: we just need a stable `SymbolId` for
@@ -280,11 +270,7 @@ impl SemanticIndexBuilder {
             let Some(parent) = self.scopes[current_scope].parent else {
                 return;
             };
-            let Some(next_idx) = stack_idx.checked_sub(1) else {
-                return;
-            };
             current_scope = parent;
-            stack_idx = next_idx;
         }
     }
 
@@ -555,14 +541,14 @@ impl SemanticIndexBuilder {
                         let target = if right { bin.right() } else { bin.left() };
                         if let Ok(target) = target {
                             if let Some((name, range)) = assignment_target_name(&target) {
-                                self.current_pre_scan.add(name, range);
+                                self.pre_scans[self.current_scope].add(name, range);
                             }
                         }
                     }
                 },
                 AnyRExpression::RForStatement(stmt) => {
                     if let Ok(variable) = stmt.variable() {
-                        self.current_pre_scan.add(
+                        self.pre_scans[self.current_scope].add(
                             identifier_text(&variable),
                             variable.syntax().text_trimmed_range(),
                         );

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -6,6 +6,7 @@ use rustc_hash::FxHashMap;
 
 use crate::index_vec::define_index;
 use crate::index_vec::IndexVec;
+use crate::use_def_map::Bindings;
 use crate::use_def_map::UseDefMap;
 
 // File-local scope identifier
@@ -19,6 +20,9 @@ define_index!(DefinitionId);
 
 // Scope-local use site identifier
 define_index!(UseId);
+
+// Scope-local enclosing snapshot identifier
+define_index!(EnclosingSnapshotId);
 
 // One `SemanticIndex` per R source file. This reflects the physical reality of
 // a single file. Cross-file resolution (e.g. package namespaces, sourced
@@ -58,6 +62,10 @@ pub struct SemanticIndex {
     // Per-scope flow-sensitive map from each use site to the set of definitions
     // that can reach it. Built alongside the other arrays during the tree walk.
     use_def_maps: IndexVec<ScopeId, UseDefMap>,
+
+    // For each free variable in a nested scope, maps to the enclosing scope and
+    // snapshot where that symbol is bound.
+    enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
 }
 
 impl SemanticIndex {
@@ -67,6 +75,7 @@ impl SemanticIndex {
         definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
         uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
         use_def_maps: IndexVec<ScopeId, UseDefMap>,
+        enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
     ) -> Self {
         Self {
             scopes,
@@ -74,6 +83,7 @@ impl SemanticIndex {
             definitions,
             uses,
             use_def_maps,
+            enclosing_snapshots,
         }
     }
 
@@ -137,7 +147,7 @@ impl SemanticIndex {
             if let Some(id) = self.symbol_tables[ancestor].id(name) {
                 if self.symbol_tables[ancestor]
                     .symbol(id)
-                    .flags
+                    .flags()
                     .contains(SymbolFlags::IS_BOUND)
                 {
                     return Some((ancestor, id));
@@ -146,6 +156,48 @@ impl SemanticIndex {
         }
         None
     }
+
+    /// Resolve a free variable's bindings from the enclosing scope.
+    ///
+    /// When a use in `scope` may be unbound (`may_be_unbound: true`), some
+    /// control-flow paths fall through to an enclosing scope. This looks up
+    /// the enclosing snapshot that was registered during the build and
+    /// returns the ancestor scope and its bindings. This covers both purely
+    /// free variables (no local definitions) and conditionally defined
+    /// variables (local definitions exist but don't cover all paths).
+    ///
+    /// Returns `None` if no enclosing snapshot was registered (e.g. the
+    /// variable is truly global or from the search path) and needs
+    /// cross-file resolution.
+    pub fn enclosing_bindings(
+        &self,
+        scope: ScopeId,
+        use_id: UseId,
+    ) -> Option<(ScopeId, &Bindings)> {
+        let use_site = &self.uses[scope][use_id];
+        let key = EnclosingSnapshotKey {
+            nested_scope: scope,
+            nested_symbol: use_site.symbol(),
+        };
+        let &(enclosing_scope, snapshot_id) = self.enclosing_snapshots.get(&key)?;
+        let bindings = self.use_def_maps[enclosing_scope].enclosing_snapshot(snapshot_id);
+        Some((enclosing_scope, bindings))
+    }
+}
+
+/// Key for looking up an enclosing snapshot. Keyed by the nested scope and the
+/// symbol's `SymbolId` in the nested scope's symbol table (not the enclosing
+/// scope's), so consumers can do an O(1) lookup directly from a `UseId` without
+/// re-walking the ancestor chain.
+///
+/// When we implement NSE, we will add a `laziness: ScopeLaziness` field to
+/// distinguish lazy snapshots (functions, accumulated union via watchers) from
+/// eager snapshots (NSE scopes like `local()`, point-in-time capture at the
+/// call site). Currently all nested scopes are lazy, so the field is omitted.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EnclosingSnapshotKey {
+    pub nested_scope: ScopeId,
+    pub nested_symbol: SymbolId,
 }
 
 // --- Scope ---

--- a/crates/oak_index/src/use_def_map.rs
+++ b/crates/oak_index/src/use_def_map.rs
@@ -1,11 +1,14 @@
 use itertools::EitherOrBoth;
 use itertools::Itertools;
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use crate::index_vec::Idx;
 use crate::index_vec::IndexVec;
 use crate::semantic_index::DefinitionId;
+use crate::semantic_index::EnclosingSnapshotId;
 use crate::semantic_index::SymbolId;
+use crate::semantic_index::Use;
 use crate::semantic_index::UseId;
 
 // Use-def tracking answers: "at this use of `x`, which specific definitions
@@ -93,7 +96,8 @@ use crate::semantic_index::UseId;
 // from the first iteration should reach `print(x)`. After the body,
 // `finish_loop_defs()` diffs the pre-loop and post-body symbol states.
 // Any new definition (here, B) is retroactively added to uses of that
-// symbol recorded during the body. Result: `print(x)` sees `{A, B}`.
+// symbol recorded during the body (identified via the scope's `uses`
+// list). Result: `print(x)` sees `{A, B}`.
 //
 // ### Deferred definitions (`record_deferred_definition()`)
 //
@@ -115,7 +119,8 @@ use crate::semantic_index::UseId;
 // during the function body walk, after `print(x)` was already recorded.
 // `record_deferred_definition()` adds it to the live state (so future uses
 // see it) and also stashes it. At finalization, `finish_deferred_defs()`
-// retroactively adds it to all uses of that symbol, including `print(x)`.
+// retroactively adds it to all uses of that symbol (iterating the scope's
+// `uses` list), including `print(x)`.
 //
 // ## Interpreting `Bindings`
 //
@@ -130,17 +135,88 @@ use crate::semantic_index::UseId;
 //   {A}         | true           | conditional definition (e.g. if without else)
 //   {}          | true           | no local def, parent scope reference
 //   {A, B}      | true           | some paths define, some don't
+//
+// ## Enclosing snapshots
+//
+// Use-def maps are per-scope, so a free variable in a nested function
+// gets `{ definitions: [], may_be_unbound: true }` locally. To resolve
+// it, we need the enclosing scope's bindings. Enclosing snapshots
+// bridge this gap.
+//
+// A snapshot is registered when `add_use` detects `may_be_unbound` in
+// the nested scope. The builder walks up the scope chain to find the
+// ancestor where the symbol is bound and records a snapshot in that
+// ancestor's `UseDefMapBuilder`. The snapshot captures what's live at
+// the nested scope's definition point, then a watcher accumulates
+// subsequent definitions. We take the union of all subsequent definitions
+// because we can't tractably know exactly when the function is called. In the
+// following example, `x`'s use sees both B and C even though from this
+// particular snippet it can only see B.
+//
+// Providing more accurate answers in the general case would require whole
+// program analysis (e.g. `f` may be passed down to other functions). For now we
+// accept the over-approximation of taking the union of subsequent definitions,
+// although we could improve on that for simple cases in the future (tracking
+// simple calls, and falling back to over-approximation in the other cases).
+//
+// ```r
+// x <- 0              # def A
+// x <- 1              # def B (shadows A)
+// f <- function() x   # snapshot initialized: {B}
+// f()
+// x <- 2              # watcher fires → snapshot: {B, C}
+// ```
+//
+// Note that the snapshot is {B, C}, not {A, B, C}, because def A was already
+// shadowed when `f` was first defined. The rule: what was live at the
+// definition point (prior shadowing applied) plus every definition added after.
+//
+// When `may_be_unbound` is true due to a conditional local definition, the
+// snapshot is also consulted (unlike Python, R has no name-binding rule, so
+// conditional local definitions don't prevent fallthrough):
+//
+// ```r
+// x <- 1
+// f <- function(cond) {
+//     if (cond) x <- 2
+//     x                  # local: {x <- 2, may_be_unbound: true}
+// }                      # enclosing snapshot: {x <- 1}
+// ```
+//
+// The consumer combines both: the local bindings and the enclosing
+// snapshot give the full picture of what `x` could be.
+//
+// For eager NSE scopes (e.g. `local()`), the snapshot will be even more
+// precise: since the body executes at the call site, the snapshot is a
+// point-in-time capture with no watcher, reflecting exactly the linear state.
+// No union over-approximation needed.
 
 /// The immutable use-def map for a single scope. For each use site, stores the
 /// set of definitions that can reach it through control flow.
+///
+/// Also stores enclosing snapshots: the bindings that lazy nested scopes
+/// (i.e. nested functions) see when they reference a symbol defined in this
+/// scope. Looked up via `SemanticIndex::enclosing_bindings()`.
 #[derive(Debug)]
 pub struct UseDefMap {
     bindings_by_use: IndexVec<UseId, Bindings>,
+
+    /// Bindings visible to nested scopes that reference symbols defined here.
+    /// Initialized from the flow state at the nested scope's definition point
+    /// (prior shadowing applied), then conservatively extended with every
+    /// subsequent definition (because we can't know staticaly when the nested
+    /// scope is called). Consulted when a use in the nested scope has
+    /// `may_be_unbound: true`.
+    enclosing_snapshots: IndexVec<EnclosingSnapshotId, Bindings>,
 }
 
 impl UseDefMap {
     pub fn bindings_at_use(&self, use_id: UseId) -> &Bindings {
         &self.bindings_by_use[use_id]
+    }
+
+    pub fn enclosing_snapshot(&self, id: EnclosingSnapshotId) -> &Bindings {
+        &self.enclosing_snapshots[id]
     }
 }
 
@@ -224,13 +300,11 @@ fn sorted_union(a: &[DefinitionId], b: &[DefinitionId]) -> SmallVec<[DefinitionI
 pub(crate) struct UseDefMapBuilder {
     symbol_states: IndexVec<SymbolId, Bindings>,
     bindings_by_use: IndexVec<UseId, Bindings>,
-    // Maps each use to its symbol, so retroactive fixups (for `<<-` and
-    // loop-carried definitions) can find which uses to patch for a given
-    // symbol.
-    symbol_for_use: IndexVec<UseId, SymbolId>,
     // Definitions whose effect on past uses is deferred to `finish()`.
     // Currently used for `<<-` extra definitions in ancestor scopes.
     deferred_defs: Vec<(SymbolId, DefinitionId)>,
+    enclosing_snapshots: IndexVec<EnclosingSnapshotId, Bindings>,
+    snapshot_watchers: FxHashMap<SymbolId, SmallVec<[EnclosingSnapshotId; 1]>>,
 }
 
 impl UseDefMapBuilder {
@@ -238,8 +312,9 @@ impl UseDefMapBuilder {
         Self {
             symbol_states: IndexVec::new(),
             bindings_by_use: IndexVec::new(),
-            symbol_for_use: IndexVec::new(),
             deferred_defs: Vec::new(),
+            enclosing_snapshots: IndexVec::new(),
+            snapshot_watchers: FxHashMap::default(),
         }
     }
 
@@ -258,16 +333,7 @@ impl UseDefMapBuilder {
     /// live definitions for that symbol.
     pub(crate) fn record_definition(&mut self, symbol_id: SymbolId, def_id: DefinitionId) {
         self.symbol_states[symbol_id].record_definition(def_id);
-    }
-
-    /// Record a definition whose effect on past uses is deferred to
-    /// `finish()`. The definition is added to the current flow state
-    /// immediately (so future uses see it), but uses already recorded
-    /// are patched up at finalization time. Used for `<<-` extra
-    /// definitions.
-    pub(crate) fn record_deferred_definition(&mut self, symbol_id: SymbolId, def_id: DefinitionId) {
-        self.symbol_states[symbol_id].add_definition(def_id);
-        self.deferred_defs.push((symbol_id, def_id));
+        self.update_enclosing_snapshots(symbol_id, def_id);
     }
 
     /// After visiting a loop body, retroactively patch uses so that
@@ -279,12 +345,12 @@ impl UseDefMapBuilder {
     /// created inside the body). Those new definitions are added to all
     /// uses of that symbol from `first_use` onwards, which covers exactly
     /// the uses recorded during the body.
-    ///
-    /// This runs after the body (not eagerly at each definition) because
-    /// the body may contain branches. A diff at the end captures the
-    /// converged state after all snapshot/restore/merge within the body
-    /// has resolved.
-    pub(crate) fn finish_loop_defs(&mut self, pre_loop: &FlowSnapshot, first_use: UseId) {
+    pub(crate) fn finish_loop_defs(
+        &mut self,
+        pre_loop: &FlowSnapshot,
+        first_use: UseId,
+        uses: &IndexVec<UseId, Use>,
+    ) {
         for i in 0..self.symbol_states.len() {
             let symbol_id = SymbolId::new(i);
 
@@ -309,11 +375,11 @@ impl UseDefMapBuilder {
                 continue;
             }
 
-            // Add new defs to uses recorded during the body (`first_use`
-            // onwards). Uses before the loop are unaffected.
+            // Now retroactively patch loop-carried definitions into uses inside
+            // the loop
             for j in first_use.index()..self.bindings_by_use.len() {
                 let use_id = UseId::new(j);
-                if self.symbol_for_use[use_id] == symbol_id {
+                if uses[use_id].symbol() == symbol_id {
                     for &def_id in &new_defs {
                         self.bindings_by_use[use_id].add_definition(def_id);
                     }
@@ -322,12 +388,22 @@ impl UseDefMapBuilder {
         }
     }
 
+    /// Record a definition whose effect on past uses is deferred to
+    /// `finish()`. The definition is added to the current flow state
+    /// immediately (so future uses see it), but uses already recorded
+    /// are patched up at finalization time. Used for `<<-` extra
+    /// definitions.
+    pub(crate) fn record_deferred_definition(&mut self, symbol_id: SymbolId, def_id: DefinitionId) {
+        self.symbol_states[symbol_id].add_definition(def_id);
+        self.deferred_defs.push((symbol_id, def_id));
+        self.update_enclosing_snapshots(symbol_id, def_id);
+    }
+
     /// Record a use of `symbol_id`. Clones the current live bindings for that
     /// symbol and associates them with `use_id`.
     pub(crate) fn record_use(&mut self, symbol_id: SymbolId, use_id: UseId) {
         let bindings = self.symbol_states[symbol_id].clone();
         let pushed_id = self.bindings_by_use.push(bindings);
-        self.symbol_for_use.push(symbol_id);
         stdext::soft_assert!(use_id == pushed_id);
     }
 
@@ -368,22 +444,57 @@ impl UseDefMapBuilder {
         }
     }
 
+    /// Returns `true` if `symbol_id` may be unbound at this point,
+    /// meaning some control-flow path falls through to an enclosing scope.
+    /// This covers both purely-free variables (no local definitions) and
+    /// conditionally-defined variables (local definitions exist but don't
+    /// cover all paths).
+    pub(crate) fn is_may_be_unbound(&self, symbol_id: SymbolId) -> bool {
+        self.symbol_states[symbol_id].may_be_unbound()
+    }
+
+    /// Register an enclosing snapshot for `symbol_id`. The snapshot starts from
+    /// the current flow state (prior shadowing applied). A watcher is
+    /// registered so that each subsequent definition of this symbol we
+    /// encounter is conservatively merged in, because we can't know statically
+    /// when the nested scope will be called.
+    pub(crate) fn register_enclosing_snapshot(
+        &mut self,
+        symbol_id: SymbolId,
+    ) -> EnclosingSnapshotId {
+        let bindings = self.symbol_states[symbol_id].clone();
+        let id = self.enclosing_snapshots.push(bindings);
+        self.snapshot_watchers
+            .entry(symbol_id)
+            .or_default()
+            .push(id);
+        id
+    }
+
+    fn update_enclosing_snapshots(&mut self, symbol_id: SymbolId, def_id: DefinitionId) {
+        if let Some(watchers) = self.snapshot_watchers.get(&symbol_id) {
+            for &snapshot_id in watchers {
+                self.enclosing_snapshots[snapshot_id].add_definition(def_id);
+            }
+        }
+    }
+
     /// Finalize into an immutable [`UseDefMap`].
-    pub(crate) fn finish(mut self) -> UseDefMap {
-        self.finish_deferred_defs();
+    pub(crate) fn finish(mut self, uses: &IndexVec<UseId, Use>) -> UseDefMap {
+        self.finish_deferred_defs(uses);
         UseDefMap {
             bindings_by_use: self.bindings_by_use,
+            enclosing_snapshots: self.enclosing_snapshots,
         }
     }
 
     /// Retroactively add deferred definitions (from `<<-`) to all
     /// uses of the corresponding symbol, including uses that were
     /// recorded before the definition was encountered in the walk.
-    fn finish_deferred_defs(&mut self) {
+    fn finish_deferred_defs(&mut self, uses: &IndexVec<UseId, Use>) {
         for &(symbol_id, def_id) in &self.deferred_defs {
-            for i in 0..self.bindings_by_use.len() {
-                let use_id = UseId::new(i);
-                if self.symbol_for_use[use_id] == symbol_id {
+            for (use_id, use_site) in uses.iter() {
+                if use_site.symbol() == symbol_id {
                     self.bindings_by_use[use_id].add_definition(def_id);
                 }
             }

--- a/crates/oak_index/tests/use_def_map.rs
+++ b/crates/oak_index/tests/use_def_map.rs
@@ -428,11 +428,11 @@ x            # use 0 -> {def 1} (repeat always executes)
 
 // --- Loop-carried definitions ---
 //
-// Uses at the top of a loop body can see definitions from the bottom of the
-// body (from a previous iteration). The builder synthesizes `LoopHeader`
-// placeholders before visiting the body, then populates them with the real
-// definitions that are live at the end of the body. The placeholders never
-// appear in `bindings_at_use` results.
+// Uses at the top of a loop body can see definitions from the bottom
+// (from a previous iteration). The builder pre-allocates placeholder
+// definitions from the pre-scan before walking the body. The
+// placeholder shares its `DefinitionId` with the real definition, so
+// uses at the top see the same ID that the actual assignment produces.
 
 #[test]
 fn test_while_loop_carried_def() {
@@ -932,4 +932,434 @@ print(x)     # use 2 (cond), use 3 (print), use 4 (x) -> {def 0, def 1}
         DefinitionId::from(1)
     ]);
     assert_not!(second_x.may_be_unbound());
+}
+
+// --- Cross-scope resolution ---
+
+#[test]
+fn test_cross_scope_simple_free_variable() {
+    let index = index(
+        "\
+x <- 1
+f <- function() x
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // `x` in the function is free, resolves to file scope
+    let (enclosing_scope, bindings) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(0));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(0)]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_def_after_function() {
+    let index = index(
+        "\
+f <- function() x
+x <- 1
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // `x` is defined after `f` in the file scope. The pre-scan finds it.
+    // The snapshot is initialized at f's definition point (x unbound)
+    // then updated when x <- 1 is encountered.
+    let (enclosing_scope, bindings) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(0));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(1)]);
+    assert!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_multiple_defs() {
+    let index = index(
+        "\
+x <- 1
+f <- function() x
+x <- 2
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // Lazy snapshot: union of all defs from definition point onward.
+    // Initialized with {x <- 1}, updated with {x <- 2}.
+    let (_, bindings) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(bindings.definitions(), &[
+        DefinitionId::from(0),
+        DefinitionId::from(2)
+    ]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_locally_bound_not_free() {
+    let index = index(
+        "\
+x <- 1
+f <- function() {
+    x <- 2
+    x
+}
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // `x` is locally bound in the function, not free
+    assert!(index.enclosing_bindings(fun, UseId::from(0)).is_none());
+}
+
+#[test]
+fn test_cross_scope_parameter_not_free() {
+    let index = index(
+        "\
+x <- 1
+f <- function(x) x
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // `x` is a parameter, not free
+    assert!(index.enclosing_bindings(fun, UseId::from(0)).is_none());
+}
+
+#[test]
+fn test_cross_scope_nested_functions() {
+    let index = index(
+        "\
+x <- 1
+f <- function() {
+    g <- function() x
+}
+",
+    );
+    // g is scope 2 (f is scope 1)
+    let g_scope = ScopeId::from(2);
+
+    // x is free in g. f (scope 1) has no binding for x, so the lookup
+    // skips f entirely and resolves to the file scope (scope 0).
+    let (enclosing_scope, bindings) = index.enclosing_bindings(g_scope, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(0));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(0)]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_resolves_to_intermediate() {
+    let index = index(
+        "\
+x <- 1
+f <- function() {
+    x <- 2
+    g <- function() x
+}
+",
+    );
+    let g_scope = ScopeId::from(2);
+
+    // x is free in g. Both the file scope (scope 0) and f (scope 1) bind x,
+    // but f is the nearest enclosing scope with a binding, so it wins.
+    let (enclosing_scope, bindings) = index.enclosing_bindings(g_scope, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(1));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(0)]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_conditional_def_in_enclosing() {
+    let index = index(
+        "\
+if (cond) x <- 1
+f <- function() x
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // x is conditionally defined. The snapshot captures the state at f's
+    // definition point: {x <- 1, may_be_unbound: true}
+    let (_, bindings) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(0)]);
+    assert!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_super_assignment_updates_snapshot() {
+    let index = index(
+        "\
+x <- 1
+f <- function() x
+g <- function() { x <<- 2 }
+",
+    );
+    let f_scope = ScopeId::from(1);
+
+    // The <<- from g adds a def to the file scope. The watcher on x
+    // should update f's snapshot to include this def.
+    let (_, bindings) = index.enclosing_bindings(f_scope, UseId::from(0)).unwrap();
+    assert_eq!(bindings.definitions(), &[
+        DefinitionId::from(0),
+        DefinitionId::from(2)
+    ]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_unbound_globally() {
+    let index = index(
+        "\
+f <- function() x
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // x is not defined anywhere in the file. No enclosing snapshot.
+    assert!(index.enclosing_bindings(fun, UseId::from(0)).is_none());
+}
+
+#[test]
+fn test_cross_scope_conditional_local_def_with_enclosing() {
+    let index = index(
+        "\
+x <- 1
+f <- function(cond) {
+    if (cond) x <- 2
+    x
+}
+",
+    );
+    let fun = ScopeId::from(1);
+    let map = index.use_def_map(fun);
+
+    // The use of `x` has a conditional local definition AND may_be_unbound.
+    // In R, the unbound path falls through to the enclosing scope's x <- 1.
+    // use 0 = `cond` (parameter reference in if condition)
+    // use 1 = `x` (the use we're testing)
+    let local = map.bindings_at_use(UseId::from(1));
+    assert_eq!(local.definitions(), &[DefinitionId::from(1)]);
+    assert!(local.may_be_unbound());
+
+    // The enclosing snapshot should also be registered, capturing x <- 1.
+    let (enclosing_scope, bindings) = index.enclosing_bindings(fun, UseId::from(1)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(0));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(0)]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_conditional_local_def_in_loop() {
+    let index = index(
+        "\
+x <- 1
+f <- function() {
+    for (i in 1:10) x <- 2
+    x
+}
+",
+    );
+    let fun = ScopeId::from(1);
+    let map = index.use_def_map(fun);
+
+    // x is defined in the for body (conditional: body may not execute).
+    // The use after the for loop has may_be_unbound: true.
+    let local = map.bindings_at_use(UseId::from(0));
+    assert!(local.may_be_unbound());
+
+    // Enclosing snapshot registered for the fallthrough path.
+    let (enclosing_scope, _) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(0));
+}
+
+#[test]
+fn test_cross_scope_unconditional_local_def_no_snapshot() {
+    let index = index(
+        "\
+x <- 1
+f <- function() {
+    x <- 2
+    x
+}
+",
+    );
+    let fun = ScopeId::from(1);
+    let map = index.use_def_map(fun);
+
+    // x is unconditionally defined locally. No fallthrough possible.
+    let local = map.bindings_at_use(UseId::from(0));
+    assert_eq!(local.definitions(), &[DefinitionId::from(0)]);
+    assert_not!(local.may_be_unbound());
+
+    // No enclosing snapshot needed.
+    assert!(index.enclosing_bindings(fun, UseId::from(0)).is_none());
+}
+
+#[test]
+fn test_cross_scope_multiple_free_variables() {
+    let index = index(
+        "\
+x <- 1
+y <- 2
+f <- function() {
+    x
+    y
+}
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // Two independent free variables, each gets its own snapshot
+    let (scope_x, bindings_x) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(scope_x, ScopeId::from(0));
+    assert_eq!(bindings_x.definitions(), &[DefinitionId::from(0)]);
+
+    let (scope_y, bindings_y) = index.enclosing_bindings(fun, UseId::from(1)).unwrap();
+    assert_eq!(scope_y, ScopeId::from(0));
+    assert_eq!(bindings_y.definitions(), &[DefinitionId::from(1)]);
+}
+
+#[test]
+fn test_cross_scope_same_free_var_used_twice() {
+    let index = index(
+        "\
+x <- 1
+f <- function() {
+    x
+    x
+}
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // Both uses of `x` are free and resolve to the same enclosing snapshot
+    let (scope1, bindings1) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    let (scope2, bindings2) = index.enclosing_bindings(fun, UseId::from(1)).unwrap();
+    assert_eq!(scope1, scope2);
+    assert_eq!(bindings1, bindings2);
+}
+
+#[test]
+fn test_cross_scope_free_var_in_function_inside_loop() {
+    let index = index(
+        "\
+x <- 1
+for (i in 1:10) {
+    f <- function() x
+}
+x <- 2
+",
+    );
+    // The function scope: for doesn't create a scope, so f's function
+    // is the only child scope.
+    let fun = ScopeId::from(1);
+
+    // x is free in f, resolves to file scope. The lazy snapshot
+    // captures both x <- 1 (from initialization) and x <- 2 (from
+    // watcher update).
+    let (enclosing_scope, bindings) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(0));
+    assert_eq!(bindings.definitions(), &[
+        DefinitionId::from(0),
+        DefinitionId::from(3)
+    ]);
+}
+
+#[test]
+fn test_cross_scope_repeated_use_reuses_snapshot() {
+    let index = index(
+        "\
+if (cond) x <- 1
+f <- function() {
+    x
+    x
+}
+",
+    );
+    let fun = ScopeId::from(1);
+    let map = index.use_def_map(fun);
+
+    // Both uses of `x` are free and resolve to the same enclosing
+    // snapshot. The first use triggers registration, the second reuses
+    // the existing entry (dedup via EnclosingSnapshotKey).
+    let local0 = map.bindings_at_use(UseId::from(0));
+    assert!(local0.definitions().is_empty());
+    assert!(local0.may_be_unbound());
+
+    let (scope0, bindings0) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    let (scope1, bindings1) = index.enclosing_bindings(fun, UseId::from(1)).unwrap();
+    assert_eq!(scope0, scope1);
+    assert_eq!(bindings0, bindings1);
+    assert_eq!(bindings0.definitions(), &[DefinitionId::from(0)]);
+    assert!(bindings0.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_nested_conditional_fallthrough() {
+    let index = index(
+        "\
+x <- 1
+f <- function(cond) {
+    if (cond) x <- 2
+    g <- function() x
+}
+",
+    );
+    // g is scope 2 (f is scope 1)
+    let g_scope = ScopeId::from(2);
+
+    // x is free in g. Both the file scope (scope 0, unconditional x <- 1) and
+    // f (scope 1, conditional x <- 2) bind x. f is the nearest enclosing
+    // scope with a binding, so it wins. The snapshot captures f's state at
+    // g's definition point: {x <- 2, may_be_unbound: true}.
+    let (enclosing_scope, bindings) = index.enclosing_bindings(g_scope, UseId::from(0)).unwrap();
+    assert_eq!(enclosing_scope, ScopeId::from(1));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(1)]);
+    assert!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_snapshot_excludes_shadowed_defs() {
+    let index = index(
+        "\
+x <- 0
+x <- 1
+f <- function() x
+",
+    );
+    let fun = ScopeId::from(1);
+
+    // x <- 0 was shadowed by x <- 1 before f was defined.
+    // The snapshot should contain only x <- 1, not both.
+    let (_, bindings) = index.enclosing_bindings(fun, UseId::from(0)).unwrap();
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(1)]);
+    assert_not!(bindings.may_be_unbound());
+}
+
+#[test]
+fn test_cross_scope_different_definition_points() {
+    let index = index(
+        "\
+x <- 1
+f <- function() x
+x <- 2
+g <- function() x
+",
+    );
+
+    // f is defined after x <- 1. Its snapshot is initialized with {x <- 1},
+    // then the watcher adds x <- 2: snapshot {x <- 1, x <- 2}.
+    let f_scope = ScopeId::from(1);
+    let (_, f_bindings) = index.enclosing_bindings(f_scope, UseId::from(0)).unwrap();
+    assert_eq!(f_bindings.definitions(), &[
+        DefinitionId::from(0),
+        DefinitionId::from(2)
+    ]);
+    assert_not!(f_bindings.may_be_unbound());
+
+    // g is defined after x <- 2, which shadowed x <- 1. Its snapshot is
+    // initialized with {x <- 2} only. No subsequent definitions, so it
+    // stays {x <- 2}.
+    let g_scope = ScopeId::from(2);
+    let (_, g_bindings) = index.enclosing_bindings(g_scope, UseId::from(0)).unwrap();
+    assert_eq!(g_bindings.definitions(), &[DefinitionId::from(2)]);
+    assert_not!(g_bindings.may_be_unbound());
 }


### PR DESCRIPTION
Branched from #1144 
Part of https://github.com/posit-dev/ark/issues/1141

From the module-level doc in `use-def-maps.rs`:

```rs
// ## Enclosing snapshots
//
// Use-def maps are per-scope, so a free variable in a nested function
// gets `{ definitions: [], may_be_unbound: true }` locally. To resolve
// it, we need the enclosing scope's bindings. Enclosing snapshots
// bridge this gap.
//
// A snapshot is registered when `add_use` detects `may_be_unbound` in
// the nested scope. The builder walks up the scope chain to find the
// ancestor where the symbol is bound and records a snapshot in that
// ancestor's `UseDefMapBuilder`. The snapshot captures what's live at
// the nested scope's definition point, then a watcher accumulates
// subsequent definitions. We take the union of all subsequent definitions
// because we can't tractably know exactly when the function is called. In the
// following example, `x`'s use sees both B and C even though from this
// particular snippet it can only see B.
//
// Providing more accurate answers in the general case would require whole
// program analysis (e.g. `f` may be passed down to other functions). For now we
// accept the over-approximation of taking the union of subsequent definitions,
// although we could improve on that for simple cases in the future (tracking
// simple calls, and falling back to over-approximation in the other cases).
//
// ```r
// x <- 0              # def A
// x <- 1              # def B (shadows A)
// f <- function() x   # snapshot initialized: {B}
// f()
// x <- 2              # watcher fires → snapshot: {B, C}
// ```
//
// Note that the snapshot is {B, C}, not {A, B, C}, because def A was already
// shadowed when `f` was first defined. The rule: what was live at the
// definition point (prior shadowing applied) plus every definition added after.
//
// When `may_be_unbound` is true due to a conditional local definition, the
// snapshot is also consulted (unlike Python, R has no name-binding rule, so
// conditional local definitions don't prevent fallthrough):
//
// ```r
// x <- 1
// f <- function(cond) {
//     if (cond) x <- 2
//     x                  # local: {x <- 2, may_be_unbound: true}
// }                      # enclosing snapshot: {x <- 1}
// ```
//
// The consumer combines both: the local bindings and the enclosing
// snapshot give the full picture of what `x` could be.
//
// For eager NSE scopes (e.g. `local()`), the snapshot will be even more
// precise: since the body executes at the call site, the snapshot is a
// point-in-time capture with no watcher, reflecting exactly the linear state.
// No union over-approximation needed.
```

To support this:

- We now do a pre-scan that allows us to see the full list of defined names before recursing into nested scopes. This way we're able to see that `x` is bound in:

  ```r
  f <- function() x
  x <- 1
  ```

- When a use may be unbound, we register an "enclosing snapshot" in the ancestor scope that captures what's live at the definition point and accumulates subsequent definitions via watchers.