### PR TITLE
Override `utils::timestamp()` on Windows and explain why

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,13 +18,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # Test on all supported R versions
+          # (Particularly important to do this on at least one OS for
+          # version dependent R hook override checks, like `utils::View()`)
           - { rust: 'stable',  r: 'release' }
-          # Oldest supported R version
+          - { rust: 'stable',  r: '4.5' }
+          - { rust: 'stable',  r: '4.4' }
+          - { rust: 'stable',  r: '4.3' }
           - { rust: 'stable',  r: '4.2' }
-          # Nightly rust
-          - { rust: 'nightly', r: 'release' }
+
           # Track upstream breaking changes
           - { rust: 'stable',  r: 'devel' }
+
+          # Nightly rust
+          - { rust: 'nightly', r: 'release' }
     timeout-minutes: 40
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -27,11 +27,9 @@ jobs:
           - { rust: 'stable',  r: '4.3' }
           - { rust: 'stable',  r: '4.2' }
 
-          # Track upstream breaking changes
-          - { rust: 'stable',  r: 'devel' }
-
-          # Nightly rust
-          - { rust: 'nightly', r: 'release' }
+          # Early warning signal for upstream changes,
+          # both in Rust and R-devel
+          - { rust: 'nightly',  r: 'devel' }
     timeout-minutes: 40
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crates/ark/src/modules/positron/history.R
+++ b/crates/ark/src/modules/positron/history.R
@@ -1,0 +1,81 @@
+# Some background on how `.Rhistory` works, and why we need a
+# `utils::timestamp()` override on Windows
+#
+# At the R level, R history is managed by 3 core functions:
+# - `savehistory()` - Save C level history buffer to a `.Rhistory` file
+# - `loadhistory()` - Load `.Rhistory` file into C level history buffer
+# - `timestamp()` - Print timestamp and write it to C level history buffer
+#
+# There are two places where this history buffer is typically written to when
+# running command line R:
+# - R `timestamp()`
+#   - Unix: `timestamp -> addhistory -> ptr_R_addhistory -> Rstd_addhistory -> GNU Readline's add_history`
+#   - Windows: `timestamp -> addhistory -> wgl_histadd`
+# - C `R_ReadConsole(addtohistory = 1)`
+#   - Unix: `R_ReadConsole -> ptr_ReadConsole -> Rstd_ReadConsole -> GNU Readline's add_history`
+#   - Windows: `R_ReadConsole -> ptr_ReadConsole -> Rp->ReadConsole -> GuiReadConsole -> ... -> wgl_histadd`
+#
+# We override `ptr_ReadConsole` directly on Unix and `Rp->ReadConsole` on
+# Windows, and currently our `read_console()` method that we override with
+# ignores `addtohistory`. We should probably implement our own history buffer at
+# some point and actually respect this. For now, we don't have to worry about
+# this path touching any C level history buffer because we control it.
+#
+# On Unix, going through `timestamp()` and GNU Readline's `add_history()` seems
+# to work fine, even though its a little misleading because we currently never
+# actually record anything else in the history buffer via `read_console()`, so
+# the history buffer is either going to be empty or just a bunch of timestamps.
+#
+# On Windows, due to `wgl_hist_init()` not being called during startup, and us
+# not having any way to do so, writing to the C history buffer via
+# `wgl_histadd()` is not allowed, because it isn't ever initialized to allocated
+# memory. Unfortunately, `timestamp()` will try and do this as shown by the path
+# written out above, and, due to this bug in R, will try to write to the buffer
+# even if it is uninitialized, resulting in a crash:
+# https://bugs.r-project.org/show_bug.cgi?id=19064
+#
+# Since on Windows there is no equivalent to `ptr_R_addhistory`, i.e. there is
+# no `Rp->addhistory` callback, the best we can do is override `timestamp()`
+# directly with a version that doesn't try to write to the history buffer.
+#
+# # Future work
+#
+# Eventually we probably want to respect `R_ReadConsole(addtohistory = 1)` so we
+# can write out `.Rhistory` files. To do this right, we should do all of these:
+#
+# - Create a Rust level `HistoryBuffer: Vec<String>`
+# - Override R level `timestamp()` to write to `HistoryBuffer`
+# - When `R_ReadConsole(addtohistory = 1)`, write `buf` to `HistoryBuffer`
+# - Override R level `savehistory(file)` to write from `HistoryBuffer` into
+#   `file` with `R_HistorySize` controlling the number of lines to write
+# - Override R level `loadhistory(file)` to write from `file` into `HistoryBuffer`
+# - Override `ptr_R_Cleanup` and `Rp->Cleanup` to write `HistoryBuffer` into
+#   `R_HistoryFile` with size `R_HistorySize` on exit if `SA_SAVE` is set
+# - On startup, if `R_RestoreHistory` is set then write from `R_HistoryFile`
+#   into `HistoryBuffer`.
+#
+# And note that `R_setupHistory()` should be called before each access to
+# `R_HistorySize` and `R_HistoryFile` to ensure that they have been updated from
+# the dynamic environment variables `R_HISTSIZE` and `R_HISTFILE`, which R will
+# do for us if we call that.
+#
+# On Unix we could override `ptr_R_loadhistory`, `ptr_R_savehistory`, and
+# `ptr_R_addhistory` instead of the R level `loadhistory()`, `savehistory()`,
+# and `timestamp()`, but since we can't do that on Windows, and since those
+# pointers aren't used from anywhere else, we might as well just consistently
+# override the R functions instead.
+
+# Precisely `utils::timestamp()`, but without the `C_addhistory` call
+windows_timestamp <- function(
+    stamp = date(),
+    prefix = "##------ ",
+    suffix = " ------##",
+    quiet = FALSE
+) {
+    stamp <- paste0(prefix, stamp, suffix)
+    # .External2(C_addhistory, stamp)
+    if (!quiet) {
+        cat(stamp, sep = "\n")
+    }
+    invisible(stamp)
+}

--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -59,9 +59,20 @@ pkg_bind <- function(pkg, name, value) {
     env <- sprintf("package:%s", pkg)
     env <- as.environment(env)
 
-    if (!exists(name, envir = env, mode = "function", inherits = FALSE)) {
+    fn <- get0(name, envir = env, mode = "function", inherits = FALSE)
+
+    if (is.null(fn)) {
         msg <- sprintf(
             "Can't register hook: function `%s::%s` not found.",
+            pkg,
+            name
+        )
+        stop(msg, call. = FALSE)
+    }
+
+    if (!identical(formals(fn), formals(value))) {
+        msg <- sprintf(
+            "Can't register hook: replacement for `%s::%s` does not have the same arguments.",
             pkg,
             name
         )
@@ -75,8 +86,19 @@ pkg_bind <- function(pkg, name, value) {
 ns_bind <- function(pkg, name, value) {
     ns <- asNamespace(pkg)
 
-    if (!exists(name, envir = ns, mode = "function", inherits = FALSE)) {
+    fn <- get0(name, envir = ns, mode = "function", inherits = FALSE)
+
+    if (is.null(fn)) {
         msg <- sprintf("Can't replace `%s` in the '%s' namespace.", name, pkg)
+        stop(msg, call. = FALSE)
+    }
+
+    if (!identical(formals(fn), formals(value))) {
+        msg <- sprintf(
+            "Can't replace `%s` in the '%s' namespace: replacement does not have the same arguments.",
+            pkg,
+            name
+        )
         stop(msg, call. = FALSE)
     }
 

--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -23,6 +23,10 @@ initialize_hooks <- function() {
         namespace = TRUE
     )
     register_getHook_hook()
+
+    if (is_windows()) {
+        rebind("utils", "timestamp", windows_timestamp, namespace = TRUE)
+    }
 }
 
 rebind <- function(pkg, name, value, namespace = FALSE) {

--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -70,7 +70,10 @@ pkg_bind <- function(pkg, name, value) {
         stop(msg, call. = FALSE)
     }
 
-    if (!identical(formals(fn), formals(value))) {
+    # Check formals, but if we are wrong, only panic in debug builds.
+    # Not worth it to bring the whole system down for this.
+    # Checked in CI across all supported R versions.
+    if (is_debug_build() && !identical(formals(fn), formals(value))) {
         msg <- sprintf(
             "Can't register hook: replacement for `%s::%s` does not have the same arguments.",
             pkg,
@@ -93,7 +96,10 @@ ns_bind <- function(pkg, name, value) {
         stop(msg, call. = FALSE)
     }
 
-    if (!identical(formals(fn), formals(value))) {
+    # Check formals, but if we are wrong, only panic in debug builds.
+    # Not worth it to bring the whole system down for this.
+    # Checked in CI across all supported R versions.
+    if (is_debug_build() && !identical(formals(fn), formals(value))) {
         msg <- sprintf(
             "Can't replace `%s` in the '%s' namespace: replacement does not have the same arguments.",
             pkg,

--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -19,7 +19,7 @@ initialize_hooks <- function() {
         "utils",
         "recover",
         # Keep this wrapped up this way for a better "Called from:" call
-        function(...) ark_recover(),
+        function() ark_recover(),
         namespace = TRUE
     )
     register_getHook_hook()

--- a/crates/ark/src/modules/positron/hooks.R
+++ b/crates/ark/src/modules/positron/hooks.R
@@ -6,7 +6,7 @@
 #
 
 initialize_hooks <- function() {
-    rebind("utils", "View", view, namespace = TRUE)
+    rebind("utils", "View", view_hook, namespace = TRUE)
     rebind("base", "debug", new_ark_debug(base::debug), namespace = TRUE)
     rebind(
         "base",

--- a/crates/ark/src/modules/positron/hooks_source.R
+++ b/crates/ark/src/modules/positron/hooks_source.R
@@ -14,46 +14,29 @@ make_ark_source <- function(original_source) {
     force(original_source)
 
     # Take all original arguments for e.g. completions
-    formals <- if (getRversion() <= "4.4.0") {
-        alist(
-            file = ,
-            local = FALSE,
-            echo = verbose,
-            print.eval = echo,
-            exprs = ,
-            spaced = use_file,
-            verbose = getOption("verbose"),
-            prompt.echo = getOption("prompt"),
-            max.deparse.length = 150,
-            width.cutoff = 60L,
-            deparseCtrl = "showAttributes",
-            chdir = FALSE,
-            # catch.aborts = FALSE,
-            encoding = getOption("encoding"),
-            continue.echo = getOption("continue"),
-            skip.echo = 0,
-            keep.source = getOption("keep.source")
-        )
-    } else {
-        alist(
-            file = ,
-            local = FALSE,
-            echo = verbose,
-            print.eval = echo,
-            exprs = ,
-            spaced = use_file,
-            verbose = getOption("verbose"),
-            prompt.echo = getOption("prompt"),
-            max.deparse.length = 150,
-            width.cutoff = 60L,
-            deparseCtrl = "showAttributes",
-            chdir = FALSE,
-            catch.aborts = FALSE,
-            encoding = getOption("encoding"),
-            continue.echo = getOption("continue"),
-            skip.echo = 0,
-            keep.source = getOption("keep.source")
-        )
+    formals <- alist(
+        file = ,
+        local = FALSE,
+        echo = verbose,
+        print.eval = echo,
+        exprs = ,
+        spaced = use_file,
+        verbose = getOption("verbose"),
+        prompt.echo = getOption("prompt"),
+        max.deparse.length = 150,
+        width.cutoff = 60L,
+        deparseCtrl = "showAttributes",
+        chdir = FALSE,
+        catch.aborts = FALSE,
+        encoding = getOption("encoding"),
+        continue.echo = getOption("continue"),
+        skip.echo = 0,
+        keep.source = getOption("keep.source")
+    )
+
+    # Remove arguments that are not yet supported
+    if (getRversion() <= "4.4.0") {
+        formals$catch.aborts <- NULL
     }
 
     body <- quote({
@@ -86,6 +69,11 @@ make_ark_source <- function(original_source) {
             skip.echo = skip.echo,
             keep.source = keep.source
         )
+
+        # Remove arguments that are not yet supported
+        if (getRversion() <= "4.4.0") {
+            args$catch.aborts <- NULL
+        }
 
         # Try to resolve the file URI early so we can attribute plots to this
         # source file. This is best-effort; if it fails we proceed without attribution.

--- a/crates/ark/src/modules/positron/hooks_source.R
+++ b/crates/ark/src/modules/positron/hooks_source.R
@@ -14,26 +14,49 @@ make_ark_source <- function(original_source) {
     force(original_source)
 
     # Take all original arguments for e.g. completions
-    function(
-        file,
-        local = FALSE,
-        echo = verbose,
-        print.eval = echo,
-        exprs,
-        spaced = use_file,
-        verbose = getOption("verbose"),
-        prompt.echo = getOption("prompt"),
-        max.deparse.length = 150,
-        width.cutoff = 60L,
-        deparseCtrl = "showAttributes",
-        chdir = FALSE,
-        catch.aborts = FALSE,
-        encoding = getOption("encoding"),
-        continue.echo = getOption("continue"),
-        skip.echo = 0,
-        keep.source = getOption("keep.source"),
-        ...
-    ) {
+    formals <- if (getRversion() <= "4.4.0") {
+        alist(
+            file = ,
+            local = FALSE,
+            echo = verbose,
+            print.eval = echo,
+            exprs = ,
+            spaced = use_file,
+            verbose = getOption("verbose"),
+            prompt.echo = getOption("prompt"),
+            max.deparse.length = 150,
+            width.cutoff = 60L,
+            deparseCtrl = "showAttributes",
+            chdir = FALSE,
+            # catch.aborts = FALSE,
+            encoding = getOption("encoding"),
+            continue.echo = getOption("continue"),
+            skip.echo = 0,
+            keep.source = getOption("keep.source")
+        )
+    } else {
+        alist(
+            file = ,
+            local = FALSE,
+            echo = verbose,
+            print.eval = echo,
+            exprs = ,
+            spaced = use_file,
+            verbose = getOption("verbose"),
+            prompt.echo = getOption("prompt"),
+            max.deparse.length = 150,
+            width.cutoff = 60L,
+            deparseCtrl = "showAttributes",
+            chdir = FALSE,
+            catch.aborts = FALSE,
+            encoding = getOption("encoding"),
+            continue.echo = getOption("continue"),
+            skip.echo = 0,
+            keep.source = getOption("keep.source")
+        )
+    }
+
+    body <- quote({
         # Compute default argument for `spaced`. Must be defined before the
         # fallback calls.
         use_file <- missing(exprs)
@@ -61,14 +84,8 @@ make_ark_source <- function(original_source) {
             encoding = encoding,
             continue.echo = continue.echo,
             skip.echo = skip.echo,
-            keep.source = keep.source,
-            ...
+            keep.source = keep.source
         )
-
-        # Remove arguments that are not yet supported
-        if (getRversion() <= "4.4.0") {
-            args$catch.aborts <- NULL
-        }
 
         # Try to resolve the file URI early so we can attribute plots to this
         # source file. This is best-effort; if it fails we proceed without attribution.
@@ -161,7 +178,13 @@ make_ark_source <- function(original_source) {
         # unexpected lengths (0 or >1). The annotated code is wrapped in
         # `withVisible()` so the result already has the right structure.
         invisible(eval(parsed, env))
-    }
+    })
+
+    out <- function() {}
+    formals(out) <- formals
+    body(out) <- body
+
+    out
 }
 
 #' @export

--- a/crates/ark/src/modules/positron/system.R
+++ b/crates/ark/src/modules/positron/system.R
@@ -14,6 +14,10 @@ system_os <- function() {
     )
 }
 
+is_windows <- function() {
+    system_os() == "windows"
+}
+
 has_aqua <- function() {
     capabilities("aqua")
 }

--- a/crates/ark/src/modules/positron/utils.R
+++ b/crates/ark/src/modules/positron/utils.R
@@ -141,6 +141,14 @@ node_poke_cdr <- function(node, cdr) {
     .ps.Call("ark_node_poke_cdr", node, cdr)
 }
 
+# Detect if ark is running under a debug build or not
+#
+# - Debug: `cargo build`
+# - Release: `cargo build --release`
+is_debug_build <- function() {
+    .ps.Call("ark_is_debug_build")
+}
+
 # Alias to make intent clear. We store values in symbols so they are reachable
 # via `base::`.
 base_bind <- function(sym, value) {

--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -5,10 +5,21 @@
 #
 #
 
-# Dispatches to object handlers. The handlers take `var` and `env` arguments.
-# These are only passed if we could infer a variable name from the input and if
-# that variable exists in the calling environment. This is used for live
-# updating the objects, if supported (e.g. data frames in the data viewer).
+# `utils::View()` replacement, with exact same arguments
+view_hook <- function(x, title) {
+    view(
+        x = x,
+        title = title,
+        name = as_label(substitute(x)),
+        env = parent.frame()
+    )
+}
+
+# Called from Rust. Dispatches to object handlers. The handlers take `name` and
+# `env` arguments. These are only passed if we could infer a variable name from
+# the input and if that variable exists in the calling environment. This is used
+# for live updating the objects, if supported (e.g. data frames in the data
+# viewer).
 view <- function(x, title, name = NULL, env = parent.frame()) {
     # Derive the name of the object from the expression passed to View()
     name <- name %||% as_label(substitute(x))

--- a/crates/ark/src/modules_utils.rs
+++ b/crates/ark/src/modules_utils.rs
@@ -7,6 +7,17 @@ pub unsafe extern "C-unwind" fn ark_node_poke_cdr(node: SEXP, cdr: SEXP) -> anyh
 }
 
 #[harp::register]
+pub unsafe extern "C-unwind" fn ark_is_debug_build() -> anyhow::Result<SEXP> {
+    cfg_if::cfg_if! {
+        if #[cfg(debug_assertions)] {
+            Ok(libr::Rf_ScalarLogical(1))
+        } else {
+            Ok(libr::Rf_ScalarLogical(0))
+        }
+    }
+}
+
+#[harp::register]
 pub unsafe extern "C-unwind" fn ps_deep_sleep(secs: SEXP) -> anyhow::Result<SEXP> {
     let secs = libr::Rf_asInteger(secs);
     let secs = std::time::Duration::from_secs(secs as u64);

--- a/crates/ark/tests/kernel-hooks-timestamp.rs
+++ b/crates/ark/tests/kernel-hooks-timestamp.rs
@@ -1,0 +1,20 @@
+use ark_test::DummyArkFrontend;
+
+#[test]
+fn test_timestamp() {
+    // This test is mostly to ensure that our `utils::timestamp()` override on Windows
+    // avoids a crash. So as long as this test passes on all platforms, we are happy!
+    // https://github.com/posit-dev/positron/issues/13261
+
+    let frontend = DummyArkFrontend::lock();
+
+    // By default it `cat()`s to stdout and returns invisibly. We want the actual
+    // string timestamp.
+    let code = "withVisible(utils::timestamp(quiet = TRUE))$value";
+
+    // The actual timestamp changes, but the start and end fragments should be there
+    frontend.execute_request(code, |result| {
+        assert!(result.contains("##------"));
+        assert!(result.contains("------##"));
+    });
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/13261

With A LOT of explanation about `.Rhistory` and what we might want to do in the future with all of this

Yay

<img width="610" height="324" alt="Screenshot 2026-04-29 at 4 46 06 PM" src="https://github.com/user-attachments/assets/07d8ab10-7aff-491e-a87f-f80deba11e56" />

