### PR TITLE
Allow build-time override of embedded version string

### DIFF
--- a/crates/ark/build.rs
+++ b/crates/ark/build.rs
@@ -42,6 +42,15 @@ fn main() {
     let build_date = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     println!("cargo:rustc-env=BUILD_DATE={}", build_date);
 
+    // Allow downstream builds (e.g. Positron prebuilds, which embed the public
+    // release version plus the submodule commit distance, like "0.1.251+10")
+    // to override the version string baked into the binary. Defaults to the
+    // version declared in `Cargo.toml`.
+    let build_version = std::env::var("ARK_BUILD_VERSION")
+        .unwrap_or_else(|_| std::env::var("CARGO_PKG_VERSION").unwrap());
+    println!("cargo:rustc-env=ARK_BUILD_VERSION={}", build_version);
+    println!("cargo:rerun-if-env-changed=ARK_BUILD_VERSION");
+
     // Embed an Application Manifest file on Windows.
     // Turns on UTF-8 support and declares our Windows version compatibility.
     // Documented to do nothing on non-Windows.

--- a/crates/ark/build.rs
+++ b/crates/ark/build.rs
@@ -46,10 +46,8 @@ fn main() {
     // release version plus the submodule commit distance, like "0.1.251+10")
     // to override the version string baked into the binary. Defaults to the
     // version declared in `Cargo.toml`.
-    let build_version = std::env::var("ARK_BUILD_VERSION")
-        .unwrap_or_else(|_| std::env::var("CARGO_PKG_VERSION").unwrap());
-    println!("cargo:rustc-env=ARK_BUILD_VERSION={}", build_version);
-    println!("cargo:rerun-if-env-changed=ARK_BUILD_VERSION");
+    let build_version = option_env!("ARK_BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    println!("cargo:rustc-env=BUILD_VERSION={}", build_version);
 
     // Embed an Application Manifest file on Windows.
     // Turns on UTF-8 support and declares our Windows version compatibility.

--- a/crates/ark/src/lib.rs
+++ b/crates/ark/src/lib.rs
@@ -51,4 +51,4 @@ pub mod viewer;
 
 pub(crate) use r_task::r_task;
 
-pub const ARK_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const ARK_VERSION: &str = env!("ARK_BUILD_VERSION");

--- a/crates/ark/src/lib.rs
+++ b/crates/ark/src/lib.rs
@@ -51,4 +51,4 @@ pub mod viewer;
 
 pub(crate) use r_task::r_task;
 
-pub const ARK_VERSION: &str = env!("ARK_BUILD_VERSION");
+pub const BUILD_VERSION: &str = env!("BUILD_VERSION");

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -133,7 +133,7 @@ pub(crate) fn initialize(
     Ok(InitializeResult {
         server_info: Some(ServerInfo {
             name: "Ark R Kernel".to_string(),
-            version: Some(env!("ARK_BUILD_VERSION").to_string()),
+            version: Some(crate::BUILD_VERSION.to_string()),
         }),
         capabilities: ServerCapabilities {
             // Currently hard-coded to UTF-16, but we might want to allow UTF-8 frontends

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -133,7 +133,7 @@ pub(crate) fn initialize(
     Ok(InitializeResult {
         server_info: Some(ServerInfo {
             name: "Ark R Kernel".to_string(),
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version: Some(env!("ARK_BUILD_VERSION").to_string()),
         }),
         capabilities: ServerCapabilities {
             // Currently hard-coded to UTF-16, but we might want to allow UTF-8 frontends

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -29,7 +29,7 @@ thread_local! {
 }
 
 fn print_usage() {
-    println!("Ark {}, an R Kernel.", env!("ARK_BUILD_VERSION"));
+    println!("Ark {}, an R Kernel.", ark::BUILD_VERSION);
     print!(
         r#"
 Usage: ark [OPTIONS]
@@ -142,7 +142,7 @@ fn main() -> anyhow::Result<()> {
                 }
             },
             "--version" => {
-                println!("Ark {}", env!("ARK_BUILD_VERSION"));
+                println!("Ark {}", ark::BUILD_VERSION);
                 return Ok(());
             },
             "--install" => {

--- a/crates/ark/src/main.rs
+++ b/crates/ark/src/main.rs
@@ -29,7 +29,7 @@ thread_local! {
 }
 
 fn print_usage() {
-    println!("Ark {}, an R Kernel.", env!("CARGO_PKG_VERSION"));
+    println!("Ark {}, an R Kernel.", env!("ARK_BUILD_VERSION"));
     print!(
         r#"
 Usage: ark [OPTIONS]
@@ -142,7 +142,7 @@ fn main() -> anyhow::Result<()> {
                 }
             },
             "--version" => {
-                println!("Ark {}", env!("CARGO_PKG_VERSION"));
+                println!("Ark {}", env!("ARK_BUILD_VERSION"));
                 return Ok(());
             },
             "--install" => {

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -157,7 +157,7 @@ impl ShellHandler for Shell {
             help_links: Vec::new(),
             language_info: info,
             implementation: String::from("ark"),
-            implementation_version: String::from(env!("ARK_BUILD_VERSION")),
+            implementation_version: String::from(crate::BUILD_VERSION),
             supported_features,
         })
     }

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -157,7 +157,9 @@ impl ShellHandler for Shell {
             help_links: Vec::new(),
             language_info: info,
             implementation: String::from("ark"),
-            implementation_version: String::from(crate::BUILD_VERSION),
+            // We use CARGO_PKG_VERSION here vs. the build version override since the Jupyter spec
+            // specifically calls out the X.Y.Z format for this value
+            implementation_version: String::from(env!("CARGO_PKG_VERSION")),
             supported_features,
         })
     }

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -157,7 +157,7 @@ impl ShellHandler for Shell {
             help_links: Vec::new(),
             language_info: info,
             implementation: String::from("ark"),
-            implementation_version: String::from(env!("CARGO_PKG_VERSION")),
+            implementation_version: String::from(env!("ARK_BUILD_VERSION")),
             supported_features,
         })
     }

--- a/crates/ark/src/version.rs
+++ b/crates/ark/src/version.rs
@@ -68,7 +68,7 @@ pub unsafe extern "C-unwind" fn ps_ark_version() -> anyhow::Result<SEXP> {
     // Set the version info in the map
     info.insert(
         String::from("version"),
-        String::from(env!("CARGO_PKG_VERSION")),
+        String::from(env!("ARK_BUILD_VERSION")),
     );
 
     // Add the current commit hash and branch; these are set by the build script (build.rs)

--- a/crates/ark/src/version.rs
+++ b/crates/ark/src/version.rs
@@ -66,10 +66,7 @@ pub fn detect_r() -> anyhow::Result<RVersion> {
 pub unsafe extern "C-unwind" fn ps_ark_version() -> anyhow::Result<SEXP> {
     let mut info = HashMap::<String, String>::new();
     // Set the version info in the map
-    info.insert(
-        String::from("version"),
-        String::from(env!("ARK_BUILD_VERSION")),
-    );
+    info.insert(String::from("version"), String::from(crate::BUILD_VERSION));
 
     // Add the current commit hash and branch; these are set by the build script (build.rs)
     info.insert(String::from("commit"), String::from(env!("BUILD_GIT_HASH")));


### PR DESCRIPTION
Adds an `ARK_BUILD_VERSION` env var that, when set, replaces `CARGO_PKG_VERSION` as the version reported by the binary (`--version`, `.ps.ark.version()`, the Jupyter kernel info banner, and the LSP `server_info`). Defaults to `CARGO_PKG_VERSION` so existing builds are unchanged.

This is the upstream hook for Positron's planned move from a prebuilt ark dependency to a git submodule (posit-dev/positron#13148). Positron prebuilds will set `ARK_BUILD_VERSION=<release>+<distance>` (e.g. `0.1.251+10`) so a user can tell at runtime which submodule commit they are running against.