### PR TITLE
Abstract DAP handler

### DIFF
--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -80,16 +80,20 @@ pub struct DapOutput {
 }
 
 impl DapOutput {
-    pub fn new(response: Response) -> Self {
+    pub(crate) fn success(req: Request, output: DapHandlerOutput) -> Self {
         Self {
-            response,
-            dap_events: vec![],
-            console_events: vec![],
+            response: req.success(output.body),
+            dap_events: output.dap_events,
+            console_events: output.console_events,
         }
     }
 
     pub fn error(req: Request, message: &str) -> Self {
-        Self::new(req.error(message))
+        Self {
+            response: req.error(message),
+            dap_events: vec![],
+            console_events: vec![],
+        }
     }
 }
 
@@ -100,16 +104,6 @@ pub(crate) struct DapHandlerOutput {
     pub body: ResponseBody,
     pub dap_events: Vec<Event>,
     pub console_events: Vec<DapConsoleEvent>,
-}
-
-impl DapHandlerOutput {
-    fn new(body: ResponseBody) -> Self {
-        Self {
-            body,
-            dap_events: vec![],
-            console_events: vec![],
-        }
-    }
 }
 
 /// Transport-agnostic handler for DAP requests. Translates each request
@@ -168,11 +162,7 @@ impl DapHandler {
         };
 
         match result {
-            Ok(output) => DapOutput {
-                response: req.success(output.body),
-                dap_events: output.dap_events,
-                console_events: output.console_events,
-            },
+            Ok(output) => DapOutput::success(req, output),
             Err(err) => DapOutput::error(req, &format!("{err}")),
         }
     }
@@ -250,11 +240,13 @@ impl DapHandler {
             Ok(uri) => uri,
             Err(err) => {
                 log::warn!("Can't set breakpoints for non-file path: '{path}': {err}");
-                return Ok(DapHandlerOutput::new(ResponseBody::SetBreakpoints(
-                    SetBreakpointsResponse {
+                return Ok(DapHandlerOutput {
+                    body: ResponseBody::SetBreakpoints(SetBreakpointsResponse {
                         breakpoints: vec![],
-                    },
-                )));
+                    }),
+                    dap_events: vec![],
+                    console_events: vec![],
+                });
             },
         };
 
@@ -280,9 +272,11 @@ impl DapHandler {
                     })
                     .collect();
 
-                return Ok(DapHandlerOutput::new(ResponseBody::SetBreakpoints(
-                    SetBreakpointsResponse { breakpoints },
-                )));
+                return Ok(DapHandlerOutput {
+                    body: ResponseBody::SetBreakpoints(SetBreakpointsResponse { breakpoints }),
+                    dap_events: vec![],
+                    console_events: vec![],
+                });
             },
         };
 
@@ -432,11 +426,13 @@ impl DapHandler {
 
         drop(state);
 
-        Ok(DapHandlerOutput::new(ResponseBody::SetBreakpoints(
-            SetBreakpointsResponse {
+        Ok(DapHandlerOutput {
+            body: ResponseBody::SetBreakpoints(SetBreakpointsResponse {
                 breakpoints: response_breakpoints,
-            },
-        )))
+            }),
+            dap_events: vec![],
+            console_events: vec![],
+        })
     }
 
     fn handle_attach(&self, _args: AttachRequestArguments) -> anyhow::Result<DapHandlerOutput> {
@@ -477,14 +473,16 @@ impl DapHandler {
     // All servers must respond to `Threads` requests, possibly with
     // a dummy thread as is the case here
     fn handle_threads(&self) -> anyhow::Result<DapHandlerOutput> {
-        Ok(DapHandlerOutput::new(ResponseBody::Threads(
-            ThreadsResponse {
+        Ok(DapHandlerOutput {
+            body: ResponseBody::Threads(ThreadsResponse {
                 threads: vec![Thread {
                     id: THREAD_ID,
                     name: String::from("R console"),
                 }],
-            },
-        )))
+            }),
+            dap_events: vec![],
+            console_events: vec![],
+        })
     }
 
     fn handle_set_exception_breakpoints(
@@ -495,14 +493,16 @@ impl DapHandler {
             let mut state = self.state.lock().unwrap();
             state.exception_breakpoint_filters = args.filters;
         }
-        Ok(DapHandlerOutput::new(
-            ResponseBody::SetExceptionBreakpoints(SetExceptionBreakpointsResponse {
+        Ok(DapHandlerOutput {
+            body: ResponseBody::SetExceptionBreakpoints(SetExceptionBreakpointsResponse {
                 // This field is only useful for reporting problems with
                 // individual filters. Since we always accept all filters,
                 // `None` is fine here.
                 breakpoints: None,
             }),
-        ))
+            dap_events: vec![],
+            console_events: vec![],
+        })
     }
 
     fn handle_stacktrace(&self, args: StackTraceArguments) -> anyhow::Result<DapHandlerOutput> {
@@ -543,12 +543,14 @@ impl DapHandler {
         };
         let stack = stack[start..end].to_vec();
 
-        Ok(DapHandlerOutput::new(ResponseBody::StackTrace(
-            StackTraceResponse {
+        Ok(DapHandlerOutput {
+            body: ResponseBody::StackTrace(StackTraceResponse {
                 stack_frames: stack,
                 total_frames: Some(total_frames),
-            },
-        )))
+            }),
+            dap_events: vec![],
+            console_events: vec![],
+        })
     }
 
     fn handle_source(&self, _args: SourceArguments) -> anyhow::Result<DapHandlerOutput> {
@@ -583,18 +585,22 @@ impl DapHandler {
         }];
 
         drop(state);
-        Ok(DapHandlerOutput::new(ResponseBody::Scopes(
-            ScopesResponse { scopes },
-        )))
+        Ok(DapHandlerOutput {
+            body: ResponseBody::Scopes(ScopesResponse { scopes }),
+            dap_events: vec![],
+            console_events: vec![],
+        })
     }
 
     fn handle_variables(&self, args: VariablesArguments) -> anyhow::Result<DapHandlerOutput> {
         let variables_reference = args.variables_reference;
         let variables = self.collect_r_variables(variables_reference);
         let variables = self.make_variables(variables);
-        Ok(DapHandlerOutput::new(ResponseBody::Variables(
-            VariablesResponse { variables },
-        )))
+        Ok(DapHandlerOutput {
+            body: ResponseBody::Variables(VariablesResponse { variables }),
+            dap_events: vec![],
+            console_events: vec![],
+        })
     }
 
     fn collect_r_variables(&self, variables_reference: i64) -> Vec<RVariable> {

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -112,7 +112,8 @@ impl DapHandler {
     pub fn dispatch(&self, req: Request) -> DapOutput {
         let cmd = req.command.clone();
 
-        match cmd {
+        let err_req = req.clone();
+        let result = match cmd {
             Command::Initialize(args) => self.handle_initialize(req, args),
             Command::Attach(args) => self.handle_attach(req, args),
             Command::Disconnect(args) => self.handle_disconnect(req, args),
@@ -144,12 +145,21 @@ impl DapHandler {
             Command::Pause(args) => self.handle_pause(req, args),
             _ => {
                 log::warn!("DAP: Unknown request");
-                DapOutput::response(req.error("Ark DAP: Unknown request"))
+                return DapOutput::response(err_req.error("Ark DAP: Unknown request"));
             },
+        };
+
+        match result {
+            Ok(output) => output,
+            Err(err) => DapOutput::response(err_req.error(&format!("{err}"))),
         }
     }
 
-    fn handle_initialize(&self, req: Request, _args: InitializeArguments) -> DapOutput {
+    fn handle_initialize(
+        &self,
+        req: Request,
+        _args: InitializeArguments,
+    ) -> anyhow::Result<DapOutput> {
         let rsp = req.success(ResponseBody::Initialize(types::Capabilities {
             supports_restart_request: Some(true),
             supports_exception_info_request: Some(false),
@@ -185,11 +195,11 @@ impl DapHandler {
             supports_log_points: Some(true),
             ..Default::default()
         }));
-        DapOutput {
+        Ok(DapOutput {
             response: rsp,
             dap_events: vec![Event::Initialized],
             console_events: vec![],
-        }
+        })
     }
 
     // Handle SetBreakpoints requests from the frontend.
@@ -207,11 +217,13 @@ impl DapHandler {
     // - When a user unchecks a breakpoint, it appears as a deletion (omitted
     //   from the request). We preserve verified breakpoints as Disabled so we
     //   can restore their state when re-enabled without requiring re-sourcing.
-    fn handle_set_breakpoints(&self, req: Request, args: SetBreakpointsArguments) -> DapOutput {
+    fn handle_set_breakpoints(
+        &self,
+        req: Request,
+        args: SetBreakpointsArguments,
+    ) -> anyhow::Result<DapOutput> {
         let Some(path) = args.source.path.as_ref() else {
-            // We don't currently have virtual documents managed via source references
-            log::warn!("Missing a path to set breakpoints for.");
-            return DapOutput::response(req.error("Missing a path to set breakpoints for"));
+            return Err(anyhow::anyhow!("Missing a path to set breakpoints for"));
         };
 
         // We currently only support "path" URIs as Positron never sends URIs.
@@ -224,7 +236,7 @@ impl DapHandler {
                 let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
                     breakpoints: vec![],
                 }));
-                return DapOutput::response(rsp);
+                return Ok(DapOutput::response(rsp));
             },
         };
 
@@ -253,7 +265,7 @@ impl DapHandler {
                 let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
                     breakpoints,
                 }));
-                return DapOutput::response(rsp);
+                return Ok(DapOutput::response(rsp));
             },
         };
 
@@ -407,22 +419,30 @@ impl DapHandler {
             breakpoints: response_breakpoints,
         }));
 
-        DapOutput::response(rsp)
+        Ok(DapOutput::response(rsp))
     }
 
-    fn handle_attach(&self, req: Request, _args: AttachRequestArguments) -> DapOutput {
+    fn handle_attach(
+        &self,
+        req: Request,
+        _args: AttachRequestArguments,
+    ) -> anyhow::Result<DapOutput> {
         let rsp = req.success(ResponseBody::Attach);
-        DapOutput {
+        Ok(DapOutput {
             response: rsp,
             dap_events: vec![Event::Thread(ThreadEventBody {
                 reason: ThreadEventReason::Started,
                 thread_id: THREAD_ID,
             })],
             console_events: vec![],
-        }
+        })
     }
 
-    fn handle_disconnect(&self, req: Request, _args: DisconnectArguments) -> DapOutput {
+    fn handle_disconnect(
+        &self,
+        req: Request,
+        _args: DisconnectArguments,
+    ) -> anyhow::Result<DapOutput> {
         // Only send `Q` if currently in a debugging session.
         let is_debugging = { self.state.lock().unwrap().is_debugging };
         let console_events = if is_debugging {
@@ -431,38 +451,38 @@ impl DapHandler {
             vec![]
         };
 
-        DapOutput {
+        Ok(DapOutput {
             response: req.success(ResponseBody::Disconnect),
             dap_events: vec![],
             console_events,
-        }
+        })
     }
 
-    fn handle_restart<T>(&self, req: Request, _args: T) -> DapOutput {
-        DapOutput {
+    fn handle_restart<T>(&self, req: Request, _args: T) -> anyhow::Result<DapOutput> {
+        Ok(DapOutput {
             response: req.success(ResponseBody::Restart),
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::Restart],
-        }
+        })
     }
 
     // All servers must respond to `Threads` requests, possibly with
     // a dummy thread as is the case here
-    fn handle_threads(&self, req: Request) -> DapOutput {
+    fn handle_threads(&self, req: Request) -> anyhow::Result<DapOutput> {
         let rsp = req.success(ResponseBody::Threads(ThreadsResponse {
             threads: vec![Thread {
                 id: THREAD_ID,
                 name: String::from("R console"),
             }],
         }));
-        DapOutput::response(rsp)
+        Ok(DapOutput::response(rsp))
     }
 
     fn handle_set_exception_breakpoints(
         &self,
         req: Request,
         args: SetExceptionBreakpointsArguments,
-    ) -> DapOutput {
+    ) -> anyhow::Result<DapOutput> {
         {
             let mut state = self.state.lock().unwrap();
             state.exception_breakpoint_filters = args.filters;
@@ -475,10 +495,14 @@ impl DapHandler {
                 breakpoints: None,
             },
         ));
-        DapOutput::response(rsp)
+        Ok(DapOutput::response(rsp))
     }
 
-    fn handle_stacktrace(&self, req: Request, args: StackTraceArguments) -> DapOutput {
+    fn handle_stacktrace(
+        &self,
+        req: Request,
+        args: StackTraceArguments,
+    ) -> anyhow::Result<DapOutput> {
         let stack = {
             let state = self.state.lock().unwrap();
             let fallback_sources = &state.fallback_sources;
@@ -496,15 +520,13 @@ impl DapHandler {
 
         let start_frame = args.start_frame.unwrap_or(0);
         let Ok(start) = usize::try_from(start_frame) else {
-            let rsp = req.error(&format!("Invalid start_frame: {start_frame}"));
-            return DapOutput::response(rsp);
+            return Err(anyhow::anyhow!("Invalid start_frame: {start_frame}"));
         };
         let start = std::cmp::min(start, n_usize);
 
         let end = if let Some(levels) = args.levels {
             let Ok(levels) = usize::try_from(levels) else {
-                let rsp = req.error(&format!("Invalid levels: {levels}"));
-                return DapOutput::response(rsp);
+                return Err(anyhow::anyhow!("Invalid levels: {levels}"));
             };
             std::cmp::min(start.saturating_add(levels), n_usize)
         } else {
@@ -512,8 +534,9 @@ impl DapHandler {
         };
 
         let Ok(total_frames) = i64::try_from(n_usize) else {
-            let rsp = req.error(&format!("Stack frame count overflows i64: {n_usize}"));
-            return DapOutput::response(rsp);
+            return Err(anyhow::anyhow!(
+                "Stack frame count overflows i64: {n_usize}"
+            ));
         };
         let stack = stack[start..end].to_vec();
 
@@ -522,16 +545,14 @@ impl DapHandler {
             total_frames: Some(total_frames),
         }));
 
-        DapOutput::response(rsp)
+        Ok(DapOutput::response(rsp))
     }
 
-    fn handle_source(&self, req: Request, _args: SourceArguments) -> DapOutput {
-        let message = "Unsupported `source` request: {req:?}";
-        log::error!("{message}");
-        DapOutput::response(req.error(message))
+    fn handle_source(&self, _req: Request, _args: SourceArguments) -> anyhow::Result<DapOutput> {
+        Err(anyhow::anyhow!("Unsupported `source` request"))
     }
 
-    fn handle_scopes(&self, req: Request, args: ScopesArguments) -> DapOutput {
+    fn handle_scopes(&self, req: Request, args: ScopesArguments) -> anyhow::Result<DapOutput> {
         let state = self.state.lock().unwrap();
         let frame_id_to_variables_reference = &state.frame_id_to_variables_reference;
 
@@ -561,15 +582,19 @@ impl DapHandler {
         let rsp = req.success(ResponseBody::Scopes(ScopesResponse { scopes }));
 
         drop(state);
-        DapOutput::response(rsp)
+        Ok(DapOutput::response(rsp))
     }
 
-    fn handle_variables(&self, req: Request, args: VariablesArguments) -> DapOutput {
+    fn handle_variables(
+        &self,
+        req: Request,
+        args: VariablesArguments,
+    ) -> anyhow::Result<DapOutput> {
         let variables_reference = args.variables_reference;
         let variables = self.collect_r_variables(variables_reference);
         let variables = self.make_variables(variables);
         let rsp = req.success(ResponseBody::Variables(VariablesResponse { variables }));
-        DapOutput::response(rsp)
+        Ok(DapOutput::response(rsp))
     }
 
     fn collect_r_variables(&self, variables_reference: i64) -> Vec<RVariable> {
@@ -605,24 +630,24 @@ impl DapHandler {
         _args: A,
         cmd: DebugRequest,
         resp: ResponseBody,
-    ) -> DapOutput {
-        DapOutput {
+    ) -> anyhow::Result<DapOutput> {
+        Ok(DapOutput {
             response: req.success(resp),
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::DebugCommand(cmd)],
-        }
+        })
     }
 
-    fn handle_pause(&self, req: Request, _args: PauseArguments) -> DapOutput {
+    fn handle_pause(&self, req: Request, _args: PauseArguments) -> anyhow::Result<DapOutput> {
         self.state.lock().unwrap().is_interrupting_for_debugger = true;
 
         log::info!("DAP: Received request to pause R, sending interrupt");
 
-        DapOutput {
+        Ok(DapOutput {
             response: req.success(ResponseBody::Pause),
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::Interrupt],
-        }
+        })
     }
 }
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -96,13 +96,13 @@ impl DapOutput {
 /// The result of a handler method. Contains a `ResponseBody` (not a full
 /// `Response`) plus any events. The dispatcher wraps the body with
 /// `req.success()` or `req.error()` to produce a transport-ready `DapOutput`.
-pub(crate) struct HandlerOutput {
+pub(crate) struct DapHandlerOutput {
     pub body: ResponseBody,
     pub dap_events: Vec<Event>,
     pub console_events: Vec<DapConsoleEvent>,
 }
 
-impl HandlerOutput {
+impl DapHandlerOutput {
     fn new(body: ResponseBody) -> Self {
         Self {
             body,
@@ -177,7 +177,7 @@ impl DapHandler {
         }
     }
 
-    fn handle_initialize(&self, _args: InitializeArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_initialize(&self, _args: InitializeArguments) -> anyhow::Result<DapHandlerOutput> {
         let body = ResponseBody::Initialize(types::Capabilities {
             supports_restart_request: Some(true),
             supports_exception_info_request: Some(false),
@@ -213,7 +213,7 @@ impl DapHandler {
             supports_log_points: Some(true),
             ..Default::default()
         });
-        Ok(HandlerOutput {
+        Ok(DapHandlerOutput {
             body,
             dap_events: vec![Event::Initialized],
             console_events: vec![],
@@ -238,7 +238,7 @@ impl DapHandler {
     fn handle_set_breakpoints(
         &self,
         args: SetBreakpointsArguments,
-    ) -> anyhow::Result<HandlerOutput> {
+    ) -> anyhow::Result<DapHandlerOutput> {
         let Some(path) = args.source.path.as_ref() else {
             return Err(anyhow::anyhow!("Missing a path to set breakpoints for"));
         };
@@ -250,7 +250,7 @@ impl DapHandler {
             Ok(uri) => uri,
             Err(err) => {
                 log::warn!("Can't set breakpoints for non-file path: '{path}': {err}");
-                return Ok(HandlerOutput::new(ResponseBody::SetBreakpoints(
+                return Ok(DapHandlerOutput::new(ResponseBody::SetBreakpoints(
                     SetBreakpointsResponse {
                         breakpoints: vec![],
                     },
@@ -280,7 +280,7 @@ impl DapHandler {
                     })
                     .collect();
 
-                return Ok(HandlerOutput::new(ResponseBody::SetBreakpoints(
+                return Ok(DapHandlerOutput::new(ResponseBody::SetBreakpoints(
                     SetBreakpointsResponse { breakpoints },
                 )));
             },
@@ -432,15 +432,15 @@ impl DapHandler {
 
         drop(state);
 
-        Ok(HandlerOutput::new(ResponseBody::SetBreakpoints(
+        Ok(DapHandlerOutput::new(ResponseBody::SetBreakpoints(
             SetBreakpointsResponse {
                 breakpoints: response_breakpoints,
             },
         )))
     }
 
-    fn handle_attach(&self, _args: AttachRequestArguments) -> anyhow::Result<HandlerOutput> {
-        Ok(HandlerOutput {
+    fn handle_attach(&self, _args: AttachRequestArguments) -> anyhow::Result<DapHandlerOutput> {
+        Ok(DapHandlerOutput {
             body: ResponseBody::Attach,
             dap_events: vec![Event::Thread(ThreadEventBody {
                 reason: ThreadEventReason::Started,
@@ -450,7 +450,7 @@ impl DapHandler {
         })
     }
 
-    fn handle_disconnect(&self, _args: DisconnectArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_disconnect(&self, _args: DisconnectArguments) -> anyhow::Result<DapHandlerOutput> {
         // Only send `Q` if currently in a debugging session.
         let is_debugging = { self.state.lock().unwrap().is_debugging };
         let console_events = if is_debugging {
@@ -459,15 +459,15 @@ impl DapHandler {
             vec![]
         };
 
-        Ok(HandlerOutput {
+        Ok(DapHandlerOutput {
             body: ResponseBody::Disconnect,
             dap_events: vec![],
             console_events,
         })
     }
 
-    fn handle_restart<T>(&self, _args: T) -> anyhow::Result<HandlerOutput> {
-        Ok(HandlerOutput {
+    fn handle_restart<T>(&self, _args: T) -> anyhow::Result<DapHandlerOutput> {
+        Ok(DapHandlerOutput {
             body: ResponseBody::Restart,
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::Restart],
@@ -476,34 +476,36 @@ impl DapHandler {
 
     // All servers must respond to `Threads` requests, possibly with
     // a dummy thread as is the case here
-    fn handle_threads(&self) -> anyhow::Result<HandlerOutput> {
-        Ok(HandlerOutput::new(ResponseBody::Threads(ThreadsResponse {
-            threads: vec![Thread {
-                id: THREAD_ID,
-                name: String::from("R console"),
-            }],
-        })))
+    fn handle_threads(&self) -> anyhow::Result<DapHandlerOutput> {
+        Ok(DapHandlerOutput::new(ResponseBody::Threads(
+            ThreadsResponse {
+                threads: vec![Thread {
+                    id: THREAD_ID,
+                    name: String::from("R console"),
+                }],
+            },
+        )))
     }
 
     fn handle_set_exception_breakpoints(
         &self,
         args: SetExceptionBreakpointsArguments,
-    ) -> anyhow::Result<HandlerOutput> {
+    ) -> anyhow::Result<DapHandlerOutput> {
         {
             let mut state = self.state.lock().unwrap();
             state.exception_breakpoint_filters = args.filters;
         }
-        Ok(HandlerOutput::new(ResponseBody::SetExceptionBreakpoints(
-            SetExceptionBreakpointsResponse {
+        Ok(DapHandlerOutput::new(
+            ResponseBody::SetExceptionBreakpoints(SetExceptionBreakpointsResponse {
                 // This field is only useful for reporting problems with
                 // individual filters. Since we always accept all filters,
                 // `None` is fine here.
                 breakpoints: None,
-            },
-        )))
+            }),
+        ))
     }
 
-    fn handle_stacktrace(&self, args: StackTraceArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_stacktrace(&self, args: StackTraceArguments) -> anyhow::Result<DapHandlerOutput> {
         let stack = {
             let state = self.state.lock().unwrap();
             let fallback_sources = &state.fallback_sources;
@@ -541,7 +543,7 @@ impl DapHandler {
         };
         let stack = stack[start..end].to_vec();
 
-        Ok(HandlerOutput::new(ResponseBody::StackTrace(
+        Ok(DapHandlerOutput::new(ResponseBody::StackTrace(
             StackTraceResponse {
                 stack_frames: stack,
                 total_frames: Some(total_frames),
@@ -549,11 +551,11 @@ impl DapHandler {
         )))
     }
 
-    fn handle_source(&self, _args: SourceArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_source(&self, _args: SourceArguments) -> anyhow::Result<DapHandlerOutput> {
         Err(anyhow::anyhow!("Unsupported `source` request"))
     }
 
-    fn handle_scopes(&self, args: ScopesArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_scopes(&self, args: ScopesArguments) -> anyhow::Result<DapHandlerOutput> {
         let state = self.state.lock().unwrap();
         let frame_id_to_variables_reference = &state.frame_id_to_variables_reference;
 
@@ -581,16 +583,16 @@ impl DapHandler {
         }];
 
         drop(state);
-        Ok(HandlerOutput::new(ResponseBody::Scopes(ScopesResponse {
-            scopes,
-        })))
+        Ok(DapHandlerOutput::new(ResponseBody::Scopes(
+            ScopesResponse { scopes },
+        )))
     }
 
-    fn handle_variables(&self, args: VariablesArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_variables(&self, args: VariablesArguments) -> anyhow::Result<DapHandlerOutput> {
         let variables_reference = args.variables_reference;
         let variables = self.collect_r_variables(variables_reference);
         let variables = self.make_variables(variables);
-        Ok(HandlerOutput::new(ResponseBody::Variables(
+        Ok(DapHandlerOutput::new(ResponseBody::Variables(
             VariablesResponse { variables },
         )))
     }
@@ -627,20 +629,20 @@ impl DapHandler {
         _args: A,
         cmd: DebugRequest,
         resp: ResponseBody,
-    ) -> anyhow::Result<HandlerOutput> {
-        Ok(HandlerOutput {
+    ) -> anyhow::Result<DapHandlerOutput> {
+        Ok(DapHandlerOutput {
             body: resp,
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::DebugCommand(cmd)],
         })
     }
 
-    fn handle_pause(&self, _args: PauseArguments) -> anyhow::Result<HandlerOutput> {
+    fn handle_pause(&self, _args: PauseArguments) -> anyhow::Result<DapHandlerOutput> {
         self.state.lock().unwrap().is_interrupting_for_debugger = true;
 
         log::info!("DAP: Received request to pause R, sending interrupt");
 
-        Ok(HandlerOutput {
+        Ok(DapHandlerOutput {
             body: ResponseBody::Pause,
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::Interrupt],

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -898,14 +898,12 @@ impl<R: Read, W: Write> DapServer<R, W> {
     }
 
     fn deliver(&mut self, output: DapOutput) -> bool {
-        if let Err(err) = self.respond(output.response) {
-            log::warn!("DAP: Failed to send response: {err:?}");
+        if self.respond(output.response).log_err().is_none() {
             return false;
         }
 
         for event in output.dap_events {
-            if let Err(err) = self.send_event(event) {
-                log::warn!("DAP: Failed to send event: {err:?}");
+            if self.send_event(event).log_err().is_none() {
                 return false;
             }
         }

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -80,9 +80,32 @@ pub struct DapOutput {
 }
 
 impl DapOutput {
-    pub fn response(response: Response) -> Self {
+    pub fn new(response: Response) -> Self {
         Self {
             response,
+            dap_events: vec![],
+            console_events: vec![],
+        }
+    }
+
+    pub fn error(req: Request, message: &str) -> Self {
+        Self::new(req.error(message))
+    }
+}
+
+/// The result of a handler method. Contains a `ResponseBody` (not a full
+/// `Response`) plus any events. The dispatcher wraps the body with
+/// `req.success()` or `req.error()` to produce a transport-ready `DapOutput`.
+pub(crate) struct HandlerOutput {
+    pub body: ResponseBody,
+    pub dap_events: Vec<Event>,
+    pub console_events: Vec<DapConsoleEvent>,
+}
+
+impl HandlerOutput {
+    fn new(body: ResponseBody) -> Self {
+        Self {
+            body,
             dap_events: vec![],
             console_events: vec![],
         }
@@ -112,55 +135,50 @@ impl DapHandler {
     pub fn dispatch(&self, req: Request) -> DapOutput {
         let cmd = req.command.clone();
 
-        let err_req = req.clone();
         let result = match cmd {
-            Command::Initialize(args) => self.handle_initialize(req, args),
-            Command::Attach(args) => self.handle_attach(req, args),
-            Command::Disconnect(args) => self.handle_disconnect(req, args),
-            Command::Restart(args) => self.handle_restart(req, args),
-            Command::Threads => self.handle_threads(req),
-            Command::SetBreakpoints(args) => self.handle_set_breakpoints(req, args),
-            Command::SetExceptionBreakpoints(args) => {
-                self.handle_set_exception_breakpoints(req, args)
-            },
-            Command::StackTrace(args) => self.handle_stacktrace(req, args),
-            Command::Source(args) => self.handle_source(req, args),
-            Command::Scopes(args) => self.handle_scopes(req, args),
-            Command::Variables(args) => self.handle_variables(req, args),
+            Command::Initialize(args) => self.handle_initialize(args),
+            Command::Attach(args) => self.handle_attach(args),
+            Command::Disconnect(args) => self.handle_disconnect(args),
+            Command::Restart(args) => self.handle_restart(args),
+            Command::Threads => self.handle_threads(),
+            Command::SetBreakpoints(args) => self.handle_set_breakpoints(args),
+            Command::SetExceptionBreakpoints(args) => self.handle_set_exception_breakpoints(args),
+            Command::StackTrace(args) => self.handle_stacktrace(args),
+            Command::Source(args) => self.handle_source(args),
+            Command::Scopes(args) => self.handle_scopes(args),
+            Command::Variables(args) => self.handle_variables(args),
             Command::Continue(args) => {
                 let resp = ResponseBody::Continue(ContinueResponse {
                     all_threads_continued: Some(true),
                 });
-                self.handle_step(req, args, DebugRequest::Continue, resp)
+                self.handle_step(args, DebugRequest::Continue, resp)
             },
-            Command::Next(args) => {
-                self.handle_step(req, args, DebugRequest::Next, ResponseBody::Next)
-            },
+            Command::Next(args) => self.handle_step(args, DebugRequest::Next, ResponseBody::Next),
             Command::StepIn(args) => {
-                self.handle_step(req, args, DebugRequest::StepIn, ResponseBody::StepIn)
+                self.handle_step(args, DebugRequest::StepIn, ResponseBody::StepIn)
             },
             Command::StepOut(args) => {
-                self.handle_step(req, args, DebugRequest::StepOut, ResponseBody::StepOut)
+                self.handle_step(args, DebugRequest::StepOut, ResponseBody::StepOut)
             },
-            Command::Pause(args) => self.handle_pause(req, args),
+            Command::Pause(args) => self.handle_pause(args),
             _ => {
                 log::warn!("DAP: Unknown request");
-                return DapOutput::response(err_req.error("Ark DAP: Unknown request"));
+                return DapOutput::error(req, "Ark DAP: Unknown request");
             },
         };
 
         match result {
-            Ok(output) => output,
-            Err(err) => DapOutput::response(err_req.error(&format!("{err}"))),
+            Ok(output) => DapOutput {
+                response: req.success(output.body),
+                dap_events: output.dap_events,
+                console_events: output.console_events,
+            },
+            Err(err) => DapOutput::error(req, &format!("{err}")),
         }
     }
 
-    fn handle_initialize(
-        &self,
-        req: Request,
-        _args: InitializeArguments,
-    ) -> anyhow::Result<DapOutput> {
-        let rsp = req.success(ResponseBody::Initialize(types::Capabilities {
+    fn handle_initialize(&self, _args: InitializeArguments) -> anyhow::Result<HandlerOutput> {
+        let body = ResponseBody::Initialize(types::Capabilities {
             supports_restart_request: Some(true),
             supports_exception_info_request: Some(false),
             exception_breakpoint_filters: Some(vec![
@@ -194,9 +212,9 @@ impl DapHandler {
             supports_hit_conditional_breakpoints: Some(true),
             supports_log_points: Some(true),
             ..Default::default()
-        }));
-        Ok(DapOutput {
-            response: rsp,
+        });
+        Ok(HandlerOutput {
+            body,
             dap_events: vec![Event::Initialized],
             console_events: vec![],
         })
@@ -219,9 +237,8 @@ impl DapHandler {
     //   can restore their state when re-enabled without requiring re-sourcing.
     fn handle_set_breakpoints(
         &self,
-        req: Request,
         args: SetBreakpointsArguments,
-    ) -> anyhow::Result<DapOutput> {
+    ) -> anyhow::Result<HandlerOutput> {
         let Some(path) = args.source.path.as_ref() else {
             return Err(anyhow::anyhow!("Missing a path to set breakpoints for"));
         };
@@ -233,10 +250,11 @@ impl DapHandler {
             Ok(uri) => uri,
             Err(err) => {
                 log::warn!("Can't set breakpoints for non-file path: '{path}': {err}");
-                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
-                    breakpoints: vec![],
-                }));
-                return Ok(DapOutput::response(rsp));
+                return Ok(HandlerOutput::new(ResponseBody::SetBreakpoints(
+                    SetBreakpointsResponse {
+                        breakpoints: vec![],
+                    },
+                )));
             },
         };
 
@@ -262,10 +280,9 @@ impl DapHandler {
                     })
                     .collect();
 
-                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
-                    breakpoints,
-                }));
-                return Ok(DapOutput::response(rsp));
+                return Ok(HandlerOutput::new(ResponseBody::SetBreakpoints(
+                    SetBreakpointsResponse { breakpoints },
+                )));
             },
         };
 
@@ -415,21 +432,16 @@ impl DapHandler {
 
         drop(state);
 
-        let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
-            breakpoints: response_breakpoints,
-        }));
-
-        Ok(DapOutput::response(rsp))
+        Ok(HandlerOutput::new(ResponseBody::SetBreakpoints(
+            SetBreakpointsResponse {
+                breakpoints: response_breakpoints,
+            },
+        )))
     }
 
-    fn handle_attach(
-        &self,
-        req: Request,
-        _args: AttachRequestArguments,
-    ) -> anyhow::Result<DapOutput> {
-        let rsp = req.success(ResponseBody::Attach);
-        Ok(DapOutput {
-            response: rsp,
+    fn handle_attach(&self, _args: AttachRequestArguments) -> anyhow::Result<HandlerOutput> {
+        Ok(HandlerOutput {
+            body: ResponseBody::Attach,
             dap_events: vec![Event::Thread(ThreadEventBody {
                 reason: ThreadEventReason::Started,
                 thread_id: THREAD_ID,
@@ -438,11 +450,7 @@ impl DapHandler {
         })
     }
 
-    fn handle_disconnect(
-        &self,
-        req: Request,
-        _args: DisconnectArguments,
-    ) -> anyhow::Result<DapOutput> {
+    fn handle_disconnect(&self, _args: DisconnectArguments) -> anyhow::Result<HandlerOutput> {
         // Only send `Q` if currently in a debugging session.
         let is_debugging = { self.state.lock().unwrap().is_debugging };
         let console_events = if is_debugging {
@@ -451,16 +459,16 @@ impl DapHandler {
             vec![]
         };
 
-        Ok(DapOutput {
-            response: req.success(ResponseBody::Disconnect),
+        Ok(HandlerOutput {
+            body: ResponseBody::Disconnect,
             dap_events: vec![],
             console_events,
         })
     }
 
-    fn handle_restart<T>(&self, req: Request, _args: T) -> anyhow::Result<DapOutput> {
-        Ok(DapOutput {
-            response: req.success(ResponseBody::Restart),
+    fn handle_restart<T>(&self, _args: T) -> anyhow::Result<HandlerOutput> {
+        Ok(HandlerOutput {
+            body: ResponseBody::Restart,
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::Restart],
         })
@@ -468,41 +476,34 @@ impl DapHandler {
 
     // All servers must respond to `Threads` requests, possibly with
     // a dummy thread as is the case here
-    fn handle_threads(&self, req: Request) -> anyhow::Result<DapOutput> {
-        let rsp = req.success(ResponseBody::Threads(ThreadsResponse {
+    fn handle_threads(&self) -> anyhow::Result<HandlerOutput> {
+        Ok(HandlerOutput::new(ResponseBody::Threads(ThreadsResponse {
             threads: vec![Thread {
                 id: THREAD_ID,
                 name: String::from("R console"),
             }],
-        }));
-        Ok(DapOutput::response(rsp))
+        })))
     }
 
     fn handle_set_exception_breakpoints(
         &self,
-        req: Request,
         args: SetExceptionBreakpointsArguments,
-    ) -> anyhow::Result<DapOutput> {
+    ) -> anyhow::Result<HandlerOutput> {
         {
             let mut state = self.state.lock().unwrap();
             state.exception_breakpoint_filters = args.filters;
         }
-        let rsp = req.success(ResponseBody::SetExceptionBreakpoints(
+        Ok(HandlerOutput::new(ResponseBody::SetExceptionBreakpoints(
             SetExceptionBreakpointsResponse {
                 // This field is only useful for reporting problems with
                 // individual filters. Since we always accept all filters,
                 // `None` is fine here.
                 breakpoints: None,
             },
-        ));
-        Ok(DapOutput::response(rsp))
+        )))
     }
 
-    fn handle_stacktrace(
-        &self,
-        req: Request,
-        args: StackTraceArguments,
-    ) -> anyhow::Result<DapOutput> {
+    fn handle_stacktrace(&self, args: StackTraceArguments) -> anyhow::Result<HandlerOutput> {
         let stack = {
             let state = self.state.lock().unwrap();
             let fallback_sources = &state.fallback_sources;
@@ -540,19 +541,19 @@ impl DapHandler {
         };
         let stack = stack[start..end].to_vec();
 
-        let rsp = req.success(ResponseBody::StackTrace(StackTraceResponse {
-            stack_frames: stack,
-            total_frames: Some(total_frames),
-        }));
-
-        Ok(DapOutput::response(rsp))
+        Ok(HandlerOutput::new(ResponseBody::StackTrace(
+            StackTraceResponse {
+                stack_frames: stack,
+                total_frames: Some(total_frames),
+            },
+        )))
     }
 
-    fn handle_source(&self, _req: Request, _args: SourceArguments) -> anyhow::Result<DapOutput> {
+    fn handle_source(&self, _args: SourceArguments) -> anyhow::Result<HandlerOutput> {
         Err(anyhow::anyhow!("Unsupported `source` request"))
     }
 
-    fn handle_scopes(&self, req: Request, args: ScopesArguments) -> anyhow::Result<DapOutput> {
+    fn handle_scopes(&self, args: ScopesArguments) -> anyhow::Result<HandlerOutput> {
         let state = self.state.lock().unwrap();
         let frame_id_to_variables_reference = &state.frame_id_to_variables_reference;
 
@@ -579,22 +580,19 @@ impl DapHandler {
             end_column: None,
         }];
 
-        let rsp = req.success(ResponseBody::Scopes(ScopesResponse { scopes }));
-
         drop(state);
-        Ok(DapOutput::response(rsp))
+        Ok(HandlerOutput::new(ResponseBody::Scopes(ScopesResponse {
+            scopes,
+        })))
     }
 
-    fn handle_variables(
-        &self,
-        req: Request,
-        args: VariablesArguments,
-    ) -> anyhow::Result<DapOutput> {
+    fn handle_variables(&self, args: VariablesArguments) -> anyhow::Result<HandlerOutput> {
         let variables_reference = args.variables_reference;
         let variables = self.collect_r_variables(variables_reference);
         let variables = self.make_variables(variables);
-        let rsp = req.success(ResponseBody::Variables(VariablesResponse { variables }));
-        Ok(DapOutput::response(rsp))
+        Ok(HandlerOutput::new(ResponseBody::Variables(
+            VariablesResponse { variables },
+        )))
     }
 
     fn collect_r_variables(&self, variables_reference: i64) -> Vec<RVariable> {
@@ -626,25 +624,24 @@ impl DapHandler {
 
     fn handle_step<A>(
         &self,
-        req: Request,
         _args: A,
         cmd: DebugRequest,
         resp: ResponseBody,
-    ) -> anyhow::Result<DapOutput> {
-        Ok(DapOutput {
-            response: req.success(resp),
+    ) -> anyhow::Result<HandlerOutput> {
+        Ok(HandlerOutput {
+            body: resp,
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::DebugCommand(cmd)],
         })
     }
 
-    fn handle_pause(&self, req: Request, _args: PauseArguments) -> anyhow::Result<DapOutput> {
+    fn handle_pause(&self, _args: PauseArguments) -> anyhow::Result<HandlerOutput> {
         self.state.lock().unwrap().is_interrupting_for_debugger = true;
 
         log::info!("DAP: Received request to pause R, sending interrupt");
 
-        Ok(DapOutput {
-            response: req.success(ResponseBody::Pause),
+        Ok(HandlerOutput {
+            body: ResponseBody::Pause,
             dap_events: vec![],
             console_events: vec![DapConsoleEvent::Interrupt],
         })

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -58,32 +58,33 @@ const THREAD_ID: i64 = -1;
 /// evaluations will run in that frame's environment.
 const SELECTED_FRAME_EXPRESSION: &str = ".positron_selected_frame";
 
-/// Side effect requested by a DAP handler that the transport layer must
-/// deliver in a transport-specific way.
-pub enum DapSideEffect {
-    /// Send a debug step/quit command to R.
+/// Events for the Console requested by a DAP handler. Either delivered by a
+/// round-trip through the frontend (so users see the command) or directly to
+/// the Console.
+pub enum DapConsoleEvent {
+    /// Send a debug step/quit command to R via the frontend.
     DebugCommand(DebugRequest),
-    /// Interrupt R for a pause.
+    /// Interrupt R for a pause. No frontend round-trip.
     Interrupt,
-    /// Request a session restart.
+    /// Request a session restart via the frontend.
     Restart,
 }
 
-/// The result of handling a single DAP request. The transport layer
-/// (TCP or Jupyter) is responsible for delivering the response, events,
-/// and side effects through the appropriate channel.
+/// The result of handling a single DAP request. The transport layer (TCP or
+/// Jupyter) is responsible for delivering the response, DAP events, and console
+/// events through the appropriate channel.
 pub struct DapOutput {
     pub response: Response,
-    pub events: Vec<Event>,
-    pub side_effects: Vec<DapSideEffect>,
+    pub dap_events: Vec<Event>,
+    pub console_events: Vec<DapConsoleEvent>,
 }
 
 impl DapOutput {
     pub fn response(response: Response) -> Self {
         Self {
             response,
-            events: vec![],
-            side_effects: vec![],
+            dap_events: vec![],
+            console_events: vec![],
         }
     }
 }
@@ -186,8 +187,8 @@ impl DapHandler {
         }));
         DapOutput {
             response: rsp,
-            events: vec![Event::Initialized],
-            side_effects: vec![],
+            dap_events: vec![Event::Initialized],
+            console_events: vec![],
         }
     }
 
@@ -413,35 +414,35 @@ impl DapHandler {
         let rsp = req.success(ResponseBody::Attach);
         DapOutput {
             response: rsp,
-            events: vec![Event::Thread(ThreadEventBody {
+            dap_events: vec![Event::Thread(ThreadEventBody {
                 reason: ThreadEventReason::Started,
                 thread_id: THREAD_ID,
             })],
-            side_effects: vec![],
+            console_events: vec![],
         }
     }
 
     fn handle_disconnect(&self, req: Request, _args: DisconnectArguments) -> DapOutput {
         // Only send `Q` if currently in a debugging session.
         let is_debugging = { self.state.lock().unwrap().is_debugging };
-        let side_effects = if is_debugging {
-            vec![DapSideEffect::DebugCommand(DebugRequest::Quit)]
+        let console_events = if is_debugging {
+            vec![DapConsoleEvent::DebugCommand(DebugRequest::Quit)]
         } else {
             vec![]
         };
 
         DapOutput {
             response: req.success(ResponseBody::Disconnect),
-            events: vec![],
-            side_effects,
+            dap_events: vec![],
+            console_events,
         }
     }
 
     fn handle_restart<T>(&self, req: Request, _args: T) -> DapOutput {
         DapOutput {
             response: req.success(ResponseBody::Restart),
-            events: vec![],
-            side_effects: vec![DapSideEffect::Restart],
+            dap_events: vec![],
+            console_events: vec![DapConsoleEvent::Restart],
         }
     }
 
@@ -607,8 +608,8 @@ impl DapHandler {
     ) -> DapOutput {
         DapOutput {
             response: req.success(resp),
-            events: vec![],
-            side_effects: vec![DapSideEffect::DebugCommand(cmd)],
+            dap_events: vec![],
+            console_events: vec![DapConsoleEvent::DebugCommand(cmd)],
         }
     }
 
@@ -619,8 +620,8 @@ impl DapHandler {
 
         DapOutput {
             response: req.success(ResponseBody::Pause),
-            events: vec![],
-            side_effects: vec![DapSideEffect::Interrupt],
+            dap_events: vec![],
+            console_events: vec![DapConsoleEvent::Interrupt],
         }
     }
 }
@@ -902,23 +903,23 @@ impl<R: Read, W: Write> DapServer<R, W> {
             return false;
         }
 
-        for event in output.events {
+        for event in output.dap_events {
             if let Err(err) = self.send_event(event) {
                 log::warn!("DAP: Failed to send event: {err:?}");
                 return false;
             }
         }
 
-        for effect in output.side_effects {
-            self.handle_side_effect(effect);
+        for event in output.console_events {
+            self.handle_console_event(event);
         }
 
         true
     }
 
-    fn handle_side_effect(&mut self, effect: DapSideEffect) {
-        match effect {
-            DapSideEffect::DebugCommand(cmd) => {
+    fn handle_console_event(&mut self, event: DapConsoleEvent) {
+        match event {
+            DapConsoleEvent::DebugCommand(cmd) => {
                 if let Some(tx) = &self.comm_tx {
                     // If we have a comm channel (always the case as of this
                     // writing) we are connected to Positron or similar. Send
@@ -936,10 +937,10 @@ impl<R: Read, W: Write> DapServer<R, W> {
                         .log_err();
                 }
             },
-            DapSideEffect::Interrupt => {
+            DapConsoleEvent::Interrupt => {
                 crate::sys::control::handle_interrupt_request();
             },
-            DapSideEffect::Restart => {
+            DapConsoleEvent::Restart => {
                 if let Some(tx) = &self.comm_tx {
                     let msg = amalthea::comm_rpc_message!("restart");
                     tx.send(msg).log_err();

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -58,6 +58,573 @@ const THREAD_ID: i64 = -1;
 /// evaluations will run in that frame's environment.
 const SELECTED_FRAME_EXPRESSION: &str = ".positron_selected_frame";
 
+/// Side effect requested by a DAP handler that the transport layer must
+/// deliver in a transport-specific way.
+pub enum DapSideEffect {
+    /// Send a debug step/quit command to R.
+    DebugCommand(DebugRequest),
+    /// Interrupt R for a pause.
+    Interrupt,
+    /// Request a session restart.
+    Restart,
+}
+
+/// The result of handling a single DAP request. The transport layer
+/// (TCP or Jupyter) is responsible for delivering the response, events,
+/// and side effects through the appropriate channel.
+pub struct DapOutput {
+    pub response: Response,
+    pub events: Vec<Event>,
+    pub side_effects: Vec<DapSideEffect>,
+}
+
+impl DapOutput {
+    pub fn response(response: Response) -> Self {
+        Self {
+            response,
+            events: vec![],
+            side_effects: vec![],
+        }
+    }
+}
+
+/// Transport-agnostic handler for DAP requests. Translates each request
+/// into a [`DapOutput`] containing the protocol response, any DAP events,
+/// and console events that the transport layer is responsible for delivering.
+pub struct DapHandler {
+    pub(crate) state: Arc<Mutex<Dap>>,
+    pub(crate) r_request_tx: Sender<RRequest>,
+}
+
+impl DapHandler {
+    pub fn new(state: Arc<Mutex<Dap>>, r_request_tx: Sender<RRequest>) -> Self {
+        Self {
+            state,
+            r_request_tx,
+        }
+    }
+
+    /// Dispatch a parsed DAP request to the appropriate handler.
+    ///
+    /// `Evaluate` is intentionally not handled here because it requires
+    /// transport-specific async response delivery.
+    pub fn dispatch(&self, req: Request) -> DapOutput {
+        let cmd = req.command.clone();
+
+        match cmd {
+            Command::Initialize(args) => self.handle_initialize(req, args),
+            Command::Attach(args) => self.handle_attach(req, args),
+            Command::Disconnect(args) => self.handle_disconnect(req, args),
+            Command::Restart(args) => self.handle_restart(req, args),
+            Command::Threads => self.handle_threads(req),
+            Command::SetBreakpoints(args) => self.handle_set_breakpoints(req, args),
+            Command::SetExceptionBreakpoints(args) => {
+                self.handle_set_exception_breakpoints(req, args)
+            },
+            Command::StackTrace(args) => self.handle_stacktrace(req, args),
+            Command::Source(args) => self.handle_source(req, args),
+            Command::Scopes(args) => self.handle_scopes(req, args),
+            Command::Variables(args) => self.handle_variables(req, args),
+            Command::Continue(args) => {
+                let resp = ResponseBody::Continue(ContinueResponse {
+                    all_threads_continued: Some(true),
+                });
+                self.handle_step(req, args, DebugRequest::Continue, resp)
+            },
+            Command::Next(args) => {
+                self.handle_step(req, args, DebugRequest::Next, ResponseBody::Next)
+            },
+            Command::StepIn(args) => {
+                self.handle_step(req, args, DebugRequest::StepIn, ResponseBody::StepIn)
+            },
+            Command::StepOut(args) => {
+                self.handle_step(req, args, DebugRequest::StepOut, ResponseBody::StepOut)
+            },
+            Command::Pause(args) => self.handle_pause(req, args),
+            _ => {
+                log::warn!("DAP: Unknown request");
+                DapOutput::response(req.error("Ark DAP: Unknown request"))
+            },
+        }
+    }
+
+    fn handle_initialize(&self, req: Request, _args: InitializeArguments) -> DapOutput {
+        let rsp = req.success(ResponseBody::Initialize(types::Capabilities {
+            supports_restart_request: Some(true),
+            supports_exception_info_request: Some(false),
+            exception_breakpoint_filters: Some(vec![
+                types::ExceptionBreakpointsFilter {
+                    filter: String::from("error"),
+                    label: String::from("Errors"),
+                    description: Some(String::from("Break on uncaught R errors")),
+                    default: Some(false),
+                    supports_condition: Some(false),
+                    condition_description: None,
+                },
+                types::ExceptionBreakpointsFilter {
+                    filter: String::from("warning"),
+                    label: String::from("Warnings"),
+                    description: Some(String::from("Break on R warnings")),
+                    default: Some(false),
+                    supports_condition: Some(false),
+                    condition_description: None,
+                },
+                types::ExceptionBreakpointsFilter {
+                    filter: String::from("interrupt"),
+                    label: String::from("Interrupts"),
+                    description: Some(String::from("Break when execution is interrupted")),
+                    default: Some(false),
+                    supports_condition: Some(false),
+                    condition_description: None,
+                },
+            ]),
+            supports_evaluate_for_hovers: Some(true),
+            supports_conditional_breakpoints: Some(true),
+            supports_hit_conditional_breakpoints: Some(true),
+            supports_log_points: Some(true),
+            ..Default::default()
+        }));
+        DapOutput {
+            response: rsp,
+            events: vec![Event::Initialized],
+            side_effects: vec![],
+        }
+    }
+
+    // Handle SetBreakpoints requests from the frontend.
+    //
+    // Breakpoint state survives DAP server disconnections via document hashing.
+    // Disconnections happen when the user uses the disconnect command (the
+    // frontend automatically reconnects) or when the console session goes to
+    // the background (the LSP is also disabled, so we don't receive document
+    // change notifications). When we come back online, we compare the document
+    // content against our stored hash to detect if breakpoints are now stale.
+    //
+    // Key implementation details:
+    // - We use `original_line` for lookup since the frontend doesn't know about
+    //   our line adjustments and always sends back the original line numbers.
+    // - When a user unchecks a breakpoint, it appears as a deletion (omitted
+    //   from the request). We preserve verified breakpoints as Disabled so we
+    //   can restore their state when re-enabled without requiring re-sourcing.
+    fn handle_set_breakpoints(&self, req: Request, args: SetBreakpointsArguments) -> DapOutput {
+        let Some(path) = args.source.path.as_ref() else {
+            // We don't currently have virtual documents managed via source references
+            log::warn!("Missing a path to set breakpoints for.");
+            return DapOutput::response(req.error("Missing a path to set breakpoints for"));
+        };
+
+        // We currently only support "path" URIs as Positron never sends URIs.
+        // In principle the DAP frontend can negotiate whether it sends URIs or
+        // file paths via the `pathFormat` field of the `Initialize` request.
+        let uri = match UrlId::from_file_path(path) {
+            Ok(uri) => uri,
+            Err(err) => {
+                log::warn!("Can't set breakpoints for non-file path: '{path}': {err}");
+                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
+                    breakpoints: vec![],
+                }));
+                return DapOutput::response(rsp);
+            },
+        };
+
+        // Read document content to compute hash. We currently assume UTF-8 even
+        // though the frontend supports files with different encodings (but
+        // UTF-8 is the default).
+        let doc_content = match std::fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(err) => {
+                // TODO: What do we do with breakpoints in virtual documents?
+                log::warn!("Failed to read file '{path}': {err:?}");
+
+                let breakpoints = args
+                    .breakpoints
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|bp| dap::types::Breakpoint {
+                        id: Some(self.state.lock().unwrap().next_breakpoint_id()),
+                        verified: false,
+                        line: Some(bp.line),
+                        message: Some(String::from("Can't read file '{path}'")),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
+                    breakpoints,
+                }));
+                return DapOutput::response(rsp);
+            },
+        };
+
+        let args_breakpoints = args.breakpoints.unwrap_or_default();
+
+        let mut state = self.state.lock().unwrap();
+        let old_breakpoints = state.breakpoints.get(&uri).cloned();
+
+        // Breakpoints are associated with this hash. If the document has
+        // changed after a reconnection, the breakpoints are no longer valid.
+        let doc_hash = blake3::hash(doc_content.as_bytes());
+        let doc_changed = match &old_breakpoints {
+            Some((existing_hash, _)) => existing_hash != &doc_hash,
+            None => true,
+        };
+
+        let new_breakpoints = if doc_changed {
+            log::trace!("DAP: Document changed for {uri}, discarding old breakpoints");
+
+            // Replace all existing breakpoints by new, unverified ones
+            args_breakpoints
+                .iter()
+                .map(|bp| {
+                    let line = Breakpoint::from_dap_line(bp.line);
+                    Breakpoint {
+                        id: state.next_breakpoint_id(),
+                        line,
+                        original_line: line,
+                        state: BreakpointState::Unverified,
+                        injected: false,
+                        condition: bp.condition.clone(),
+                        log_message: bp.log_message.clone(),
+                        hit_condition: bp.hit_condition.clone(),
+                        hit_count: 0,
+                    }
+                })
+                .collect()
+        } else {
+            log::trace!("DAP: Document unchanged for {uri}, preserving breakpoint states");
+
+            // Unwrap Safety: `doc_changed` is false, so `old_breakpoints` is Some
+            let (_, old_breakpoints) = old_breakpoints.unwrap();
+            // Use original_line for lookup since that's what the frontend sends back
+            let mut old_by_line: HashMap<u32, Breakpoint> = old_breakpoints
+                .into_iter()
+                .map(|bp| (bp.original_line, bp))
+                .collect();
+
+            let mut breakpoints: Vec<Breakpoint> = Vec::new();
+
+            for bp in &args_breakpoints {
+                let line = Breakpoint::from_dap_line(bp.line);
+
+                if let Some(old_bp) = old_by_line.remove(&line) {
+                    // Breakpoint already exists at this line
+                    let (new_state, injected) = match old_bp.state {
+                        // This breakpoint used to be verified, was disabled, and is now back
+                        // online. Restore to Verified immediately.
+                        BreakpointState::Disabled => (BreakpointState::Verified, old_bp.injected),
+                        // Invalid breakpoints are reset to Unverified so they can be
+                        // re-validated on next source.
+                        BreakpointState::Invalid(_) => (BreakpointState::Unverified, false),
+                        // We preserve other states (verified or unverified)
+                        other => (other, old_bp.injected),
+                    };
+
+                    breakpoints.push(Breakpoint {
+                        id: old_bp.id,
+                        // Preserve the actual (anchored) line from previous verification
+                        line: old_bp.line,
+                        original_line: line,
+                        state: new_state,
+                        injected,
+                        condition: bp.condition.clone(),
+                        log_message: bp.log_message.clone(),
+                        hit_condition: bp.hit_condition.clone(),
+                        hit_count: 0,
+                    });
+                } else {
+                    // New breakpoints always start as Unverified, until they get evaluated once
+                    breakpoints.push(Breakpoint {
+                        id: state.next_breakpoint_id(),
+                        line,
+                        original_line: line,
+                        state: BreakpointState::Unverified,
+                        injected: false,
+                        condition: bp.condition.clone(),
+                        log_message: bp.log_message.clone(),
+                        hit_condition: bp.hit_condition.clone(),
+                        hit_count: 0,
+                    });
+                }
+            }
+
+            // Remaining verified breakpoints need to be preserved in memory
+            // when deleted. That's because when user unchecks a breakpoint on
+            // the frontend, the breakpoint is actually deleted (i.e. omitted)
+            // by a `SetBreakpoints()` request. When the user reenables the
+            // breakpoint, we have to restore the verification state.
+            // Unverified/Invalid breakpoints on the other hand are simply
+            // dropped since there's no verified state that needs to be
+            // preserved.
+            for (original_line, old_bp) in old_by_line {
+                if matches!(old_bp.state, BreakpointState::Verified) {
+                    breakpoints.push(Breakpoint {
+                        id: old_bp.id,
+                        line: old_bp.line,
+                        original_line,
+                        state: BreakpointState::Disabled,
+                        injected: true,
+                        condition: old_bp.condition.clone(),
+                        log_message: old_bp.log_message.clone(),
+                        hit_condition: old_bp.hit_condition,
+                        hit_count: 0,
+                    });
+                }
+            }
+
+            breakpoints
+        };
+
+        log::trace!(
+            "DAP: URI {uri} now has {} breakpoints:\n{:#?}",
+            new_breakpoints.len(),
+            new_breakpoints
+        );
+
+        let response_breakpoints: Vec<dap::types::Breakpoint> = new_breakpoints
+            .iter()
+            .filter(|bp| !matches!(bp.state, BreakpointState::Disabled))
+            .map(|bp| {
+                let message = match &bp.state {
+                    BreakpointState::Invalid(reason) => Some(reason.message().to_string()),
+                    _ => None,
+                };
+                dap::types::Breakpoint {
+                    id: Some(bp.id),
+                    verified: matches!(bp.state, BreakpointState::Verified),
+                    line: Some(Breakpoint::to_dap_line(bp.line)),
+                    message,
+                    ..Default::default()
+                }
+            })
+            .collect();
+
+        state.breakpoints.insert(uri, (doc_hash, new_breakpoints));
+
+        drop(state);
+
+        let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
+            breakpoints: response_breakpoints,
+        }));
+
+        DapOutput::response(rsp)
+    }
+
+    fn handle_attach(&self, req: Request, _args: AttachRequestArguments) -> DapOutput {
+        let rsp = req.success(ResponseBody::Attach);
+        DapOutput {
+            response: rsp,
+            events: vec![Event::Thread(ThreadEventBody {
+                reason: ThreadEventReason::Started,
+                thread_id: THREAD_ID,
+            })],
+            side_effects: vec![],
+        }
+    }
+
+    fn handle_disconnect(&self, req: Request, _args: DisconnectArguments) -> DapOutput {
+        // Only send `Q` if currently in a debugging session.
+        let is_debugging = { self.state.lock().unwrap().is_debugging };
+        let side_effects = if is_debugging {
+            vec![DapSideEffect::DebugCommand(DebugRequest::Quit)]
+        } else {
+            vec![]
+        };
+
+        DapOutput {
+            response: req.success(ResponseBody::Disconnect),
+            events: vec![],
+            side_effects,
+        }
+    }
+
+    fn handle_restart<T>(&self, req: Request, _args: T) -> DapOutput {
+        DapOutput {
+            response: req.success(ResponseBody::Restart),
+            events: vec![],
+            side_effects: vec![DapSideEffect::Restart],
+        }
+    }
+
+    // All servers must respond to `Threads` requests, possibly with
+    // a dummy thread as is the case here
+    fn handle_threads(&self, req: Request) -> DapOutput {
+        let rsp = req.success(ResponseBody::Threads(ThreadsResponse {
+            threads: vec![Thread {
+                id: THREAD_ID,
+                name: String::from("R console"),
+            }],
+        }));
+        DapOutput::response(rsp)
+    }
+
+    fn handle_set_exception_breakpoints(
+        &self,
+        req: Request,
+        args: SetExceptionBreakpointsArguments,
+    ) -> DapOutput {
+        {
+            let mut state = self.state.lock().unwrap();
+            state.exception_breakpoint_filters = args.filters;
+        }
+        let rsp = req.success(ResponseBody::SetExceptionBreakpoints(
+            SetExceptionBreakpointsResponse {
+                // This field is only useful for reporting problems with
+                // individual filters. Since we always accept all filters,
+                // `None` is fine here.
+                breakpoints: None,
+            },
+        ));
+        DapOutput::response(rsp)
+    }
+
+    fn handle_stacktrace(&self, req: Request, args: StackTraceArguments) -> DapOutput {
+        let stack = {
+            let state = self.state.lock().unwrap();
+            let fallback_sources = &state.fallback_sources;
+            match &state.stack {
+                Some(stack) => stack
+                    .iter()
+                    .map(|frame| into_dap_frame(frame, fallback_sources))
+                    .collect(),
+                _ => vec![],
+            }
+        };
+
+        // Slice the stack as requested
+        let n_usize = stack.len();
+
+        let start_frame = args.start_frame.unwrap_or(0);
+        let Ok(start) = usize::try_from(start_frame) else {
+            let rsp = req.error(&format!("Invalid start_frame: {start_frame}"));
+            return DapOutput::response(rsp);
+        };
+        let start = std::cmp::min(start, n_usize);
+
+        let end = if let Some(levels) = args.levels {
+            let Ok(levels) = usize::try_from(levels) else {
+                let rsp = req.error(&format!("Invalid levels: {levels}"));
+                return DapOutput::response(rsp);
+            };
+            std::cmp::min(start.saturating_add(levels), n_usize)
+        } else {
+            n_usize
+        };
+
+        let Ok(total_frames) = i64::try_from(n_usize) else {
+            let rsp = req.error(&format!("Stack frame count overflows i64: {n_usize}"));
+            return DapOutput::response(rsp);
+        };
+        let stack = stack[start..end].to_vec();
+
+        let rsp = req.success(ResponseBody::StackTrace(StackTraceResponse {
+            stack_frames: stack,
+            total_frames: Some(total_frames),
+        }));
+
+        DapOutput::response(rsp)
+    }
+
+    fn handle_source(&self, req: Request, _args: SourceArguments) -> DapOutput {
+        let message = "Unsupported `source` request: {req:?}";
+        log::error!("{message}");
+        DapOutput::response(req.error(message))
+    }
+
+    fn handle_scopes(&self, req: Request, args: ScopesArguments) -> DapOutput {
+        let state = self.state.lock().unwrap();
+        let frame_id_to_variables_reference = &state.frame_id_to_variables_reference;
+
+        // Entirely possible that the requested `frame_id` doesn't have any
+        // variables (like the top most frame where the call was made). We send
+        // back `0` in those cases, which is an indication of "no variables".
+        let variables_reference = frame_id_to_variables_reference
+            .get(&args.frame_id)
+            .copied()
+            .unwrap_or(0);
+
+        // Only 1 overarching scope for now
+        let scopes = vec![Scope {
+            name: String::from("Locals"),
+            presentation_hint: Some(ScopePresentationhint::Locals),
+            variables_reference,
+            named_variables: None,
+            indexed_variables: None,
+            expensive: false,
+            source: None,
+            line: None,
+            column: None,
+            end_line: None,
+            end_column: None,
+        }];
+
+        let rsp = req.success(ResponseBody::Scopes(ScopesResponse { scopes }));
+
+        drop(state);
+        DapOutput::response(rsp)
+    }
+
+    fn handle_variables(&self, req: Request, args: VariablesArguments) -> DapOutput {
+        let variables_reference = args.variables_reference;
+        let variables = self.collect_r_variables(variables_reference);
+        let variables = self.make_variables(variables);
+        let rsp = req.success(ResponseBody::Variables(VariablesResponse { variables }));
+        DapOutput::response(rsp)
+    }
+
+    fn collect_r_variables(&self, variables_reference: i64) -> Vec<RVariable> {
+        // Wait until we're in the `r_task()` to lock
+        // See https://github.com/posit-dev/positron/issues/5024
+        let state = self.state.clone();
+
+        let variables = r_task(move || {
+            let state = state.lock().unwrap();
+            let variables_reference_to_r_object = &state.variables_reference_to_r_object;
+
+            let Some(object) = variables_reference_to_r_object.get(&variables_reference) else {
+                log::error!(
+                    "Failed to locate R object for `variables_reference` {variables_reference}."
+                );
+                return Vec::new();
+            };
+
+            let object = object.get();
+            object_variables(object.sexp)
+        });
+
+        variables
+    }
+
+    fn make_variables(&self, variables: Vec<RVariable>) -> Vec<Variable> {
+        self.state.lock().unwrap().make_variables(variables)
+    }
+
+    fn handle_step<A>(
+        &self,
+        req: Request,
+        _args: A,
+        cmd: DebugRequest,
+        resp: ResponseBody,
+    ) -> DapOutput {
+        DapOutput {
+            response: req.success(resp),
+            events: vec![],
+            side_effects: vec![DapSideEffect::DebugCommand(cmd)],
+        }
+    }
+
+    fn handle_pause(&self, req: Request, _args: PauseArguments) -> DapOutput {
+        self.state.lock().unwrap().is_interrupting_for_debugger = true;
+
+        log::info!("DAP: Received request to pause R, sending interrupt");
+
+        DapOutput {
+            response: req.success(ResponseBody::Pause),
+            events: vec![],
+            side_effects: vec![DapSideEffect::Interrupt],
+        }
+    }
+}
+
 // TODO: Handle comm close to shut down the DAP server thread.
 //
 // The DAP comm is allowed to persist across TCP sessions. This supports session
@@ -274,8 +841,7 @@ fn listen_dap_events<W: Write>(
 pub struct DapServer<R: Read, W: Write> {
     server: Server<R, W>,
     pub output: Arc<Mutex<ServerOutput<W>>>,
-    state: Arc<Mutex<Dap>>,
-    r_request_tx: Sender<RRequest>,
+    pub(crate) handler: DapHandler,
     comm_tx: Option<CommOutgoingTx>,
     responses_tx: Sender<Response>,
 }
@@ -291,11 +857,11 @@ impl<R: Read, W: Write> DapServer<R, W> {
     ) -> Self {
         let server = Server::new(reader, writer);
         let output = server.output.clone();
+        let handler = DapHandler::new(state, r_request_tx);
         Self {
             server,
             output,
-            state,
-            r_request_tx,
+            handler,
             comm_tx: Some(comm_tx),
             responses_tx,
         }
@@ -313,52 +879,73 @@ impl<R: Read, W: Write> DapServer<R, W> {
         };
         log::trace!("DAP: Got request: {:#?}", req);
 
-        let cmd = req.command.clone();
+        // Evaluate is async: the response is sent later via `responses_tx`.
+        // It is the only command that needs transport-specific handling.
+        if matches!(&req.command, Command::Evaluate(_)) {
+            let Command::Evaluate(args) = req.command.clone() else {
+                unreachable!()
+            };
+            if let Err(err) = self.handle_evaluate(req, args) {
+                log::warn!("DAP: Handler failed, closing connection: {err:?}");
+                return false;
+            }
+            return true;
+        }
 
-        let result = match cmd {
-            Command::Initialize(args) => self.handle_initialize(req, args),
-            Command::Attach(args) => self.handle_attach(req, args),
-            Command::Disconnect(args) => self.handle_disconnect(req, args),
-            Command::Restart(args) => self.handle_restart(req, args),
-            Command::Threads => self.handle_threads(req),
-            Command::SetBreakpoints(args) => self.handle_set_breakpoints(req, args),
-            Command::SetExceptionBreakpoints(args) => {
-                self.handle_set_exception_breakpoints(req, args)
-            },
-            Command::StackTrace(args) => self.handle_stacktrace(req, args),
-            Command::Source(args) => self.handle_source(req, args),
-            Command::Scopes(args) => self.handle_scopes(req, args),
-            Command::Variables(args) => self.handle_variables(req, args),
-            Command::Evaluate(args) => self.handle_evaluate(req, args),
-            Command::Continue(args) => {
-                let resp = ResponseBody::Continue(ContinueResponse {
-                    all_threads_continued: Some(true),
-                });
-                self.handle_step(req, args, DebugRequest::Continue, resp)
-            },
-            Command::Next(args) => {
-                self.handle_step(req, args, DebugRequest::Next, ResponseBody::Next)
-            },
-            Command::StepIn(args) => {
-                self.handle_step(req, args, DebugRequest::StepIn, ResponseBody::StepIn)
-            },
-            Command::StepOut(args) => {
-                self.handle_step(req, args, DebugRequest::StepOut, ResponseBody::StepOut)
-            },
-            Command::Pause(args) => self.handle_pause(req, args),
-            _ => {
-                log::warn!("DAP: Unknown request");
-                let rsp = req.error("Ark DAP: Unknown request");
-                self.respond(rsp)
-            },
-        };
+        let output = self.handler.dispatch(req);
+        self.deliver(output)
+    }
 
-        if let Err(err) = result {
-            log::warn!("DAP: Handler failed, closing connection: {err:?}");
+    fn deliver(&mut self, output: DapOutput) -> bool {
+        if let Err(err) = self.respond(output.response) {
+            log::warn!("DAP: Failed to send response: {err:?}");
             return false;
         }
 
+        for event in output.events {
+            if let Err(err) = self.send_event(event) {
+                log::warn!("DAP: Failed to send event: {err:?}");
+                return false;
+            }
+        }
+
+        for effect in output.side_effects {
+            self.handle_side_effect(effect);
+        }
+
         true
+    }
+
+    fn handle_side_effect(&mut self, effect: DapSideEffect) {
+        match effect {
+            DapSideEffect::DebugCommand(cmd) => {
+                if let Some(tx) = &self.comm_tx {
+                    // If we have a comm channel (always the case as of this
+                    // writing) we are connected to Positron or similar. Send
+                    // control events so that the IDE can execute these as if they
+                    // were sent by the user. This ensures prompts are updated.
+                    let msg = amalthea::comm_rpc_message!(
+                        "execute",
+                        command = debug_request_command(cmd)
+                    );
+                    tx.send(msg).log_err();
+                } else {
+                    self.handler
+                        .r_request_tx
+                        .send(RRequest::DebugCommand(cmd))
+                        .log_err();
+                }
+            },
+            DapSideEffect::Interrupt => {
+                crate::sys::control::handle_interrupt_request();
+            },
+            DapSideEffect::Restart => {
+                if let Some(tx) = &self.comm_tx {
+                    let msg = amalthea::comm_rpc_message!("restart");
+                    tx.send(msg).log_err();
+                }
+            },
+        }
     }
 
     fn respond(&mut self, rsp: Response) -> Result<(), ServerError> {
@@ -371,448 +958,6 @@ impl<R: Read, W: Write> DapServer<R, W> {
         self.server.send_event(event)
     }
 
-    fn handle_initialize(
-        &mut self,
-        req: Request,
-        _args: InitializeArguments,
-    ) -> Result<(), ServerError> {
-        let rsp = req.success(ResponseBody::Initialize(types::Capabilities {
-            supports_restart_request: Some(true),
-            supports_exception_info_request: Some(false),
-            exception_breakpoint_filters: Some(vec![
-                types::ExceptionBreakpointsFilter {
-                    filter: String::from("error"),
-                    label: String::from("Errors"),
-                    description: Some(String::from("Break on uncaught R errors")),
-                    default: Some(false),
-                    supports_condition: Some(false),
-                    condition_description: None,
-                },
-                types::ExceptionBreakpointsFilter {
-                    filter: String::from("warning"),
-                    label: String::from("Warnings"),
-                    description: Some(String::from("Break on R warnings")),
-                    default: Some(false),
-                    supports_condition: Some(false),
-                    condition_description: None,
-                },
-                types::ExceptionBreakpointsFilter {
-                    filter: String::from("interrupt"),
-                    label: String::from("Interrupts"),
-                    description: Some(String::from("Break when execution is interrupted")),
-                    default: Some(false),
-                    supports_condition: Some(false),
-                    condition_description: None,
-                },
-            ]),
-            supports_evaluate_for_hovers: Some(true),
-            supports_conditional_breakpoints: Some(true),
-            supports_hit_conditional_breakpoints: Some(true),
-            supports_log_points: Some(true),
-            ..Default::default()
-        }));
-        self.respond(rsp)?;
-        self.send_event(Event::Initialized)
-    }
-
-    // Handle SetBreakpoints requests from the frontend.
-    //
-    // Breakpoint state survives DAP server disconnections via document hashing.
-    // Disconnections happen when the user uses the disconnect command (the
-    // frontend automatically reconnects) or when the console session goes to
-    // the background (the LSP is also disabled, so we don't receive document
-    // change notifications). When we come back online, we compare the document
-    // content against our stored hash to detect if breakpoints are now stale.
-    //
-    // Key implementation details:
-    // - We use `original_line` for lookup since the frontend doesn't know about
-    //   our line adjustments and always sends back the original line numbers.
-    // - When a user unchecks a breakpoint, it appears as a deletion (omitted
-    //   from the request). We preserve verified breakpoints as Disabled so we
-    //   can restore their state when re-enabled without requiring re-sourcing.
-    fn handle_set_breakpoints(
-        &mut self,
-        req: Request,
-        args: SetBreakpointsArguments,
-    ) -> Result<(), ServerError> {
-        let Some(path) = args.source.path.as_ref() else {
-            // We don't currently have virtual documents managed via source references
-            log::warn!("Missing a path to set breakpoints for.");
-            return self.respond(req.error("Missing a path to set breakpoints for"));
-        };
-
-        // We currently only support "path" URIs as Positron never sends URIs.
-        // In principle the DAP frontend can negotiate whether it sends URIs or
-        // file paths via the `pathFormat` field of the `Initialize` request.
-        let uri = match UrlId::from_file_path(path) {
-            Ok(uri) => uri,
-            Err(err) => {
-                log::warn!("Can't set breakpoints for non-file path: '{path}': {err}");
-                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
-                    breakpoints: vec![],
-                }));
-                return self.respond(rsp);
-            },
-        };
-
-        // Read document content to compute hash. We currently assume UTF-8 even
-        // though the frontend supports files with different encodings (but
-        // UTF-8 is the default).
-        let doc_content = match std::fs::read_to_string(path) {
-            Ok(content) => content,
-            Err(err) => {
-                // TODO: What do we do with breakpoints in virtual documents?
-                log::warn!("Failed to read file '{path}': {err:?}");
-
-                let breakpoints = args
-                    .breakpoints
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|bp| dap::types::Breakpoint {
-                        id: Some(self.state.lock().unwrap().next_breakpoint_id()),
-                        verified: false,
-                        line: Some(bp.line),
-                        message: Some(String::from("Can't read file '{path}'")),
-                        ..Default::default()
-                    })
-                    .collect();
-
-                let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
-                    breakpoints,
-                }));
-                return self.respond(rsp);
-            },
-        };
-
-        let args_breakpoints = args.breakpoints.unwrap_or_default();
-
-        let mut state = self.state.lock().unwrap();
-        let old_breakpoints = state.breakpoints.get(&uri).cloned();
-
-        // Breakpoints are associated with this hash. If the document has
-        // changed after a reconnection, the breakpoints are no longer valid.
-        let doc_hash = blake3::hash(doc_content.as_bytes());
-        let doc_changed = match &old_breakpoints {
-            Some((existing_hash, _)) => existing_hash != &doc_hash,
-            None => true,
-        };
-
-        let new_breakpoints = if doc_changed {
-            log::trace!("DAP: Document changed for {uri}, discarding old breakpoints");
-
-            // Replace all existing breakpoints by new, unverified ones
-            args_breakpoints
-                .iter()
-                .map(|bp| {
-                    let line = Breakpoint::from_dap_line(bp.line);
-                    Breakpoint {
-                        id: state.next_breakpoint_id(),
-                        line,
-                        original_line: line,
-                        state: BreakpointState::Unverified,
-                        injected: false,
-                        condition: bp.condition.clone(),
-                        log_message: bp.log_message.clone(),
-                        hit_condition: bp.hit_condition.clone(),
-                        hit_count: 0,
-                    }
-                })
-                .collect()
-        } else {
-            log::trace!("DAP: Document unchanged for {uri}, preserving breakpoint states");
-
-            // Unwrap Safety: `doc_changed` is false, so `old_breakpoints` is Some
-            let (_, old_breakpoints) = old_breakpoints.unwrap();
-            // Use original_line for lookup since that's what the frontend sends back
-            let mut old_by_line: HashMap<u32, Breakpoint> = old_breakpoints
-                .into_iter()
-                .map(|bp| (bp.original_line, bp))
-                .collect();
-
-            let mut breakpoints: Vec<Breakpoint> = Vec::new();
-
-            for bp in &args_breakpoints {
-                let line = Breakpoint::from_dap_line(bp.line);
-
-                if let Some(old_bp) = old_by_line.remove(&line) {
-                    // Breakpoint already exists at this line
-                    let (new_state, injected) = match old_bp.state {
-                        // This breakpoint used to be verified, was disabled, and is now back
-                        // online. Restore to Verified immediately.
-                        BreakpointState::Disabled => (BreakpointState::Verified, old_bp.injected),
-                        // Invalid breakpoints are reset to Unverified so they can be
-                        // re-validated on next source.
-                        BreakpointState::Invalid(_) => (BreakpointState::Unverified, false),
-                        // We preserve other states (verified or unverified)
-                        other => (other, old_bp.injected),
-                    };
-
-                    breakpoints.push(Breakpoint {
-                        id: old_bp.id,
-                        // Preserve the actual (anchored) line from previous verification
-                        line: old_bp.line,
-                        original_line: line,
-                        state: new_state,
-                        injected,
-                        condition: bp.condition.clone(),
-                        log_message: bp.log_message.clone(),
-                        hit_condition: bp.hit_condition.clone(),
-                        hit_count: 0,
-                    });
-                } else {
-                    // New breakpoints always start as Unverified, until they get evaluated once
-                    breakpoints.push(Breakpoint {
-                        id: state.next_breakpoint_id(),
-                        line,
-                        original_line: line,
-                        state: BreakpointState::Unverified,
-                        injected: false,
-                        condition: bp.condition.clone(),
-                        log_message: bp.log_message.clone(),
-                        hit_condition: bp.hit_condition.clone(),
-                        hit_count: 0,
-                    });
-                }
-            }
-
-            // Remaining verified breakpoints need to be preserved in memory
-            // when deleted. That's because when user unchecks a breakpoint on
-            // the frontend, the breakpoint is actually deleted (i.e. omitted)
-            // by a `SetBreakpoints()` request. When the user reenables the
-            // breakpoint, we have to restore the verification state.
-            // Unverified/Invalid breakpoints on the other hand are simply
-            // dropped since there's no verified state that needs to be
-            // preserved.
-            for (original_line, old_bp) in old_by_line {
-                if matches!(old_bp.state, BreakpointState::Verified) {
-                    breakpoints.push(Breakpoint {
-                        id: old_bp.id,
-                        line: old_bp.line,
-                        original_line,
-                        state: BreakpointState::Disabled,
-                        injected: true,
-                        condition: old_bp.condition.clone(),
-                        log_message: old_bp.log_message.clone(),
-                        hit_condition: old_bp.hit_condition,
-                        hit_count: 0,
-                    });
-                }
-            }
-
-            breakpoints
-        };
-
-        log::trace!(
-            "DAP: URI {uri} now has {} breakpoints:\n{:#?}",
-            new_breakpoints.len(),
-            new_breakpoints
-        );
-
-        let response_breakpoints: Vec<dap::types::Breakpoint> = new_breakpoints
-            .iter()
-            .filter(|bp| !matches!(bp.state, BreakpointState::Disabled))
-            .map(|bp| {
-                let message = match &bp.state {
-                    BreakpointState::Invalid(reason) => Some(reason.message().to_string()),
-                    _ => None,
-                };
-                dap::types::Breakpoint {
-                    id: Some(bp.id),
-                    verified: matches!(bp.state, BreakpointState::Verified),
-                    line: Some(Breakpoint::to_dap_line(bp.line)),
-                    message,
-                    ..Default::default()
-                }
-            })
-            .collect();
-
-        state.breakpoints.insert(uri, (doc_hash, new_breakpoints));
-
-        drop(state);
-
-        let rsp = req.success(ResponseBody::SetBreakpoints(SetBreakpointsResponse {
-            breakpoints: response_breakpoints,
-        }));
-
-        self.respond(rsp)
-    }
-
-    fn handle_attach(
-        &mut self,
-        req: Request,
-        _args: AttachRequestArguments,
-    ) -> Result<(), ServerError> {
-        let rsp = req.success(ResponseBody::Attach);
-        self.respond(rsp)?;
-
-        self.send_event(Event::Thread(ThreadEventBody {
-            reason: ThreadEventReason::Started,
-            thread_id: THREAD_ID,
-        }))
-    }
-
-    fn handle_disconnect(
-        &mut self,
-        req: Request,
-        _args: DisconnectArguments,
-    ) -> Result<(), ServerError> {
-        // Only send `Q` if currently in a debugging session.
-        let is_debugging = { self.state.lock().unwrap().is_debugging };
-        if is_debugging {
-            self.send_command(DebugRequest::Quit);
-        }
-
-        let rsp = req.success(ResponseBody::Disconnect);
-        self.respond(rsp)
-    }
-
-    fn handle_restart<T>(&mut self, req: Request, _args: T) -> Result<(), ServerError> {
-        // If connected to Positron, forward the restart command to the
-        // frontend. Otherwise ignore it.
-        if let Some(tx) = &self.comm_tx {
-            let msg = amalthea::comm_rpc_message!("restart");
-            tx.send(msg).log_err();
-        }
-
-        let rsp = req.success(ResponseBody::Restart);
-        self.respond(rsp)
-    }
-
-    // All servers must respond to `Threads` requests, possibly with
-    // a dummy thread as is the case here
-    fn handle_threads(&mut self, req: Request) -> Result<(), ServerError> {
-        let rsp = req.success(ResponseBody::Threads(ThreadsResponse {
-            threads: vec![Thread {
-                id: THREAD_ID,
-                name: String::from("R console"),
-            }],
-        }));
-        self.respond(rsp)
-    }
-
-    fn handle_set_exception_breakpoints(
-        &mut self,
-        req: Request,
-        args: SetExceptionBreakpointsArguments,
-    ) -> Result<(), ServerError> {
-        {
-            let mut state = self.state.lock().unwrap();
-            state.exception_breakpoint_filters = args.filters;
-        }
-        let rsp = req.success(ResponseBody::SetExceptionBreakpoints(
-            SetExceptionBreakpointsResponse {
-                // This field is only useful for reporting problems with
-                // individual filters. Since we always accept all filters,
-                // `None` is fine here.
-                breakpoints: None,
-            },
-        ));
-        self.respond(rsp)
-    }
-
-    fn handle_stacktrace(
-        &mut self,
-        req: Request,
-        args: StackTraceArguments,
-    ) -> Result<(), ServerError> {
-        let stack = {
-            let state = self.state.lock().unwrap();
-            let fallback_sources = &state.fallback_sources;
-            match &state.stack {
-                Some(stack) => stack
-                    .iter()
-                    .map(|frame| into_dap_frame(frame, fallback_sources))
-                    .collect(),
-                _ => vec![],
-            }
-        };
-
-        // Slice the stack as requested
-        let n_usize = stack.len();
-
-        let start_frame = args.start_frame.unwrap_or(0);
-        let Ok(start) = usize::try_from(start_frame) else {
-            let rsp = req.error(&format!("Invalid start_frame: {start_frame}"));
-            return self.respond(rsp);
-        };
-        let start = std::cmp::min(start, n_usize);
-
-        let end = if let Some(levels) = args.levels {
-            let Ok(levels) = usize::try_from(levels) else {
-                let rsp = req.error(&format!("Invalid levels: {levels}"));
-                return self.respond(rsp);
-            };
-            std::cmp::min(start.saturating_add(levels), n_usize)
-        } else {
-            n_usize
-        };
-
-        let Ok(total_frames) = i64::try_from(n_usize) else {
-            let rsp = req.error(&format!("Stack frame count overflows i64: {n_usize}"));
-            return self.respond(rsp);
-        };
-        let stack = stack[start..end].to_vec();
-
-        let rsp = req.success(ResponseBody::StackTrace(StackTraceResponse {
-            stack_frames: stack,
-            total_frames: Some(total_frames),
-        }));
-
-        self.respond(rsp)
-    }
-
-    fn handle_source(&mut self, req: Request, _args: SourceArguments) -> Result<(), ServerError> {
-        let message = "Unsupported `source` request: {req:?}";
-        log::error!("{message}");
-        let rsp = req.error(message);
-        self.respond(rsp)
-    }
-
-    fn handle_scopes(&mut self, req: Request, args: ScopesArguments) -> Result<(), ServerError> {
-        let state = self.state.lock().unwrap();
-        let frame_id_to_variables_reference = &state.frame_id_to_variables_reference;
-
-        // Entirely possible that the requested `frame_id` doesn't have any
-        // variables (like the top most frame where the call was made). We send
-        // back `0` in those cases, which is an indication of "no variables".
-        let variables_reference = frame_id_to_variables_reference
-            .get(&args.frame_id)
-            .copied()
-            .unwrap_or(0);
-
-        // Only 1 overarching scope for now
-        let scopes = vec![Scope {
-            name: String::from("Locals"),
-            presentation_hint: Some(ScopePresentationhint::Locals),
-            variables_reference,
-            named_variables: None,
-            indexed_variables: None,
-            expensive: false,
-            source: None,
-            line: None,
-            column: None,
-            end_line: None,
-            end_column: None,
-        }];
-
-        let rsp = req.success(ResponseBody::Scopes(ScopesResponse { scopes }));
-
-        drop(state);
-        self.respond(rsp)
-    }
-
-    fn handle_variables(
-        &mut self,
-        req: Request,
-        args: VariablesArguments,
-    ) -> Result<(), ServerError> {
-        let variables_reference = args.variables_reference;
-        let variables = self.collect_r_variables(variables_reference);
-        let variables = self.make_variables(variables);
-        let rsp = req.success(ResponseBody::Variables(VariablesResponse { variables }));
-        self.respond(rsp)
-    }
-
     fn handle_evaluate(
         &mut self,
         req: Request,
@@ -820,7 +965,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
     ) -> Result<(), ServerError> {
         let expression = args.expression;
         let frame_id = args.frame_id;
-        let state = self.state.clone();
+        let state = self.handler.state.clone();
         let responses_tx = self.responses_tx.clone();
 
         log::trace!("DAP: Spawning idle task for evaluate");
@@ -863,70 +1008,6 @@ impl<R: Read, W: Write> DapServer<R, W> {
         }));
 
         Ok(())
-    }
-
-    fn collect_r_variables(&self, variables_reference: i64) -> Vec<RVariable> {
-        // Wait until we're in the `r_task()` to lock
-        // See https://github.com/posit-dev/positron/issues/5024
-        let state = self.state.clone();
-
-        let variables = r_task(move || {
-            let state = state.lock().unwrap();
-            let variables_reference_to_r_object = &state.variables_reference_to_r_object;
-
-            let Some(object) = variables_reference_to_r_object.get(&variables_reference) else {
-                log::error!(
-                    "Failed to locate R object for `variables_reference` {variables_reference}."
-                );
-                return Vec::new();
-            };
-
-            let object = object.get();
-            object_variables(object.sexp)
-        });
-
-        variables
-    }
-
-    fn make_variables(&self, variables: Vec<RVariable>) -> Vec<Variable> {
-        self.state.lock().unwrap().make_variables(variables)
-    }
-
-    fn handle_step<A>(
-        &mut self,
-        req: Request,
-        _args: A,
-        cmd: DebugRequest,
-        resp: ResponseBody,
-    ) -> Result<(), ServerError> {
-        self.send_command(cmd);
-        let rsp = req.success(resp);
-        self.respond(rsp)
-    }
-
-    fn handle_pause(&mut self, req: Request, _args: PauseArguments) -> Result<(), ServerError> {
-        self.state.lock().unwrap().is_interrupting_for_debugger = true;
-
-        log::info!("DAP: Received request to pause R, sending interrupt");
-        crate::sys::control::handle_interrupt_request();
-
-        let rsp = req.success(ResponseBody::Pause);
-        self.respond(rsp)
-    }
-
-    fn send_command(&mut self, cmd: DebugRequest) {
-        if let Some(tx) = &self.comm_tx {
-            // If we have a comm channel (always the case as of this
-            // writing) we are connected to Positron or similar. Send
-            // control events so that the IDE can execute these as if they
-            // were sent by the user. This ensures prompts are updated.
-            let msg = amalthea::comm_rpc_message!("execute", command = debug_request_command(cmd));
-
-            tx.send(msg).log_err();
-        } else {
-            // Otherwise, send command to R's `ReadConsole()` frontend method
-            self.r_request_tx.send(RRequest::DebugCommand(cmd)).unwrap();
-        }
     }
 }
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -156,7 +156,7 @@ impl DapHandler {
             },
             Command::Pause(args) => self.handle_pause(args),
             _ => {
-                log::warn!("DAP: Unknown request");
+                log::warn!("DAP: Unknown request: {cmd:?}");
                 return DapOutput::error(req, "Ark DAP: Unknown request");
             },
         };
@@ -626,6 +626,8 @@ impl DapHandler {
         variables
     }
 
+    // `make_variables()` doesn't require R, so locking outside of an
+    // `r_task()` is fine here, unlike in `collect_r_variables()`.
     fn make_variables(&self, variables: Vec<RVariable>) -> Vec<Variable> {
         self.state.lock().unwrap().make_variables(variables)
     }
@@ -912,10 +914,8 @@ impl<R: Read, W: Write> DapServer<R, W> {
 
         // Evaluate is async: the response is sent later via `responses_tx`.
         // It is the only command that needs transport-specific handling.
-        if matches!(&req.command, Command::Evaluate(_)) {
-            let Command::Evaluate(args) = req.command.clone() else {
-                unreachable!()
-            };
+        if let Command::Evaluate(args) = &req.command {
+            let args = args.clone();
             if let Err(err) = self.handle_evaluate(req, args) {
                 log::warn!("DAP: Handler failed, closing connection: {err:?}");
                 return false;
@@ -969,6 +969,8 @@ impl<R: Read, W: Write> DapServer<R, W> {
                 crate::sys::control::handle_interrupt_request();
             },
             DapConsoleEvent::Restart => {
+                // If connected to Positron, forward the restart command to
+                // the frontend. Otherwise ignore it.
                 if let Some(tx) = &self.comm_tx {
                     let msg = amalthea::comm_rpc_message!("restart");
                     tx.send(msg).log_err();
@@ -978,7 +980,7 @@ impl<R: Read, W: Write> DapServer<R, W> {
     }
 
     fn respond(&mut self, rsp: Response) -> Result<(), ServerError> {
-        log::trace!("DAP: Responding to request: {rsp:#?}");
+        log::trace!("DAP: Sending response: {rsp:#?}");
         self.server.respond(rsp)
     }
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -928,6 +928,10 @@ impl<R: Read, W: Write> DapServer<R, W> {
     }
 
     fn deliver(&mut self, output: DapOutput) -> bool {
+        for event in output.console_events {
+            self.handle_console_event(event);
+        }
+
         if self.respond(output.response).log_err().is_none() {
             return false;
         }
@@ -936,10 +940,6 @@ impl<R: Read, W: Write> DapServer<R, W> {
             if self.send_event(event).log_err().is_none() {
                 return false;
             }
-        }
-
-        for event in output.console_events {
-            self.handle_console_event(event);
         }
 
         true

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -981,6 +981,8 @@ impl<R: Read, W: Write> DapServer<R, W> {
         self.server.send_event(event)
     }
 
+    // Tied to the TCP transport for now. For Jupyter we need to figure out how
+    // to do async responses with Jupyter's Control channel.
     fn handle_evaluate(
         &mut self,
         req: Request,


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/positron/issues/12104

We're going to have two handlers for DAP messages, one through the TCP connection for Console debugging, and one through a Jupyter connection (Control socket) for Notebook debugging.

This PR abstracts out DAP handling to make it agnostic to the transport: a `DapHandler` takes a DAP message, handles it, and returns a `Result<DapHandlerOutput>`. `dispatch()` is in charge of transforming error cases to a DAP response (success or error). The caller (transport layer) then propagates via appropriate transport.

Evaluate remains tied to the TCP transport because it needs to run R code asynchronously, and Jupyter's Control socket requires quick synchronous replies.

This PR is pure reorganisation, no functional difference.