### PR TITLE
Add nextest support to `Run Test` and `Run Tests`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,20 @@
     "rust-analyzer.check.extraArgs": [
         "--target-dir", "${workspaceFolder}/target/check"
     ],
+    // `Run Test` and `Run Tests` nextest support
+    "rust-analyzer.runnables.test.overrideCommand": [
+        "cargo",
+        "nextest",
+        "run",
+        "--package",
+        "${package}",
+        "${target_arg}",
+        "${target}",
+        "--",
+        "${test_name}",
+        "${exact}",
+        "${include_ignored}"
+    ],
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
Thanks to some back and forth with the rust-analyzer team https://github.com/rust-lang/rust-analyzer/issues/21137 we can now use nextest as the test backend for the `Run Test` and `Run Tests` buttons in VS Code. You'll need the pre-release version of rust-analyzer, but I think we all use that.

Runnables aren't yet supported in Zed IIUC, so I didn't change any setting there.

See https://github.com/rust-lang/rust-analyzer/issues/21137#issuecomment-4254611341 for some examples of how I use this. 

In particular, it is fantastic for `Run Tests` on a group of tests that access R and _must_ run in separate processes via nextest. Previously, it you hit that shiny `Run Tests` button then you'd footgun yourself and hang one of the R sessions.