### PR TITLE
Switch back to R release on Windows arm64 CI

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -14,8 +14,8 @@ jobs:
         config:
           # x64
           - { rust: 'stable', r: 'release', runs_on: 'windows-latest' }
-          # arm64 (pinned to 4.5 until 4.6 has ARM64 binaries)
-          - { rust: 'stable', r: '4.5', runs_on: 'windows-11-arm' }
+          # arm64
+          - { rust: 'stable', r: 'release', runs_on: 'windows-11-arm' }
     timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit b25fba10f0d96414ae2c74e5b0817ea568a9d629.

Closes https://github.com/posit-dev/ark/issues/1194

@gaborcsardi kindly kicked off a build of pak for the platform.