### PR TITLE
fix: prevent stack overflow in `obj_size_tree` for deeply nested R objects

### DIFF
--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -72,8 +72,9 @@ fn obj_size_tree(
     seen: &mut HashSet<SEXP>,
     depth: usize,
 ) -> usize {
-    // Guard against stack overflow from deeply nested R objects
-    if depth > MAX_DEPTH {
+    // Guard against stack overflow from deeply nested R objects.
+    // Returns 0 (undercounting) rather than crashing when depth limit is exceeded.
+    if depth >= MAX_DEPTH {
         return 0;
     }
 

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -70,8 +70,10 @@ fn obj_size_tree(
     sizeof_node: usize,
     sizeof_vector: usize,
     seen: &mut HashSet<SEXP>,
-    depth: usize,
+    mut depth: usize,
 ) -> usize {
+    depth += 1;
+
     // Guard against stack overflow from deeply nested R objects.
     // Returns 0 (undercounting) rather than crashing when depth limit is exceeded.
     if depth >= MAX_DEPTH {
@@ -107,7 +109,7 @@ fn obj_size_tree(
         let klass = unsafe { libr::ALTREP_CLASS(x) };
         size += 3 * size_of::<SEXP>();
 
-        size += obj_size_tree(klass, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+        size += obj_size_tree(klass, base_env, sizeof_node, sizeof_vector, seen, depth);
 
         size += obj_size_tree(
             unsafe { libr::R_altrep_data1(x) },
@@ -115,7 +117,7 @@ fn obj_size_tree(
             sizeof_node,
             sizeof_vector,
             seen,
-            depth + 1,
+            depth,
         );
         size += obj_size_tree(
             unsafe { libr::R_altrep_data2(x) },
@@ -123,7 +125,7 @@ fn obj_size_tree(
             sizeof_node,
             sizeof_vector,
             seen,
-            depth + 1,
+            depth,
         );
 
         return size;
@@ -132,8 +134,8 @@ fn obj_size_tree(
     if r_typeof(x) != CHARSXP && attrib_has_any(x) {
         attrib_for_each(x, |tag, val| {
             size += sizeof_node;
-            size += obj_size_tree(tag, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
-            size += obj_size_tree(val, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            size += obj_size_tree(tag, base_env, sizeof_node, sizeof_vector, seen, depth);
+            size += obj_size_tree(val, base_env, sizeof_node, sizeof_vector, seen, depth);
         });
     }
 
@@ -160,7 +162,7 @@ fn obj_size_tree(
                     sizeof_node,
                     sizeof_vector,
                     seen,
-                    depth + 1,
+                    depth,
                 );
             }
         },
@@ -177,7 +179,7 @@ fn obj_size_tree(
                     sizeof_node,
                     sizeof_vector,
                     seen,
-                    depth + 1,
+                    depth,
                 )
             }
         },
@@ -198,7 +200,7 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
-                        depth + 1,
+                        depth,
                     );
                     size += obj_size_tree(
                         unsafe { libr::CAR(cons) },
@@ -206,12 +208,12 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
-                        depth + 1,
+                        depth,
                     );
                     cons = unsafe { libr::CDR(cons) };
                 }
                 // Handle non-nil CDRs
-                size += obj_size_tree(cons, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+                size += obj_size_tree(cons, base_env, sizeof_node, sizeof_vector, seen, depth);
             }
         },
         BCODESXP => {
@@ -221,7 +223,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
             size += obj_size_tree(
                 unsafe { libr::CAR(x) },
@@ -229,7 +231,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
             size += obj_size_tree(
                 unsafe { libr::CDR(x) },
@@ -237,7 +239,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
         },
         // Environments
@@ -267,14 +269,9 @@ fn obj_size_tree(
 
                 size += match binding.value {
                     // For active bindings, we compute the size of the function
-                    BindingValue::Active { fun } => obj_size_tree(
-                        fun.sexp,
-                        base_env,
-                        sizeof_node,
-                        sizeof_vector,
-                        seen,
-                        depth + 1,
-                    ),
+                    BindingValue::Active { fun } => {
+                        obj_size_tree(fun.sexp, base_env, sizeof_node, sizeof_vector, seen, depth)
+                    },
                     // `obj_size_tree` is aware of altrep objects.
                     BindingValue::Altrep { object, .. } => obj_size_tree(
                         object.sexp,
@@ -282,7 +279,7 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
-                        depth + 1,
+                        depth,
                     ),
                     // `object_size_tree` is aware of promise objects.
                     // The environment iterator will automatically return `PRVALUE` as
@@ -295,7 +292,7 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
-                        depth + 1,
+                        depth,
                     ),
                     // Immediate bindings are expanded, thus we might overestimate the size of
                     // environments that use this kind of bindings.
@@ -306,7 +303,7 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
-                        depth + 1,
+                        depth,
                     ),
                 }
             }
@@ -317,7 +314,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
         },
         // Functions
@@ -328,7 +325,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
             size += obj_size_tree(
                 fn_body(x),
@@ -336,16 +333,9 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
-            size += obj_size_tree(
-                fn_env(x),
-                base_env,
-                sizeof_node,
-                sizeof_vector,
-                seen,
-                depth + 1,
-            );
+            size += obj_size_tree(fn_env(x), base_env, sizeof_node, sizeof_vector, seen, depth);
         },
         PROMSXP => {
             size += obj_size_tree(
@@ -354,7 +344,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
             size += obj_size_tree(
                 unsafe { libr::PRCODE(x) },
@@ -362,7 +352,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
             size += obj_size_tree(
                 unsafe { libr::PRENV(x) },
@@ -370,7 +360,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
         },
         EXTPTRSXP => {
@@ -381,7 +371,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
             size += obj_size_tree(
                 unsafe { libr::R_ExternalPtrTag(x) },
@@ -389,7 +379,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
         },
         S4SXP => {
@@ -399,7 +389,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
-                depth + 1,
+                depth,
             );
         },
         SYMSXP => {},

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -154,7 +154,14 @@ fn obj_size_tree(
         STRSXP => {
             size += v_size(r_length(x) as usize, size_of::<SEXP>());
             for i in 0..r_length(x) {
-                size += obj_size_tree(r_chr_get(x, i), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+                size += obj_size_tree(
+                    r_chr_get(x, i),
+                    base_env,
+                    sizeof_node,
+                    sizeof_vector,
+                    seen,
+                    depth + 1,
+                );
             }
         },
         CHARSXP => {
@@ -164,7 +171,14 @@ fn obj_size_tree(
         VECSXP | EXPRSXP | WEAKREFSXP => {
             size += v_size(r_length(x) as usize, size_of::<SEXP>());
             for i in 0..r_length(x) {
-                size += obj_size_tree(list_get(x, i), base_env, sizeof_node, sizeof_vector, seen, depth + 1)
+                size += obj_size_tree(
+                    list_get(x, i),
+                    base_env,
+                    sizeof_node,
+                    sizeof_vector,
+                    seen,
+                    depth + 1,
+                )
             }
         },
         // Nodes
@@ -253,37 +267,85 @@ fn obj_size_tree(
 
                 size += match binding.value {
                     // For active bindings, we compute the size of the function
-                    BindingValue::Active { fun } => {
-                        obj_size_tree(fun.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
-                    },
+                    BindingValue::Active { fun } => obj_size_tree(
+                        fun.sexp,
+                        base_env,
+                        sizeof_node,
+                        sizeof_vector,
+                        seen,
+                        depth + 1,
+                    ),
                     // `obj_size_tree` is aware of altrep objects.
-                    BindingValue::Altrep { object, .. } => {
-                        obj_size_tree(object.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
-                    },
+                    BindingValue::Altrep { object, .. } => obj_size_tree(
+                        object.sexp,
+                        base_env,
+                        sizeof_node,
+                        sizeof_vector,
+                        seen,
+                        depth + 1,
+                    ),
                     // `object_size_tree` is aware of promise objects.
                     // The environment iterator will automatically return `PRVALUE` as
                     // a `Standard` binding though. So this is only seeing unevaluated promises.
                     // For evaluated promises, we are not counting the size of `PRCODE`, but hopefully
                     // their sizes are negligible, mostly just symbols or small expressions.
-                    BindingValue::Promise { promise } => {
-                        obj_size_tree(promise.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
-                    },
+                    BindingValue::Promise { promise } => obj_size_tree(
+                        promise.sexp,
+                        base_env,
+                        sizeof_node,
+                        sizeof_vector,
+                        seen,
+                        depth + 1,
+                    ),
                     // Immediate bindings are expanded, thus we might overestimate the size of
                     // environments that use this kind of bindings.
                     // See more in https://github.com/r-devel/r-svn/blob/31340c871c7df54e45bfc7c4f49d09bb5806ec70/doc/notes/immbnd.md
-                    BindingValue::Standard { object, .. } => {
-                        obj_size_tree(object.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
-                    },
+                    BindingValue::Standard { object, .. } => obj_size_tree(
+                        object.sexp,
+                        base_env,
+                        sizeof_node,
+                        sizeof_vector,
+                        seen,
+                        depth + 1,
+                    ),
                 }
             }
 
-            size += obj_size_tree(env_parent(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            size += obj_size_tree(
+                env_parent(x),
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
         },
         // Functions
         CLOSXP => {
-            size += obj_size_tree(fn_formals(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
-            size += obj_size_tree(fn_body(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
-            size += obj_size_tree(fn_env(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            size += obj_size_tree(
+                fn_formals(x),
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                fn_body(x),
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
+            size += obj_size_tree(
+                fn_env(x),
+                base_env,
+                sizeof_node,
+                sizeof_vector,
+                seen,
+                depth + 1,
+            );
         },
         PROMSXP => {
             size += obj_size_tree(

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -77,6 +77,9 @@ fn obj_size_tree(
     // Guard against stack overflow from deeply nested R objects.
     // Returns 0 (undercounting) rather than crashing when depth limit is exceeded.
     if depth >= MAX_DEPTH {
+        log::warn!(
+            "`obj_size_tree()`: recursion depth limit ({MAX_DEPTH}) exceeded, undercounting to size 0"
+        );
         return 0;
     }
 

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -35,6 +35,11 @@ use crate::RObject;
 // `utils::object.size()` is too slow on large datasets and this code path is used trough the
 // variables pane which required more performance.
 // See for more info.
+
+// Maximum recursion depth to prevent stack overflow on deeply nested R objects.
+// https://github.com/posit-dev/positron/issues/13294
+const MAX_DEPTH: usize = 500;
+
 pub fn r_size(x: SEXP) -> harp::Result<usize> {
     let mut seen: HashSet<SEXP> = HashSet::new();
 
@@ -54,6 +59,7 @@ pub fn r_size(x: SEXP) -> harp::Result<usize> {
             sizeof_node as usize,
             sizeof_vector as usize,
             &mut seen,
+            0,
         )
     })
 }
@@ -64,7 +70,13 @@ fn obj_size_tree(
     sizeof_node: usize,
     sizeof_vector: usize,
     seen: &mut HashSet<SEXP>,
+    depth: usize,
 ) -> usize {
+    // Guard against stack overflow from deeply nested R objects
+    if depth > MAX_DEPTH {
+        return 0;
+    }
+
     // In case there's a nullptr, return 0
     if x.is_null() {
         return 0;
@@ -94,7 +106,7 @@ fn obj_size_tree(
         let klass = unsafe { libr::ALTREP_CLASS(x) };
         size += 3 * size_of::<SEXP>();
 
-        size += obj_size_tree(klass, base_env, sizeof_node, sizeof_vector, seen);
+        size += obj_size_tree(klass, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
 
         size += obj_size_tree(
             unsafe { libr::R_altrep_data1(x) },
@@ -102,6 +114,7 @@ fn obj_size_tree(
             sizeof_node,
             sizeof_vector,
             seen,
+            depth + 1,
         );
         size += obj_size_tree(
             unsafe { libr::R_altrep_data2(x) },
@@ -109,6 +122,7 @@ fn obj_size_tree(
             sizeof_node,
             sizeof_vector,
             seen,
+            depth + 1,
         );
 
         return size;
@@ -117,8 +131,8 @@ fn obj_size_tree(
     if r_typeof(x) != CHARSXP && attrib_has_any(x) {
         attrib_for_each(x, |tag, val| {
             size += sizeof_node;
-            size += obj_size_tree(tag, base_env, sizeof_node, sizeof_vector, seen);
-            size += obj_size_tree(val, base_env, sizeof_node, sizeof_vector, seen);
+            size += obj_size_tree(tag, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            size += obj_size_tree(val, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
         });
     }
 
@@ -139,7 +153,7 @@ fn obj_size_tree(
         STRSXP => {
             size += v_size(r_length(x) as usize, size_of::<SEXP>());
             for i in 0..r_length(x) {
-                size += obj_size_tree(r_chr_get(x, i), base_env, sizeof_node, sizeof_vector, seen);
+                size += obj_size_tree(r_chr_get(x, i), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
             }
         },
         CHARSXP => {
@@ -149,7 +163,7 @@ fn obj_size_tree(
         VECSXP | EXPRSXP | WEAKREFSXP => {
             size += v_size(r_length(x) as usize, size_of::<SEXP>());
             for i in 0..r_length(x) {
-                size += obj_size_tree(list_get(x, i), base_env, sizeof_node, sizeof_vector, seen)
+                size += obj_size_tree(list_get(x, i), base_env, sizeof_node, sizeof_vector, seen, depth + 1)
             }
         },
         // Nodes
@@ -169,6 +183,7 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
+                        depth + 1,
                     );
                     size += obj_size_tree(
                         unsafe { libr::CAR(cons) },
@@ -176,11 +191,12 @@ fn obj_size_tree(
                         sizeof_node,
                         sizeof_vector,
                         seen,
+                        depth + 1,
                     );
                     cons = unsafe { libr::CDR(cons) };
                 }
                 // Handle non-nil CDRs
-                size += obj_size_tree(cons, base_env, sizeof_node, sizeof_vector, seen);
+                size += obj_size_tree(cons, base_env, sizeof_node, sizeof_vector, seen, depth + 1);
             }
         },
         BCODESXP => {
@@ -190,6 +206,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
             size += obj_size_tree(
                 unsafe { libr::CAR(x) },
@@ -197,6 +214,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
             size += obj_size_tree(
                 unsafe { libr::CDR(x) },
@@ -204,6 +222,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
         },
         // Environments
@@ -234,11 +253,11 @@ fn obj_size_tree(
                 size += match binding.value {
                     // For active bindings, we compute the size of the function
                     BindingValue::Active { fun } => {
-                        obj_size_tree(fun.sexp, base_env, sizeof_node, sizeof_vector, seen)
+                        obj_size_tree(fun.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
                     },
                     // `obj_size_tree` is aware of altrep objects.
                     BindingValue::Altrep { object, .. } => {
-                        obj_size_tree(object.sexp, base_env, sizeof_node, sizeof_vector, seen)
+                        obj_size_tree(object.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
                     },
                     // `object_size_tree` is aware of promise objects.
                     // The environment iterator will automatically return `PRVALUE` as
@@ -246,24 +265,24 @@ fn obj_size_tree(
                     // For evaluated promises, we are not counting the size of `PRCODE`, but hopefully
                     // their sizes are negligible, mostly just symbols or small expressions.
                     BindingValue::Promise { promise } => {
-                        obj_size_tree(promise.sexp, base_env, sizeof_node, sizeof_vector, seen)
+                        obj_size_tree(promise.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
                     },
                     // Immediate bindings are expanded, thus we might overestimate the size of
                     // environments that use this kind of bindings.
                     // See more in https://github.com/r-devel/r-svn/blob/31340c871c7df54e45bfc7c4f49d09bb5806ec70/doc/notes/immbnd.md
                     BindingValue::Standard { object, .. } => {
-                        obj_size_tree(object.sexp, base_env, sizeof_node, sizeof_vector, seen)
+                        obj_size_tree(object.sexp, base_env, sizeof_node, sizeof_vector, seen, depth + 1)
                     },
                 }
             }
 
-            size += obj_size_tree(env_parent(x), base_env, sizeof_node, sizeof_vector, seen);
+            size += obj_size_tree(env_parent(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
         },
         // Functions
         CLOSXP => {
-            size += obj_size_tree(fn_formals(x), base_env, sizeof_node, sizeof_vector, seen);
-            size += obj_size_tree(fn_body(x), base_env, sizeof_node, sizeof_vector, seen);
-            size += obj_size_tree(fn_env(x), base_env, sizeof_node, sizeof_vector, seen);
+            size += obj_size_tree(fn_formals(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            size += obj_size_tree(fn_body(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
+            size += obj_size_tree(fn_env(x), base_env, sizeof_node, sizeof_vector, seen, depth + 1);
         },
         PROMSXP => {
             size += obj_size_tree(
@@ -272,6 +291,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
             size += obj_size_tree(
                 unsafe { libr::PRCODE(x) },
@@ -279,6 +299,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
             size += obj_size_tree(
                 unsafe { libr::PRENV(x) },
@@ -286,6 +307,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
         },
         EXTPTRSXP => {
@@ -296,6 +318,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
             size += obj_size_tree(
                 unsafe { libr::R_ExternalPtrTag(x) },
@@ -303,6 +326,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
         },
         S4SXP => {
@@ -312,6 +336,7 @@ fn obj_size_tree(
                 sizeof_node,
                 sizeof_vector,
                 seen,
+                depth + 1,
             );
         },
         SYMSXP => {},

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -70,9 +70,9 @@ fn obj_size_tree(
     sizeof_node: usize,
     sizeof_vector: usize,
     seen: &mut HashSet<SEXP>,
-    mut depth: usize,
+    depth: usize,
 ) -> usize {
-    depth += 1;
+    let depth = depth + 1;
 
     // Guard against stack overflow from deeply nested R objects.
     // Returns 0 (undercounting) rather than crashing when depth limit is exceeded.

--- a/crates/harp/src/size.rs
+++ b/crates/harp/src/size.rs
@@ -72,8 +72,6 @@ fn obj_size_tree(
     seen: &mut HashSet<SEXP>,
     depth: usize,
 ) -> usize {
-    let depth = depth + 1;
-
     // Guard against stack overflow from deeply nested R objects.
     // Returns 0 (undercounting) rather than crashing when depth limit is exceeded.
     if depth >= MAX_DEPTH {
@@ -82,6 +80,8 @@ fn obj_size_tree(
         );
         return 0;
     }
+
+    let depth = depth + 1;
 
     // In case there's a nullptr, return 0
     if x.is_null() {


### PR DESCRIPTION
Resolves https://github.com/posit-dev/positron/issues/13294

`harp::size::obj_size_tree` is an unbounded recursive tree-walker. Complex objects like tibbles returned by `readr::read_csv` — with nested column specs, closures, and environment chains — can produce recursion deep enough to overflow the native call stack, crashing the kernel with SIGSEGV (signal 11).

## Changes

- **`crates/harp/src/size.rs`**: Add `MAX_DEPTH = 500` constant and a depth guard at the top of `obj_size_tree`. When the limit is hit, the subtree contributes `0` to the size (intentional undercount rather than crash). The `depth` counter is threaded through all ~27 recursive call sites, starting at `0` from `r_size`.

The relevant portion of the crash backtrace:
```
3: harp::size::obj_size_tree
4: harp::size::obj_size_tree
5: harp::size::obj_size_tree
...
11: harp::size::r_size
12: ark::variables::variable::PositronVariable::new
13: ark::variables::r_variables::RVariables::update
```

Agent-Logs-Url: https://github.com/kv9898/ark/sessions/84c11583-0e0e-4be8-ab0d-961075a0b1bd

Co-authored-by: kv9898 <105025148+kv9898@users.noreply.github.com>