### PR TITLE
Assert that yes, `polled_events()` is really not run on Windows

### DIFF
--- a/crates/ark/src/console.rs
+++ b/crates/ark/src/console.rs
@@ -60,7 +60,6 @@ use harp::environment::r_ns_env;
 use harp::environment::Environment;
 use harp::environment::R_ENVS;
 use harp::exec::exec_with_cleanup;
-use harp::exec::r_check_stack;
 use harp::exec::r_peek_error_buffer;
 use harp::exec::r_sandbox;
 use harp::exec::with_calling_error_handler;

--- a/crates/ark/src/console/console_filter.rs
+++ b/crates/ark/src/console/console_filter.rs
@@ -263,6 +263,7 @@ impl ConsoleFilter {
     /// Check for timeout and handle state transitions.
     /// Timeout means we didn't reach ReadConsole to confirm debug output,
     /// so we emit the accumulated content back to the user.
+    #[cfg(any(unix, test))]
     pub(super) fn check_timeout(&mut self) -> Option<String> {
         self.drain_on_timeout()
     }

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -2354,6 +2354,7 @@ impl Console {
     }
 
     /// Invoked by the R event loop
+    #[cfg(unix)]
     fn polled_events(&mut self) {
         // Don't process tasks until R is fully initialized
         if !Self::is_initialized() {
@@ -2366,7 +2367,7 @@ impl Console {
         // Skip running tasks if we don't have 128KB of stack space available.
         // This is 1/8th of the typical Windows stack space (1MB, whereas macOS
         // and Linux have 8MB).
-        if r_check_stack(Some(128 * 1024)).is_err() {
+        if harp::exec::r_check_stack(Some(128 * 1024)).is_err() {
             return;
         }
 


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/ark/pull/1175 now that I have my real Windows machine up. Without this we get:

<img width="801" height="471" alt="Screenshot 2026-04-29 at 4 57 33 PM" src="https://github.com/user-attachments/assets/613fa094-6ecc-4feb-b6d0-d8d7b35c6e74" />


@lionel- is it concerning that `polled_events()` never runs on Windows?

I see we do `self.handle_task_interrupt()` elsewhere inside `run_event_loop()` so those tasks probably get to run eventually even if they can't run at interrupt time.

But this part of `polled_events()` feels kind of important?

```
        // Check stream filter timeout to handle long computations between
        // WriteConsole calls. Timeout means we didn't reach ReadConsole to
        // confirm debug output within a reasonable amount of time, so
        // accumulated content is emitted. This allows user code to produce
        // output that looks like debug lines emitted by R without them getting
        // filtered out or held up too long.
        if let Some(text) = self.debug_filter.check_timeout() {
            self.emit_stdout(text);
        }
```