### PR TITLE
Pin R to 4.5 on win arm64 CI until pak has binaries

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -14,8 +14,8 @@ jobs:
         config:
           # x64
           - { rust: 'stable', r: 'release', runs_on: 'windows-latest' }
-          # arm64
-          - { rust: 'stable', r: 'release', runs_on: 'windows-11-arm' }
+          # arm64 (pinned to 4.5 until 4.6 has ARM64 binaries)
+          - { rust: 'stable', r: '4.5', runs_on: 'windows-11-arm' }
     timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To fix:

```
Install pak
  Warning: Warning: unable to access index for repository https://r-lib.github.io/p/pak/stable/windows.binary.clang-aarch64/mingw32/aarch64/src/contrib:
    cannot open URL 'https://r-lib.github.io/p/pak/stable/windows.binary.clang-aarch64/mingw32/aarch64/src/contrib/PACKAGES'
  Warning: Warning: unable to access index for repository https://r-lib.github.io/p/pak/stable/windows.binary.clang-aarch64/mingw32/aarch64/bin/windows/clang-aarch64/contrib/4.6:
    cannot open URL 'https://r-lib.github.io/p/pak/stable/windows.binary.clang-aarch64/mingw32/aarch64/bin/windows/clang-aarch64/contrib/4.6/PACKAGES'
  Warning message:
  package 'pak' is not available for this version of R
  
  A version of this package for your version of R might be available elsewhere,
  see the ideas at
  https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#Installing-packages 
```