### PR TITLE
Mark `r_polled_events()` callback as Unix specific

### DIFF
--- a/crates/ark/src/console.rs
+++ b/crates/ark/src/console.rs
@@ -116,6 +116,7 @@ use console_filter::strip_step_lines;
 use console_filter::ConsoleFilter;
 pub(crate) use console_repl::console_inputs;
 pub(crate) use console_repl::r_busy;
+#[cfg(unix)]
 pub(crate) use console_repl::r_polled_events;
 pub(crate) use console_repl::r_read_console;
 pub(crate) use console_repl::r_show_message;

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -2714,6 +2714,7 @@ pub extern "C-unwind" fn r_suicide(buf: *const c_char) {
     panic!("Suicide: {}", msg.to_str().unwrap());
 }
 
+#[cfg(unix)]
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C-unwind" fn r_polled_events() {
     if let Err(err) = r_sandbox(|| Console::get_mut().polled_events()) {


### PR DESCRIPTION
It is not used on Windows, and I don't think it even can be IIUC

Our Windows builds have been seeing this

```
warning: unused import: `console_repl::r_polled_events`
   --> crates\ark\src\console.rs:119:16
    |
119 | pub(crate) use console_repl::r_polled_events;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```