### PR TITLE
Switch to ureq for our simple sync HTTP get request

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
+          windows-path-include-rtools: false
 
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -38,13 +38,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
-          # Putting Rtools related tooling on the PATH causes Rust crate
-          # compilation to pick up Rtools's `link.exe` and mingw32 related
-          # tooling, in particular it can cause aws-lc-sys compilation to fail
-          # on ARM Windows, where it uses clang-cl and has to compile in a bunch
-          # of C code.
-          # https://github.com/aws/aws-lc-rs/blob/main/book/src/requirements/windows.md
-          windows-path-include-rtools: false
 
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
+          # Putting Rtools related tooling on the PATH causes Rust crate
+          # compilation to pick up Rtools's MinGW tooling, in particular it can
+          # cause ring (used by ureq) compilation to fail on ARM Windows, where
+          # it uses clang and has to compile in a bunch of C code.
+          # https://github.com/briansmith/ring/blob/main/BUILDING.md
           windows-path-include-rtools: false
 
       - name: Install R Packages Required For Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,28 +480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-expr"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,12 +761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,25 +772,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -860,16 +807,6 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1161,12 +1098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "echo"
 version = "0.1.0"
 dependencies = [
@@ -1327,12 +1258,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1730,22 +1655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http 1.1.0",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,50 +1918,6 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.40",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.111",
-]
 
 [[package]]
 name = "jobserver"
@@ -2478,12 +2343,12 @@ dependencies = [
  "oak_fs",
  "oak_package",
  "oak_r_process",
- "reqwest",
  "serde",
  "serde_json",
  "sha2",
  "tar",
  "tempfile",
+ "ureq",
 ]
 
 [[package]]
@@ -2500,12 +2365,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "overload"
@@ -2766,59 +2625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.5.4",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.2.9",
- "rand 0.8.5",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.3",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,28 +2849,20 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http 1.1.0",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -3219,24 +3017,13 @@ version = "0.23.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
 dependencies = [
- "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3245,36 +3032,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3282,7 +3041,6 @@ version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3310,15 +3068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,29 +3087,6 @@ dependencies = [
  "selectors",
  "smallvec",
  "tendril",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3915,21 +3641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,16 +3668,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -4306,6 +4007,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.1.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +4053,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4500,20 +4236,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "webpki-roots"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ paste = "1.0.14"
 quote = "1.0.42"
 rand = "0.8.5"
 regex = "1.10.0"
-reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
+reqwest = { version = "0.13.2", default-features = false, features = ["json"] }
 reqwest-middleware = "0.5.1"
 reqwest-retry = "0.9.1"
 rust-embed = "8.2.0"
@@ -113,6 +113,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tree-sitter = "0.24.7"
 tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "95aff097aa927a66bb357f715b58cde821be8867" }
+ureq = "3.3.0"
 url = "2.5.7"
 uuid = { version = "1.3.0", features = ["v4"] }
 walkdir = "2"

--- a/crates/oak_sources/Cargo.toml
+++ b/crates/oak_sources/Cargo.toml
@@ -16,12 +16,12 @@ log.workspace = true
 oak_fs.workspace = true
 oak_package.workspace = true
 oak_r_process.workspace = true
-reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+ureq.workspace = true
 
 [lints]
 workspace = true

--- a/crates/oak_sources/src/cran.rs
+++ b/crates/oak_sources/src/cran.rs
@@ -1,8 +1,10 @@
-use std::io::Cursor;
 use std::path::Path;
 
 use flate2::read::GzDecoder;
 use oak_fs::file_lock::FileLock;
+
+use crate::download::download_with_mirrors;
+use crate::download::Outcome;
 
 /// Downloads an R package's source files from CRAN if possible and adds them to the cache
 /// at the parent folder containing `destination_lock`
@@ -11,92 +13,52 @@ pub(crate) fn cache_cran(
     version: &str,
     destination_lock: &FileLock,
 ) -> anyhow::Result<bool> {
-    let response = download(package, version)?;
+    match download(package, version) {
+        Ok(Outcome::Success(response)) => {
+            let destination = destination_lock.parent().join("R");
+            std::fs::create_dir(&destination)?;
+            extract(package, response, destination.as_path())?;
+            Ok(true)
+        },
 
-    // "Not on CRAN" isn't an error
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        return Ok(false);
+        Ok(Outcome::NotFound) => {
+            // "Not on CRAN" isn't an error
+            Ok(false)
+        },
+
+        Err(err) => Err(anyhow::anyhow!(
+            "Failed to download {package} {version}: {err:?}"
+        )),
     }
-
-    // But anything else is
-    if !response.status().is_success() {
-        return Err(anyhow::anyhow!(
-            "Failed to download {package} {version}: HTTP {status}",
-            status = response.status()
-        ));
-    }
-
-    let destination = destination_lock.parent().join("R");
-    std::fs::create_dir(&destination)?;
-
-    extract(package, response, destination.as_path())?;
-
-    Ok(true)
 }
 
-fn download(package: &str, version: &str) -> anyhow::Result<reqwest::blocking::Response> {
+fn download(package: &str, version: &str) -> anyhow::Result<Outcome> {
     let mirrors = ["https://cran.r-project.org", "https://cran.rstudio.com"];
 
     // Try released version
-    let response =
+    let outcome =
         download_with_mirrors(&format!("src/contrib/{package}_{version}.tar.gz"), &mirrors)?;
 
-    if response.status() != reqwest::StatusCode::NOT_FOUND {
-        // Found it
-        return Ok(response);
+    if matches!(outcome, Outcome::Success(_)) {
+        return Ok(outcome);
     }
 
     // Try archive
-    let response = download_with_mirrors(
+    download_with_mirrors(
         &format!("src/contrib/Archive/{package}/{package}_{version}.tar.gz"),
         &mirrors,
-    )?;
-
-    // Return `response` whether or not we found something
-    Ok(response)
-}
-
-fn download_with_mirrors(
-    suffix: &str,
-    mirrors: &[&str],
-) -> anyhow::Result<reqwest::blocking::Response> {
-    if mirrors.is_empty() {
-        panic!("`mirrors` can't be empty.");
-    }
-
-    let mut out = None;
-
-    for mirror in mirrors {
-        let url = format!("{mirror}/{suffix}");
-        let response = reqwest::blocking::get(&url)?;
-        let status = response.status();
-
-        out = Some(response);
-
-        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
-            // Try next mirror, this one is temporarily unavailable
-            continue;
-        } else {
-            // We got an actual response of some kind from this mirror, return it
-            break;
-        }
-    }
-
-    // Safety: We guarantee that there is at least 1 mirror
-    Ok(out.unwrap())
+    )
 }
 
 fn extract(
     package: &str,
-    response: reqwest::blocking::Response,
+    response: ureq::http::Response<ureq::Body>,
     destination: &Path,
 ) -> anyhow::Result<()> {
-    // Pass response bytes of the `.tar.gz` into a gzip decoder, wrapped in a tar archive
-    // reader, this abstracts away all the details, so we can just iterate over the
-    // entries
-    let bytes = response.bytes()?;
-    let cursor = Cursor::new(bytes);
-    let gz = GzDecoder::new(cursor);
+    // Stream the response body through a gzip decoder wrapped in a tar archive reader
+    // so we can just iterate over entries. `into_reader()` is unlimited by default.
+    let reader = response.into_body().into_reader();
+    let gz = GzDecoder::new(reader);
     let mut archive = tar::Archive::new(gz);
 
     // Looking for files under `R/`

--- a/crates/oak_sources/src/download.rs
+++ b/crates/oak_sources/src/download.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+
+const HTTP_NOT_FOUND: u16 = 404;
+const HTTP_SERVICE_UNAVAILABLE: u16 = 503;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const GLOBAL_TIMEOUT: Duration = Duration::from_secs(40);
+
+/// Outcome of a CRAN mirror HTTP request
+pub(crate) enum Outcome {
+    Success(ureq::http::Response<ureq::Body>),
+    NotFound,
+}
+
+pub(crate) fn download_with_mirrors(suffix: &str, mirrors: &[&str]) -> anyhow::Result<Outcome> {
+    if mirrors.is_empty() {
+        panic!("`mirrors` can't be empty.");
+    }
+
+    let mut last_error = None;
+
+    for mirror in mirrors {
+        let url = format!("{mirror}/{suffix}");
+
+        let request = ureq::get(&url)
+            .config()
+            .timeout_connect(Some(CONNECT_TIMEOUT))
+            .timeout_global(Some(GLOBAL_TIMEOUT))
+            .build();
+
+        match request.call() {
+            Ok(response) => return Ok(Outcome::Success(response)),
+
+            // Known to be not there, don't try any other mirrors
+            Err(ureq::Error::StatusCode(HTTP_NOT_FOUND)) => return Ok(Outcome::NotFound),
+
+            // Try next mirror, this one is temporarily unavailable
+            Err(ureq::Error::StatusCode(HTTP_SERVICE_UNAVAILABLE)) => {
+                last_error = Some(Err(ureq::Error::StatusCode(HTTP_SERVICE_UNAVAILABLE).into()));
+                continue;
+            },
+
+            // Try next mirror, this one timed out
+            Err(ureq::Error::Timeout(timeout)) => {
+                last_error = Some(Err(ureq::Error::Timeout(timeout).into()));
+                continue;
+            },
+
+            // Some unhandled error occurred, bail
+            Err(err) => return Err(err.into()),
+        };
+    }
+
+    // Every mirror returned `HTTP_SERVICE_UNAVAILABLE` or timed out
+    last_error.expect("`mirrors` was non-empty and we always set `last_error`")
+}

--- a/crates/oak_sources/src/lib.rs
+++ b/crates/oak_sources/src/lib.rs
@@ -1,4 +1,5 @@
 mod cran;
+mod download;
 mod fs;
 mod srcref;
 


### PR DESCRIPTION
Turns out that you aren't allowed to call `reqwest::blocking::get()` from inside `tokio::block_on()`

reqwest uses tokio internally, which means that `reqwest::blocking::get()` tries to use tokio blocking APIs, but when you're already inside a tokio runtime (which we are due to our top level `tokio::block_on()`) you can't use any additional tokio blocking APIs. It results in a full panic and a confusing message.

You can supposedly do stuff like this to push the blocking work onto an actual blocking thread used by tokio

```
let resp = tokio::task::spawn_blocking(|| {
    cache::get("dplyr")
}).await.unwrap();
```

but thats so awkward to think about, especially considering that we want the cache to be "warm" most of the time, not requiring tokio at all.

---

Instead, I think we should switch to ureq, which is one of the other popular but more minimal HTTP clients and is _always blocking_, which is fine for us right now.

This still requires the tweaks to the Windows github action. ureq uses ring under the hood (at least for now, see https://github.com/algesten/ureq/issues/1141). On ARM Windows where we have an MSVC target of `aarch64-pc-windows-msvc`, ureq needs to compile in a lot of C code with clang, but ends up finding the Rtools MinGW tooling that is put on the PATH, and that causes it to fail with an `<assert.h>` missing header error.