### PR TITLE
Report attached status from pkg_list

### DIFF
--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -8,48 +8,34 @@
 # This file contains RPC functions for the packages pane.
 # These functions are called via callMethod from the Positron R extension.
 
-# Return a list of installed packages
+# Return a list of installed packages.
+#
+# The `method` parameter is accepted for compatibility with the existing
+# Positron R extension RPC contract but is unused: base R's
+# installed.packages() reads from .libPaths(), which renv overrides in an
+# active project, so the same call works for pak/base/renv callers.
 #' @export
 .ps.rpc.pkg_list <- function(method = c("pak", "base", "renv")) {
-    method <- match.arg(method)
-    switch(
-        method,
-        pak = {
-            old_opt <- options(pak.no_extra_messages = TRUE)
-            on.exit(options(old_opt), add = TRUE)
-            pkgs <- pak::lib_status()
-            lapply(seq_len(nrow(pkgs)), function(i) {
-                list(
-                    id = paste0(pkgs$package[[i]], "-", pkgs$version[[i]]),
-                    name = pkgs$package[[i]],
-                    displayName = pkgs$package[[i]],
-                    version = as.character(pkgs$version[[i]])
-                )
-            })
-        },
-        base = {
-            ip <- utils::installed.packages()
-            lapply(seq_len(nrow(ip)), function(i) {
-                list(
-                    id = paste0(ip[i, "Package"], "-", ip[i, "Version"]),
-                    name = ip[i, "Package"],
-                    displayName = ip[i, "Package"],
-                    version = ip[i, "Version"]
-                )
-            })
-        },
-        renv = {
-            ip <- utils::installed.packages(lib.loc = renv::paths$library())
-            lapply(seq_len(nrow(ip)), function(i) {
-                list(
-                    id = paste0(ip[i, "Package"], "-", ip[i, "Version"]),
-                    name = ip[i, "Package"],
-                    displayName = ip[i, "Package"],
-                    version = ip[i, "Version"]
-                )
-            })
-        }
-    )
+    ip <- utils::installed.packages()
+    name <- ip[, "Package"]
+    version <- ip[, "Version"]
+    id <- paste0(name, "-", version)
+    # `attached` mirrors search() membership; we deliberately don't use
+    # "loaded" here since loadedNamespaces() is a strict superset (a
+    # package can be loaded as a dependency without being attached).
+    attached <- paste0("package:", name) %in% search()
+    # `Map(list, id = ...)` would name the output list by `id`'s values
+    # (mapply USE.NAMES semantics for a character first arg), and a named
+    # list serializes to a JSON object instead of the array the frontend
+    # expects. Strip the names with unname().
+    unname(Map(
+        list,
+        id = id,
+        name = name,
+        displayName = name,
+        version = version,
+        attached = attached
+    ))
 }
 
 


### PR DESCRIPTION
The Positron Packages pane renders a read-only attached indicator (filled green dot when attached, empty ring when not) using a single new field:

```
attached = paste0("package:", name) %in% search()
```

The field is named `attached` rather than `loaded` because R's `loadedNamespaces()` is a strict superset of `search()`: a package can be loaded as a transitive dependency without being attached. The new name reflects what we actually report.

The pak/base/renv method branches collapse to a single `utils::installed.packages()` call. renv overrides `.libPaths()` in an active project, so the same call works there too. The `method` parameter stays in the signature for RPC compatibility but is unused.

See posit-dev/positron#13184