### PR TITLE
Use `libr::SEXP` in debug only builds

### DIFF
--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -16,6 +16,7 @@ use crossbeam::channel::bounded;
 use crossbeam::channel::unbounded;
 use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
+#[cfg(debug_assertions)]
 use libr::SEXP;
 use uuid::Uuid;
 


### PR DESCRIPTION
Otherwise you see this with `cargo build --release`

```
warning: unused import: `libr::SEXP`
  --> crates/ark/src/r_task.rs:19:5
   |
19 | use libr::SEXP;
   |     ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```