### PR TITLE
Bypass library finalisation to fix libgomp crash

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -40,6 +40,16 @@ jobs:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
+      # This configures Makevars to look for brew headers and libraries. Useful
+      # to compile packages used in tests when they have just been released to
+      # CRAN and there is no binary we can download yet. We've needed this for
+      # data.table.
+      - name: Configure R compilation flags
+        run: |
+          mkdir -p ~/.R
+          echo "CPPFLAGS += -I$(brew --prefix gettext)/include" >> ~/.R/Makevars
+          echo "LDFLAGS += -L$(brew --prefix gettext)/lib" >> ~/.R/Makevars
+
       - name: Install R Packages Required For Tests
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "crossbeam",
  "dap",
  "harp",
+ "libc",
  "log",
  "regex",
  "serde",

--- a/crates/ark_test/Cargo.toml
+++ b/crates/ark_test/Cargo.toml
@@ -20,6 +20,7 @@ ark.workspace = true
 crossbeam.workspace = true
 dap = { workspace = true, features = ["client"] }
 harp.workspace = true
+libc.workspace = true
 log.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/crates/ark_test/src/dummy_frontend.rs
+++ b/crates/ark_test/src/dummy_frontend.rs
@@ -768,8 +768,6 @@ impl DummyArkFrontend {
     #[cfg(unix)]
     #[track_caller]
     pub fn wait_for_cleanup() {
-        use std::time::Duration;
-
         use ark::sys::console::CLEANUP_SIGNAL;
 
         let (lock, cvar) = &CLEANUP_SIGNAL;
@@ -1793,6 +1791,40 @@ impl DummyArkFrontend {
         // we redirect stdout.
         // https://github.com/r-lib/cli/blob/1220ed092c03e167ff0062e9839c81d7258a4600/R/onload.R#L33-L40
         unsafe { std::env::set_var("R_CLI_HIDE_CURSOR", "false") };
+
+        // On Linux, register an atexit handler that calls `_exit(0)` to skip
+        // library fini sections (`.fini_array` destructors). libgomp's
+        // `.fini_array` destructor can trigger a re-initialization crash on
+        // Ubuntu CI runners:
+        //
+        // ```
+        // test test_dap_reconnect_basic ... ok
+        // test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+        // dap_breakpoints_reconnect-abc123: ../../../src/libgomp/oacc-init.c:84:
+        //   goacc_register: Assertion `!dispatchers[disp->type]' failed.
+        // (test aborted with signal 6: SIGABRT)
+        // ```
+        //
+        // In glibc, `_dl_fini()` (which runs `.fini_array` destructors for all
+        // loaded shared objects) is itself an atexit handler, registered by the
+        // dynamic linker at process startup. Since atexit is LIFO and `_dl_fini`
+        // is registered before any user code, it executes after all
+        // user-registered handlers. Our handler, registered here during test
+        // init, executes before `_dl_fini` and calls `_exit(0)` to terminate
+        // the process, preventing `_dl_fini` from ever running. Registering
+        // early also means handlers registered later (by R, Rust runtime, etc.)
+        // execute before ours, so normal cleanup still happens.
+        //
+        // From exit(3): "If one of these functions [from atexit] does not
+        // return (e.g., it calls _exit(2)), then none of the remaining
+        // functions is called, and further exit processing [...] is abandoned."
+        #[cfg(target_os = "linux")]
+        unsafe {
+            extern "C" fn skip_fini() {
+                unsafe { libc::_exit(0) };
+            }
+            libc::atexit(skip_fini);
+        }
 
         let connection = DummyConnection::new();
         let (connection_file, registration_file) = connection.get_connection_files();


### PR DESCRIPTION
(Hopefully) fixes these flakes:

```
     SIGABRT [   0.980s] ( 667/1297) ark::dap_notebook test_notebook_debug_info
  stdout ───

    running 1 test
    test test_notebook_debug_info ... ok

    test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out; finished in 0.21s

  stderr ───
    dap_notebook-d63c677b2730ef53: ../../../src/libgomp/oacc-init.c:84: goacc_register: Assertion `!dispatchers[disp->type]' failed.

    (test aborted with signal 6: SIGABRT)
```

libgomp is a library loaded via BLAS on our Ubuntu runners. The stderr output indicates that the library is getting initialised a second time, triggering this assertion abort.

We still don't know why libgomp is getting initialised a second time, but we know that it happens after the test passed (e.g. `ok` result in output). We also know from `LD_DEBUG` output that it happens during linked library teardown when the process exits:

```
calling fini: libR.so [0]
calling fini: libgomp.so.1 [0]
find library=libR.so [0]; searching
calling init: libgomp.so.1    ← second init triggers assertion failure
```

According to glibc'd deepwiki, library finalisation happens via the atexit hook, registered very early by the dynamic linker at process startup. The workaround implemented in this PR is to register an atexit hook in the test harness on Linux to call `_exit()`, which is documented to exit immediately without any further cleanup (https://man7.org/linux/man-pages/man2/_exit.2.html):

> The function _exit() is like exit(3), but does not call any functions registered with atexit(3) or on_exit(3).

Furthermore, from `exit()` (https://man7.org/linux/man-pages/man3/exit.3.html):

> If one of these functions [from atexit] does not return (e.g., it calls _exit(2), or kills itself with a signal), then none of the remaining functions is called, and further exit processing (in particular, flushing of stdio(3) streams) is abandoned.

So exiting with code 0 from an atexit hook should circumvent all this library finalisation procedure.