### PR TITLE
Update nix from 0.26 to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "libc",
  "log",
  "nix",
  "rand 0.10.1",
@@ -813,6 +814,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -2300,15 +2307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,15 +2352,14 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "cfg-if",
+ "cfg_aliases",
  "libc",
- "memoffset",
- "pin-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ libloading = "0.9.0"
 libr = { path = "crates/libr" }
 log = "0.4.29"
 mime_guess = "2.0.5"
-nix = { version = "0.26.4", features = ["signal"] }
+nix = { version = "0.31", features = ["fs", "poll", "process", "signal"] }
 notify = "8.2.0"
 oak_core = { path = "crates/oak_core" }
 oak_fs = { path = "crates/oak_fs" }

--- a/crates/amalthea/Cargo.toml
+++ b/crates/amalthea/Cargo.toml
@@ -21,6 +21,7 @@ dirs.workspace = true
 futures.workspace = true
 hex.workspace = true
 hmac.workspace = true
+libc.workspace = true
 log.workspace = true
 nix.workspace = true
 rand.workspace = true

--- a/crates/amalthea/src/sys/unix/stream_capture.rs
+++ b/crates/amalthea/src/sys/unix/stream_capture.rs
@@ -5,8 +5,10 @@
  *
  */
 
-use std::os::unix::prelude::AsRawFd;
-use std::os::unix::prelude::RawFd;
+use std::os::fd::AsFd;
+use std::os::fd::AsRawFd;
+use std::os::fd::BorrowedFd;
+use std::os::fd::OwnedFd;
 
 use crossbeam::channel::Sender;
 use log::warn;
@@ -38,13 +40,13 @@ impl StreamCapture {
     fn output_capture(iopub_tx: Sender<IOPubMessage>) -> Result<(), Error> {
         // Create redirected file descriptors for stdout and stderr. These are
         // pipes into which stdout/stderr are redirected.
-        let stdout_fd = Self::redirect_fd(nix::libc::STDOUT_FILENO)?;
-        let stderr_fd = Self::redirect_fd(nix::libc::STDERR_FILENO)?;
+        let stdout_fd = Self::redirect_fd(libc::STDOUT_FILENO)?;
+        let stderr_fd = Self::redirect_fd(libc::STDERR_FILENO)?;
 
         // Create poll descriptors for both streams. These are used as
         // arguments to a poll(2) wrapper.
-        let stdout_poll = nix::poll::PollFd::new(stdout_fd, nix::poll::PollFlags::POLLIN);
-        let stderr_poll = nix::poll::PollFd::new(stderr_fd, nix::poll::PollFlags::POLLIN);
+        let stdout_poll = nix::poll::PollFd::new(stdout_fd.as_fd(), nix::poll::PollFlags::POLLIN);
+        let stderr_poll = nix::poll::PollFd::new(stderr_fd.as_fd(), nix::poll::PollFlags::POLLIN);
         let mut poll_fds = [stdout_poll, stderr_poll];
 
         log::info!("Starting thread for stdout/stderr capture");
@@ -53,7 +55,8 @@ impl StreamCapture {
             // Wait for data to be available on either stdout or stderr.  This
             // blocks until data is available, the streams are interrupted, or
             // the timeout occurs.
-            let count = match nix::poll::poll(&mut poll_fds, 1000) {
+            let count = match nix::poll::poll(&mut poll_fds, nix::poll::PollTimeout::from(1000u16))
+            {
                 Ok(c) => c,
                 Err(err) => {
                     // https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
@@ -88,19 +91,19 @@ impl StreamCapture {
                 // If the stream has input (POLLIN), read it and send it to the
                 // IOPub socket.
                 if revents.contains(nix::poll::PollFlags::POLLIN) {
-                    let fd = poll_fd.as_raw_fd();
+                    let raw_fd = poll_fd.as_fd().as_raw_fd();
                     // Look up the stream name from its file descriptor.
-                    let stream = if fd == stdout_fd {
+                    let stream = if raw_fd == stdout_fd.as_raw_fd() {
                         Stream::Stdout
-                    } else if fd == stderr_fd {
+                    } else if raw_fd == stderr_fd.as_raw_fd() {
                         Stream::Stderr
                     } else {
-                        log::warn!("Unknown stream fd: {}", fd);
+                        log::warn!("Unknown stream fd: {}", raw_fd);
                         continue;
                     };
 
                     // Read the data from the stream and send it to iopub.
-                    Self::fd_to_iopub(fd, stream, iopub_tx.clone());
+                    Self::fd_to_iopub(poll_fd.as_fd(), stream, iopub_tx.clone());
                 }
             }
         }
@@ -110,7 +113,7 @@ impl StreamCapture {
     }
 
     /// Reads data from a file descriptor and sends it to the IOPub socket.
-    fn fd_to_iopub(fd: RawFd, stream: Stream, iopub_tx: Sender<IOPubMessage>) {
+    fn fd_to_iopub(fd: BorrowedFd, stream: Stream, iopub_tx: Sender<IOPubMessage>) {
         // Read up to 1024 bytes from the stream into `buf`
         let mut buf = [0u8; 1024];
         let count = match nix::unistd::read(fd, &mut buf) {
@@ -142,7 +145,7 @@ impl StreamCapture {
 
     /// Redirects a standard output stream to a pipe and returns the read end of
     /// the pipe.
-    fn redirect_fd(fd: RawFd) -> Result<RawFd, Error> {
+    fn redirect_fd(fd: i32) -> Result<OwnedFd, Error> {
         // Create a pipe to redirect the stream to
         let (read, write) = match nix::unistd::pipe() {
             Ok((read, write)) => (read, write),
@@ -154,17 +157,23 @@ impl StreamCapture {
             },
         };
 
-        // Redirect the stream into the write end of the pipe
-        if let Err(e) = nix::unistd::dup2(write, fd) {
+        // Redirect the stream into the write end of the pipe.
+        // We use `libc::dup2()` directly because nix's `dup2` now requires
+        // `&mut OwnedFd` for the target, but STDOUT/STDERR are not owned.
+        // Overwriting a global fd is a fundamentally unsafe operation for which
+        // nix has no support.
+        if unsafe { libc::dup2(write.as_raw_fd(), fd) } == -1 {
             return Err(Error::SysError(
                 format!("redirect stream for {}", fd),
-                format!("{e}"),
+                std::io::Error::last_os_error().to_string(),
             ));
         }
+        // `write` is dropped at the end of the block, closing the write end of
+        // the original pipe. The dup2'd copy on `fd` keeps it alive.
 
         // Make reads non-blocking on the read end of the pipe
         if let Err(e) = nix::fcntl::fcntl(
-            read,
+            read.as_fd(),
             nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK),
         ) {
             return Err(Error::SysError(

--- a/crates/ark/tests/kernel-stream-capture.rs
+++ b/crates/ark/tests/kernel-stream-capture.rs
@@ -1,0 +1,51 @@
+//
+// kernel-stream-capture.rs
+//
+// Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+//
+// Integration tests for fd-level stream capture (`StreamCapture`).
+//
+// R's own output goes through `WriteConsole` callbacks, but child processes
+// spawned by `system()` write directly to the inherited file descriptors.
+// `StreamCapture` redirects stdout/stderr into pipes so that output is
+// forwarded to the frontend via IOPub.
+//
+// These tests use `DummyArkFrontendStreamCapture` which enables stream
+// capture. Because the redirect affects global file descriptors, panic
+// messages won't be visible in test runner output.
+
+// Stream capture is currently not supported on Windows
+#![cfg(unix)]
+
+use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use ark_test::DummyArkFrontendStreamCapture;
+
+#[test]
+fn test_system_stdout_captured() {
+    let frontend = DummyArkFrontendStreamCapture::lock();
+
+    frontend.send_execute_request(
+        "system('echo hello_from_system')",
+        ExecuteRequestOptions::default(),
+    );
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.assert_stream_stdout_contains("hello_from_system");
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}
+
+#[test]
+fn test_system_stderr_captured() {
+    let frontend = DummyArkFrontendStreamCapture::lock();
+
+    frontend.send_execute_request(
+        "system('echo error_from_system >&2')",
+        ExecuteRequestOptions::default(),
+    );
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.assert_stream_stderr_contains("error_from_system");
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}

--- a/crates/ark_test/src/dummy_frontend.rs
+++ b/crates/ark_test/src/dummy_frontend.rs
@@ -119,6 +119,7 @@ struct DummyArkFrontendOptions {
     site_r_profile: bool,
     user_r_profile: bool,
     r_environ: bool,
+    capture_streams: bool,
     session_mode: SessionMode,
     default_repos: DefaultRepos,
     startup_file: Option<String>,
@@ -1825,7 +1826,7 @@ impl DummyArkFrontend {
                 r_args,
                 options.startup_file,
                 options.session_mode,
-                false,
+                options.capture_streams,
                 options.default_repos,
             );
         });
@@ -2127,6 +2128,57 @@ impl DerefMut for DummyArkFrontendRprofile {
     }
 }
 
+/// Wrapper around `DummyArkFrontend` with fd-level stream capture enabled.
+///
+/// This enables the `StreamCapture` thread that redirects the process's
+/// stdout/stderr file descriptors into pipes, capturing output from child
+/// processes (e.g. `system()` calls) that write directly to the inherited fds.
+///
+/// Because the redirect affects the global file descriptors, panic messages
+/// and test framework output will also be captured and won't be visible in
+/// test runner output.
+#[cfg(unix)]
+pub struct DummyArkFrontendStreamCapture {
+    inner: DummyArkFrontend,
+}
+
+#[cfg(unix)]
+impl DummyArkFrontendStreamCapture {
+    /// NOTE: Only one `DummyArkFrontend` variant should call `lock()` within
+    /// a given process.
+    pub fn lock() -> Self {
+        Self::init();
+
+        Self {
+            inner: DummyArkFrontend::lock(),
+        }
+    }
+
+    fn init() {
+        let options = DummyArkFrontendOptions {
+            capture_streams: true,
+            ..Default::default()
+        };
+        FRONTEND.get_or_init(|| Arc::new(Mutex::new(DummyArkFrontend::init(options))));
+    }
+}
+
+#[cfg(unix)]
+impl Deref for DummyArkFrontendStreamCapture {
+    type Target = DummyArkFrontend;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(unix)]
+impl DerefMut for DummyArkFrontendStreamCapture {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
 impl Default for DummyArkFrontendOptions {
     fn default() -> Self {
         Self {
@@ -2134,6 +2186,7 @@ impl Default for DummyArkFrontendOptions {
             site_r_profile: false,
             user_r_profile: false,
             r_environ: false,
+            capture_streams: false,
             session_mode: SessionMode::Console,
             default_repos: DefaultRepos::Auto,
             startup_file: None,


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1162

The two main breaking changes were introduced in 0.27:

- All Cargo features have been removed from the default set. Users will need to
  specify which features they depend on in their Cargo.toml.
  ([#2091](https://github.com/nix-rust/nix/pull/2091))

- Implemented I/O safety for many, but not all, of Nix's APIs.  Many public
  functions argument and return types have changed:
  | Original Type | New Type              |
  | ------------- | --------------------- |
  | AsRawFd       | AsFd                  |
  | RawFd         | BorrowedFd or OwnedFd |

  (#[1906](https://github.com/nix-rust/nix/pull/1906))

We now mention in Cargo.toml which features we require.

The switch to owned types changes a bunch of signatures. It also required changing to libc version of `dup2()`, in an unsafe block. This is a more honest view of what we're doing since we're mutating the global file descriptors stdout/stderr.
