### PR TITLE
Update to zeromq 4.3.5 to solve polling on Windows arm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4900,9 +4900,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zeromq-src"
-version = "0.2.6+4.3.4"
+version = "0.3.6+4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc120b771270365d5ed0dfb4baf1005f2243ae1ae83703265cb3504070f4160b"
+checksum = "d9a1c884770df9c1b3eb0a0ad01d7516234879e0ce144c505348550f2492923e"
 dependencies = [
  "cc",
  "dircpy",
@@ -4950,8 +4950,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "zmq"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3091dd571fb84a9b3e5e5c6a807d186c411c812c8618786c3c30e5349234e7"
+source = "git+https://github.com/erickt/rust-zmq?rev=5d78967#5d78967001abb1aece2fba878d6151cb66cd1767"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -4961,8 +4960,7 @@ dependencies = [
 [[package]]
 name = "zmq-sys"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8351dc72494b4d7f5652a681c33634063bbad58046c1689e75270908fdc864"
+source = "git+https://github.com/erickt/rust-zmq?rev=5d78967#5d78967001abb1aece2fba878d6151cb66cd1767"
 dependencies = [
  "libc",
  "system-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,3 +119,8 @@ winsafe = { version = "0.0.27", features = ["kernel"] }
 xdg = "3.0.0"
 yaml-rust2 = "0.11"
 zmq = "0.10.0"
+
+[patch.crates-io]
+# We need ZMQ 4.3.5 to fix polling issues on Windows arm64
+zmq = { git = "https://github.com/erickt/rust-zmq", rev = "5d78967" }
+zmq-sys = { git = "https://github.com/erickt/rust-zmq", rev = "5d78967" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,9 +118,5 @@ windows-sys ="0.61.2"
 winsafe = { version = "0.0.27", features = ["kernel"] }
 xdg = "3.0.0"
 yaml-rust2 = "0.11"
-zmq = "0.10.0"
-
-[patch.crates-io]
 # We need ZMQ 4.3.5 to fix polling issues on Windows arm64
 zmq = { git = "https://github.com/erickt/rust-zmq", rev = "5d78967" }
-zmq-sys = { git = "https://github.com/erickt/rust-zmq", rev = "5d78967" }

--- a/crates/amalthea/src/kernel.rs
+++ b/crates/amalthea/src/kernel.rs
@@ -531,69 +531,37 @@ fn socket_bridge_thread(
     };
 
     loop {
-        // On Windows ARM, zmq::poll with a non-zero timeout blocks forever
-        // and inproc notification sockets may not wake the poll at all.
-        // Use a fully separate polling path that doesn't rely on ZMQ
-        // readability reporting: non-blocking poll + unconditional drain
-        // of all sources + short sleep when idle.
-        #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-        {
-            // Drain outbound messages (IOPub, StdIn) unconditionally
-            consume_outbound_notification();
-            forward_outbound();
+        let n = unwrap!(
+            zmq::poll(&mut poll_items, -1),
+            Err(err) => {
+                debug_panic!("While polling 0MQ items: {err:?}");
+                0
+            }
+        );
 
-            // Check inbound sockets with non-blocking poll
+        for _ in 0..n {
+            if consume_outbound_notification() {
+                forward_outbound();
+                continue;
+            }
+
             if has_inbound(&stdin_socket) {
                 unwrap!(
                     forward_inbound(&stdin_socket, &stdin_inbound_tx),
                     Err(err) => debug_panic!("While forwarding inbound message: {err:?}")
                 );
+                continue;
             }
+
             if has_inbound(&iopub_socket) {
                 unwrap!(
                     forward_inbound_subscription(&iopub_socket, &iopub_inbound_tx),
                     Err(err) => debug_panic!("While forwarding inbound message: {err:?}")
                 );
+                continue;
             }
 
-            std::thread::sleep(std::time::Duration::from_millis(1));
-            continue;
-        }
-
-        #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
-        {
-            let n = unwrap!(
-                zmq::poll(&mut poll_items, -1),
-                Err(err) => {
-                    debug_panic!("While polling 0MQ items: {err:?}");
-                    0
-                }
-            );
-
-            for _ in 0..n {
-                if consume_outbound_notification() {
-                    forward_outbound();
-                    continue;
-                }
-
-                if has_inbound(&stdin_socket) {
-                    unwrap!(
-                        forward_inbound(&stdin_socket, &stdin_inbound_tx),
-                        Err(err) => debug_panic!("While forwarding inbound message: {err:?}")
-                    );
-                    continue;
-                }
-
-                if has_inbound(&iopub_socket) {
-                    unwrap!(
-                        forward_inbound_subscription(&iopub_socket, &iopub_inbound_tx),
-                        Err(err) => debug_panic!("While forwarding inbound message: {err:?}")
-                    );
-                    continue;
-                }
-
-                debug_panic!("Could not find readable message");
-            }
+            debug_panic!("Could not find readable message");
         }
     }
 }

--- a/crates/amalthea/src/socket.rs
+++ b/crates/amalthea/src/socket.rs
@@ -214,36 +214,8 @@ impl Socket {
         }
     }
 
-    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
     pub fn poll_incoming(&self, timeout_ms: i64) -> zmq::Result<bool> {
         Ok(self.socket.poll(zmq::PollEvents::POLLIN, timeout_ms)? != 0)
-    }
-
-    /// On Windows ARM, ZMQ poll with a non-zero timeout blocks forever
-    /// instead of respecting the timeout. Use non-blocking poll with
-    /// manual timing.
-    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-    pub fn poll_incoming(&self, timeout_ms: i64) -> zmq::Result<bool> {
-        if timeout_ms == 0 {
-            return Ok(self.socket.poll(zmq::PollEvents::POLLIN, 0)? != 0);
-        }
-
-        let start = std::time::Instant::now();
-        let timeout = if timeout_ms < 0 {
-            std::time::Duration::from_secs(u64::MAX / 2)
-        } else {
-            std::time::Duration::from_millis(timeout_ms as u64)
-        };
-
-        loop {
-            if self.socket.poll(zmq::PollEvents::POLLIN, 0)? != 0 {
-                return Ok(true);
-            }
-            if start.elapsed() >= timeout {
-                return Ok(false);
-            }
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
     }
 
     pub fn has_incoming_data(&self) -> zmq::Result<bool> {

--- a/crates/amalthea/src/socket/shell.rs
+++ b/crates/amalthea/src/socket/shell.rs
@@ -111,29 +111,6 @@ impl Shell {
 
     /// Main loop for the Shell thread; to be invoked by the kernel.
     pub fn listen(&mut self) {
-        #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-        self.listen_polling();
-
-        #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
-        self.listen_blocking();
-    }
-
-    /// On Windows ARM, zmq::poll with a non-zero timeout blocks forever
-    /// and inproc notification sockets may not wake the poll. Use
-    /// non-blocking poll with unconditional comm checks and a short sleep.
-    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-    fn listen_polling(&mut self) {
-        loop {
-            self.process_comm_notification();
-            if self.socket.has_incoming_data().unwrap_or(false) {
-                self.process_shell_socket();
-            }
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
-    }
-
-    #[cfg(not(all(target_os = "windows", target_arch = "aarch64")))]
-    fn listen_blocking(&mut self) {
         loop {
             log::trace!("Waiting for shell messages or comm events");
 


### PR DESCRIPTION
In https://github.com/posit-dev/ark/pull/1033 and https://github.com/posit-dev/ark/pull/1171, I've had to add ugly workarounds for Windows arm64, very deep in polling internals of Ark. On that platform, polling on sockets with a timeout hanged indefinitely instead of resolving after the timeout. The workaround was to sample-poll with short timeouts manually.

While investigating the cause of this issue, I noticed that ZMQ 4.3.5 did not have this issue. We're currently on 4.3.4, which hasn't been released to crates.io yet (https://github.com/erickt/rust-zmq/issues/420). The ZMQ update is on main branch though, so this PR switches us to the latest commit on the repo. An alternative would be to use that fork that is more actively maintained, we could consider that in the future if the community converges there: https://github.com/rdaum/rust-zmq/