### PR TITLE
Add plumbing for resolving `::` and `:::`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,9 +2412,11 @@ name = "oak_ide"
 version = "0.1.0"
 dependencies = [
  "air_r_parser",
+ "air_r_syntax",
  "assert_matches",
  "biome_rowan",
  "log",
+ "oak_core",
  "oak_index",
  "oak_package",
  "stdext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,9 +2260,11 @@ name = "oak_ide"
 version = "0.1.0"
 dependencies = [
  "air_r_parser",
+ "air_r_syntax",
  "assert_matches",
  "biome_rowan",
  "log",
+ "oak_core",
  "oak_index",
  "oak_package",
  "stdext",

--- a/crates/ark/src/lsp/document.rs
+++ b/crates/ark/src/lsp/document.rs
@@ -8,6 +8,7 @@
 use aether_lsp_utils::proto::from_proto;
 use aether_lsp_utils::proto::to_proto;
 use aether_lsp_utils::proto::PositionEncoding;
+use anyhow::anyhow;
 use oak_index::semantic_index::SemanticIndex;
 use tower_lsp::lsp_types;
 use tree_sitter::Parser;
@@ -203,8 +204,12 @@ impl Document {
 
     /// Accessor that returns an annotated `RSyntaxNode` type.
     /// More convenient than the generic `biome_rowan::SyntaxNode<L>` type.
-    pub fn syntax(&self) -> aether_syntax::RSyntaxNode {
-        self.parse.syntax()
+    /// Returns an error if the document has parse errors.
+    pub fn syntax(&self) -> anyhow::Result<aether_syntax::RSyntaxNode> {
+        if self.parse.has_error() {
+            return Err(anyhow!("Document has parse errors"));
+        }
+        Ok(self.parse.syntax())
     }
 
     /// Recomputed every time for now, we'll track this with Salsa soon.
@@ -283,7 +288,7 @@ mod tests {
         let len: u32 = syntax.text_range_with_trivia().len().into();
         assert!(len > 0);
 
-        let syntax2 = document.syntax();
+        let syntax2 = document.syntax().unwrap();
         assert_eq!(
             syntax.text_range_with_trivia(),
             syntax2.text_range_with_trivia()
@@ -408,6 +413,6 @@ mod tests {
         assert!(node.is_some(), "Should find spanning node at end of 'lib'");
 
         // The Rowan tree contains the updated document
-        assert_eq!(document.syntax().text_with_trivia(), "lib");
+        assert_eq!(document.syntax().unwrap().text_with_trivia(), "lib");
     }
 }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -25,9 +25,11 @@ pub(crate) fn goto_definition(
     )?;
 
     let index = document.semantic_index();
+    let root = document.syntax();
     let targets = oak_ide::goto_definition(
         offset,
         &uri,
+        &root,
         &index,
         &state.file_scope(&uri),
         &state.library,

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -24,9 +24,11 @@ pub(crate) fn goto_definition(
     )?;
 
     let index = document.semantic_index();
+    let root = document.syntax();
     let targets = oak_ide::goto_definition(
         offset,
         &uri,
+        &root,
         &index,
         &state.file_scope(&uri),
         &state.library,

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -25,7 +25,7 @@ pub(crate) fn goto_definition(
     )?;
 
     let index = document.semantic_index();
-    let root = document.syntax();
+    let root = document.syntax()?;
     let targets = oak_ide::goto_definition(
         offset,
         &uri,

--- a/crates/oak_ide/Cargo.toml
+++ b/crates/oak_ide/Cargo.toml
@@ -14,8 +14,10 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aether_syntax.workspace = true
 biome_rowan.workspace = true
 log.workspace = true
+oak_core.workspace = true
 oak_index.workspace = true
 oak_package.workspace = true
 stdext.workspace = true

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -1,5 +1,7 @@
+use aether_syntax::RSyntaxNode;
 use biome_rowan::TextSize;
 use oak_index::external::resolve_external_name;
+use oak_index::external::resolve_in_package;
 use oak_index::external::ExternalDefinition;
 use oak_index::external::ScopeLayer;
 use oak_index::semantic_index::SemanticIndex;
@@ -11,11 +13,12 @@ use oak_package::library::Library;
 use url::Url;
 
 use crate::ExternalScope;
+use crate::Identifier;
 use crate::NavigationTarget;
 
 /// Resolve the symbol at `offset` in a file.
 ///
-/// Queries the semantic index to classify the offset:
+/// Uses `Identifier::classify` to determine what the offset points at:
 ///
 /// - Definition site (LHS of assignment, parameter, for variable):
 ///   navigates to itself. We round-trip through the index to get
@@ -27,37 +30,47 @@ use crate::NavigationTarget;
 /// - Use site (name reference): resolves via the use-def map, enclosing
 ///   scopes, and the external scope chain.
 ///
-/// Returns an empty `Vec` if the offset doesn't point at a definition or
-/// use site, or if the symbol cannot be resolved.
+/// - Namespace access (`pkg::sym` or `pkg:::sym`): resolves the symbol
+///   directly in the named package.
+///
+/// Returns an empty `Vec` if the offset doesn't point at a known
+/// identifier, or if the symbol cannot be resolved.
 pub fn goto_definition(
     offset: TextSize,
     file: &Url,
+    root: &RSyntaxNode,
     index: &SemanticIndex,
     scope: &ExternalScope,
     library: &Library,
 ) -> Vec<NavigationTarget> {
-    let (scope_id, _) = index.scope_at(offset);
+    let Some(ident) = Identifier::classify(root, index, offset) else {
+        return Vec::new();
+    };
 
-    // Definition site: navigate to itself.
-    if let Some((_def_id, def)) = index.definitions(scope_id).contains(offset) {
-        let name = index.symbols(scope_id).symbol(def.symbol()).name();
+    match ident {
+        Identifier::Definition { scope_id, def_id } => {
+            let def = &index.definitions(scope_id)[def_id];
+            let name = index.symbols(scope_id).symbol(def.symbol()).name();
 
-        return vec![NavigationTarget {
-            file: file.clone(),
-            name: name.to_string(),
-            full_range: def.range(),
-            focus_range: def.range(),
-        }];
+            vec![NavigationTarget {
+                file: file.clone(),
+                name: name.to_string(),
+                full_range: def.range(),
+                focus_range: def.range(),
+            }]
+        },
+        Identifier::Use { scope_id, use_id } => {
+            let use_site = &index.uses(scope_id)[use_id];
+            resolve_use(
+                index, scope_id, use_id, use_site, file, offset, scope, library,
+            )
+        },
+        Identifier::NamespaceAccess {
+            ref package,
+            ref symbol,
+            ..
+        } => resolve_namespace_access(library, package, symbol),
     }
-
-    // Use site: resolve through use-def map, enclosing scopes, external.
-    if let Some((use_id, use_site)) = index.uses(scope_id).contains(offset) {
-        return resolve_use(
-            index, scope_id, use_id, use_site, file, offset, scope, library,
-        );
-    }
-
-    Vec::new()
 }
 
 fn resolve_use(
@@ -122,6 +135,17 @@ fn resolve_use(
     external_targets()
 }
 
+fn resolve_namespace_access(
+    library: &Library,
+    package: &str,
+    symbol: &str,
+) -> Vec<NavigationTarget> {
+    let Some(external) = resolve_in_package(library, package, symbol) else {
+        return Vec::new();
+    };
+    external_to_targets(external)
+}
+
 fn resolve_external(
     library: &Library,
     scope_chain: &[ScopeLayer],
@@ -130,7 +154,10 @@ fn resolve_external(
     let Some(external) = resolve_external_name(library, scope_chain, symbol_name) else {
         return Vec::new();
     };
+    external_to_targets(external)
+}
 
+fn external_to_targets(external: ExternalDefinition) -> Vec<NavigationTarget> {
     match external {
         ExternalDefinition::ProjectFile { file, name, range } => {
             vec![NavigationTarget {

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -1,5 +1,7 @@
+use aether_syntax::RSyntaxNode;
 use biome_rowan::TextSize;
 use oak_index::external::resolve_external_name;
+use oak_index::external::resolve_in_package;
 use oak_index::external::BindingSource;
 use oak_index::external::ExternalDefinition;
 use oak_index::semantic_index::SemanticIndex;
@@ -10,11 +12,12 @@ use oak_package::library::Library;
 use url::Url;
 
 use crate::FileScope;
+use crate::Identifier;
 use crate::NavigationTarget;
 
 /// Resolve the symbol at `offset` in a file.
 ///
-/// Queries the semantic index to classify the offset:
+/// Uses `Identifier::classify` to determine what the offset points at:
 ///
 /// - Definition site (LHS of assignment, parameter, for variable):
 ///   navigates to itself. We round-trip through the index to get
@@ -26,35 +29,45 @@ use crate::NavigationTarget;
 /// - Use site (name reference): resolves via the use-def map, enclosing
 ///   scopes, and the external scope chain.
 ///
-/// Returns an empty `Vec` if the offset doesn't point at a definition or
-/// use site, or if the symbol cannot be resolved.
+/// - Namespace access (`pkg::sym` or `pkg:::sym`): resolves the symbol
+///   directly in the named package.
+///
+/// Returns an empty `Vec` if the offset doesn't point at a known
+/// identifier, or if the symbol cannot be resolved.
 pub fn goto_definition(
     offset: TextSize,
     file: &Url,
+    root: &RSyntaxNode,
     index: &SemanticIndex,
     scope: &FileScope,
     library: &Library,
 ) -> Vec<NavigationTarget> {
-    // Definition site: navigate to itself.
-    if let Some((scope_id, def_id)) = index.definition_at_offset(offset) {
-        let def = &index.definitions(scope_id)[def_id];
-        let name = index.symbols(scope_id).symbol(def.symbol()).name();
+    let Some(ident) = Identifier::classify(root, index, offset) else {
+        return Vec::new();
+    };
 
-        return vec![NavigationTarget {
-            file: file.clone(),
-            name: name.to_string(),
-            full_range: def.range(),
-            focus_range: def.range(),
-        }];
+    match ident {
+        Identifier::Definition { scope_id, def_id } => {
+            let def = &index.definitions(scope_id)[def_id];
+            let name = index.symbols(scope_id).symbol(def.symbol()).name();
+
+            vec![NavigationTarget {
+                file: file.clone(),
+                name: name.to_string(),
+                full_range: def.range(),
+                focus_range: def.range(),
+            }]
+        },
+        Identifier::Use { scope_id, use_id } => {
+            let scope_chain = scope.at(index, offset);
+            resolve_use(scope_id, use_id, file, index, scope_chain, library)
+        },
+        Identifier::NamespaceAccess {
+            ref package,
+            ref symbol,
+            ..
+        } => resolve_namespace_access(library, package, symbol),
     }
-
-    // Use site: resolve through use-def map, enclosing scopes, external.
-    if let Some((scope_id, use_id)) = index.use_at_offset(offset) {
-        let scope_chain = scope.at(index, offset);
-        return resolve_use(scope_id, use_id, file, index, scope_chain, library);
-    }
-
-    Vec::new()
 }
 
 fn resolve_use(
@@ -114,6 +127,17 @@ fn resolve_use(
     external_targets()
 }
 
+fn resolve_namespace_access(
+    library: &Library,
+    package: &str,
+    symbol: &str,
+) -> Vec<NavigationTarget> {
+    let Some(external) = resolve_in_package(library, package, symbol) else {
+        return Vec::new();
+    };
+    external_to_targets(external)
+}
+
 fn resolve_external(
     library: &Library,
     scope_chain: &[BindingSource],
@@ -122,7 +146,10 @@ fn resolve_external(
     let Some(external) = resolve_external_name(library, scope_chain, symbol_name) else {
         return Vec::new();
     };
+    external_to_targets(external)
+}
 
+fn external_to_targets(external: ExternalDefinition) -> Vec<NavigationTarget> {
     match external {
         ExternalDefinition::ProjectFile { file, name, range } => {
             vec![NavigationTarget {

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -1,0 +1,82 @@
+use aether_syntax::AnyRSelector;
+use aether_syntax::RNamespaceExpression;
+use aether_syntax::RSyntaxKind;
+use aether_syntax::RSyntaxNode;
+use biome_rowan::AstNode;
+use biome_rowan::TextRange;
+use biome_rowan::TextSize;
+use oak_core::syntax_ext::RIdentifierExt;
+use oak_core::syntax_ext::RStringValueExt;
+use oak_index::semantic_index::SemanticIndex;
+use oak_index::DefinitionId;
+use oak_index::ScopeId;
+use oak_index::UseId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Identifier {
+    Definition {
+        scope_id: ScopeId,
+        def_id: DefinitionId,
+    },
+
+    Use {
+        scope_id: ScopeId,
+        use_id: UseId,
+    },
+
+    NamespaceAccess {
+        package: String,
+        symbol: String,
+        internal: bool,
+        package_range: TextRange,
+        symbol_range: TextRange,
+    },
+}
+
+impl Identifier {
+    pub fn classify(root: &RSyntaxNode, index: &SemanticIndex, offset: TextSize) -> Option<Self> {
+        if let Some((scope_id, def_id)) = index.definition_at_offset(offset) {
+            return Some(Identifier::Definition { scope_id, def_id });
+        }
+
+        if let Some((scope_id, use_id)) = index.use_at_offset(offset) {
+            return Some(Identifier::Use { scope_id, use_id });
+        }
+
+        classify_namespace(root, offset)
+    }
+}
+
+fn classify_namespace(root: &RSyntaxNode, offset: TextSize) -> Option<Identifier> {
+    let token = root.token_at_offset(offset).right_biased()?;
+
+    let ns_expr = token
+        .parent()
+        .and_then(|p| p.ancestors().find_map(RNamespaceExpression::cast))?;
+
+    let left = ns_expr.left().ok()?;
+    let right = ns_expr.right().ok()?;
+
+    let package = selector_name(&left)?;
+    let symbol = selector_name(&right)?;
+
+    let internal = ns_expr.operator().ok()?.kind() == RSyntaxKind::COLON3;
+    let package_range = left.syntax().text_trimmed_range();
+    let symbol_range = right.syntax().text_trimmed_range();
+
+    Some(Identifier::NamespaceAccess {
+        package,
+        symbol,
+        internal,
+        package_range,
+        symbol_range,
+    })
+}
+
+fn selector_name(selector: &AnyRSelector) -> Option<String> {
+    match selector {
+        AnyRSelector::RIdentifier(ident) => Some(ident.name_text()),
+        AnyRSelector::RStringValue(s) => s.string_text(),
+        _ => None,
+    }
+}

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -1,0 +1,84 @@
+use aether_syntax::AnyRSelector;
+use aether_syntax::RNamespaceExpression;
+use aether_syntax::RSyntaxKind;
+use aether_syntax::RSyntaxNode;
+use biome_rowan::AstNode;
+use biome_rowan::TextRange;
+use biome_rowan::TextSize;
+use oak_core::syntax_ext::RIdentifierExt;
+use oak_core::syntax_ext::RStringValueExt;
+use oak_index::semantic_index::SemanticIndex;
+use oak_index::DefinitionId;
+use oak_index::ScopeId;
+use oak_index::UseId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Identifier {
+    Definition {
+        scope_id: ScopeId,
+        def_id: DefinitionId,
+    },
+
+    Use {
+        scope_id: ScopeId,
+        use_id: UseId,
+    },
+
+    NamespaceAccess {
+        package: String,
+        symbol: String,
+        internal: bool,
+        package_range: TextRange,
+        symbol_range: TextRange,
+    },
+}
+
+impl Identifier {
+    pub fn classify(root: &RSyntaxNode, index: &SemanticIndex, offset: TextSize) -> Option<Self> {
+        let (scope_id, _) = index.scope_at(offset);
+
+        if let Some((def_id, _)) = index.definitions(scope_id).contains(offset) {
+            return Some(Identifier::Definition { scope_id, def_id });
+        }
+
+        if let Some((use_id, _)) = index.uses(scope_id).contains(offset) {
+            return Some(Identifier::Use { scope_id, use_id });
+        }
+
+        classify_namespace(root, offset)
+    }
+}
+
+fn classify_namespace(root: &RSyntaxNode, offset: TextSize) -> Option<Identifier> {
+    let token = root.token_at_offset(offset).right_biased()?;
+
+    let ns_expr = token
+        .parent()
+        .and_then(|p| p.ancestors().find_map(RNamespaceExpression::cast))?;
+
+    let left = ns_expr.left().ok()?;
+    let right = ns_expr.right().ok()?;
+
+    let package = selector_name(&left)?;
+    let symbol = selector_name(&right)?;
+
+    let internal = ns_expr.operator().ok()?.kind() == RSyntaxKind::COLON3;
+    let package_range = left.syntax().text_trimmed_range();
+    let symbol_range = right.syntax().text_trimmed_range();
+
+    Some(Identifier::NamespaceAccess {
+        package,
+        symbol,
+        internal,
+        package_range,
+        symbol_range,
+    })
+}
+
+fn selector_name(selector: &AnyRSelector) -> Option<String> {
+    match selector {
+        AnyRSelector::RIdentifier(ident) => Some(ident.name_text()),
+        AnyRSelector::RStringValue(s) => s.string_text(),
+        _ => None,
+    }
+}

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -45,7 +45,11 @@ impl Identifier {
             return Some(Identifier::Use { scope_id, use_id });
         }
 
-        classify_namespace(root, offset)
+        if let Some(namespace_access) = classify_namespace(root, offset) {
+            return Some(namespace_access);
+        }
+
+        None
     }
 }
 

--- a/crates/oak_ide/src/lib.rs
+++ b/crates/oak_ide/src/lib.rs
@@ -1,8 +1,10 @@
 mod goto_definition;
+mod identifier;
 
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 pub use goto_definition::goto_definition;
+pub use identifier::Identifier;
 use oak_index::external::BindingSource;
 use oak_index::semantic_index::ScopeKind;
 use oak_index::semantic_index::SemanticIndex;

--- a/crates/oak_ide/src/lib.rs
+++ b/crates/oak_ide/src/lib.rs
@@ -1,9 +1,11 @@
 mod external_scope;
 mod goto_definition;
+mod identifier;
 
 use biome_rowan::TextRange;
 pub use external_scope::ExternalScope;
 pub use goto_definition::goto_definition;
+pub use identifier::Identifier;
 use url::Url;
 
 /// A location in source code that the editor can navigate to.

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use aether_parser::parse;
 use aether_parser::RParserOptions;
+use aether_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_ide::goto_definition;
@@ -18,9 +19,11 @@ use oak_package::package_description::Description;
 use oak_package::package_namespace::Namespace;
 use url::Url;
 
-fn parse_source(source: &str) -> SemanticIndex {
+fn parse_source(source: &str) -> (RSyntaxNode, SemanticIndex) {
     let parsed = parse(source, RParserOptions::default());
-    semantic_index(&parsed.tree())
+    let root = parsed.syntax();
+    let index = semantic_index(&parsed.tree());
+    (root, index)
 }
 
 fn empty_library() -> Library {
@@ -64,10 +67,17 @@ fn test_local_simple() {
     //  0123456 78
     let source = "x <- 1\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(7), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -81,10 +91,17 @@ fn test_local_reassignment_shadows() {
     // Straight-line reassignment: second def kills the first
     let source = "x <- 1\nx <- 2\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(14), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(14),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -97,7 +114,7 @@ fn test_local_reassignment_shadows() {
 fn test_local_conditional_returns_both() {
     let source = "if (TRUE) x <- 1 else x <- 2\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
@@ -105,6 +122,7 @@ fn test_local_conditional_returns_both() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -129,13 +147,14 @@ fn test_local_conditional_returns_both() {
 fn test_local_in_function() {
     let source = "f <- function() {\n  x <- 1\n  x\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -152,13 +171,14 @@ fn test_local_in_function() {
 fn test_local_parameter() {
     let source = "f <- function(x) {\n  x\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -177,13 +197,14 @@ fn test_local_parameter() {
 fn test_enclosing_scope() {
     let source = "x <- 1\nf <- function() {\n  x\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -202,17 +223,18 @@ fn test_enclosing_scope() {
 fn test_external_project_file() {
     let source = "foo\n";
     let file = file_url("current.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let other_url = file_url("other.R");
     let other_source = "foo <- 42\n";
-    let other_idx = parse_source(other_source);
+    let (_other_root, other_idx) = parse_source(other_source);
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
     let targets = goto_definition(
         offset(0),
         &file,
+        &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -231,7 +253,7 @@ fn test_external_project_file() {
 fn test_external_package() {
     let source = "mutate\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
     let scope_chain = vec![ScopeLayer::PackageExports("dplyr".to_string())];
@@ -239,6 +261,7 @@ fn test_external_package() {
     let targets = goto_definition(
         offset(0),
         &file,
+        &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -253,7 +276,7 @@ fn test_external_package() {
 fn test_external_import_from() {
     let source = "tibble\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let mut imports = HashMap::new();
@@ -263,6 +286,7 @@ fn test_external_import_from() {
     let targets = goto_definition(
         offset(0),
         &file,
+        &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -278,11 +302,18 @@ fn test_dollar_lhs_resolves() {
     // Cursor on `foo` in `foo$bar` resolves to the definition of `foo`
     let source = "foo <- list()\nfoo$bar\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `foo` in `foo$bar` starts at offset 14
-    let targets = goto_definition(offset(14), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(14),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "foo".to_string(),
@@ -296,11 +327,18 @@ fn test_dollar_rhs_no_resolution() {
     // Cursor on `bar` in `foo$bar`: member names are not tracked by the index
     let source = "foo <- list()\nfoo$bar\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `bar` starts at offset 18
-    let targets = goto_definition(offset(18), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(18),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert!(targets.is_empty());
 }
 
@@ -313,10 +351,10 @@ fn test_use_in_function_body_resolves_via_external() {
     // through enclosing scopes to the external scope chain.
     let source = "f <- function(x) {\n  if (is_null(x)) NULL\n}\n";
     let file = file_url("R/cnd-last.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
 
     let other_source = "is_null <- is.null\n";
-    let other_idx = parse_source(other_source);
+    let (_other_root, other_idx) = parse_source(other_source);
     let other_url = file_url("R/types.R");
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
@@ -328,7 +366,14 @@ fn test_use_in_function_body_resolves_via_external() {
 
     let scope = ExternalScope::package(Vec::new(), scope_chain);
 
-    let targets = goto_definition(offset(is_null_offset as u32), &file, &idx, &scope, &library);
+    let targets = goto_definition(
+        offset(is_null_offset as u32),
+        &file,
+        &root,
+        &idx,
+        &scope,
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file: other_url,
         name: "is_null".to_string(),
@@ -343,10 +388,17 @@ fn test_use_in_function_body_resolves_via_external() {
 fn test_no_use_at_offset() {
     let source = "x <- 1\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(3), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(3),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert!(targets.is_empty());
 }
 
@@ -354,10 +406,17 @@ fn test_no_use_at_offset() {
 fn test_unresolved_symbol() {
     let source = "foo\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(0), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(0),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert!(targets.is_empty());
 }
 
@@ -367,7 +426,7 @@ fn test_unresolved_symbol() {
 fn test_local_shadows_external() {
     let source = "foo <- 1\nfoo\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = test_library(vec![("pkg", vec!["foo"])]);
 
     let scope_chain = vec![ScopeLayer::PackageExports("pkg".to_string())];
@@ -376,6 +435,7 @@ fn test_local_shadows_external() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -394,11 +454,11 @@ fn test_local_shadows_external() {
 fn test_conditional_definition_includes_external() {
     let source = "if (TRUE) x <- 1\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
 
     let other_url = file_url("other.R");
     let other_source = "x <- 99\n";
-    let other_idx = parse_source(other_source);
+    let (_other_root, other_idx) = parse_source(other_source);
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
     let library = empty_library();
@@ -407,6 +467,7 @@ fn test_conditional_definition_includes_external() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -434,10 +495,17 @@ fn test_definition_site_assignment() {
     // Cursor on the `foo` in `foo <- 1` should navigate to itself
     let source = "foo <- 1\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(0), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(0),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "foo".to_string(),
@@ -450,11 +518,18 @@ fn test_definition_site_assignment() {
 fn test_definition_site_parameter() {
     let source = "f <- function(x) { x }\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // Cursor on the `x` parameter name (offset 14)
-    let targets = goto_definition(offset(14), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(14),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -467,11 +542,18 @@ fn test_definition_site_parameter() {
 fn test_definition_site_for_variable() {
     let source = "for (i in 1:10) i\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // Cursor on the `i` in `for (i in ...)`
-    let targets = goto_definition(offset(5), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "i".to_string(),
@@ -487,10 +569,17 @@ fn test_right_assignment_definition_site() {
     // `1 -> x`: cursor on `x` (the definition target)
     let source = "1 -> x\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(5), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file: file.clone(),
         name: "x".to_string(),
@@ -504,10 +593,17 @@ fn test_right_assignment_use_resolves() {
     // `1 -> x` then use `x`
     let source = "1 -> x\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(7), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -524,7 +620,7 @@ fn test_super_assignment_resolves_in_enclosing() {
     // A use of `x` in another function should resolve to it.
     let source = "f <- function() x <<- 1\ng <- function() x\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `x` use in `g` body
@@ -532,6 +628,7 @@ fn test_super_assignment_resolves_in_enclosing() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -546,7 +643,7 @@ fn test_super_assignment_definition_site() {
     // Cursor on `x` in `x <<- 1`
     let source = "f <- function() {\n  x <<- 1\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `x` at offset 20
@@ -554,6 +651,7 @@ fn test_super_assignment_definition_site() {
     let targets = goto_definition(
         offset(def_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -569,11 +667,18 @@ fn test_string_definition() {
     // `"foo" <- 1` is equivalent to `foo <- 1` in R
     let source = "\"foo\" <- 1\nfoo\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // Use of `foo` at offset 11
-    let targets = goto_definition(offset(11), &file, &idx, &ExternalScope::default(), &library);
+    let targets = goto_definition(
+        offset(11),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "foo".to_string(),
@@ -590,13 +695,14 @@ fn test_deeply_nested_function() {
     // Free variable `z` resolves through two function scopes to file scope
     let source = "z <- 1\nf <- function() {\n  g <- function() {\n    z\n  }\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('z').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -616,7 +722,7 @@ fn test_use_on_rhs_of_assignment() {
     // `x <- x + 1`: the `x` on the RHS refers to the previous binding
     let source = "x <- 1\nx <- x + 1\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // The `x` on the RHS of the second assignment. `x <- x + 1` starts at
@@ -625,6 +731,7 @@ fn test_use_on_rhs_of_assignment() {
     let targets = goto_definition(
         offset(rhs_offset),
         &file,
+        &root,
         &idx,
         &ExternalScope::default(),
         &library,
@@ -645,19 +752,318 @@ fn test_library_directive_in_predecessor() {
     // aaa.R has `library(dplyr)`, bbb.R uses `mutate`.
     // The library() directive in aaa.R should make dplyr exports visible.
     let aaa_source = "library(dplyr)\n";
-    let aaa_idx = parse_source(aaa_source);
+    let (_aaa_root, aaa_idx) = parse_source(aaa_source);
     let aaa_url = file_url("R/aaa.R");
 
     let bbb_source = "mutate\n";
     let bbb_url = file_url("R/bbb.R");
-    let bbb_idx = parse_source(bbb_source);
+    let (bbb_root, bbb_idx) = parse_source(bbb_source);
 
     let aaa_layers = file_layers(aaa_url, &aaa_idx);
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
     let scope = ExternalScope::package(aaa_layers.clone(), aaa_layers);
 
-    let targets = goto_definition(offset(0), &bbb_url, &bbb_idx, &scope, &library);
+    let targets = goto_definition(offset(0), &bbb_url, &bbb_root, &bbb_idx, &scope, &library);
     // dplyr::mutate is a package symbol, no file/range to navigate to
     assert!(targets.is_empty());
+}
+
+// --- Namespace access (:: and :::) ---
+
+#[test]
+fn test_fixme_namespace_access_exported_symbol() {
+    // "dplyr::mutate\n"
+    //  0123456789...
+    // Cursor on `mutate` (offset 7)
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_access_unknown_symbol() {
+    // Symbol not in exports
+    let source = "dplyr::nonexistent\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_access_unknown_package() {
+    let source = "bogus::foo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = empty_library();
+
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_triple_colon() {
+    // "pkg:::internal_fn\n"
+    //  01234567890...
+    // Cursor on `internal_fn` (offset 6)
+    let source = "pkg:::internal_fn\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("pkg", vec!["internal_fn"])]);
+
+    let targets = goto_definition(
+        offset(6),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_cursor_on_package_name() {
+    // Cursor on `dplyr` (offset 0) — the LHS of ::
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(0),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    // FIXME: Cursor on the package name still classifies as NamespaceAccess,
+    // resolves `mutate` in `dplyr` — but package symbols have no target yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_cursor_on_operator() {
+    // Cursor on `::` (offset 5)
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    // FIXME: Operator token is inside the RNamespaceExpression, still resolves
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_classify() {
+    use oak_ide::Identifier;
+
+    let source = "dplyr::mutate\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    // Cursor on `mutate` (offset 7)
+    let ident = Identifier::classify(&root, &idx, offset(7));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "dplyr".to_string(),
+            symbol: "mutate".to_string(),
+            internal: false,
+            package_range: text_range(0, 5),
+            symbol_range: text_range(7, 13),
+        })
+    );
+
+    // Cursor on `dplyr` (offset 2)
+    let ident = Identifier::classify(&root, &idx, offset(2));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "dplyr".to_string(),
+            symbol: "mutate".to_string(),
+            internal: false,
+            package_range: text_range(0, 5),
+            symbol_range: text_range(7, 13),
+        })
+    );
+}
+
+#[test]
+fn test_namespace_classify_triple_colon() {
+    use oak_ide::Identifier;
+
+    let source = "pkg:::sym\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    let ident = Identifier::classify(&root, &idx, offset(6));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "pkg".to_string(),
+            symbol: "sym".to_string(),
+            internal: true,
+            package_range: text_range(0, 3),
+            symbol_range: text_range(6, 9),
+        })
+    );
+}
+
+#[test]
+fn test_fixme_namespace_access_in_call() {
+    // foo::bar() — cursor on `bar`
+    let source = "foo::bar()\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("foo", vec!["bar"])]);
+
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_in_extract() {
+    // foo::bar$baz — cursor on `bar`
+    let source = "foo::bar$baz\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("foo", vec!["bar"])]);
+
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &ExternalScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_classify_in_call() {
+    use oak_ide::Identifier;
+
+    // foo::bar()
+    // 0123456789
+    let source = "foo::bar()\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    let ident = Identifier::classify(&root, &idx, offset(5));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "foo".to_string(),
+            symbol: "bar".to_string(),
+            internal: false,
+            package_range: text_range(0, 3),
+            symbol_range: text_range(5, 8),
+        })
+    );
+}
+
+#[test]
+fn test_namespace_classify_in_extract() {
+    use oak_ide::Identifier;
+
+    // foo::bar$baz
+    // 0123456789...
+    let source = "foo::bar$baz\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    // Cursor on `bar` (offset 5) — inside the RNamespaceExpression
+    let ident = Identifier::classify(&root, &idx, offset(5));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "foo".to_string(),
+            symbol: "bar".to_string(),
+            internal: false,
+            package_range: text_range(0, 3),
+            symbol_range: text_range(5, 8),
+        })
+    );
+
+    // Cursor on `baz` (offset 9) — RHS of $, not a namespace access
+    let ident = Identifier::classify(&root, &idx, offset(9));
+    assert_eq!(ident, None);
+}
+
+#[test]
+fn test_namespace_classify_string_selectors() {
+    use oak_ide::Identifier;
+
+    // "foo"::"bar"
+    //  0123456789...
+    let source = "\"foo\"::\"bar\"\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    let ident = Identifier::classify(&root, &idx, offset(7));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "foo".to_string(),
+            symbol: "bar".to_string(),
+            internal: false,
+            package_range: text_range(0, 5),
+            symbol_range: text_range(7, 12),
+        })
+    );
 }

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use aether_parser::parse;
 use aether_parser::RParserOptions;
+use aether_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_ide::goto_definition;
@@ -18,9 +19,11 @@ use oak_package::package_description::Description;
 use oak_package::package_namespace::Namespace;
 use url::Url;
 
-fn parse_source(source: &str) -> SemanticIndex {
+fn parse_source(source: &str) -> (RSyntaxNode, SemanticIndex) {
     let parsed = parse(source, RParserOptions::default());
-    semantic_index(&parsed.tree())
+    let root = parsed.syntax();
+    let index = semantic_index(&parsed.tree());
+    (root, index)
 }
 
 fn empty_library() -> Library {
@@ -64,10 +67,17 @@ fn test_local_simple() {
     //  0123456 78
     let source = "x <- 1\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(7), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -81,10 +91,17 @@ fn test_local_reassignment_shadows() {
     // Straight-line reassignment: second def kills the first
     let source = "x <- 1\nx <- 2\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(14), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(14),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -97,7 +114,7 @@ fn test_local_reassignment_shadows() {
 fn test_local_conditional_returns_both() {
     let source = "if (TRUE) x <- 1 else x <- 2\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
@@ -105,6 +122,7 @@ fn test_local_conditional_returns_both() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -129,13 +147,14 @@ fn test_local_conditional_returns_both() {
 fn test_local_in_function() {
     let source = "f <- function() {\n  x <- 1\n  x\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -152,13 +171,14 @@ fn test_local_in_function() {
 fn test_local_parameter() {
     let source = "f <- function(x) {\n  x\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -177,13 +197,14 @@ fn test_local_parameter() {
 fn test_enclosing_scope() {
     let source = "x <- 1\nf <- function() {\n  x\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -202,17 +223,18 @@ fn test_enclosing_scope() {
 fn test_external_project_file() {
     let source = "foo\n";
     let file = file_url("current.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let other_url = file_url("other.R");
     let other_source = "foo <- 42\n";
-    let other_idx = parse_source(other_source);
+    let (_other_root, other_idx) = parse_source(other_source);
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
     let targets = goto_definition(
         offset(0),
         &file,
+        &root,
         &idx,
         &FileScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -231,7 +253,7 @@ fn test_external_project_file() {
 fn test_external_package() {
     let source = "mutate\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
     let scope_chain = vec![BindingSource::PackageExports("dplyr".to_string())];
@@ -239,6 +261,7 @@ fn test_external_package() {
     let targets = goto_definition(
         offset(0),
         &file,
+        &root,
         &idx,
         &FileScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -253,7 +276,7 @@ fn test_external_package() {
 fn test_external_import_from() {
     let source = "tibble\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let mut imports = HashMap::new();
@@ -263,6 +286,7 @@ fn test_external_import_from() {
     let targets = goto_definition(
         offset(0),
         &file,
+        &root,
         &idx,
         &FileScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -278,11 +302,18 @@ fn test_dollar_lhs_resolves() {
     // Cursor on `foo` in `foo$bar` resolves to the definition of `foo`
     let source = "foo <- list()\nfoo$bar\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `foo` in `foo$bar` starts at offset 14
-    let targets = goto_definition(offset(14), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(14),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "foo".to_string(),
@@ -296,11 +327,18 @@ fn test_dollar_rhs_no_resolution() {
     // Cursor on `bar` in `foo$bar`: member names are not tracked by the index
     let source = "foo <- list()\nfoo$bar\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `bar` starts at offset 18
-    let targets = goto_definition(offset(18), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(18),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert!(targets.is_empty());
 }
 
@@ -313,10 +351,10 @@ fn test_use_in_function_body_resolves_via_external() {
     // through enclosing scopes to the external scope chain.
     let source = "f <- function(x) {\n  if (is_null(x)) NULL\n}\n";
     let file = file_url("R/cnd-last.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
 
     let other_source = "is_null <- is.null\n";
-    let other_idx = parse_source(other_source);
+    let (_other_root, other_idx) = parse_source(other_source);
     let other_url = file_url("R/types.R");
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
@@ -328,7 +366,14 @@ fn test_use_in_function_body_resolves_via_external() {
 
     let scope = FileScope::package(Vec::new(), scope_chain);
 
-    let targets = goto_definition(offset(is_null_offset as u32), &file, &idx, &scope, &library);
+    let targets = goto_definition(
+        offset(is_null_offset as u32),
+        &file,
+        &root,
+        &idx,
+        &scope,
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file: other_url,
         name: "is_null".to_string(),
@@ -343,10 +388,17 @@ fn test_use_in_function_body_resolves_via_external() {
 fn test_no_use_at_offset() {
     let source = "x <- 1\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(3), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(3),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert!(targets.is_empty());
 }
 
@@ -354,10 +406,17 @@ fn test_no_use_at_offset() {
 fn test_unresolved_symbol() {
     let source = "foo\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(0), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(0),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert!(targets.is_empty());
 }
 
@@ -367,7 +426,7 @@ fn test_unresolved_symbol() {
 fn test_local_shadows_external() {
     let source = "foo <- 1\nfoo\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = test_library(vec![("pkg", vec!["foo"])]);
 
     let scope_chain = vec![BindingSource::PackageExports("pkg".to_string())];
@@ -376,6 +435,7 @@ fn test_local_shadows_external() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -394,11 +454,11 @@ fn test_local_shadows_external() {
 fn test_conditional_definition_includes_external() {
     let source = "if (TRUE) x <- 1\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
 
     let other_url = file_url("other.R");
     let other_source = "x <- 99\n";
-    let other_idx = parse_source(other_source);
+    let (_other_root, other_idx) = parse_source(other_source);
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
     let library = empty_library();
@@ -407,6 +467,7 @@ fn test_conditional_definition_includes_external() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::package(scope_chain.clone(), scope_chain),
         &library,
@@ -434,10 +495,17 @@ fn test_definition_site_assignment() {
     // Cursor on the `foo` in `foo <- 1` should navigate to itself
     let source = "foo <- 1\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(0), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(0),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "foo".to_string(),
@@ -450,11 +518,18 @@ fn test_definition_site_assignment() {
 fn test_definition_site_parameter() {
     let source = "f <- function(x) { x }\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // Cursor on the `x` parameter name (offset 14)
-    let targets = goto_definition(offset(14), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(14),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -467,11 +542,18 @@ fn test_definition_site_parameter() {
 fn test_definition_site_for_variable() {
     let source = "for (i in 1:10) i\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // Cursor on the `i` in `for (i in ...)`
-    let targets = goto_definition(offset(5), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "i".to_string(),
@@ -487,10 +569,17 @@ fn test_right_assignment_definition_site() {
     // `1 -> x`: cursor on `x` (the definition target)
     let source = "1 -> x\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(5), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file: file.clone(),
         name: "x".to_string(),
@@ -504,10 +593,17 @@ fn test_right_assignment_use_resolves() {
     // `1 -> x` then use `x`
     let source = "1 -> x\nx\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
-    let targets = goto_definition(offset(7), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "x".to_string(),
@@ -524,7 +620,7 @@ fn test_super_assignment_resolves_in_enclosing() {
     // A use of `x` in another function should resolve to it.
     let source = "f <- function() x <<- 1\ng <- function() x\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `x` use in `g` body
@@ -532,6 +628,7 @@ fn test_super_assignment_resolves_in_enclosing() {
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -546,7 +643,7 @@ fn test_super_assignment_definition_site() {
     // Cursor on `x` in `x <<- 1`
     let source = "f <- function() {\n  x <<- 1\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // `x` at offset 20
@@ -554,6 +651,7 @@ fn test_super_assignment_definition_site() {
     let targets = goto_definition(
         offset(def_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -569,11 +667,18 @@ fn test_string_definition() {
     // `"foo" <- 1` is equivalent to `foo <- 1` in R
     let source = "\"foo\" <- 1\nfoo\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // Use of `foo` at offset 11
-    let targets = goto_definition(offset(11), &file, &idx, &FileScope::default(), &library);
+    let targets = goto_definition(
+        offset(11),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
     assert_eq!(targets, vec![NavigationTarget {
         file,
         name: "foo".to_string(),
@@ -590,13 +695,14 @@ fn test_deeply_nested_function() {
     // Free variable `z` resolves through two function scopes to file scope
     let source = "z <- 1\nf <- function() {\n  g <- function() {\n    z\n  }\n}\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     let use_offset = source.rfind('z').unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -616,7 +722,7 @@ fn test_use_on_rhs_of_assignment() {
     // `x <- x + 1`: the `x` on the RHS refers to the previous binding
     let source = "x <- 1\nx <- x + 1\n";
     let file = file_url("test.R");
-    let idx = parse_source(source);
+    let (root, idx) = parse_source(source);
     let library = empty_library();
 
     // The `x` on the RHS of the second assignment. `x <- x + 1` starts at
@@ -625,6 +731,7 @@ fn test_use_on_rhs_of_assignment() {
     let targets = goto_definition(
         offset(rhs_offset),
         &file,
+        &root,
         &idx,
         &FileScope::default(),
         &library,
@@ -645,19 +752,318 @@ fn test_library_directive_in_predecessor() {
     // aaa.R has `library(dplyr)`, bbb.R uses `mutate`.
     // The library() directive in aaa.R should make dplyr exports visible.
     let aaa_source = "library(dplyr)\n";
-    let aaa_idx = parse_source(aaa_source);
+    let (_aaa_root, aaa_idx) = parse_source(aaa_source);
     let aaa_url = file_url("R/aaa.R");
 
     let bbb_source = "mutate\n";
     let bbb_url = file_url("R/bbb.R");
-    let bbb_idx = parse_source(bbb_source);
+    let (bbb_root, bbb_idx) = parse_source(bbb_source);
 
     let aaa_layers = file_layers(aaa_url, &aaa_idx);
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
     let scope = FileScope::package(aaa_layers.clone(), aaa_layers);
 
-    let targets = goto_definition(offset(0), &bbb_url, &bbb_idx, &scope, &library);
+    let targets = goto_definition(offset(0), &bbb_url, &bbb_root, &bbb_idx, &scope, &library);
     // dplyr::mutate is a package symbol, no file/range to navigate to
     assert!(targets.is_empty());
+}
+
+// --- Namespace access (:: and :::) ---
+
+#[test]
+fn test_fixme_namespace_access_exported_symbol() {
+    // "dplyr::mutate\n"
+    //  0123456789...
+    // Cursor on `mutate` (offset 7)
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_access_unknown_symbol() {
+    // Symbol not in exports
+    let source = "dplyr::nonexistent\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_access_unknown_package() {
+    let source = "bogus::foo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = empty_library();
+
+    let targets = goto_definition(
+        offset(7),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_triple_colon() {
+    // "pkg:::internal_fn\n"
+    //  01234567890...
+    // Cursor on `internal_fn` (offset 6)
+    let source = "pkg:::internal_fn\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("pkg", vec!["internal_fn"])]);
+
+    let targets = goto_definition(
+        offset(6),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_cursor_on_package_name() {
+    // Cursor on `dplyr` (offset 0) — the LHS of ::
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(0),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    // FIXME: Cursor on the package name still classifies as NamespaceAccess,
+    // resolves `mutate` in `dplyr` — but package symbols have no target yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_cursor_on_operator() {
+    // Cursor on `::` (offset 5)
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    // FIXME: Operator token is inside the RNamespaceExpression, still resolves
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_classify() {
+    use oak_ide::Identifier;
+
+    let source = "dplyr::mutate\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    // Cursor on `mutate` (offset 7)
+    let ident = Identifier::classify(&root, &idx, offset(7));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "dplyr".to_string(),
+            symbol: "mutate".to_string(),
+            internal: false,
+            package_range: text_range(0, 5),
+            symbol_range: text_range(7, 13),
+        })
+    );
+
+    // Cursor on `dplyr` (offset 2)
+    let ident = Identifier::classify(&root, &idx, offset(2));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "dplyr".to_string(),
+            symbol: "mutate".to_string(),
+            internal: false,
+            package_range: text_range(0, 5),
+            symbol_range: text_range(7, 13),
+        })
+    );
+}
+
+#[test]
+fn test_namespace_classify_triple_colon() {
+    use oak_ide::Identifier;
+
+    let source = "pkg:::sym\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    let ident = Identifier::classify(&root, &idx, offset(6));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "pkg".to_string(),
+            symbol: "sym".to_string(),
+            internal: true,
+            package_range: text_range(0, 3),
+            symbol_range: text_range(6, 9),
+        })
+    );
+}
+
+#[test]
+fn test_fixme_namespace_access_in_call() {
+    // foo::bar() — cursor on `bar`
+    let source = "foo::bar()\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("foo", vec!["bar"])]);
+
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_fixme_namespace_access_in_extract() {
+    // foo::bar$baz — cursor on `bar`
+    let source = "foo::bar$baz\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+    let library = test_library(vec![("foo", vec!["bar"])]);
+
+    let targets = goto_definition(
+        offset(5),
+        &file,
+        &root,
+        &idx,
+        &FileScope::default(),
+        &library,
+    );
+    // FIXME: Package symbol, no NavigationTarget yet
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_namespace_classify_in_call() {
+    use oak_ide::Identifier;
+
+    // foo::bar()
+    // 0123456789
+    let source = "foo::bar()\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    let ident = Identifier::classify(&root, &idx, offset(5));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "foo".to_string(),
+            symbol: "bar".to_string(),
+            internal: false,
+            package_range: text_range(0, 3),
+            symbol_range: text_range(5, 8),
+        })
+    );
+}
+
+#[test]
+fn test_namespace_classify_in_extract() {
+    use oak_ide::Identifier;
+
+    // foo::bar$baz
+    // 0123456789...
+    let source = "foo::bar$baz\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    // Cursor on `bar` (offset 5) — inside the RNamespaceExpression
+    let ident = Identifier::classify(&root, &idx, offset(5));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "foo".to_string(),
+            symbol: "bar".to_string(),
+            internal: false,
+            package_range: text_range(0, 3),
+            symbol_range: text_range(5, 8),
+        })
+    );
+
+    // Cursor on `baz` (offset 9) — RHS of $, not a namespace access
+    let ident = Identifier::classify(&root, &idx, offset(9));
+    assert_eq!(ident, None);
+}
+
+#[test]
+fn test_namespace_classify_string_selectors() {
+    use oak_ide::Identifier;
+
+    // "foo"::"bar"
+    //  0123456789...
+    let source = "\"foo\"::\"bar\"\n";
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let idx = semantic_index(&parsed.tree());
+
+    let ident = Identifier::classify(&root, &idx, offset(7));
+    assert_eq!(
+        ident,
+        Some(Identifier::NamespaceAccess {
+            package: "foo".to_string(),
+            symbol: "bar".to_string(),
+            internal: false,
+            package_range: text_range(0, 5),
+            symbol_range: text_range(7, 12),
+        })
+    );
 }

--- a/crates/oak_index/src/external.rs
+++ b/crates/oak_index/src/external.rs
@@ -84,6 +84,26 @@ pub fn resolve_external_name(
     None
 }
 
+/// Resolve a name in a specific package's exported symbols.
+pub fn resolve_in_package(
+    library: &Library,
+    package: &str,
+    name: &str,
+) -> Option<ExternalDefinition> {
+    let pkg = library.get(package)?;
+    if pkg
+        .exported_symbols
+        .binary_search(&name.to_string())
+        .is_ok()
+    {
+        return Some(ExternalDefinition::Package {
+            package: package.to_string(),
+            name: name.to_string(),
+        });
+    }
+    None
+}
+
 /// Compute the binding-source layers that a single file contributes to the
 /// scope chain: one `FileExports` layer from its top-level definitions, plus
 /// one `PackageExports` layer per `library()`/`require()` directive.

--- a/crates/oak_index/src/external.rs
+++ b/crates/oak_index/src/external.rs
@@ -84,6 +84,26 @@ pub fn resolve_external_name(
     None
 }
 
+/// Resolve a name in a specific package's exported symbols.
+pub fn resolve_in_package(
+    library: &Library,
+    package: &str,
+    name: &str,
+) -> Option<ExternalDefinition> {
+    let pkg = library.get(package)?;
+    if pkg
+        .exported_symbols
+        .binary_search(&name.to_string())
+        .is_ok()
+    {
+        return Some(ExternalDefinition::Package {
+            package: package.to_string(),
+            name: name.to_string(),
+        });
+    }
+    None
+}
+
 /// Compute the scope layers that a single file contributes to the
 /// scope chain: one `FileExports` layer from its top-level definitions, plus
 /// one `PackageExports` layer per `library()`/`require()` directive.

--- a/crates/oak_index/src/external.rs
+++ b/crates/oak_index/src/external.rs
@@ -68,14 +68,8 @@ pub fn resolve_external_name(
             },
 
             ScopeLayer::PackageExports(pkg_name) => {
-                let Some(pkg) = library.get(pkg_name) else {
-                    continue;
-                };
-                if pkg.exported_symbols.contains_str(name) {
-                    return Some(ExternalDefinition::Package {
-                        package: pkg_name.clone(),
-                        name: name.to_string(),
-                    });
+                if let Some(def) = resolve_in_package(library, pkg_name, name) {
+                    return Some(def);
                 }
             },
         }
@@ -91,11 +85,7 @@ pub fn resolve_in_package(
     name: &str,
 ) -> Option<ExternalDefinition> {
     let pkg = library.get(package)?;
-    if pkg
-        .exported_symbols
-        .binary_search(&name.to_string())
-        .is_ok()
-    {
+    if pkg.exported_symbols.contains_str(name) {
         return Some(ExternalDefinition::Package {
             package: package.to_string(),
             name: name.to_string(),


### PR DESCRIPTION
Branched from #1153 

Currently unused in goto-definition but in the future will map to package source provided by #1146 

Supported by new `oak_ide::Identifier` struct with `classify()` constructor.