### PR TITLE
Prefer explicitly specified dimensions

### DIFF
--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -963,7 +963,7 @@ impl DeviceContext {
         id: &PlotId,
         ctx: &ExecutionContext,
     ) -> Result<serde_json::Value, anyhow::Error> {
-        let base = ctx.render_settings.unwrap_or_else(|| PlotRenderSettings {
+        let base = ctx.render_settings.unwrap_or(PlotRenderSettings {
             size: PlotSize {
                 width: 800,
                 height: 600,

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -963,21 +963,28 @@ impl DeviceContext {
         id: &PlotId,
         ctx: &ExecutionContext,
     ) -> Result<serde_json::Value, anyhow::Error> {
-        let settings = ctx.render_settings.unwrap_or_else(|| {
-            let width = r_option_positive_f64("ark.plot.width")
-                .map(|w| (w * DEFAULT_DPI).round() as i64)
-                .unwrap_or(800);
-            let height = r_option_positive_f64("ark.plot.height")
-                .map(|h| (h * DEFAULT_DPI).round() as i64)
-                .unwrap_or(600);
-            let pixel_ratio = r_option_positive_f64("ark.plot.pixel_ratio").unwrap_or(1.0);
-
-            PlotRenderSettings {
-                size: PlotSize { width, height },
-                pixel_ratio,
-                format: PlotRenderFormat::Png,
-            }
+        let base = ctx.render_settings.unwrap_or_else(|| PlotRenderSettings {
+            size: PlotSize {
+                width: 800,
+                height: 600,
+            },
+            pixel_ratio: 1.0,
+            format: PlotRenderFormat::Png,
         });
+
+        let width = r_option_positive_f64("ark.plot.width")
+            .map(|w| (w * DEFAULT_DPI).round() as i64)
+            .unwrap_or(base.size.width);
+        let height = r_option_positive_f64("ark.plot.height")
+            .map(|h| (h * DEFAULT_DPI).round() as i64)
+            .unwrap_or(base.size.height);
+        let pixel_ratio = r_option_positive_f64("ark.plot.pixel_ratio").unwrap_or(base.pixel_ratio);
+
+        let settings = PlotRenderSettings {
+            size: PlotSize { width, height },
+            pixel_ratio,
+            format: base.format,
+        };
 
         let data = unwrap!(self.render_plot(id, &settings), Err(error) => {
             return Err(anyhow!("Failed to render plot with id {id} due to: {error}."));

--- a/justfile
+++ b/justfile
@@ -15,3 +15,7 @@ test-insta:
 # Run clippy
 clippy:
   cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# Reformat source files
+format:
+  cargo +nightly fmt --all


### PR DESCRIPTION
Currently, the `ark.plot.width` / `ark.plot.height` options are fallbacks and only consulted when we do not have viewport info from render settings. This makes it difficult to use these options in Positron notebooks since the notebook dimensions take precedence.

This change simply flips the order of precedence so that if the options are set, they are preferred over the more implicit render settings. 

Part of https://github.com/posit-dev/positron/issues/9378.