### PR TITLE
Add support for source() directive in symbol resolution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,9 @@ updates:
     # and let rapid follow-up releases collapse into a single bump
     cooldown:
       default-days: 14
-    # Only bump Cargo.toml specifiers for major changes, let
-    # minor/patch versions drift in the lockfile
-    versioning-strategy: increase-if-necessary
+    # Cargo only supports `lockfile-only` and `auto`. `auto` lets
+    # dependabot bump Cargo.toml when ranges don't cover the new version.
+    versioning-strategy: auto
     open-pull-requests-limit: 10
     groups:
       # Group all crate updates into one weekly PR. Major updates get

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "nix",
  "notify",
  "oak_core",
+ "oak_db",
  "oak_ide",
  "oak_index",
  "oak_package_metadata",
@@ -2448,6 +2449,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_db"
+version = "0.1.0"
+dependencies = [
+ "oak_index",
+ "url",
+]
+
+[[package]]
 name = "oak_fs"
 version = "0.1.0"
 dependencies = [
@@ -2467,6 +2476,7 @@ dependencies = [
  "biome_rowan",
  "log",
  "oak_core",
+ "oak_db",
  "oak_index",
  "oak_package_metadata",
  "oak_sources",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ mime_guess = "2.0.5"
 nix = { version = "0.31", features = ["fs", "poll", "process", "signal"] }
 notify = "8.2.0"
 oak_core = { path = "crates/oak_core" }
+oak_db = { path = "crates/oak_db" }
 oak_fs = { path = "crates/oak_fs" }
 oak_ide = { path = "crates/oak_ide" }
 oak_index = { path = "crates/oak_index" }

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -44,6 +44,7 @@ mime_guess.workspace = true
 nix.workspace = true
 notify.workspace = true
 oak_core.workspace = true
+oak_db.workspace = true
 oak_ide.workspace = true
 oak_index.workspace = true
 oak_sources.workspace = true

--- a/crates/ark/src/lsp/document.rs
+++ b/crates/ark/src/lsp/document.rs
@@ -212,9 +212,10 @@ impl Document {
         Ok(self.parse.syntax())
     }
 
-    /// Recomputed every time for now, we'll track this with Salsa soon.
-    pub fn semantic_index(&self) -> SemanticIndex {
-        oak_index::semantic_index(&self.parse.tree())
+    /// TODO(salsa) Recomputed every time for now, but we'll track this with
+    /// Salsa soon.
+    pub fn semantic_index(&self, file: &url::Url) -> SemanticIndex {
+        oak_index::semantic_index(&self.parse.tree(), file)
     }
 
     pub fn tree_sitter_point_from_lsp_position(

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -550,7 +550,7 @@ mod tests {
     #[test]
     fn test_script_source_directive_resolves() {
         // script.R has `source("helpers.R")` then uses `helper`.
-        // WorldState::file_scope() should resolve the source() directive
+        // WorldState::file_analysis() should resolve the source() directive
         // and make helpers.R's exports visible via the search path.
         let script_dir = std::env::temp_dir().join("test_script_source");
 

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -981,4 +981,53 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_script_source_in_function_packages_scoped() {
+        // source() inside a function where the sourced file calls library(dplyr).
+        // The dplyr Attach directive should be scoped to the function: visible
+        // inside f (and nested scopes) but NOT at file scope.
+        //
+        // We verify by checking the scope chain at two offsets. Package symbols
+        // produce no NavigationTarget, so goto_definition can't distinguish
+        // "resolved to package" from "unresolved". The scope chain check is
+        // more direct.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(
+            dir.path().join("helpers.R"),
+            "library(dplyr)\nhelper <- function() 1\n",
+        )
+        .unwrap();
+
+        //  "f <- function() {\n"              offset 0
+        //  "  source(\"helpers.R\")\n"         offset 18
+        //  "  mutate\n"                        offset 39
+        //  "}\n"                               offset 48
+        //  "mutate\n"                          offset 50
+        let script_source = "f <- function() {\n  source(\"helpers.R\")\n  mutate\n}\nmutate\n";
+        let script_doc = Document::new(script_source, None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        let (index, file_scope) = state.file_analysis(&script_uri, &script_doc);
+
+        let has_dplyr = |layers: &[oak_index::external::ScopeLayer]| -> bool {
+            layers.iter().any(|l| matches!(l, oak_index::external::ScopeLayer::PackageExports(pkg) if pkg == "dplyr"))
+        };
+
+        // Inside f (offset 41, on "mutate"): dplyr should be in the scope chain
+        let inner_offset = biome_rowan::TextSize::from(41);
+        let inner_chain = file_scope.at(&index, inner_offset);
+        assert!(has_dplyr(&inner_chain));
+
+        // Outside f (offset 50, on "mutate"): dplyr should NOT be in the scope chain
+        let outer_offset = biome_rowan::TextSize::from(50);
+        let outer_chain = file_scope.at(&index, outer_offset);
+        assert!(!has_dplyr(&outer_chain));
+    }
 }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -26,7 +26,7 @@ pub(crate) fn goto_definition(
 
     let (index, scope) = state.file_analysis(&uri, document);
     let root = document.syntax()?;
-    let targets = oak_ide::goto_definition(offset, &uri, &root, &index, &scope, &state.library);
+    let targets = oak_ide::goto_definition(state, offset, &uri, &root, &index, &scope);
 
     if targets.is_empty() {
         return Ok(None);
@@ -1161,39 +1161,39 @@ mod tests {
     }
 
     #[test]
-    fn test_script_source_local_false_does_not_shadow_local_def() {
-        // `source()` (default `local = FALSE`) in a function scope does
-        // not shadow a prior local binding.
+    fn test_script_source_shadows_local_def() {
+        // A local definition followed by source() of a file that also
+        // defines the same name: the use after source() should resolve
+        // to the sourced file's definition (later shadows earlier).
         let dir = tempfile::tempdir().unwrap();
 
-        std::fs::write(dir.path().join("helpers.R"), "foo <- function() 1\n").unwrap();
+        std::fs::write(dir.path().join("helpers.R"), "helper <- function() 1\n").unwrap();
 
-        //  Line 0: "f <- function() {\n"
-        //  Line 1: "  foo <- \"local\"\n"
-        //  Line 2: "  source(\"helpers.R\")\n"
-        //  Line 3: "  foo\n"
-        //  Line 4: "}\n"
-        let script_source =
-            "f <- function() {\n  foo <- \"local\"\n  source(\"helpers.R\")\n  foo\n}\n";
+        //  Line 0: "helper <- 'local'\n"
+        //  Line 1: "source(\"helpers.R\")\n"
+        //  Line 2: "helper\n"
+        let script_source = "helper <- 'local'\nsource(\"helpers.R\")\nhelper\n";
         let script_doc = Document::new(script_source, None);
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
         let mut state = WorldState::default();
         state
             .documents
             .insert(script_uri.clone(), script_doc.clone());
 
-        // `foo` on line 3 resolves to the local definition on line 1
-        let params = make_params(script_uri.clone(), 3, 2);
+        // `helper` on line 2 should resolve to helpers.R (source() shadows local)
+        let params = make_params(script_uri, 2, 0);
         assert_matches!(
             goto_definition(&script_doc, params, &state).unwrap(),
             Some(GotoDefinitionResponse::Link(ref links)) => {
-                assert_eq!(links[0].target_uri, script_uri);
+                assert_eq!(links[0].target_uri, helpers_uri);
                 assert_eq!(
                     links[0].target_range,
                     lsp_types::Range {
-                        start: lsp_types::Position::new(1, 2),
-                        end: lsp_types::Position::new(1, 5),
+                        start: lsp_types::Position::new(0, 0),
+                        end: lsp_types::Position::new(0, 6),
                     }
                 );
             }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -1030,4 +1030,33 @@ mod tests {
         let outer_chain = file_scope.at(&index, outer_offset);
         assert!(!has_dplyr(&outer_chain));
     }
+
+    #[test]
+    fn test_script_source_later_shadows_earlier() {
+        // When two sourced files define the same name, the later
+        // source() call shadows the earlier one.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("a.R"), "foo <- 1\n").unwrap();
+        std::fs::write(dir.path().join("b.R"), "foo <- 2\n").unwrap();
+
+        let script_doc = Document::new("source(\"a.R\")\nsource(\"b.R\")\nfoo\n", None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        let b_uri = lsp_types::Url::from_file_path(dir.path().join("b.R")).unwrap();
+
+        // `foo` (line 2) should resolve to b.R (later source shadows earlier)
+        let params = make_params(script_uri, 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, b_uri);
+            }
+        );
+    }
 }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -1040,8 +1040,8 @@ mod tests {
 
         let (index, file_scope) = state.file_analysis(&script_uri, &script_doc);
 
-        let has_dplyr = |layers: &[oak_index::external::ScopeLayer]| -> bool {
-            layers.iter().any(|l| matches!(l, oak_index::external::ScopeLayer::PackageExports(pkg) if pkg == "dplyr"))
+        let has_dplyr = |layers: &[oak_index::scope_layer::ScopeLayer]| -> bool {
+            layers.iter().any(|l| matches!(l, oak_index::scope_layer::ScopeLayer::PackageExports(pkg) if pkg == "dplyr"))
         };
 
         // Before f (offset 0, on "mutate"): dplyr is NOT visible because the

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -793,11 +793,8 @@ mod tests {
 
     #[test]
     fn test_script_source_in_function_scoping() {
-        // source() inside a function body: definitions are visible inside
-        // the function and its nested scopes, but NOT outside.
-        // This is independent of `local = TRUE/FALSE`. Even if sourced in the
-        // global environment, only code following the `source()` call in the
-        // current scope can assume these symbols are in scope.
+        // `source(local = FALSE)` inside a function scopes directives to the
+        // function scope, so definitions are NOT visible at file scope.
         let dir = tempfile::tempdir().unwrap();
 
         std::fs::write(dir.path().join("helpers.R"), "helper <- function() 1\n").unwrap();
@@ -838,7 +835,7 @@ mod tests {
             }
         );
 
-        // `helper` on line 5 (outside f) — should NOT resolve
+        // `helper` on line 5 (outside f) — NOT visible
         let params = make_params(script_uri, 5, 0);
         let result = goto_definition(&script_doc, params, &state).unwrap();
         assert_eq!(result, None);
@@ -984,14 +981,8 @@ mod tests {
 
     #[test]
     fn test_script_source_in_function_packages_scoped() {
-        // source() inside a function where the sourced file calls library(dplyr).
-        // The dplyr Attach directive should be scoped to the function: visible
-        // inside f (and nested scopes) but NOT at file scope.
-        //
-        // We verify by checking the scope chain at two offsets. Package symbols
-        // produce no NavigationTarget, so goto_definition can't distinguish
-        // "resolved to package" from "unresolved". The scope chain check is
-        // more direct.
+        // `source(local = FALSE)` inside a function scopes package directives
+        // to the function scope, so they are NOT visible at file scope.
         let dir = tempfile::tempdir().unwrap();
 
         std::fs::write(
@@ -1000,12 +991,14 @@ mod tests {
         )
         .unwrap();
 
-        //  "f <- function() {\n"              offset 0
-        //  "  source(\"helpers.R\")\n"         offset 18
-        //  "  mutate\n"                        offset 39
-        //  "}\n"                               offset 48
-        //  "mutate\n"                          offset 50
-        let script_source = "f <- function() {\n  source(\"helpers.R\")\n  mutate\n}\nmutate\n";
+        //  "mutate\n"                          offset 0
+        //  "f <- function() {\n"              offset 7
+        //  "  source(\"helpers.R\")\n"         offset 25
+        //  "  mutate\n"                        offset 46
+        //  "}\n"                               offset 55
+        //  "mutate\n"                          offset 57
+        let script_source =
+            "mutate\nf <- function() {\n  source(\"helpers.R\")\n  mutate\n}\nmutate\n";
         let script_doc = Document::new(script_source, None);
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
@@ -1020,13 +1013,19 @@ mod tests {
             layers.iter().any(|l| matches!(l, oak_index::external::ScopeLayer::PackageExports(pkg) if pkg == "dplyr"))
         };
 
-        // Inside f (offset 41, on "mutate"): dplyr should be in the scope chain
-        let inner_offset = biome_rowan::TextSize::from(41);
+        // Before f (offset 0, on "mutate"): dplyr is NOT visible because the
+        // directive's offset is the `source()` call site inside f.
+        let before_offset = biome_rowan::TextSize::from(0);
+        let before_chain = file_scope.at(&index, before_offset);
+        assert!(!has_dplyr(&before_chain));
+
+        // Inside f (offset 48, on "mutate"): dplyr should be in the scope chain
+        let inner_offset = biome_rowan::TextSize::from(48);
         let inner_chain = file_scope.at(&index, inner_offset);
         assert!(has_dplyr(&inner_chain));
 
-        // Outside f (offset 50, on "mutate"): dplyr should NOT be in the scope chain
-        let outer_offset = biome_rowan::TextSize::from(50);
+        // After f (offset 57, on "mutate"): dplyr is NOT visible
+        let outer_offset = biome_rowan::TextSize::from(57);
         let outer_chain = file_scope.at(&index, outer_offset);
         assert!(!has_dplyr(&outer_chain));
     }
@@ -1056,6 +1055,116 @@ mod tests {
             goto_definition(&script_doc, params, &state).unwrap(),
             Some(GotoDefinitionResponse::Link(ref links)) => {
                 assert_eq!(links[0].target_uri, b_uri);
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_local_true_in_function_scoping() {
+        // `source(local = TRUE)` injects definitions into the function
+        // scope, so `helper` is visible inside f but not outside.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "helper <- function() 1\n").unwrap();
+
+        let script_source =
+            "f <- function() {\n  source(\"helpers.R\", local = TRUE)\n  helper\n}\nhelper\n";
+        let script_doc = Document::new(script_source, None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
+
+        // `helper` on line 2 (inside f, after source(local = TRUE)) — resolves
+        let params = make_params(script_uri.clone(), 2, 2);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+            }
+        );
+
+        // `helper` on line 4 (outside f) — does NOT resolve
+        let params = make_params(script_uri, 4, 0);
+        let result = goto_definition(&script_doc, params, &state).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_script_source_local_true_shadows_local_def() {
+        // `source(local = TRUE)` injects into the use-def map and
+        // shadows a prior local binding.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "foo <- function() 1\n").unwrap();
+
+        //  Line 0: "f <- function() {\n"
+        //  Line 1: "  foo <- \"local\"\n"
+        //  Line 2: "  source(\"helpers.R\", local = TRUE)\n"
+        //  Line 3: "  foo\n"
+        //  Line 4: "}\n"
+        let script_source =
+            "f <- function() {\n  foo <- \"local\"\n  source(\"helpers.R\", local = TRUE)\n  foo\n}\n";
+        let script_doc = Document::new(script_source, None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
+
+        // `foo` on line 3 resolves to helpers.R (sourced def shadows local)
+        let params = make_params(script_uri, 3, 2);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_local_false_does_not_shadow_local_def() {
+        // `source()` (default `local = FALSE`) in a function scope does
+        // not shadow a prior local binding.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "foo <- function() 1\n").unwrap();
+
+        //  Line 0: "f <- function() {\n"
+        //  Line 1: "  foo <- \"local\"\n"
+        //  Line 2: "  source(\"helpers.R\")\n"
+        //  Line 3: "  foo\n"
+        //  Line 4: "}\n"
+        let script_source =
+            "f <- function() {\n  foo <- \"local\"\n  source(\"helpers.R\")\n  foo\n}\n";
+        let script_doc = Document::new(script_source, None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        // `foo` on line 3 resolves to the local definition on line 1
+        let params = make_params(script_uri.clone(), 3, 2);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, script_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(1, 2),
+                        end: lsp_types::Position::new(1, 5),
+                    }
+                );
             }
         );
     }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -24,16 +24,9 @@ pub(crate) fn goto_definition(
         document.position_encoding,
     )?;
 
-    let index = document.semantic_index();
+    let (index, scope) = state.file_analysis(&uri, document);
     let root = document.syntax()?;
-    let targets = oak_ide::goto_definition(
-        offset,
-        &uri,
-        &root,
-        &index,
-        &state.external_scope(&uri),
-        &state.library,
-    );
+    let targets = oak_ide::goto_definition(offset, &uri, &root, &index, &scope, &state.library);
 
     if targets.is_empty() {
         return Ok(None);
@@ -794,6 +787,197 @@ mod tests {
             goto_definition(&script_doc, params, &state).unwrap(),
             Some(GotoDefinitionResponse::Link(ref links)) => {
                 assert_eq!(links[0].target_uri, b_uri);
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_in_function_scoping() {
+        // source() inside a function body: definitions are visible inside
+        // the function and its nested scopes, but NOT outside.
+        // This is independent of `local = TRUE/FALSE`. Even if sourced in the
+        // global environment, only code following the `source()` call in the
+        // current scope can assume these symbols are in scope.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "helper <- function() 1\n").unwrap();
+
+        //  Line 0: "f <- function() {\n"
+        //  Line 1: "  source(\"helpers.R\")\n"
+        //  Line 2: "  helper\n"               <- inside f, after source()
+        //  Line 3: "  function() helper\n"    <- nested scope inside f
+        //  Line 4: "}\n"
+        //  Line 5: "helper\n"                 <- outside f
+        let script_source =
+            "f <- function() {\n  source(\"helpers.R\")\n  helper\n  function() helper\n}\nhelper\n";
+        let script_doc = Document::new(script_source, None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
+
+        // `helper` on line 2 (inside f, after source()) — should resolve
+        let params = make_params(script_uri.clone(), 2, 2);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+            }
+        );
+
+        // `helper` on line 3 (nested function inside f) — should resolve
+        let params = make_params(script_uri.clone(), 3, 14);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+            }
+        );
+
+        // `helper` on line 5 (outside f) — should NOT resolve
+        let params = make_params(script_uri, 5, 0);
+        let result = goto_definition(&script_doc, params, &state).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_script_source_does_not_shadow_local_def() {
+        // A local definition should take precedence over a sourced one.
+        // `source()` at file scope defines `foo`, but a subsequent local
+        // `foo <- "local"` should shadow it.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "foo <- function() 1\n").unwrap();
+
+        //  Line 0: "source(\"helpers.R\")\n"
+        //  Line 1: "foo <- \"local\"\n"
+        //  Line 2: "foo\n"
+        let script_source = "source(\"helpers.R\")\nfoo <- \"local\"\nfoo\n";
+        let script_doc = Document::new(script_source, None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        // `foo` on line 2 should resolve to the LOCAL definition on line 1,
+        // not to the sourced one from helpers.R.
+        let params = make_params(script_uri.clone(), 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, script_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(1, 0),
+                        end: lsp_types::Position::new(1, 3),
+                    }
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_diamond_dependency() {
+        // Diamond: a.R and b.R both source helpers.R.
+        // script.R sources both a.R and b.R.
+        // `helper` (from helpers.R) should be visible — the grey-set
+        // cycle detection must not prevent re-resolving a shared dependency.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "helper <- function() 1\n").unwrap();
+        std::fs::write(
+            dir.path().join("a.R"),
+            "source(\"helpers.R\")\nfrom_a <- 1\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("b.R"),
+            "source(\"helpers.R\")\nfrom_b <- 2\n",
+        )
+        .unwrap();
+
+        let script_doc = Document::new(
+            "source(\"a.R\")\nsource(\"b.R\")\nhelper\nfrom_a\nfrom_b\n",
+            None,
+        );
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
+        let a_uri = lsp_types::Url::from_file_path(dir.path().join("a.R")).unwrap();
+        let b_uri = lsp_types::Url::from_file_path(dir.path().join("b.R")).unwrap();
+
+        // `helper` (line 2) — from helpers.R, reachable through both a.R and b.R
+        let params = make_params(script_uri.clone(), 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+            }
+        );
+
+        // `from_a` (line 3) — from a.R
+        let params = make_params(script_uri.clone(), 3, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, a_uri);
+            }
+        );
+
+        // `from_b` (line 4) — from b.R
+        let params = make_params(script_uri, 4, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, b_uri);
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_self_reference() {
+        // script.R sources itself. The grey-set pre-seeds the current file
+        // so the self-reference is a no-op and doesn't create duplicate
+        // definitions.
+        let dir = tempfile::tempdir().unwrap();
+
+        let script_path = dir.path().join("script.R");
+        std::fs::write(&script_path, "source(\"script.R\")\nmy_var <- 1\nmy_var\n").unwrap();
+        let script_uri = lsp_types::Url::from_file_path(&script_path).unwrap();
+
+        let script_doc = Document::new("source(\"script.R\")\nmy_var <- 1\nmy_var\n", None);
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        // `my_var` (line 2) should resolve to its own definition on line 1,
+        // not to a Sourced duplicate.
+        let params = make_params(script_uri.clone(), 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, script_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(1, 0),
+                        end: lsp_types::Position::new(1, 6),
+                    }
+                );
             }
         );
     }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -548,6 +548,37 @@ mod tests {
     // --- source() directive in scripts ---
 
     #[test]
+    fn test_script_source_resolves_from_workspace_root() {
+        // source() paths are resolved relative to the workspace root,
+        // not the sourcing file's directory. Here script.R is in a
+        // subdirectory but sources "helpers.R" which lives at the root.
+        let dir = tempfile::tempdir().unwrap();
+        let subdir = dir.path().join("subdir");
+        std::fs::create_dir(&subdir).unwrap();
+
+        std::fs::write(dir.path().join("helpers.R"), "helper <- function() 1\n").unwrap();
+
+        let script_doc = Document::new("source(\"helpers.R\")\nhelper\n", None);
+        let script_uri = lsp_types::Url::from_file_path(subdir.join("script.R")).unwrap();
+
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+        state.workspace.folders = vec![lsp_types::Url::from_directory_path(dir.path()).unwrap()];
+
+        let params = make_params(script_uri, 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+            }
+        );
+    }
+
+    #[test]
     fn test_script_source_directive_resolves() {
         // script.R has `source("helpers.R")` then uses `helper`.
         // WorldState::file_analysis() should resolve the source() directive

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -704,4 +704,97 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_script_source_transitive() {
+        // script.R sources a.R, a.R sources b.R.
+        // script.R should see b.R's exports transitively.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(
+            dir.path().join("b.R"),
+            "library(dplyr)\nfrom_b <- function() 1\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("a.R"),
+            "source(\"b.R\")\nfrom_a <- function() 2\n",
+        )
+        .unwrap();
+
+        let script_doc = Document::new("source(\"a.R\")\nfrom_a\nfrom_b\nmutate\n", None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let Some(library) = r_library() else {
+            eprintln!("skipping: R not found");
+            return;
+        };
+
+        let mut state = make_state(&script_uri, &script_doc);
+        state.library = library;
+
+        // `from_a` (line 1) — defined in a.R
+        let a_uri = lsp_types::Url::from_file_path(dir.path().join("a.R")).unwrap();
+        let params = make_params(script_uri.clone(), 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, a_uri);
+            }
+        );
+
+        // `from_b` (line 2) — defined in b.R, reachable transitively
+        let b_uri = lsp_types::Url::from_file_path(dir.path().join("b.R")).unwrap();
+        let params = make_params(script_uri.clone(), 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, b_uri);
+            }
+        );
+
+        // `mutate` (line 3) — from dplyr, attached by b.R's library() call.
+        // Package symbol, no NavigationTarget.
+        let params = make_params(script_uri, 3, 0);
+        let result = goto_definition(&script_doc, params, &state).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_script_source_cycle_does_not_hang() {
+        // a.R sources b.R, b.R sources a.R. Should not recurse infinitely.
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("a.R"), "source(\"b.R\")\nfrom_a <- 1\n").unwrap();
+        std::fs::write(dir.path().join("b.R"), "source(\"a.R\")\nfrom_b <- 2\n").unwrap();
+
+        let script_doc = Document::new("source(\"a.R\")\nfrom_a\nfrom_b\n", None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        // Should resolve without hanging. Both symbols are reachable
+        // because a.R is visited first (gets its exports + b.R's exports),
+        // and b.R's attempt to re-source a.R is a no-op due to cycle detection.
+        let a_uri = lsp_types::Url::from_file_path(dir.path().join("a.R")).unwrap();
+        let params = make_params(script_uri.clone(), 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, a_uri);
+            }
+        );
+
+        let b_uri = lsp_types::Url::from_file_path(dir.path().join("b.R")).unwrap();
+        let params = make_params(script_uri, 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, b_uri);
+            }
+        );
+    }
 }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -1199,4 +1199,43 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_script_source_last_def_wins_in_target() {
+        // If the sourced file defines the same name twice, the LAST
+        // definition is the one that goto-definition navigates to.
+        let dir = tempfile::tempdir().unwrap();
+
+        // helpers.R defines `fn` twice — second def is at line 1
+        std::fs::write(
+            dir.path().join("helpers.R"),
+            "fn <- function() 'first'\nfn <- function() 'second'\n",
+        )
+        .unwrap();
+
+        let script_doc = Document::new("source(\"helpers.R\")\nfn\n", None);
+        let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
+        let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        // `fn` on line 1 should resolve to the SECOND def in helpers.R (line 1)
+        let params = make_params(script_uri, 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(1, 0),
+                        end: lsp_types::Position::new(1, 2),
+                    }
+                );
+            }
+        );
+    }
 }

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -551,4 +551,157 @@ mod tests {
         let result = goto_definition(&doc, params, &state).unwrap();
         assert_eq!(result, None);
     }
+
+    // --- source() directive in scripts ---
+
+    #[test]
+    fn test_script_source_directive_resolves() {
+        // script.R has `source("helpers.R")` then uses `helper`.
+        // WorldState::file_scope() should resolve the source() directive
+        // and make helpers.R's exports visible via the search path.
+        let script_dir = std::env::temp_dir().join("test_script_source");
+
+        let helpers_doc = Document::new("helper <- function() 1\n", None);
+        let helpers_uri = lsp_types::Url::from_file_path(script_dir.join("helpers.R")).unwrap();
+
+        let script_doc = Document::new("source(\"helpers.R\")\nhelper\n", None);
+        let script_uri = lsp_types::Url::from_file_path(script_dir.join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state.documents.insert(helpers_uri.clone(), helpers_doc);
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+
+        // Cursor on `helper` (line 1, col 0)
+        let params = make_params(script_uri, 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(0, 0),
+                        end: lsp_types::Position::new(0, 6),
+                    }
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_directive_resolves_nested_library() {
+        // helpers.R has `library(dplyr)` and defines `helper`.
+        // script.R sources helpers.R then uses `mutate` (from dplyr).
+        // The nested library() directive should be visible through
+        // the source() resolution.
+        let Some(library) = r_library() else {
+            eprintln!("skipping: R not found");
+            return;
+        };
+
+        let script_dir = std::env::temp_dir().join("test_script_source_nested");
+
+        let helpers_doc = Document::new("library(dplyr)\nhelper <- function() 1\n", None);
+        let helpers_uri = lsp_types::Url::from_file_path(script_dir.join("helpers.R")).unwrap();
+
+        let script_doc = Document::new("source(\"helpers.R\")\nmutate\nhelper\n", None);
+        let script_uri = lsp_types::Url::from_file_path(script_dir.join("script.R")).unwrap();
+
+        let mut state = make_state(&script_uri, &script_doc);
+        state.library = library;
+        state.documents.insert(helpers_uri.clone(), helpers_doc);
+
+        // `mutate` (line 1) resolves via dplyr, attached by helpers.R's library() call.
+        // Package symbol, no NavigationTarget.
+        let params = make_params(script_uri.clone(), 1, 0);
+        let result = goto_definition(&script_doc, params, &state).unwrap();
+        assert_eq!(result, None);
+
+        // `helper` (line 2) resolves to helpers.R's definition
+        let params = make_params(script_uri, 2, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(1, 0),
+                        end: lsp_types::Position::new(1, 6),
+                    }
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_source_resolves_from_disk() {
+        // helpers.R exists on disk but is NOT in state.documents.
+        // script.R sources it. The resolver should read from disk.
+        let script_dir = tempfile::tempdir().unwrap();
+
+        let helpers_path = script_dir.path().join("helpers.R");
+        std::fs::write(&helpers_path, "helper <- function() 1\n").unwrap();
+        let helpers_uri = lsp_types::Url::from_file_path(&helpers_path).unwrap();
+
+        let script_doc = Document::new("source(\"helpers.R\")\nhelper\n", None);
+        let script_uri =
+            lsp_types::Url::from_file_path(script_dir.path().join("script.R")).unwrap();
+
+        let mut state = WorldState::default();
+        state
+            .documents
+            .insert(script_uri.clone(), script_doc.clone());
+        // helpers.R is intentionally NOT inserted into state.documents
+
+        let params = make_params(script_uri, 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(links[0].target_uri, helpers_uri);
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(0, 0),
+                        end: lsp_types::Position::new(0, 6),
+                    }
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_script_file_scope_from_disk() {
+        // The script itself is on disk, not in state.documents.
+        // file_scope should still read it and resolve its directives.
+        let script_dir = tempfile::tempdir().unwrap();
+
+        let helpers_path = script_dir.path().join("helpers.R");
+        std::fs::write(&helpers_path, "helper <- function() 1\n").unwrap();
+
+        let script_path = script_dir.path().join("script.R");
+        std::fs::write(&script_path, "source(\"helpers.R\")\nhelper\n").unwrap();
+        let script_uri = lsp_types::Url::from_file_path(&script_path).unwrap();
+
+        let script_doc = Document::new("source(\"helpers.R\")\nhelper\n", None);
+
+        // Neither file is in state.documents
+        let state = WorldState::default();
+
+        let params = make_params(script_uri, 1, 0);
+        assert_matches!(
+            goto_definition(&script_doc, params, &state).unwrap(),
+            Some(GotoDefinitionResponse::Link(ref links)) => {
+                assert_eq!(
+                    links[0].target_range,
+                    lsp_types::Range {
+                        start: lsp_types::Position::new(0, 0),
+                        end: lsp_types::Position::new(0, 6),
+                    }
+                );
+            }
+        );
+    }
 }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
@@ -107,13 +108,14 @@ impl WorldState {
     ///
     /// TODO: Replace with a proper VFS so non-opened workspace documents
     /// are cached rather than re-read on every query.
-    fn workspace_document(&self, uri: &Url) -> Option<Document> {
+    fn workspace_document(&self, uri: &Url) -> Option<Cow<'_, Document>> {
         if let Some(doc) = self.documents.get(uri) {
-            return Some(doc.clone());
+            return Some(Cow::Borrowed(doc));
         }
+
         let path = uri.to_file_path().log_err()?;
         let contents = std::fs::read_to_string(&path).log_err()?;
-        Some(Document::new(&contents, None))
+        Some(Cow::Owned(Document::new(&contents, None)))
     }
 
     /// Create the semantic index and scope chain for a particular file.
@@ -251,7 +253,10 @@ impl WorldState {
             return None;
         }
 
-        let sourced_doc = self.workspace_document(&url)?;
+        let Some(sourced_doc) = self.workspace_document(&url) else {
+            stack.remove(&url);
+            return None;
+        };
 
         // Build the sourced file's index with a nested resolver so that
         // transitive `source()` calls are also resolved. The base

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -366,7 +366,7 @@ mod tests {
         let after = scope.at(&index, TextSize::from(code.rfind("inform").unwrap() as u32));
         assert!(has_package(&after, "rlang"));
 
-        assert!(has_package(scope.lazy(), "rlang"));
+        assert!(has_package(&scope.lazy(), "rlang"));
     }
 
     #[test]
@@ -394,6 +394,6 @@ mod tests {
 
         let (_index, scope) = state.file_analysis(&uri, &doc);
         let layers = scope.lazy();
-        assert_not!(has_package(layers, "rlang"));
+        assert_not!(has_package(&layers, "rlang"));
     }
 }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -297,8 +297,8 @@ impl WorldState {
 
         let names: Vec<String> = index
             .file_exports()
-            .into_iter()
-            .map(|(name, _range)| name.to_string())
+            .keys()
+            .map(|name| name.to_string())
             .collect();
 
         let packages: Vec<String> = index

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::anyhow;
+use biome_rowan::TextRange;
 use oak_core::file::list_r_files;
 use oak_ide::ExternalScope;
 use oak_index::library::Library;
@@ -187,9 +188,9 @@ impl WorldState {
     /// Build the semantic index and scope for a script file (not inside a
     /// package).
     ///
-    /// The index is built with a resolver callback so that `source()`
-    /// definitions are injected into the use-def map. `library()`
-    /// directives are extracted into the external scope chain.
+    /// The index is built with a source resolver so that `source()`
+    /// directives carry the sourced file's exports. `library()` and
+    /// `source()` directives are extracted into the external scope chain.
     fn script_file_analysis(&self, file: &Url, doc: &Document) -> (SemanticIndex, ExternalScope) {
         let file_path = file.to_file_path().ok();
         let file_dir = file_path.and_then(|p| p.parent().map(|d| d.to_path_buf()));
@@ -244,19 +245,28 @@ impl WorldState {
             self.resolve_source(dir, nested_path, stack)
         });
 
-        let definitions = index
+        let mut definitions: Vec<(String, Url, TextRange)> = index
             .file_all_definitions(&url)
             .into_iter()
             .map(|(name, file, range)| (name.to_string(), file, range))
             .collect();
 
-        let packages = index
-            .file_directives()
-            .iter()
-            .map(|d| match d.kind() {
-                oak_index::semantic_index::DirectiveKind::Attach(pkg) => pkg.clone(),
-            })
-            .collect();
+        let mut packages = Vec::new();
+        for d in index.file_directives() {
+            match d.kind() {
+                oak_index::semantic_index::DirectiveKind::Attach(pkg) => {
+                    packages.push(pkg.clone());
+                },
+                oak_index::semantic_index::DirectiveKind::Source {
+                    file: source_file,
+                    exports,
+                } => {
+                    for (name, range) in exports {
+                        definitions.push((name.clone(), source_file.clone(), *range));
+                    }
+                },
+            }
+        }
 
         stack.remove(&url);
 

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -201,14 +201,26 @@ impl WorldState {
     }
 
     fn script_file_analysis(&self, file: &Url, doc: &Document) -> (SemanticIndex, ExternalScope) {
-        let file_path = file.to_file_path().ok();
-        let file_dir = file_path.and_then(|p| p.parent().map(|d| d.to_path_buf()));
+        // Resolve `source()` paths relative to the workspace root,
+        // matching RStudio's behaviour of setting the working directory
+        // to the project root. Fall back to the file's own directory
+        // when no workspace folder is open.
+        let file_dir = file
+            .to_file_path()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
+        let source_root = self
+            .workspace
+            .folders
+            .first()
+            .and_then(|url| url.to_file_path().ok())
+            .or(file_dir);
 
         let mut stack = HashSet::new();
         stack.insert(file.clone());
 
         let index = semantic_index_with_source_resolver(&doc.parse.tree(), |path| {
-            let dir = file_dir.as_ref()?;
+            let dir = source_root.as_ref()?;
             self.resolve_source(dir, path, &mut stack)
         });
 
@@ -240,13 +252,12 @@ impl WorldState {
         }
 
         let sourced_doc = self.workspace_document(&url)?;
-        let source_dir = resolved.parent().map(PathBuf::from);
 
         // Build the sourced file's index with a nested resolver so that
-        // transitive `source()` calls are also resolved.
+        // transitive `source()` calls are also resolved. The base
+        // directory stays the same (workspace root) throughout the chain.
         let index = semantic_index_with_source_resolver(&sourced_doc.parse.tree(), |nested_path| {
-            let dir = source_dir.as_ref()?;
-            self.resolve_source(dir, nested_path, stack)
+            self.resolve_source(base_dir, nested_path, stack)
         });
 
         let mut definitions: Vec<(String, Url, TextRange)> = index

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -105,17 +105,26 @@ impl WorldState {
     /// Create the semantic index and scope chain for a particular file.
     ///
     /// For scripts, the index is built with a source resolver so that
-    /// `source()` definitions are injected into the use-def map.
-    /// For packages, the index is the plain per-file index.
+    /// `source()` directives carry the sourced file's exports.
+    /// For packages, cross-file visibility comes from NAMESPACE imports and
+    /// collation ordering.
     pub(crate) fn file_analysis(
         &self,
         file: &Url,
         doc: &Document,
     ) -> (SemanticIndex, ExternalScope) {
-        let Some(SourceRoot::Package(ref pkg)) = self.root else {
-            return self.script_file_analysis(file, doc);
-        };
+        match self.root {
+            Some(SourceRoot::Package(ref pkg)) => self.package_file_analysis(file, doc, pkg),
+            _ => self.script_file_analysis(file, doc),
+        }
+    }
 
+    fn package_file_analysis(
+        &self,
+        file: &Url,
+        doc: &Document,
+        pkg: &oak_index::package::Package,
+    ) -> (SemanticIndex, ExternalScope) {
         let root_layers = package_root_layers(pkg.namespace());
 
         // FIXME: This only works for source packages. If we do #1168, then the
@@ -185,18 +194,13 @@ impl WorldState {
         )
     }
 
-    /// Build the semantic index and scope for a script file (not inside a
-    /// package).
-    ///
-    /// The index is built with a source resolver so that `source()`
-    /// directives carry the sourced file's exports. `library()` and
-    /// `source()` directives are extracted into the external scope chain.
     fn script_file_analysis(&self, file: &Url, doc: &Document) -> (SemanticIndex, ExternalScope) {
         let file_path = file.to_file_path().ok();
         let file_dir = file_path.and_then(|p| p.parent().map(|d| d.to_path_buf()));
 
         let mut stack = HashSet::new();
         stack.insert(file.clone());
+
         let index = semantic_index_with_source_resolver(&doc.parse.tree(), |path| {
             let dir = file_dir.as_ref()?;
             self.resolve_source(dir, path, &mut stack)

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -260,28 +260,17 @@ impl WorldState {
             self.resolve_source(base_dir, nested_path, stack)
         });
 
-        let mut definitions: Vec<(String, Url, TextRange)> = index
-            .file_all_definitions(&url)
+        let definitions: Vec<(String, Url, TextRange)> = index
+            .file_source_exports(&url)
             .into_iter()
             .map(|(name, file, range)| (name.to_string(), file, range))
             .collect();
 
-        let mut packages = Vec::new();
-        for d in index.file_directives() {
-            match d.kind() {
-                oak_index::semantic_index::DirectiveKind::Attach(pkg) => {
-                    packages.push(pkg.clone());
-                },
-                oak_index::semantic_index::DirectiveKind::Source {
-                    file: source_file,
-                    exports,
-                } => {
-                    for (name, range) in exports {
-                        definitions.push((name.clone(), source_file.clone(), *range));
-                    }
-                },
-            }
-        }
+        let packages: Vec<String> = index
+            .file_attached_packages()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
 
         stack.remove(&url);
 

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::anyhow;
-use biome_rowan::TextRange;
 use oak_core::file::list_r_files;
 use oak_ide::ExternalScope;
 use oak_index::library::Library;
@@ -16,6 +15,7 @@ use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::SourceResolution;
+use oak_index::FileDefinition;
 use stdext::result::ResultExt;
 use url::Url;
 
@@ -265,10 +265,14 @@ impl WorldState {
             self.resolve_source(base_dir, nested_path, stack)
         });
 
-        let definitions: Vec<(String, Url, TextRange)> = index
+        let definitions: Vec<FileDefinition> = index
             .file_source_exports(&url)
             .into_iter()
-            .map(|(name, file, range)| (name.to_string(), file, range))
+            .map(|(name, file, range)| FileDefinition {
+                name: name.to_string(),
+                file,
+                range,
+            })
             .collect();
 
         let packages: Vec<String> = index

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -9,9 +9,9 @@ use oak_core::file::list_r_files;
 use oak_db::Db;
 use oak_ide::ExternalScope;
 use oak_index::library::Library;
+use oak_index::scope_layer::default_search_path;
 use oak_index::scope_layer::file_layers;
 use oak_index::scope_layer::package_root_layers;
-use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::SourceResolution;
@@ -314,27 +314,6 @@ impl WorldState {
             packages,
         })
     }
-}
-
-/// The default R search path for scripts: the default packages that R
-/// attaches on startup, in search order (last attached = searched first).
-fn default_search_path() -> Vec<ScopeLayer> {
-    // R's default packages, in reverse attachment order (most recently
-    // attached first). These are always on the search path unless
-    // overridden by `R_DEFAULT_PACKAGES`.
-    let default_packages = [
-        "utils",
-        "stats",
-        "datasets",
-        "methods",
-        "grDevices",
-        "graphics",
-        "base",
-    ];
-    default_packages
-        .into_iter()
-        .map(|pkg| ScopeLayer::PackageExports(pkg.to_string()))
-        .collect()
 }
 
 pub(crate) fn with_document<T, F>(

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -9,7 +9,6 @@ use oak_core::file::list_r_files;
 use oak_db::Db;
 use oak_ide::ExternalScope;
 use oak_index::library::Library;
-use oak_index::scope_layer::directive_layers;
 use oak_index::scope_layer::file_layers;
 use oak_index::scope_layer::package_root_layers;
 use oak_index::scope_layer::ScopeLayer;
@@ -255,7 +254,7 @@ impl WorldState {
             self.resolve_source(dir, path, &mut stack)
         });
 
-        let directives = directive_layers(index.file_directives());
+        let directives = index.file_directives().to_vec();
         (
             index,
             ExternalScope::search_path(directives, default_search_path()),

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -102,6 +102,20 @@ impl WorldState {
         }
     }
 
+    /// Look up a document by URL: returns an open document if available,
+    /// otherwise reads from disk.
+    ///
+    /// TODO: Replace with a proper VFS so non-opened workspace documents
+    /// are cached rather than re-read on every query.
+    fn workspace_document(&self, uri: &Url) -> Option<Document> {
+        if let Some(doc) = self.documents.get(uri) {
+            return Some(doc.clone());
+        }
+        let path = uri.to_file_path().log_err()?;
+        let contents = std::fs::read_to_string(&path).log_err()?;
+        Some(Document::new(&contents, None))
+    }
+
     /// Create the semantic index and scope chain for a particular file.
     ///
     /// For scripts, the index is built with a source resolver so that
@@ -166,16 +180,8 @@ impl WorldState {
             let Some(uri) = Url::from_file_path(path).log_err() else {
                 continue;
             };
-
-            // Use the open document if available, otherwise read from disk.
-            // TODO: Store non-opened workspace documents in VFS.
-            let doc = if let Some(open) = self.documents.get(&uri) {
-                open
-            } else {
-                let Some(contents) = std::fs::read_to_string(path).log_err() else {
-                    continue;
-                };
-                &Document::new(&contents, None)
+            let Some(doc) = self.workspace_document(&uri) else {
+                continue;
             };
 
             let layers = file_layers(uri, &doc.semantic_index());
@@ -233,13 +239,7 @@ impl WorldState {
             return None;
         }
 
-        let sourced_doc = if let Some(open) = self.documents.get(&url) {
-            open
-        } else {
-            let contents = std::fs::read_to_string(&resolved).log_err()?;
-            &Document::new(&contents, None)
-        };
-
+        let sourced_doc = self.workspace_document(&url)?;
         let source_dir = resolved.parent().map(PathBuf::from);
 
         // Build the sourced file's index with a nested resolver so that

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use anyhow::anyhow;
 use oak_core::file::list_r_files;
+use oak_db::Db;
 use oak_ide::ExternalScope;
 use oak_index::library::Library;
 use oak_index::scope_layer::directive_layers;
@@ -15,13 +16,33 @@ use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::SourceResolution;
-use oak_index::FileDefinition;
 use stdext::result::ResultExt;
 use url::Url;
 
 use crate::lsp::config::LspConfig;
 use crate::lsp::document::Document;
 use crate::lsp::inputs::source_root::SourceRoot;
+
+impl Db for WorldState {
+    fn semantic_index(&self, file: &Url) -> Option<SemanticIndex> {
+        let doc = self.workspace_document(file)?;
+        let source_root = self.source_root(file);
+
+        let mut stack = HashSet::new();
+        stack.insert(file.clone());
+
+        let index = semantic_index_with_source_resolver(&doc.parse.tree(), file, |path| {
+            let dir = source_root.as_ref()?;
+            self.resolve_source(dir, path, &mut stack)
+        });
+
+        Some(index)
+    }
+
+    fn library(&self) -> &Library {
+        &self.library
+    }
+}
 
 #[derive(Clone, Default, Debug)]
 /// The world state, i.e. all the inputs necessary for analysing or refactoring
@@ -106,9 +127,9 @@ impl WorldState {
     /// Look up a document by URL: returns an open document if available,
     /// otherwise reads from disk.
     ///
-    /// TODO: Replace with a proper VFS so non-opened workspace documents
+    /// TODO(salsa): Replace with a proper VFS so non-opened workspace documents
     /// are cached rather than re-read on every query.
-    fn workspace_document(&self, uri: &Url) -> Option<Cow<'_, Document>> {
+    pub(crate) fn workspace_document(&self, uri: &Url) -> Option<Cow<'_, Document>> {
         if let Some(doc) = self.documents.get(uri) {
             return Some(Cow::Borrowed(doc));
         }
@@ -116,6 +137,22 @@ impl WorldState {
         let path = uri.to_file_path().log_err()?;
         let contents = std::fs::read_to_string(&path).log_err()?;
         Some(Cow::Owned(Document::new(&contents, None)))
+    }
+
+    /// Resolve from the workspace root, falling back to the file's directory.
+    /// This matches RStudio behaviour. Potential improvements: support
+    /// `setwd()` calls and find the workspace containing the file if there are
+    /// multiple.
+    fn source_root(&self, file: &Url) -> Option<PathBuf> {
+        self.workspace
+            .folders
+            .first()
+            .and_then(|url| url.to_file_path().ok())
+            .or_else(|| {
+                file.to_file_path()
+                    .ok()
+                    .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            })
     }
 
     /// Create the semantic index and scope chain for a particular file.
@@ -135,6 +172,11 @@ impl WorldState {
         }
     }
 
+    // TODO(salsa): Align with the deferred-resolution model used for scripts. Package
+    // files should produce Import-kind forwarding definitions and resolve
+    // through `resolve_definition()`, rather than pre-resolving through the
+    // scope chain. This will happen naturally once Salsa provides cheap
+    // cross-file index access.
     fn package_file_analysis(
         &self,
         file: &Url,
@@ -163,7 +205,7 @@ impl WorldState {
             });
 
         let Some(file_path) = file.to_file_path().ok() else {
-            return (doc.semantic_index(), ExternalScope::default());
+            return (doc.semantic_index(file), ExternalScope::default());
         };
 
         // Iterate in reverse collation order so later files (which shadow
@@ -186,7 +228,7 @@ impl WorldState {
                 continue;
             };
 
-            let layers = file_layers(uri, &doc.semantic_index());
+            let layers = file_layers(uri.clone(), &doc.semantic_index(&uri));
             lazy.extend(layers.clone());
             if past_current {
                 top_level.extend(layers);
@@ -197,31 +239,18 @@ impl WorldState {
         lazy.extend(root_layers);
 
         (
-            doc.semantic_index(),
+            doc.semantic_index(file),
             ExternalScope::package(top_level, lazy),
         )
     }
 
     fn script_file_analysis(&self, file: &Url, doc: &Document) -> (SemanticIndex, ExternalScope) {
-        // Resolve `source()` paths relative to the workspace root,
-        // matching RStudio's behaviour of setting the working directory
-        // to the project root. Fall back to the file's own directory
-        // when no workspace folder is open.
-        let source_root = self
-            .workspace
-            .folders
-            .first()
-            .and_then(|url| url.to_file_path().ok())
-            .or_else(|| {
-                file.to_file_path()
-                    .ok()
-                    .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-            });
+        let source_root = self.source_root(file);
 
         let mut stack = HashSet::new();
         stack.insert(file.clone());
 
-        let index = semantic_index_with_source_resolver(&doc.parse.tree(), |path| {
+        let index = semantic_index_with_source_resolver(&doc.parse.tree(), file, |path| {
             let dir = source_root.as_ref()?;
             self.resolve_source(dir, path, &mut stack)
         });
@@ -234,7 +263,7 @@ impl WorldState {
     }
 
     /// Resolve a `source()` call into a [`SourceResolution`] containing the
-    /// sourced file's exported definitions and `library()` package attachments.
+    /// sourced file's exported names and `library()` package attachments.
     ///
     /// `stack` tracks files currently being resolved (grey set) to break
     /// cycles. A file is added when resolution starts and removed when it
@@ -261,18 +290,15 @@ impl WorldState {
         // Build the sourced file's index with a nested resolver so that
         // transitive `source()` calls are also resolved. The base
         // directory stays the same (workspace root) throughout the chain.
-        let index = semantic_index_with_source_resolver(&sourced_doc.parse.tree(), |nested_path| {
-            self.resolve_source(base_dir, nested_path, stack)
-        });
+        let index =
+            semantic_index_with_source_resolver(&sourced_doc.parse.tree(), &url, |nested_path| {
+                self.resolve_source(base_dir, nested_path, stack)
+            });
 
-        let definitions: Vec<FileDefinition> = index
-            .file_source_exports(&url)
+        let names: Vec<String> = index
+            .file_exports()
             .into_iter()
-            .map(|(name, file, range)| FileDefinition {
-                name: name.to_string(),
-                file,
-                range,
-            })
+            .map(|(name, _range)| name.to_string())
             .collect();
 
         let packages: Vec<String> = index
@@ -284,7 +310,8 @@ impl WorldState {
         stack.remove(&url);
 
         Some(SourceResolution {
-            definitions,
+            file: url,
+            names,
             packages,
         })
     }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -3,14 +3,13 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::anyhow;
-use biome_rowan::TextSize;
 use oak_core::file::list_r_files;
 use oak_ide::ExternalScope;
 use oak_index::library::Library;
+use oak_index::scope_layer::directive_layers;
 use oak_index::scope_layer::file_layers;
 use oak_index::scope_layer::package_root_layers;
 use oak_index::scope_layer::ScopeLayer;
-use oak_index::semantic_index::DirectiveKind;
 use stdext::result::ResultExt;
 use url::Url;
 
@@ -104,8 +103,7 @@ impl WorldState {
     /// collation order.
     pub(crate) fn external_scope(&self, file: &Url) -> ExternalScope {
         let Some(SourceRoot::Package(ref pkg)) = self.root else {
-            let directives = self.directive_layers(file);
-            return ExternalScope::search_path(directives, default_search_path());
+            return self.script_file_scope(file);
         };
 
         let root_layers = package_root_layers(pkg.namespace());
@@ -174,18 +172,69 @@ impl WorldState {
         ExternalScope::package(top_level, lazy)
     }
 
-    fn directive_layers(&self, file: &Url) -> Vec<(TextSize, ScopeLayer)> {
-        let Some(doc) = self.documents.get(file) else {
-            return Vec::new();
+    /// Build the scope for a script file (not inside a package).
+    ///
+    /// Resolves `library()` and `source()` directives from the file's own
+    /// content, then appends the default R search path.
+    fn script_file_scope(&self, file: &Url) -> ExternalScope {
+        let file_path = file.to_file_path().ok();
+
+        let doc = if let Some(open) = self.documents.get(file) {
+            open
+        } else if let Some(contents) = file_path
+            .as_ref()
+            .and_then(|p| std::fs::read_to_string(p).log_err())
+        {
+            &Document::new(&contents, None)
+        } else {
+            return ExternalScope::search_path(Vec::new(), default_search_path());
         };
+
         let index = doc.semantic_index();
-        index
-            .file_directives()
-            .iter()
-            .map(|d| match d.kind() {
-                DirectiveKind::Attach(pkg) => (d.offset(), ScopeLayer::PackageExports(pkg.clone())),
-            })
-            .collect()
+
+        let file_dir = file_path.and_then(|p| p.parent().map(|d| d.to_path_buf()));
+
+        let directives = directive_layers(index.file_directives(), |path| {
+            let dir = file_dir.as_ref()?;
+            self.resolve_source_layers(dir, path)
+        });
+
+        ExternalScope::search_path(directives, default_search_path())
+    }
+
+    /// Resolve a `source()` directive into the full set of layers the sourced
+    /// file contributes: its own exports, `PackageExports` from any
+    /// `library()` calls, and layers from nested `source()` calls.
+    fn resolve_source_layers(&self, base_dir: &Path, path: &str) -> Option<Vec<ScopeLayer>> {
+        let resolved = base_dir.join(path);
+        let url = Url::from_file_path(&resolved).log_err()?;
+
+        let sourced_doc = if let Some(open) = self.documents.get(&url) {
+            open
+        } else {
+            let contents = std::fs::read_to_string(&resolved).log_err()?;
+            &Document::new(&contents, None)
+        };
+
+        let index = sourced_doc.semantic_index();
+
+        let mut layers = Vec::new();
+
+        let exports = index
+            .file_exports()
+            .into_iter()
+            .map(|(name, range)| (name.to_string(), range))
+            .collect();
+        layers.push(ScopeLayer::FileExports { file: url, exports });
+
+        // Recurse into the sourced document in case it itself calls `source()`
+        let source_dir = resolved.parent()?;
+        let nested = directive_layers(index.file_directives(), |nested_path| {
+            self.resolve_source_layers(source_dir, nested_path)
+        });
+        layers.extend(nested.into_iter().map(|(_, l)| l));
+
+        Some(layers)
     }
 }
 

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -194,9 +195,10 @@ impl WorldState {
 
         let file_dir = file_path.and_then(|p| p.parent().map(|d| d.to_path_buf()));
 
+        let mut visited = HashSet::new();
         let directives = directive_layers(index.file_directives(), |path| {
             let dir = file_dir.as_ref()?;
-            self.resolve_source_layers(dir, path)
+            self.resolve_source_layers(dir, path, &mut visited)
         });
 
         ExternalScope::search_path(directives, default_search_path())
@@ -205,9 +207,20 @@ impl WorldState {
     /// Resolve a `source()` directive into the full set of layers the sourced
     /// file contributes: its own exports, `PackageExports` from any
     /// `library()` calls, and layers from nested `source()` calls.
-    fn resolve_source_layers(&self, base_dir: &Path, path: &str) -> Option<Vec<ScopeLayer>> {
+    ///
+    /// `visited` tracks files already being resolved to break cycles.
+    fn resolve_source_layers(
+        &self,
+        base_dir: &Path,
+        path: &str,
+        visited: &mut HashSet<Url>,
+    ) -> Option<Vec<ScopeLayer>> {
         let resolved = base_dir.join(path);
         let url = Url::from_file_path(&resolved).log_err()?;
+
+        if !visited.insert(url.clone()) {
+            return None;
+        }
 
         let sourced_doc = if let Some(open) = self.documents.get(&url) {
             open
@@ -230,7 +243,7 @@ impl WorldState {
         // Recurse into the sourced document in case it itself calls `source()`
         let source_dir = resolved.parent()?;
         let nested = directive_layers(index.file_directives(), |nested_path| {
-            self.resolve_source_layers(source_dir, nested_path)
+            self.resolve_source_layers(source_dir, nested_path, visited)
         });
         layers.extend(nested.into_iter().map(|(_, l)| l));
 

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -207,16 +207,16 @@ impl WorldState {
         // matching RStudio's behaviour of setting the working directory
         // to the project root. Fall back to the file's own directory
         // when no workspace folder is open.
-        let file_dir = file
-            .to_file_path()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
         let source_root = self
             .workspace
             .folders
             .first()
             .and_then(|url| url.to_file_path().ok())
-            .or(file_dir);
+            .or_else(|| {
+                file.to_file_path()
+                    .ok()
+                    .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            });
 
         let mut stack = HashSet::new();
         stack.insert(file.clone());

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -11,6 +11,9 @@ use oak_index::scope_layer::directive_layers;
 use oak_index::scope_layer::file_layers;
 use oak_index::scope_layer::package_root_layers;
 use oak_index::scope_layer::ScopeLayer;
+use oak_index::semantic_index::SemanticIndex;
+use oak_index::semantic_index_with_source_resolver;
+use oak_index::SourceResolution;
 use stdext::result::ResultExt;
 use url::Url;
 
@@ -98,13 +101,18 @@ impl WorldState {
         }
     }
 
-    /// Create a scope chain for a particular file, taking into account the
-    /// current project type. For packages, this creates a scope containing
-    /// imports and top-level definitions in other files, respecting the
-    /// collation order.
-    pub(crate) fn external_scope(&self, file: &Url) -> ExternalScope {
+    /// Create the semantic index and scope chain for a particular file.
+    ///
+    /// For scripts, the index is built with a source resolver so that
+    /// `source()` definitions are injected into the use-def map.
+    /// For packages, the index is the plain per-file index.
+    pub(crate) fn file_analysis(
+        &self,
+        file: &Url,
+        doc: &Document,
+    ) -> (SemanticIndex, ExternalScope) {
         let Some(SourceRoot::Package(ref pkg)) = self.root else {
-            return self.script_file_scope(file);
+            return self.script_file_analysis(file, doc);
         };
 
         let root_layers = package_root_layers(pkg.namespace());
@@ -129,7 +137,7 @@ impl WorldState {
             });
 
         let Some(file_path) = file.to_file_path().ok() else {
-            return ExternalScope::default();
+            return (doc.semantic_index(), ExternalScope::default());
         };
 
         // Iterate in reverse collation order so later files (which shadow
@@ -170,55 +178,53 @@ impl WorldState {
         top_level.extend(root_layers.clone());
         lazy.extend(root_layers);
 
-        ExternalScope::package(top_level, lazy)
+        (
+            doc.semantic_index(),
+            ExternalScope::package(top_level, lazy),
+        )
     }
 
-    /// Build the scope for a script file (not inside a package).
+    /// Build the semantic index and scope for a script file (not inside a
+    /// package).
     ///
-    /// Resolves `library()` and `source()` directives from the file's own
-    /// content, then appends the default R search path.
-    fn script_file_scope(&self, file: &Url) -> ExternalScope {
+    /// The index is built with a resolver callback so that `source()`
+    /// definitions are injected into the use-def map. `library()`
+    /// directives are extracted into the external scope chain.
+    fn script_file_analysis(&self, file: &Url, doc: &Document) -> (SemanticIndex, ExternalScope) {
         let file_path = file.to_file_path().ok();
-
-        let doc = if let Some(open) = self.documents.get(file) {
-            open
-        } else if let Some(contents) = file_path
-            .as_ref()
-            .and_then(|p| std::fs::read_to_string(p).log_err())
-        {
-            &Document::new(&contents, None)
-        } else {
-            return ExternalScope::search_path(Vec::new(), default_search_path());
-        };
-
-        let index = doc.semantic_index();
-
         let file_dir = file_path.and_then(|p| p.parent().map(|d| d.to_path_buf()));
 
-        let mut visited = HashSet::new();
-        let directives = directive_layers(index.file_directives(), |path| {
+        let mut stack = HashSet::new();
+        stack.insert(file.clone());
+        let index = semantic_index_with_source_resolver(&doc.parse.tree(), |path| {
             let dir = file_dir.as_ref()?;
-            self.resolve_source_layers(dir, path, &mut visited)
+            self.resolve_source(dir, path, &mut stack)
         });
 
-        ExternalScope::search_path(directives, default_search_path())
+        let directives = directive_layers(index.file_directives());
+        (
+            index,
+            ExternalScope::search_path(directives, default_search_path()),
+        )
     }
 
-    /// Resolve a `source()` directive into the full set of layers the sourced
-    /// file contributes: its own exports, `PackageExports` from any
-    /// `library()` calls, and layers from nested `source()` calls.
+    /// Resolve a `source()` call into a [`SourceResolution`] containing the
+    /// sourced file's exported definitions and `library()` package attachments.
     ///
-    /// `visited` tracks files already being resolved to break cycles.
-    fn resolve_source_layers(
+    /// `stack` tracks files currently being resolved (grey set) to break
+    /// cycles. A file is added when resolution starts and removed when it
+    /// finishes, so shared dependencies (diamond patterns) are resolved
+    /// independently for each parent.
+    fn resolve_source(
         &self,
         base_dir: &Path,
         path: &str,
-        visited: &mut HashSet<Url>,
-    ) -> Option<Vec<ScopeLayer>> {
+        stack: &mut HashSet<Url>,
+    ) -> Option<SourceResolution> {
         let resolved = base_dir.join(path);
         let url = Url::from_file_path(&resolved).log_err()?;
 
-        if !visited.insert(url.clone()) {
+        if !stack.insert(url.clone()) {
             return None;
         }
 
@@ -229,25 +235,35 @@ impl WorldState {
             &Document::new(&contents, None)
         };
 
-        let index = sourced_doc.semantic_index();
+        let source_dir = resolved.parent().map(PathBuf::from);
 
-        let mut layers = Vec::new();
-
-        let exports = index
-            .file_exports()
-            .into_iter()
-            .map(|(name, range)| (name.to_string(), range))
-            .collect();
-        layers.push(ScopeLayer::FileExports { file: url, exports });
-
-        // Recurse into the sourced document in case it itself calls `source()`
-        let source_dir = resolved.parent()?;
-        let nested = directive_layers(index.file_directives(), |nested_path| {
-            self.resolve_source_layers(source_dir, nested_path, visited)
+        // Build the sourced file's index with a nested resolver so that
+        // transitive `source()` calls are also resolved.
+        let index = semantic_index_with_source_resolver(&sourced_doc.parse.tree(), |nested_path| {
+            let dir = source_dir.as_ref()?;
+            self.resolve_source(dir, nested_path, stack)
         });
-        layers.extend(nested.into_iter().map(|(_, l)| l));
 
-        Some(layers)
+        let definitions = index
+            .file_all_definitions(&url)
+            .into_iter()
+            .map(|(name, file, range)| (name.to_string(), file, range))
+            .collect();
+
+        let packages = index
+            .file_directives()
+            .iter()
+            .map(|d| match d.kind() {
+                oak_index::semantic_index::DirectiveKind::Attach(pkg) => pkg.clone(),
+            })
+            .collect();
+
+        stack.remove(&url);
+
+        Some(SourceResolution {
+            definitions,
+            packages,
+        })
     }
 }
 
@@ -342,8 +358,7 @@ mod tests {
         let uri = test_path("script.R");
         let state = make_state(&uri, &doc);
 
-        let scope = state.external_scope(&uri);
-        let index = doc.semantic_index();
+        let (index, scope) = state.file_analysis(&uri, &doc);
 
         let before = scope.at(&index, TextSize::from(0));
         assert_not!(has_package(&before, "rlang"));
@@ -364,8 +379,7 @@ mod tests {
         let uri = test_path("script.R");
         let state = make_state(&uri, &doc);
 
-        let scope = state.external_scope(&uri);
-        let index = doc.semantic_index();
+        let (index, scope) = state.file_analysis(&uri, &doc);
 
         let in_function = scope.at(&index, TextSize::from(code.find("inform").unwrap() as u32));
         assert!(has_package(&in_function, "rlang"));
@@ -378,7 +392,7 @@ mod tests {
         let uri = test_path("script.R");
         let state = make_state(&uri, &doc);
 
-        let scope = state.external_scope(&uri);
+        let (_index, scope) = state.file_analysis(&uri, &doc);
         let layers = scope.lazy();
         assert_not!(has_package(layers, "rlang"));
     }

--- a/crates/oak_core/src/declaration.rs
+++ b/crates/oak_core/src/declaration.rs
@@ -1,0 +1,134 @@
+//! Helpers for detecting `declare()` annotations in R source code.
+//!
+//! `declare()` is a no-op function in R (>= 4.5) meant to hold static
+//! annotations. The compat syntax uses `~declare(...)` (a formula, also a
+//! no-op) for older R versions.
+//!
+//! This module recognises the `declare()` wrapper and returns its arguments for
+//! the caller to interpret.
+
+use aether_syntax::AnyRExpression;
+use aether_syntax::RCall;
+use aether_syntax::RCallArguments;
+use aether_syntax::RSyntaxKind;
+
+use crate::syntax_ext::RIdentifierExt;
+
+/// If `expr` is `declare(...)` or `~declare(...)`, return the arguments
+/// of the `declare()` call. Returns `None` if the expression doesn't
+/// match either pattern.
+pub fn as_declare_args(expr: &AnyRExpression) -> Option<RCallArguments> {
+    let call = as_declare_call(expr)?;
+    call.arguments().ok()
+}
+
+/// Unwrap `declare(...)` or `~declare(...)` to get the `declare` call node.
+fn as_declare_call(expr: &AnyRExpression) -> Option<RCall> {
+    match expr {
+        AnyRExpression::RCall(call) if is_declare(call) => Some(call.clone()),
+
+        AnyRExpression::RUnaryExpression(unary) => {
+            let op = unary.operator().ok()?;
+            if op.kind() != RSyntaxKind::TILDE {
+                return None;
+            }
+            let AnyRExpression::RCall(call) = unary.argument().ok()? else {
+                return None;
+            };
+            if is_declare(&call) {
+                Some(call)
+            } else {
+                None
+            }
+        },
+
+        _ => None,
+    }
+}
+
+fn is_declare(call: &RCall) -> bool {
+    let Ok(AnyRExpression::RIdentifier(ident)) = call.function() else {
+        return false;
+    };
+    ident.name_text() == "declare"
+}
+
+#[cfg(test)]
+mod tests {
+    use aether_parser::RParserOptions;
+    use aether_syntax::AnyRExpression;
+    use biome_rowan::AstNode;
+    use biome_rowan::AstNodeList;
+    use biome_rowan::AstSeparatedList;
+
+    use super::*;
+
+    fn parse_single_expr(code: &str) -> AnyRExpression {
+        let parsed = aether_parser::parse(code, RParserOptions::default());
+        parsed.tree().expressions().iter().next().unwrap()
+    }
+
+    fn declare_arg_values(code: &str) -> Option<Vec<String>> {
+        let expr = parse_single_expr(code);
+        let args = as_declare_args(&expr)?;
+        Some(
+            args.items()
+                .iter()
+                .filter_map(|arg| {
+                    let arg = arg.ok()?;
+                    Some(arg.value()?.syntax().text_trimmed().to_string())
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn test_declare_returns_arguments() {
+        let values = declare_arg_values("declare(source(\"helpers.R\"))");
+        assert_eq!(values, Some(vec!["source(\"helpers.R\")".to_string()]));
+    }
+
+    #[test]
+    fn test_tilde_declare_returns_arguments() {
+        let values = declare_arg_values("~declare(source(\"helpers.R\"))");
+        assert_eq!(values, Some(vec!["source(\"helpers.R\")".to_string()]));
+    }
+
+    #[test]
+    fn test_bare_call_not_declare() {
+        let values = declare_arg_values("source(\"helpers.R\")");
+        assert_eq!(values, None);
+    }
+
+    #[test]
+    fn test_tilde_not_declare() {
+        let values = declare_arg_values("~other(source(\"helpers.R\"))");
+        assert_eq!(values, None);
+    }
+
+    #[test]
+    fn test_declare_no_args() {
+        let values = declare_arg_values("declare()");
+        assert_eq!(values, Some(vec![]));
+    }
+
+    #[test]
+    fn test_declare_multiple_args() {
+        let values = declare_arg_values("declare(source(\"a.R\"), source(\"b.R\"))");
+        assert_eq!(
+            values,
+            Some(vec![
+                "source(\"a.R\")".to_string(),
+                "source(\"b.R\")".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_declare_preserves_named_args() {
+        let expr = parse_single_expr("declare(foo = source(\"a.R\"))");
+        let args = as_declare_args(&expr).unwrap();
+        let arg = args.items().iter().next().unwrap().unwrap();
+        assert!(arg.name_clause().is_some());
+    }
+}

--- a/crates/oak_core/src/lib.rs
+++ b/crates/oak_core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod declaration;
 pub mod file;
 pub mod range;
 pub mod syntax_ext;

--- a/crates/oak_db/Cargo.toml
+++ b/crates/oak_db/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "oak_db"
+version = "0.1.0"
+description = """
+Database trait for cross-file queries. Foundation for Salsa integration.
+"""
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+oak_index.workspace = true
+url.workspace = true

--- a/crates/oak_db/src/lib.rs
+++ b/crates/oak_db/src/lib.rs
@@ -1,0 +1,15 @@
+use oak_index::library::Library;
+use oak_index::semantic_index::SemanticIndex;
+use url::Url;
+
+/// Database trait for cross-file queries.
+///
+/// This will become a Salsa `#[salsa::db]` trait. For now it's a plain
+/// trait that abstracts over how other files' semantic indexes are obtained.
+pub trait Db {
+    /// TODO(salsa): With tracked file inputs this becomes infallible in
+    /// practice. `None` means the file disappeared between index-build
+    /// and query time, which is an edge case, not a normal path.
+    fn semantic_index(&self, file: &Url) -> Option<SemanticIndex>;
+    fn library(&self) -> &Library;
+}

--- a/crates/oak_ide/Cargo.toml
+++ b/crates/oak_ide/Cargo.toml
@@ -18,6 +18,7 @@ aether_syntax.workspace = true
 biome_rowan.workspace = true
 log.workspace = true
 oak_core.workspace = true
+oak_db.workspace = true
 oak_index.workspace = true
 oak_sources.workspace = true
 stdext.workspace = true

--- a/crates/oak_ide/src/external_scope.rs
+++ b/crates/oak_ide/src/external_scope.rs
@@ -4,6 +4,7 @@ use biome_rowan::TextSize;
 use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index::ScopeKind;
 use oak_index::semantic_index::SemanticIndex;
+use oak_index::ScopeId;
 
 /// The external scope chain for a file, determined by its project context.
 #[derive(Debug)]
@@ -29,9 +30,7 @@ pub enum ExternalScope {
     /// called after the full script has been sourced.
     SearchPath {
         base: Vec<ScopeLayer>,
-        directives: Vec<(TextSize, ScopeLayer)>,
-        /// All directive layers and the base ones.
-        lazy: Vec<ScopeLayer>,
+        directives: Vec<(TextSize, ScopeId, ScopeLayer)>,
     },
 }
 
@@ -40,7 +39,6 @@ impl Default for ExternalScope {
         Self::SearchPath {
             base: Vec::new(),
             directives: Vec::new(),
-            lazy: Vec::new(),
         }
     }
 }
@@ -50,17 +48,11 @@ impl ExternalScope {
         Self::Package { top_level, lazy }
     }
 
-    pub fn search_path(directives: Vec<(TextSize, ScopeLayer)>, base: Vec<ScopeLayer>) -> Self {
-        let lazy: Vec<_> = directives
-            .iter()
-            .map(|(_, b)| b.clone())
-            .chain(base.iter().cloned())
-            .collect();
-        Self::SearchPath {
-            base,
-            directives,
-            lazy,
-        }
+    pub fn search_path(
+        directives: Vec<(TextSize, ScopeId, ScopeLayer)>,
+        base: Vec<ScopeLayer>,
+    ) -> Self {
+        Self::SearchPath { base, directives }
     }
 
     /// Return the scope chain appropriate for the given offset. For
@@ -77,34 +69,47 @@ impl ExternalScope {
                     ScopeKind::Function => Cow::Borrowed(lazy),
                 }
             },
-            Self::SearchPath {
-                base,
-                directives,
-                lazy,
-            } => {
-                let (_, scope) = index.scope_at(offset);
-                match scope.kind() {
-                    ScopeKind::File => {
-                        let layers: Vec<_> = directives
-                            .iter()
-                            .filter(|(off, _)| *off < offset)
-                            .map(|(_, b)| b.clone())
-                            .chain(base.iter().cloned())
-                            .collect();
-                        Cow::Owned(layers)
-                    },
-                    ScopeKind::Function => Cow::Borrowed(lazy),
-                }
+            Self::SearchPath { base, directives } => {
+                let (cursor_scope, _) = index.scope_at(offset);
+                let file_scope = ScopeId::from(0);
+                let in_function = cursor_scope != file_scope;
+                let layers: Vec<_> = directives
+                    .iter()
+                    .filter(|(off, dir_scope, _)| {
+                        // File-scope directives are always visible inside
+                        // function bodies (the function is typically called
+                        // after the full script has been sourced).
+                        if in_function && *dir_scope == file_scope {
+                            return true;
+                        }
+                        *off < offset &&
+                            index.ancestor_scopes(cursor_scope).any(|s| s == *dir_scope)
+                    })
+                    .map(|(_, _, b)| b.clone())
+                    .chain(base.iter().cloned())
+                    .collect();
+                Cow::Owned(layers)
             },
         }
     }
 
     /// The full scope for lazy contexts. Useful for features that don't
     /// have a cursor position (e.g. completions, workspace symbols).
-    pub fn lazy(&self) -> &[ScopeLayer] {
+    pub fn lazy(&self) -> Cow<'_, [ScopeLayer]> {
         match self {
-            Self::Package { lazy, .. } => lazy,
-            Self::SearchPath { lazy, .. } => lazy,
+            Self::Package { lazy, .. } => Cow::Borrowed(lazy),
+            Self::SearchPath {
+                directives, base, ..
+            } => {
+                let file_scope = ScopeId::from(0);
+                let mut layers: Vec<ScopeLayer> = directives
+                    .iter()
+                    .filter(|(_, scope, _)| *scope == file_scope)
+                    .map(|(_, _, l)| l.clone())
+                    .collect();
+                layers.extend(base.iter().cloned());
+                Cow::Owned(layers)
+            },
         }
     }
 }

--- a/crates/oak_ide/src/external_scope.rs
+++ b/crates/oak_ide/src/external_scope.rs
@@ -75,6 +75,7 @@ impl ExternalScope {
                 let in_function = cursor_scope != file_scope;
                 let layers: Vec<_> = directives
                     .iter()
+                    .rev()
                     .filter(|(off, dir_scope, _)| {
                         // File-scope directives are always visible inside
                         // function bodies (the function is typically called
@@ -104,6 +105,7 @@ impl ExternalScope {
                 let file_scope = ScopeId::from(0);
                 let mut layers: Vec<ScopeLayer> = directives
                     .iter()
+                    .rev()
                     .filter(|(_, scope, _)| *scope == file_scope)
                     .map(|(_, _, l)| l.clone())
                     .collect();

--- a/crates/oak_ide/src/external_scope.rs
+++ b/crates/oak_ide/src/external_scope.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 
 use biome_rowan::TextSize;
 use oak_index::scope_layer::ScopeLayer;
+use oak_index::semantic_index::Directive;
+use oak_index::semantic_index::DirectiveKind;
 use oak_index::semantic_index::ScopeKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::ScopeId;
@@ -30,7 +32,7 @@ pub enum ExternalScope {
     /// called after the full script has been sourced.
     SearchPath {
         base: Vec<ScopeLayer>,
-        directives: Vec<(TextSize, ScopeId, ScopeLayer)>,
+        directives: Vec<Directive>,
     },
 }
 
@@ -48,10 +50,7 @@ impl ExternalScope {
         Self::Package { top_level, lazy }
     }
 
-    pub fn search_path(
-        directives: Vec<(TextSize, ScopeId, ScopeLayer)>,
-        base: Vec<ScopeLayer>,
-    ) -> Self {
+    pub fn search_path(directives: Vec<Directive>, base: Vec<ScopeLayer>) -> Self {
         Self::SearchPath { base, directives }
     }
 
@@ -76,17 +75,20 @@ impl ExternalScope {
                 let layers: Vec<_> = directives
                     .iter()
                     .rev()
-                    .filter(|(off, dir_scope, _)| {
+                    .filter(|d| {
+                        let dir_scope = d.scope();
                         // File-scope directives are always visible inside
                         // function bodies (the function is typically called
                         // after the full script has been sourced).
-                        if in_function && *dir_scope == file_scope {
+                        if in_function && dir_scope == file_scope {
                             return true;
                         }
-                        *off < offset &&
-                            index.ancestor_scopes(cursor_scope).any(|s| s == *dir_scope)
+                        d.offset() < offset &&
+                            index.ancestor_scopes(cursor_scope).any(|s| s == dir_scope)
                     })
-                    .map(|(_, _, b)| b.clone())
+                    .map(|d| match d.kind() {
+                        DirectiveKind::Attach(pkg) => ScopeLayer::PackageExports(pkg.clone()),
+                    })
                     .chain(base.iter().cloned())
                     .collect();
                 Cow::Owned(layers)
@@ -106,8 +108,10 @@ impl ExternalScope {
                 let mut layers: Vec<ScopeLayer> = directives
                     .iter()
                     .rev()
-                    .filter(|(_, scope, _)| *scope == file_scope)
-                    .map(|(_, _, l)| l.clone())
+                    .filter(|d| d.scope() == file_scope)
+                    .map(|d| match d.kind() {
+                        DirectiveKind::Attach(pkg) => ScopeLayer::PackageExports(pkg.clone()),
+                    })
                     .collect();
                 layers.extend(base.iter().cloned());
                 Cow::Owned(layers)

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -53,7 +53,7 @@ pub fn goto_definition(
     match ident {
         Identifier::Definition { scope_id, def_id } => {
             let def = &index.definitions(scope_id)[def_id];
-            let name = index.symbols(scope_id).symbol_id(def.symbol()).name();
+            let name = index.symbols(scope_id).symbol(def.symbol()).name();
 
             vec![NavigationTarget {
                 file: file.clone(),
@@ -94,7 +94,7 @@ fn resolve_use(
     let use_def_map = index.use_def_map(scope_id);
     let bindings = use_def_map.bindings_at_use(use_id);
 
-    let symbol_name = index.symbols(scope_id).symbol_id(use_site.symbol()).name();
+    let symbol_name = index.symbols(scope_id).symbol(use_site.symbol()).name();
 
     let definitions = bindings.definitions();
 
@@ -175,7 +175,7 @@ fn resolve_import_inner(
     let (_def_id, def) = target_index
         .definitions(file_scope)
         .iter()
-        .filter(|(_id, def)| symbols.symbol_id(def.symbol()).name() == name)
+        .filter(|(_id, def)| symbols.symbol(def.symbol()).name() == name)
         .last()?;
 
     match def.kind() {

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -175,7 +175,8 @@ fn resolve_import_inner(
     let (_def_id, def) = target_index
         .definitions(file_scope)
         .iter()
-        .find(|(_id, def)| symbols.symbol_id(def.symbol()).name() == name)?;
+        .filter(|(_id, def)| symbols.symbol_id(def.symbol()).name() == name)
+        .last()?;
 
     match def.kind() {
         DefinitionKind::Import {

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -5,6 +5,7 @@ use oak_index::external::resolve_in_package;
 use oak_index::library::Library;
 use oak_index::package_definitions::PackageDefinitionVisibility;
 use oak_index::scope_layer::ScopeLayer;
+use oak_index::semantic_index::DefinitionKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index::Use;
 use oak_index::DefinitionId;
@@ -102,8 +103,12 @@ fn resolve_use(
         defs.iter()
             .map(|&def_id| {
                 let def = &index.definitions(scope)[def_id];
+                let target_file = match def.kind() {
+                    DefinitionKind::Sourced { file: source_file } => source_file.clone(),
+                    _ => file.clone(),
+                };
                 NavigationTarget {
-                    file: file.clone(),
+                    file: target_file,
                     name: symbol_name.to_string(),
                     full_range: def.range(),
                     focus_range: def.range(),

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -5,7 +5,6 @@ use oak_index::external::resolve_in_package;
 use oak_index::library::Library;
 use oak_index::package_definitions::PackageDefinitionVisibility;
 use oak_index::scope_layer::ScopeLayer;
-use oak_index::semantic_index::DefinitionKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index::Use;
 use oak_index::DefinitionId;
@@ -103,10 +102,7 @@ fn resolve_use(
         defs.iter()
             .map(|&def_id| {
                 let def = &index.definitions(scope)[def_id];
-                let target_file = match def.kind() {
-                    DefinitionKind::Sourced { file: source_file } => source_file.clone(),
-                    _ => file.clone(),
-                };
+                let target_file = def.file().cloned().unwrap_or_else(|| file.clone());
                 NavigationTarget {
                     file: target_file,
                     name: symbol_name.to_string(),

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -1,10 +1,13 @@
+use std::collections::HashSet;
+
 use aether_syntax::RSyntaxNode;
 use biome_rowan::TextSize;
+use oak_db::Db;
 use oak_index::external::resolve_external_name;
 use oak_index::external::resolve_in_package;
-use oak_index::library::Library;
 use oak_index::package_definitions::PackageDefinitionVisibility;
 use oak_index::scope_layer::ScopeLayer;
+use oak_index::semantic_index::DefinitionKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index::Use;
 use oak_index::DefinitionId;
@@ -36,12 +39,12 @@ use crate::NavigationTarget;
 /// Returns an empty `Vec` if the offset doesn't point at a known
 /// identifier, or if the symbol cannot be resolved.
 pub fn goto_definition(
+    db: &dyn Db,
     offset: TextSize,
     file: &Url,
     root: &RSyntaxNode,
     index: &SemanticIndex,
     scope: &ExternalScope,
-    library: &Library,
 ) -> Vec<NavigationTarget> {
     let Some(ident) = Identifier::classify(root, index, offset) else {
         return Vec::new();
@@ -50,7 +53,7 @@ pub fn goto_definition(
     match ident {
         Identifier::Definition { scope_id, def_id } => {
             let def = &index.definitions(scope_id)[def_id];
-            let name = index.symbols(scope_id).symbol(def.symbol()).name();
+            let name = index.symbols(scope_id).symbol_id(def.symbol()).name();
 
             vec![NavigationTarget {
                 file: file.clone(),
@@ -61,9 +64,7 @@ pub fn goto_definition(
         },
         Identifier::Use { scope_id, use_id } => {
             let use_site = &index.uses(scope_id)[use_id];
-            resolve_use(
-                index, scope_id, use_id, use_site, file, offset, scope, library,
-            )
+            resolve_use(db, index, scope_id, use_id, use_site, offset, scope)
         },
         Identifier::NamespaceAccess {
             ref package,
@@ -76,38 +77,39 @@ pub fn goto_definition(
             } else {
                 PackageDefinitionVisibility::Exported
             };
-            resolve_namespace_access(symbol, package, visibility, library)
+            resolve_namespace_access(db, symbol, package, visibility)
         },
     }
 }
 
 fn resolve_use(
+    db: &dyn Db,
     index: &SemanticIndex,
     scope_id: ScopeId,
     use_id: UseId,
     use_site: &Use,
-    file: &Url,
     offset: TextSize,
     scope: &ExternalScope,
-    library: &Library,
 ) -> Vec<NavigationTarget> {
     let use_def_map = index.use_def_map(scope_id);
     let bindings = use_def_map.bindings_at_use(use_id);
 
-    let symbol_name = index.symbols(scope_id).symbol(use_site.symbol()).name();
+    let symbol_name = index.symbols(scope_id).symbol_id(use_site.symbol()).name();
 
     let definitions = bindings.definitions();
 
     let local_targets = |scope, defs: &[DefinitionId]| -> Vec<NavigationTarget> {
         defs.iter()
-            .map(|&def_id| {
+            .filter_map(|&def_id| {
                 let def = &index.definitions(scope)[def_id];
-                let target_file = def.file().cloned().unwrap_or_else(|| file.clone());
-                NavigationTarget {
-                    file: target_file,
-                    name: symbol_name.to_string(),
-                    full_range: def.range(),
-                    focus_range: def.range(),
+                match def.kind() {
+                    DefinitionKind::Import { file, name, .. } => resolve_import(db, file, name),
+                    _ => Some(NavigationTarget {
+                        file: def.file().clone(),
+                        name: symbol_name.to_string(),
+                        full_range: def.range(),
+                        focus_range: def.range(),
+                    }),
                 }
             })
             .collect()
@@ -115,7 +117,7 @@ fn resolve_use(
 
     let external_targets = || {
         let scope_chain = scope.at(index, offset);
-        resolve_external(symbol_name, &scope_chain, library)
+        resolve_external(db, symbol_name, &scope_chain)
     };
 
     if !definitions.is_empty() {
@@ -144,24 +146,70 @@ fn resolve_use(
     external_targets()
 }
 
+/// Chase a `DefinitionKind::Import` forwarding binding to the actual
+/// definition in the target file. Recurses through chains of Import
+/// definitions (e.g., a.R sources b.R sources c.R).
+///
+/// TODO(salsa): Move to `oak_index` once it depends on `oak_db`.
+fn resolve_import(db: &dyn Db, file: &Url, name: &str) -> Option<NavigationTarget> {
+    let mut visited = HashSet::new();
+    resolve_import_inner(db, file, name, &mut visited)
+}
+
+fn resolve_import_inner(
+    db: &dyn Db,
+    file: &Url,
+    name: &str,
+    visited: &mut HashSet<(Url, String)>,
+) -> Option<NavigationTarget> {
+    if !visited.insert((file.clone(), name.to_string())) {
+        return None;
+    }
+
+    let target_index = db.semantic_index(file)?;
+
+    // Imports always target top-level definitions in the sourced file.
+    let file_scope = ScopeId::from(0);
+    let symbols = &target_index.symbols(file_scope);
+
+    let (_def_id, def) = target_index
+        .definitions(file_scope)
+        .iter()
+        .find(|(_id, def)| symbols.symbol_id(def.symbol()).name() == name)?;
+
+    match def.kind() {
+        DefinitionKind::Import {
+            file: next_file,
+            name: next_name,
+            ..
+        } => resolve_import_inner(db, next_file, next_name, visited),
+        _ => Some(NavigationTarget {
+            file: file.clone(),
+            name: name.to_string(),
+            full_range: def.range(),
+            focus_range: def.range(),
+        }),
+    }
+}
+
 fn resolve_namespace_access(
+    db: &dyn Db,
     symbol: &str,
     package: &str,
     visibility: PackageDefinitionVisibility,
-    library: &Library,
 ) -> Vec<NavigationTarget> {
-    let Some(external) = resolve_in_package(symbol, package, visibility, library) else {
+    let Some(external) = resolve_in_package(db.library(), package, symbol, visibility) else {
         return Vec::new();
     };
     vec![external.into()]
 }
 
 fn resolve_external(
+    db: &dyn Db,
     symbol: &str,
     scope_chain: &[ScopeLayer],
-    library: &Library,
 ) -> Vec<NavigationTarget> {
-    let Some(external) = resolve_external_name(library, scope_chain, symbol) else {
+    let Some(external) = resolve_external_name(db.library(), scope_chain, symbol) else {
         return Vec::new();
     };
     vec![external.into()]

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -37,13 +37,10 @@ impl Identifier {
     pub fn classify(root: &RSyntaxNode, index: &SemanticIndex, offset: TextSize) -> Option<Self> {
         let (scope_id, _) = index.scope_at(offset);
 
-        if let Some((def_id, def)) = index.definitions(scope_id).contains(offset) {
-            if !matches!(
-                def.kind(),
-                oak_index::semantic_index::DefinitionKind::Import { .. }
-            ) {
-                return Some(Identifier::Definition { scope_id, def_id });
-            }
+        // Definitions with empty ranges (e.g. imports) are naturally excluded
+        // here since they can't contain the offset
+        if let Some((def_id, _def)) = index.definitions(scope_id).contains(offset) {
+            return Some(Identifier::Definition { scope_id, def_id });
         }
 
         if let Some((use_id, _)) = index.uses(scope_id).contains(offset) {

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -37,8 +37,10 @@ impl Identifier {
     pub fn classify(root: &RSyntaxNode, index: &SemanticIndex, offset: TextSize) -> Option<Self> {
         let (scope_id, _) = index.scope_at(offset);
 
-        // Definitions with empty ranges (e.g. imports) are naturally excluded
-        // here since they can't contain the offset
+        // `Import` definitions have empty ranges (no physical text position,
+        // since `source()` injects them) so `contains()` skips them. If the
+        // cursor is on the `source` symbol, the offset classifies instead as a
+        // use of `source` via the check below.
         if let Some((def_id, _def)) = index.definitions(scope_id).contains(offset) {
             return Some(Identifier::Definition { scope_id, def_id });
         }

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -7,6 +7,7 @@ use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
+use oak_index::semantic_index::DefinitionKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::DefinitionId;
 use oak_index::ScopeId;
@@ -37,8 +38,10 @@ impl Identifier {
     pub fn classify(root: &RSyntaxNode, index: &SemanticIndex, offset: TextSize) -> Option<Self> {
         let (scope_id, _) = index.scope_at(offset);
 
-        if let Some((def_id, _)) = index.definitions(scope_id).contains(offset) {
-            return Some(Identifier::Definition { scope_id, def_id });
+        if let Some((def_id, def)) = index.definitions(scope_id).contains(offset) {
+            if !matches!(def.kind(), DefinitionKind::Sourced { .. }) {
+                return Some(Identifier::Definition { scope_id, def_id });
+            }
         }
 
         if let Some((use_id, _)) = index.uses(scope_id).contains(offset) {

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -7,7 +7,6 @@ use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
-use oak_index::semantic_index::DefinitionKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::DefinitionId;
 use oak_index::ScopeId;
@@ -39,7 +38,7 @@ impl Identifier {
         let (scope_id, _) = index.scope_at(offset);
 
         if let Some((def_id, def)) = index.definitions(scope_id).contains(offset) {
-            if !matches!(def.kind(), DefinitionKind::Sourced { .. }) {
+            if def.file().is_none() {
                 return Some(Identifier::Definition { scope_id, def_id });
             }
         }

--- a/crates/oak_ide/src/identifier.rs
+++ b/crates/oak_ide/src/identifier.rs
@@ -38,7 +38,10 @@ impl Identifier {
         let (scope_id, _) = index.scope_at(offset);
 
         if let Some((def_id, def)) = index.definitions(scope_id).contains(offset) {
-            if def.file().is_none() {
+            if !matches!(
+                def.kind(),
+                oak_index::semantic_index::DefinitionKind::Import { .. }
+            ) {
                 return Some(Identifier::Definition { scope_id, def_id });
             }
         }

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -12,9 +12,11 @@ use oak_ide::ExternalScope;
 use oak_ide::NavigationTarget;
 use oak_index::library::Library;
 use oak_index::package::Package;
+use oak_index::scope_layer::directive_layers;
 use oak_index::scope_layer::file_layers;
 use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index;
+use oak_index::semantic_index::DirectiveKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_package_metadata::description::Description;
 use oak_package_metadata::namespace::Namespace;
@@ -1205,4 +1207,290 @@ fn test_namespace_classify_string_selectors() {
             symbol_range: text_range(7, 12),
         })
     );
+}
+
+// --- source() directive ---
+
+#[test]
+fn test_source_directive_resolves_to_sourced_file() {
+    // script.R has `source("helpers.R")` then uses `helper`.
+    // The caller detects the Source directive and splices in the
+    // sourced file's exports, enabling goto-definition.
+    let helpers_source = "helper <- function() 1\n";
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
+    let helpers_url = file_url("helpers.R");
+
+    let script_source = "source(\"helpers.R\")\nhelper\n";
+    let script_url = file_url("script.R");
+    let (script_root, script_idx) = parse_source(script_source);
+
+    // The semantic index detects the source() directive
+    let directives = script_idx.file_directives();
+    assert_eq!(directives.len(), 1);
+    assert_eq!(
+        directives[0].kind(),
+        &DirectiveKind::Source("helpers.R".into())
+    );
+
+    // The caller resolves Source directives via `directive_layers`, which
+    // calls back to get the full layers the sourced file contributes.
+    let helpers_url_clone = helpers_url.clone();
+    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
+        let exports = helpers_idx
+            .file_exports()
+            .into_iter()
+            .map(|(name, range)| (name.to_string(), range))
+            .collect();
+        Some(vec![ScopeLayer::FileExports {
+            file: helpers_url_clone.clone(),
+            exports,
+        }])
+    });
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    let library = empty_library();
+
+    let use_offset = script_source.rfind("helper").unwrap() as u32;
+    let targets = goto_definition(
+        offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert_eq!(targets, vec![NavigationTarget {
+        file: helpers_url,
+        name: "helper".to_string(),
+        full_range: text_range(0, 6),
+        focus_range: text_range(0, 6),
+    }]);
+}
+
+#[test]
+fn test_source_directive_resolves_nested_library() {
+    // helpers.R has `library(dplyr)` and defines `helper`.
+    // script.R sources helpers.R then uses `mutate` (from dplyr).
+    // The nested library() directive should be visible.
+    let helpers_source = "library(dplyr)\nhelper <- function() 1\n";
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
+    let helpers_url = file_url("helpers.R");
+
+    let script_source = "source(\"helpers.R\")\nmutate\n";
+    let script_url = file_url("script.R");
+    let (script_root, script_idx) = parse_source(script_source);
+
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let helpers_url_clone = helpers_url.clone();
+    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
+        let exports = helpers_idx
+            .file_exports()
+            .into_iter()
+            .map(|(name, range)| (name.to_string(), range))
+            .collect();
+        let mut layers = vec![ScopeLayer::FileExports {
+            file: helpers_url_clone.clone(),
+            exports,
+        }];
+        // Nested directives from helpers.R (unstamped, they inherit the
+        // parent source() directive's offset)
+        let nested = directive_layers(helpers_idx.file_directives(), |_| None);
+        layers.extend(nested.into_iter().map(|(_, l)| l));
+        Some(layers)
+    });
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    // `mutate` resolves via dplyr (attached by helpers.R's library() call)
+    let use_offset = script_source.rfind("mutate").unwrap() as u32;
+    let targets = goto_definition(
+        offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    // Package symbol, no NavigationTarget
+    assert!(targets.is_empty());
+
+    // `helper` still resolves to helpers.R
+    let source_with_helper = "source(\"helpers.R\")\nhelper\n";
+    let (script_root2, script_idx2) = parse_source(source_with_helper);
+
+    let helpers_url_clone = helpers_url.clone();
+    let dir_layers = directive_layers(script_idx2.file_directives(), |_path| {
+        let exports = helpers_idx
+            .file_exports()
+            .into_iter()
+            .map(|(name, range)| (name.to_string(), range))
+            .collect();
+        let mut layers = vec![ScopeLayer::FileExports {
+            file: helpers_url_clone.clone(),
+            exports,
+        }];
+        let nested = directive_layers(helpers_idx.file_directives(), |_| None);
+        layers.extend(nested.into_iter().map(|(_, l)| l));
+        Some(layers)
+    });
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    let use_offset = source_with_helper.rfind("helper").unwrap() as u32;
+    let targets = goto_definition(
+        offset(use_offset),
+        &script_url,
+        &script_root2,
+        &script_idx2,
+        &scope,
+        &library,
+    );
+    assert_eq!(targets, vec![NavigationTarget {
+        file: helpers_url,
+        name: "helper".to_string(),
+        full_range: text_range(15, 21),
+        focus_range: text_range(15, 21),
+    }]);
+}
+
+#[test]
+fn test_directive_not_visible_before_call_site() {
+    // Directives are position-stamped: only code AFTER a `source()` or
+    // `library()` call sees its effects.
+    //
+    //  "mutate\n"                     offset 0..6
+    //  "helper\n"                     offset 7..13
+    //  "library(dplyr)\n"             offset 14..28
+    //  "source(\"helpers.R\")\n"      offset 29..48
+    //  "mutate\n"                     offset 49..55
+    //  "helper\n"                     offset 56..62
+    let helpers_source = "helper <- function() 1\n";
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
+    let helpers_url = file_url("helpers.R");
+
+    let script_source = "mutate\nhelper\nlibrary(dplyr)\nsource(\"helpers.R\")\nmutate\nhelper\n";
+    let script_url = file_url("script.R");
+    let (script_root, script_idx) = parse_source(script_source);
+
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    let helpers_url_clone = helpers_url.clone();
+    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
+        let exports = helpers_idx
+            .file_exports()
+            .into_iter()
+            .map(|(name, range)| (name.to_string(), range))
+            .collect();
+        Some(vec![ScopeLayer::FileExports {
+            file: helpers_url_clone.clone(),
+            exports,
+        }])
+    });
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    // `mutate` before library(dplyr) (offset 0) — should NOT resolve
+    let targets = goto_definition(
+        offset(0),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert!(targets.is_empty());
+
+    // `helper` before source() (offset 7) — should NOT resolve
+    let targets = goto_definition(
+        offset(7),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert!(targets.is_empty());
+
+    // `mutate` after library(dplyr) (offset 49) — package symbol, no NavigationTarget yet (FIXME)
+    let targets = goto_definition(
+        offset(49),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert!(targets.is_empty());
+
+    // `helper` after source() (offset 56) — should resolve to helpers.R
+    let targets = goto_definition(
+        offset(56),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert_eq!(targets, vec![NavigationTarget {
+        file: helpers_url,
+        name: "helper".to_string(),
+        full_range: text_range(0, 6),
+        focus_range: text_range(0, 6),
+    }]);
+}
+
+#[test]
+fn test_directives_in_function_body_are_inert() {
+    // `source()` and `library()` inside a function body should NOT
+    // produce directives. They're lazy (only evaluated when the
+    // function is called), so they don't affect the file's scope.
+    let helpers_source = "helper <- function() 1\n";
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
+    let helpers_url = file_url("helpers.R");
+
+    let script_source =
+        "f <- function() {\n  source(\"helpers.R\")\n  library(dplyr)\n}\nhelper\nmutate\n";
+    let script_url = file_url("script.R");
+    let (script_root, script_idx) = parse_source(script_source);
+
+    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+
+    // No file-level directives should be detected
+    assert!(script_idx.file_directives().is_empty());
+
+    let helpers_url_clone = helpers_url.clone();
+    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
+        let exports = helpers_idx
+            .file_exports()
+            .into_iter()
+            .map(|(name, range)| (name.to_string(), range))
+            .collect();
+        Some(vec![ScopeLayer::FileExports {
+            file: helpers_url_clone.clone(),
+            exports,
+        }])
+    });
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    // `helper` — not resolved (source() was inside a function)
+    let use_offset = script_source.find("\nhelper").unwrap() as u32 + 1;
+    let targets = goto_definition(
+        offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert!(targets.is_empty());
+
+    // `mutate` — not resolved (library() was inside a function)
+    let use_offset = script_source.find("\nmutate").unwrap() as u32 + 1;
+    let targets = goto_definition(
+        offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert!(targets.is_empty());
 }

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -19,6 +19,7 @@ use oak_index::semantic_index;
 use oak_index::semantic_index::DirectiveKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index_with_source_resolver;
+use oak_index::ScopeId;
 use oak_index::SourceResolution;
 use oak_package_metadata::description::Description;
 use oak_package_metadata::namespace::Namespace;
@@ -1441,24 +1442,40 @@ fn test_directive_not_visible_before_call_site() {
 }
 
 #[test]
-fn test_directives_in_function_body_are_inert() {
-    // `source()` and `library()` inside a function body should NOT
-    // produce file-level directives. `library()` is guarded to file
-    // scope; `source()` without a resolver is a no-op.
+fn test_directives_in_function_body_are_scoped() {
+    // `library()` inside a function body produces a scoped directive:
+    // visible inside the function but not at file scope.
+    // `source()` without a resolver is still a no-op.
     let script_source =
-        "f <- function() {\n  source(\"helpers.R\")\n  library(dplyr)\n}\nhelper\nmutate\n";
+        "f <- function() {\n  source(\"helpers.R\")\n  library(dplyr)\n  mutate\n}\nhelper\nmutate\n";
     let script_url = file_url("script.R");
     let (script_root, script_idx) = parse_source(script_source);
 
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
-    // No file-level directives should be detected
-    assert!(script_idx.file_directives().is_empty());
+    // library() inside f produces a scoped directive
+    let directives = script_idx.file_directives();
+    assert_eq!(directives.len(), 1);
+    assert_eq!(directives[0].kind(), &DirectiveKind::Attach("dplyr".into()));
+    assert_ne!(directives[0].scope(), ScopeId::from(0));
 
     let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
-    // `helper` — not resolved (source() was inside a function, no resolver)
+    // `mutate` inside f (after library()) — resolves via scoped dplyr
+    let use_offset = script_source.find("  mutate").unwrap() as u32 + 2;
+    let targets = goto_definition(
+        offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    // Package symbol, no NavigationTarget
+    assert!(targets.is_empty());
+
+    // `helper` at file scope — not resolved (source() had no resolver)
     let use_offset = script_source.find("\nhelper").unwrap() as u32 + 1;
     let targets = goto_definition(
         offset(use_offset),
@@ -1470,8 +1487,9 @@ fn test_directives_in_function_body_are_inert() {
     );
     assert!(targets.is_empty());
 
-    // `mutate` — not resolved (library() was inside a function)
-    let use_offset = script_source.find("\nmutate").unwrap() as u32 + 1;
+    // `mutate` at file scope — not resolved (library() directive is
+    // scoped to f, not visible here)
+    let use_offset = script_source.rfind("mutate").unwrap() as u32;
     let targets = goto_definition(
         offset(use_offset),
         &script_url,

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -18,6 +18,8 @@ use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index;
 use oak_index::semantic_index::DirectiveKind;
 use oak_index::semantic_index::SemanticIndex;
+use oak_index::semantic_index_with_source_resolver;
+use oak_index::SourceResolution;
 use oak_package_metadata::description::Description;
 use oak_package_metadata::namespace::Namespace;
 use oak_sources::test::TestPackageCache;
@@ -1214,7 +1216,7 @@ fn test_namespace_classify_string_selectors() {
 #[test]
 fn test_source_directive_resolves_to_sourced_file() {
     // script.R has `source("helpers.R")` then uses `helper`.
-    // The caller detects the Source directive and splices in the
+    // The builder resolves source() via the callback and injects the
     // sourced file's exports, enabling goto-definition.
     let helpers_source = "helper <- function() 1\n";
     let (_helpers_root, helpers_idx) = parse_source(helpers_source);
@@ -1222,30 +1224,24 @@ fn test_source_directive_resolves_to_sourced_file() {
 
     let script_source = "source(\"helpers.R\")\nhelper\n";
     let script_url = file_url("script.R");
-    let (script_root, script_idx) = parse_source(script_source);
 
-    // The semantic index detects the source() directive
-    let directives = script_idx.file_directives();
-    assert_eq!(directives.len(), 1);
-    assert_eq!(
-        directives[0].kind(),
-        &DirectiveKind::Source("helpers.R".into())
-    );
-
-    // The caller resolves Source directives via `directive_layers`, which
-    // calls back to get the full layers the sourced file contributes.
     let helpers_url_clone = helpers_url.clone();
-    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
-        let exports = helpers_idx
-            .file_exports()
-            .into_iter()
-            .map(|(name, range)| (name.to_string(), range))
-            .collect();
-        Some(vec![ScopeLayer::FileExports {
-            file: helpers_url_clone.clone(),
-            exports,
-        }])
+    let helpers_exports: Vec<_> = helpers_idx
+        .file_exports()
+        .into_iter()
+        .map(|(name, range)| (name.to_string(), helpers_url_clone.clone(), range))
+        .collect();
+
+    let parsed = parse(script_source, RParserOptions::default());
+    let script_root = parsed.syntax();
+    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
+        Some(SourceResolution {
+            definitions: helpers_exports.clone(),
+            packages: Vec::new(),
+        })
     });
+
+    let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let library = empty_library();
@@ -1271,34 +1267,41 @@ fn test_source_directive_resolves_to_sourced_file() {
 fn test_source_directive_resolves_nested_library() {
     // helpers.R has `library(dplyr)` and defines `helper`.
     // script.R sources helpers.R then uses `mutate` (from dplyr).
-    // The nested library() directive should be visible.
+    // The nested library() directive should be visible via the resolver.
     let helpers_source = "library(dplyr)\nhelper <- function() 1\n";
     let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
 
+    let helpers_exports: Vec<_> = helpers_idx
+        .file_exports()
+        .into_iter()
+        .map(|(name, range)| (name.to_string(), helpers_url.clone(), range))
+        .collect();
+    let helpers_packages: Vec<_> = helpers_idx
+        .file_directives()
+        .iter()
+        .map(|d| match d.kind() {
+            DirectiveKind::Attach(pkg) => pkg.clone(),
+        })
+        .collect();
+
     let script_source = "source(\"helpers.R\")\nmutate\n";
     let script_url = file_url("script.R");
-    let (script_root, script_idx) = parse_source(script_source);
 
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
-    let helpers_url_clone = helpers_url.clone();
-    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
-        let exports = helpers_idx
-            .file_exports()
-            .into_iter()
-            .map(|(name, range)| (name.to_string(), range))
-            .collect();
-        let mut layers = vec![ScopeLayer::FileExports {
-            file: helpers_url_clone.clone(),
-            exports,
-        }];
-        // Nested directives from helpers.R (unstamped, they inherit the
-        // parent source() directive's offset)
-        let nested = directive_layers(helpers_idx.file_directives(), |_| None);
-        layers.extend(nested.into_iter().map(|(_, l)| l));
-        Some(layers)
+    let exports_clone = helpers_exports.clone();
+    let packages_clone = helpers_packages.clone();
+    let parsed = parse(script_source, RParserOptions::default());
+    let script_root = parsed.syntax();
+    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
+        Some(SourceResolution {
+            definitions: exports_clone.clone(),
+            packages: packages_clone.clone(),
+        })
     });
+
+    let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     // `mutate` resolves via dplyr (attached by helpers.R's library() call)
@@ -1316,23 +1319,19 @@ fn test_source_directive_resolves_nested_library() {
 
     // `helper` still resolves to helpers.R
     let source_with_helper = "source(\"helpers.R\")\nhelper\n";
-    let (script_root2, script_idx2) = parse_source(source_with_helper);
 
-    let helpers_url_clone = helpers_url.clone();
-    let dir_layers = directive_layers(script_idx2.file_directives(), |_path| {
-        let exports = helpers_idx
-            .file_exports()
-            .into_iter()
-            .map(|(name, range)| (name.to_string(), range))
-            .collect();
-        let mut layers = vec![ScopeLayer::FileExports {
-            file: helpers_url_clone.clone(),
-            exports,
-        }];
-        let nested = directive_layers(helpers_idx.file_directives(), |_| None);
-        layers.extend(nested.into_iter().map(|(_, l)| l));
-        Some(layers)
+    let exports_clone = helpers_exports.clone();
+    let packages_clone = helpers_packages.clone();
+    let parsed2 = parse(source_with_helper, RParserOptions::default());
+    let script_root2 = parsed2.syntax();
+    let script_idx2 = semantic_index_with_source_resolver(&parsed2.tree(), move |_path| {
+        Some(SourceResolution {
+            definitions: exports_clone.clone(),
+            packages: packages_clone.clone(),
+        })
     });
+
+    let dir_layers = directive_layers(script_idx2.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let use_offset = source_with_helper.rfind("helper").unwrap() as u32;
@@ -1369,22 +1368,26 @@ fn test_directive_not_visible_before_call_site() {
 
     let script_source = "mutate\nhelper\nlibrary(dplyr)\nsource(\"helpers.R\")\nmutate\nhelper\n";
     let script_url = file_url("script.R");
-    let (script_root, script_idx) = parse_source(script_source);
 
     let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
 
     let helpers_url_clone = helpers_url.clone();
-    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
-        let exports = helpers_idx
-            .file_exports()
-            .into_iter()
-            .map(|(name, range)| (name.to_string(), range))
-            .collect();
-        Some(vec![ScopeLayer::FileExports {
-            file: helpers_url_clone.clone(),
-            exports,
-        }])
+    let helpers_exports: Vec<_> = helpers_idx
+        .file_exports()
+        .into_iter()
+        .map(|(name, range)| (name.to_string(), helpers_url_clone.clone(), range))
+        .collect();
+
+    let parsed = parse(script_source, RParserOptions::default());
+    let script_root = parsed.syntax();
+    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
+        Some(SourceResolution {
+            definitions: helpers_exports.clone(),
+            packages: Vec::new(),
+        })
     });
+
+    let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     // `mutate` before library(dplyr) (offset 0) — should NOT resolve
@@ -1440,12 +1443,8 @@ fn test_directive_not_visible_before_call_site() {
 #[test]
 fn test_directives_in_function_body_are_inert() {
     // `source()` and `library()` inside a function body should NOT
-    // produce directives. They're lazy (only evaluated when the
-    // function is called), so they don't affect the file's scope.
-    let helpers_source = "helper <- function() 1\n";
-    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
-    let helpers_url = file_url("helpers.R");
-
+    // produce file-level directives. `library()` is guarded to file
+    // scope; `source()` without a resolver is a no-op.
     let script_source =
         "f <- function() {\n  source(\"helpers.R\")\n  library(dplyr)\n}\nhelper\nmutate\n";
     let script_url = file_url("script.R");
@@ -1456,21 +1455,10 @@ fn test_directives_in_function_body_are_inert() {
     // No file-level directives should be detected
     assert!(script_idx.file_directives().is_empty());
 
-    let helpers_url_clone = helpers_url.clone();
-    let dir_layers = directive_layers(script_idx.file_directives(), |_path| {
-        let exports = helpers_idx
-            .file_exports()
-            .into_iter()
-            .map(|(name, range)| (name.to_string(), range))
-            .collect();
-        Some(vec![ScopeLayer::FileExports {
-            file: helpers_url_clone.clone(),
-            exports,
-        }])
-    });
+    let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
-    // `helper` — not resolved (source() was inside a function)
+    // `helper` — not resolved (source() was inside a function, no resolver)
     let use_offset = script_source.find("\nhelper").unwrap() as u32 + 1;
     let targets = goto_definition(
         offset(use_offset),
@@ -1486,6 +1474,68 @@ fn test_directives_in_function_body_are_inert() {
     let use_offset = script_source.find("\nmutate").unwrap() as u32 + 1;
     let targets = goto_definition(
         offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert!(targets.is_empty());
+}
+
+#[test]
+fn test_source_in_function_body_scoping() {
+    // `source()` inside a function body with a resolver injects definitions
+    // into the function scope. `helper` resolves inside f but not at file level.
+    let helpers_source = "helper <- function() 1\n";
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
+    let helpers_url = file_url("helpers.R");
+
+    let script_source = "f <- function() {\n  source(\"helpers.R\")\n  helper\n}\nhelper\n";
+    let script_url = file_url("script.R");
+
+    let helpers_url_clone = helpers_url.clone();
+    let helpers_exports: Vec<_> = helpers_idx
+        .file_exports()
+        .into_iter()
+        .map(|(name, range)| (name.to_string(), helpers_url_clone.clone(), range))
+        .collect();
+
+    let parsed = parse(script_source, RParserOptions::default());
+    let script_root = parsed.syntax();
+    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
+        Some(SourceResolution {
+            definitions: helpers_exports.clone(),
+            packages: Vec::new(),
+        })
+    });
+
+    let dir_layers = directive_layers(script_idx.file_directives());
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    let library = empty_library();
+
+    // `helper` inside the function body — should resolve to helpers.R
+    let inner_offset = script_source.find("  helper\n}").unwrap() as u32 + 2;
+    let targets = goto_definition(
+        offset(inner_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+        &library,
+    );
+    assert_eq!(targets, vec![NavigationTarget {
+        file: helpers_url,
+        name: "helper".to_string(),
+        full_range: text_range(0, 6),
+        focus_range: text_range(0, 6),
+    }]);
+
+    // `helper` outside the function — should NOT resolve
+    let outer_offset = script_source.rfind("\nhelper\n").unwrap() as u32 + 1;
+    let targets = goto_definition(
+        offset(outer_offset),
         &script_url,
         &script_root,
         &script_idx,

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -1281,8 +1281,9 @@ fn test_source_directive_resolves_nested_library() {
     let helpers_packages: Vec<_> = helpers_idx
         .file_directives()
         .iter()
-        .map(|d| match d.kind() {
-            DirectiveKind::Attach(pkg) => pkg.clone(),
+        .filter_map(|d| match d.kind() {
+            DirectiveKind::Attach(pkg) => Some(pkg.clone()),
+            DirectiveKind::Source { .. } => None,
         })
         .collect();
 
@@ -1503,8 +1504,8 @@ fn test_directives_in_function_body_are_scoped() {
 
 #[test]
 fn test_source_in_function_body_scoping() {
-    // `source()` inside a function body with a resolver injects definitions
-    // into the function scope. `helper` resolves inside f but not at file level.
+    // `source(local = FALSE)` inside a function body scopes directives to the
+    // function scope, so sourced definitions are NOT visible at file scope.
     let helpers_source = "helper <- function() 1\n";
     let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
@@ -1550,7 +1551,7 @@ fn test_source_in_function_body_scoping() {
         focus_range: text_range(0, 6),
     }]);
 
-    // `helper` outside the function — should NOT resolve
+    // `helper` outside the function — NOT visible
     let outer_offset = script_source.rfind("\nhelper\n").unwrap() as u32 + 1;
     let targets = goto_definition(
         offset(outer_offset),

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -7,6 +7,7 @@ use aether_parser::RParserOptions;
 use aether_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
+use oak_db::Db;
 use oak_ide::goto_definition;
 use oak_ide::ExternalScope;
 use oak_ide::NavigationTarget;
@@ -21,7 +22,6 @@ use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::ScopeId;
 use oak_index::SourceResolution;
-use oak_index::FileDefinition;
 use oak_package_metadata::description::Description;
 use oak_package_metadata::namespace::Namespace;
 use oak_sources::test::TestPackageCache;
@@ -31,8 +31,26 @@ use url::Url;
 fn parse_source(source: &str) -> (RSyntaxNode, SemanticIndex) {
     let parsed = parse(source, RParserOptions::default());
     let root = parsed.syntax();
-    let index = semantic_index(&parsed.tree());
+    let index = semantic_index(&parsed.tree(), &file_url("test.R"));
     (root, index)
+}
+
+struct TestDb {
+    library: Library,
+    sources: HashMap<Url, String>,
+}
+
+impl Db for TestDb {
+    fn semantic_index(&self, file: &Url) -> Option<SemanticIndex> {
+        // Rebuild from source for tests. We store the source instead.
+        self.sources.get(file).map(|source| {
+            let parsed = parse(source, RParserOptions::default());
+            semantic_index(&parsed.tree(), file)
+        })
+    }
+    fn library(&self) -> &Library {
+        &self.library
+    }
 }
 
 fn empty_library() -> Library {
@@ -131,15 +149,18 @@ fn test_local_simple() {
     let source = "x <- 1\nx\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(7),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -155,15 +176,18 @@ fn test_local_reassignment_shadows() {
     let source = "x <- 1\nx <- 2\nx\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(14),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -178,17 +202,20 @@ fn test_local_conditional_returns_both() {
     let source = "if (TRUE) x <- 1 else x <- 2\nx\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let use_offset = source.rfind('x').unwrap() as u32;
 
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![
         NavigationTarget {
@@ -211,16 +238,19 @@ fn test_local_in_function() {
     let source = "f <- function() {\n  x <- 1\n  x\n}\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -235,16 +265,19 @@ fn test_local_parameter() {
     let source = "f <- function(x) {\n  x\n}\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -261,16 +294,19 @@ fn test_enclosing_scope() {
     let source = "x <- 1\nf <- function() {\n  x\n}\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -287,7 +323,10 @@ fn test_external_project_file() {
     let source = "foo\n";
     let file = file_url("current.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let other_url = file_url("other.R");
     let other_source = "foo <- 42\n";
@@ -295,12 +334,12 @@ fn test_external_project_file() {
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
     let targets = goto_definition(
+        &db,
         offset(0),
         &file,
         &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: other_url,
@@ -323,16 +362,20 @@ fn test_external_package() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let scope_chain = vec![ScopeLayer::PackageExports("dplyr".to_string())];
 
     let targets = goto_definition(
+        &db,
         offset(0),
         &file,
         &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
-        &library,
     );
 
     assert_eq!(targets.len(), 1);
@@ -349,19 +392,22 @@ fn test_external_import_from() {
     let source = "tibble\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let mut imports = HashMap::new();
     imports.insert("tibble".to_string(), "tibble".to_string());
     let scope_chain = vec![ScopeLayer::PackageImports(imports)];
 
     let targets = goto_definition(
+        &db,
         offset(0),
         &file,
         &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
-        &library,
     );
     // importFrom resolves to a package, no file/range to navigate to
     assert!(targets.is_empty());
@@ -375,16 +421,19 @@ fn test_dollar_lhs_resolves() {
     let source = "foo <- list()\nfoo$bar\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // `foo` in `foo$bar` starts at offset 14
     let targets = goto_definition(
+        &db,
         offset(14),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -400,16 +449,19 @@ fn test_dollar_rhs_no_resolution() {
     let source = "foo <- list()\nfoo$bar\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // `bar` starts at offset 18
     let targets = goto_definition(
+        &db,
         offset(18),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert!(targets.is_empty());
 }
@@ -430,7 +482,10 @@ fn test_use_in_function_body_resolves_via_external() {
     let other_url = file_url("R/types.R");
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // `is_null` starts at offset 24
     let is_null_offset = source.find("is_null").unwrap();
@@ -439,12 +494,12 @@ fn test_use_in_function_body_resolves_via_external() {
     let scope = ExternalScope::package(Vec::new(), scope_chain);
 
     let targets = goto_definition(
+        &db,
         offset(is_null_offset as u32),
         &file,
         &root,
         &idx,
         &scope,
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: other_url,
@@ -461,15 +516,18 @@ fn test_no_use_at_offset() {
     let source = "x <- 1\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(3),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert!(targets.is_empty());
 }
@@ -479,15 +537,18 @@ fn test_unresolved_symbol() {
     let source = "foo\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(0),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert!(targets.is_empty());
 }
@@ -500,17 +561,21 @@ fn test_local_shadows_external() {
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
     let library = test_library(vec![TestPackage::new("pkg", "pkg.R", vec!["foo"], vec![])]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let scope_chain = vec![ScopeLayer::PackageExports("pkg".to_string())];
 
     let use_offset = source.rfind("foo").unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -533,16 +598,19 @@ fn test_conditional_definition_includes_external() {
     let (_other_root, other_idx) = parse_source(other_source);
     let scope_chain = file_layers(other_url.clone(), &other_idx);
 
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::package(scope_chain.clone(), scope_chain),
-        &library,
     );
     assert_eq!(targets, vec![
         NavigationTarget {
@@ -568,15 +636,18 @@ fn test_definition_site_assignment() {
     let source = "foo <- 1\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(0),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -591,16 +662,19 @@ fn test_definition_site_parameter() {
     let source = "f <- function(x) { x }\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // Cursor on the `x` parameter name (offset 14)
     let targets = goto_definition(
+        &db,
         offset(14),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -615,16 +689,19 @@ fn test_definition_site_for_variable() {
     let source = "for (i in 1:10) i\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // Cursor on the `i` in `for (i in ...)`
     let targets = goto_definition(
+        &db,
         offset(5),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -642,15 +719,18 @@ fn test_right_assignment_definition_site() {
     let source = "1 -> x\nx\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(5),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: file.clone(),
@@ -666,15 +746,18 @@ fn test_right_assignment_use_resolves() {
     let source = "1 -> x\nx\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(7),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -693,17 +776,20 @@ fn test_super_assignment_resolves_in_enclosing() {
     let source = "f <- function() x <<- 1\ng <- function() x\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // `x` use in `g` body
     let use_offset = source.rfind('x').unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets.len(), 1);
     assert_eq!(targets[0].name, "x");
@@ -716,17 +802,20 @@ fn test_super_assignment_definition_site() {
     let source = "f <- function() {\n  x <<- 1\n}\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // `x` at offset 20
     let def_offset = source.find("x <<-").unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(def_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets.len(), 1);
     assert_eq!(targets[0].name, "x");
@@ -740,16 +829,19 @@ fn test_string_definition() {
     let source = "\"foo\" <- 1\nfoo\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // Use of `foo` at offset 11
     let targets = goto_definition(
+        &db,
         offset(11),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -768,16 +860,19 @@ fn test_deeply_nested_function() {
     let source = "z <- 1\nf <- function() {\n  g <- function() {\n    z\n  }\n}\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     let use_offset = source.rfind('z').unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -795,18 +890,21 @@ fn test_use_on_rhs_of_assignment() {
     let source = "x <- 1\nx <- x + 1\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
-    let library = empty_library();
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::new(),
+    };
 
     // The `x` on the RHS of the second assignment. `x <- x + 1` starts at
     // offset 7, the RHS `x` is at offset 12.
     let rhs_offset = 7 + "x <- ".len() as u32;
     let targets = goto_definition(
+        &db,
         offset(rhs_offset),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file,
@@ -838,10 +936,14 @@ fn test_library_directive_in_predecessor() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let scope = ExternalScope::package(aaa_layers.clone(), aaa_layers);
 
-    let targets = goto_definition(offset(0), &bbb_url, &bbb_root, &bbb_idx, &scope, &library);
+    let targets = goto_definition(&db, offset(0), &bbb_url, &bbb_root, &bbb_idx, &scope);
 
     assert_eq!(targets.len(), 1);
 
@@ -866,14 +968,18 @@ fn test_namespace_access_exported_symbol() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(7),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
 
     assert_eq!(targets.len(), 1);
@@ -895,14 +1001,18 @@ fn test_namespace_access_unknown_symbol() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(7),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert!(targets.is_empty());
 }
@@ -913,14 +1023,18 @@ fn test_namespace_access_unknown_package() {
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
     let library = test_library(vec![]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(7),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert!(targets.is_empty());
 }
@@ -933,6 +1047,10 @@ fn test_namespace_access_triple_colon() {
         vec!["external_fn"],
         vec!["internal_fn"],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     // "pkg:::internal_fn\n"
     //  01234567890...
@@ -941,12 +1059,12 @@ fn test_namespace_access_triple_colon() {
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
     let targets = goto_definition(
+        &db,
         offset(6),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets.len(), 1);
     let target = targets.first().unwrap();
@@ -960,12 +1078,12 @@ fn test_namespace_access_triple_colon() {
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
     let targets = goto_definition(
+        &db,
         offset(6),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     assert_eq!(targets.len(), 1);
     let target = targets.first().unwrap();
@@ -985,14 +1103,18 @@ fn test_fixme_namespace_access_cursor_on_package_name() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(0),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     // FIXME: Cursor on the package name still classifies as NamespaceAccess
     // and resolves `mutate` in `dplyr`.
@@ -1014,14 +1136,18 @@ fn test_fixme_namespace_access_cursor_on_operator() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(5),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
     // FIXME: Operator token is inside the RNamespaceExpression, still resolves.
     assert_eq!(targets.len(), 1);
@@ -1037,7 +1163,7 @@ fn test_namespace_classify() {
     let source = "dplyr::mutate\n";
     let parsed = parse(source, RParserOptions::default());
     let root = parsed.syntax();
-    let idx = semantic_index(&parsed.tree());
+    let idx = semantic_index(&parsed.tree(), &file_url("test.R"));
 
     // Cursor on `mutate` (offset 7)
     let ident = Identifier::classify(&root, &idx, offset(7));
@@ -1073,7 +1199,7 @@ fn test_namespace_classify_triple_colon() {
     let source = "pkg:::sym\n";
     let parsed = parse(source, RParserOptions::default());
     let root = parsed.syntax();
-    let idx = semantic_index(&parsed.tree());
+    let idx = semantic_index(&parsed.tree(), &file_url("test.R"));
 
     let ident = Identifier::classify(&root, &idx, offset(6));
     assert_eq!(
@@ -1095,14 +1221,18 @@ fn test_namespace_access_in_call() {
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
     let library = test_library(vec![TestPackage::new("foo", "foo.R", vec!["bar"], vec![])]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(5),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
 
     assert_eq!(targets.len(), 1);
@@ -1119,14 +1249,18 @@ fn test_namespace_access_in_extract() {
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
     let library = test_library(vec![TestPackage::new("foo", "foo.R", vec!["bar"], vec![])]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     let targets = goto_definition(
+        &db,
         offset(5),
         &file,
         &root,
         &idx,
         &ExternalScope::default(),
-        &library,
     );
 
     assert_eq!(targets.len(), 1);
@@ -1145,7 +1279,7 @@ fn test_namespace_classify_in_call() {
     let source = "foo::bar()\n";
     let parsed = parse(source, RParserOptions::default());
     let root = parsed.syntax();
-    let idx = semantic_index(&parsed.tree());
+    let idx = semantic_index(&parsed.tree(), &file_url("test.R"));
 
     let ident = Identifier::classify(&root, &idx, offset(5));
     assert_eq!(
@@ -1169,7 +1303,7 @@ fn test_namespace_classify_in_extract() {
     let source = "foo::bar$baz\n";
     let parsed = parse(source, RParserOptions::default());
     let root = parsed.syntax();
-    let idx = semantic_index(&parsed.tree());
+    let idx = semantic_index(&parsed.tree(), &file_url("test.R"));
 
     // Cursor on `bar` (offset 5) — inside the RNamespaceExpression
     let ident = Identifier::classify(&root, &idx, offset(5));
@@ -1198,7 +1332,7 @@ fn test_namespace_classify_string_selectors() {
     let source = "\"foo\"::\"bar\"\n";
     let parsed = parse(source, RParserOptions::default());
     let root = parsed.syntax();
-    let idx = semantic_index(&parsed.tree());
+    let idx = semantic_index(&parsed.tree(), &file_url("test.R"));
 
     let ident = Identifier::classify(&root, &idx, offset(7));
     assert_eq!(
@@ -1221,45 +1355,48 @@ fn test_source_directive_resolves_to_sourced_file() {
     // The builder resolves source() via the callback and injects the
     // sourced file's exports, enabling goto-definition.
     let helpers_source = "helper <- function() 1\n";
-    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
 
     let script_source = "source(\"helpers.R\")\nhelper\n";
     let script_url = file_url("script.R");
 
-    let helpers_url_clone = helpers_url.clone();
-    let helpers_exports: Vec<FileDefinition> = helpers_idx
+    let helpers_names: Vec<String> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| FileDefinition {
-            name: name.to_string(),
-            file: helpers_url_clone.clone(),
-            range,
-        })
+        .map(|(name, _range)| name.to_string())
         .collect();
 
+    let helpers_url_clone = helpers_url.clone();
     let parsed = parse(script_source, RParserOptions::default());
     let script_root = parsed.syntax();
-    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
-        Some(SourceResolution {
-            definitions: helpers_exports.clone(),
-            packages: Vec::new(),
-        })
-    });
+    let script_idx =
+        semantic_index_with_source_resolver(&parsed.tree(), &script_url, move |_path| {
+            Some(SourceResolution {
+                file: helpers_url_clone.clone(),
+                names: helpers_names.clone(),
+                packages: Vec::new(),
+            })
+        });
 
     let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
-    let library = empty_library();
+    let mut sources = HashMap::new();
+    sources.insert(helpers_url.clone(), helpers_source.to_string());
+    let db = TestDb {
+        library: empty_library(),
+        sources,
+    };
 
     let use_offset = script_source.rfind("helper").unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: helpers_url,
@@ -1275,24 +1412,19 @@ fn test_source_directive_resolves_nested_library() {
     // script.R sources helpers.R then uses `mutate` (from dplyr).
     // The nested library() directive should be visible via the resolver.
     let helpers_source = "library(dplyr)\nhelper <- function() 1\n";
-    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
 
-    let helpers_exports: Vec<FileDefinition> = helpers_idx
+    let helpers_names: Vec<String> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| FileDefinition {
-            name: name.to_string(),
-            file: helpers_url.clone(),
-            range,
-        })
+        .map(|(name, _range)| name.to_string())
         .collect();
     let helpers_packages: Vec<_> = helpers_idx
         .file_directives()
         .iter()
-        .filter_map(|d| match d.kind() {
-            DirectiveKind::Attach(pkg) => Some(pkg.clone()),
-            DirectiveKind::Source { .. } => None,
+        .map(|d| match d.kind() {
+            DirectiveKind::Attach(pkg) => pkg.clone(),
         })
         .collect();
 
@@ -1306,56 +1438,66 @@ fn test_source_directive_resolves_nested_library() {
         vec![],
     )]);
 
-    let exports_clone = helpers_exports.clone();
+    let helpers_url_clone = helpers_url.clone();
+    let names_clone = helpers_names.clone();
     let packages_clone = helpers_packages.clone();
     let parsed = parse(script_source, RParserOptions::default());
     let script_root = parsed.syntax();
-    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
-        Some(SourceResolution {
-            definitions: exports_clone.clone(),
-            packages: packages_clone.clone(),
-        })
-    });
+    let script_idx =
+        semantic_index_with_source_resolver(&parsed.tree(), &script_url, move |_path| {
+            Some(SourceResolution {
+                file: helpers_url_clone.clone(),
+                names: names_clone.clone(),
+                packages: packages_clone.clone(),
+            })
+        });
 
     let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
+    let mut sources = HashMap::new();
+    sources.insert(helpers_url.clone(), helpers_source.to_string());
+    let db = TestDb { library, sources };
+
     // `mutate` resolves via dplyr (attached by helpers.R's library() call)
     let use_offset = script_source.rfind("mutate").unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     // `mutate` resolves via dplyr (attached by helpers.R's library() call)
     assert!(!targets.is_empty());
     let source_with_helper = "source(\"helpers.R\")\nhelper\n";
 
-    let exports_clone = helpers_exports.clone();
+    let helpers_url_clone = helpers_url.clone();
+    let names_clone = helpers_names.clone();
     let packages_clone = helpers_packages.clone();
     let parsed2 = parse(source_with_helper, RParserOptions::default());
     let script_root2 = parsed2.syntax();
-    let script_idx2 = semantic_index_with_source_resolver(&parsed2.tree(), move |_path| {
-        Some(SourceResolution {
-            definitions: exports_clone.clone(),
-            packages: packages_clone.clone(),
-        })
-    });
+    let script_idx2 =
+        semantic_index_with_source_resolver(&parsed2.tree(), &script_url, move |_path| {
+            Some(SourceResolution {
+                file: helpers_url_clone.clone(),
+                names: names_clone.clone(),
+                packages: packages_clone.clone(),
+            })
+        });
 
     let dir_layers = directive_layers(script_idx2.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let use_offset = source_with_helper.rfind("helper").unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &script_url,
         &script_root2,
         &script_idx2,
         &scope,
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: helpers_url,
@@ -1377,8 +1519,8 @@ fn test_directive_not_visible_before_call_site() {
     //  "mutate\n"                     offset 49..55
     //  "helper\n"                     offset 56..62
     let helpers_source = "helper <- function() 1\n";
-    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
 
     let script_source = "mutate\nhelper\nlibrary(dplyr)\nsource(\"helpers.R\")\nmutate\nhelper\n";
     let script_url = file_url("script.R");
@@ -1391,69 +1533,71 @@ fn test_directive_not_visible_before_call_site() {
     )]);
 
     let helpers_url_clone = helpers_url.clone();
-    let helpers_exports: Vec<FileDefinition> = helpers_idx
+    let helpers_names: Vec<String> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| FileDefinition {
-            name: name.to_string(),
-            file: helpers_url_clone.clone(),
-            range,
-        })
+        .map(|(name, _range)| name.to_string())
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());
     let script_root = parsed.syntax();
-    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
-        Some(SourceResolution {
-            definitions: helpers_exports.clone(),
-            packages: Vec::new(),
-        })
-    });
+    let script_idx =
+        semantic_index_with_source_resolver(&parsed.tree(), &script_url, move |_path| {
+            Some(SourceResolution {
+                file: helpers_url_clone.clone(),
+                names: helpers_names.clone(),
+                packages: Vec::new(),
+            })
+        });
 
     let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
+    let mut sources = HashMap::new();
+    sources.insert(helpers_url.clone(), helpers_source.to_string());
+    let db = TestDb { library, sources };
+
     // `mutate` before library(dplyr) (offset 0) — should NOT resolve
     let targets = goto_definition(
+        &db,
         offset(0),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert!(targets.is_empty());
 
     // `helper` before source() (offset 7) — should NOT resolve
     let targets = goto_definition(
+        &db,
         offset(7),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert!(targets.is_empty());
 
     // `mutate` after library(dplyr) (offset 49) — resolves via dplyr
     let targets = goto_definition(
+        &db,
         offset(49),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert!(!targets.is_empty());
 
     // `helper` after source() (offset 56) — should resolve to helpers.R
     let targets = goto_definition(
+        &db,
         offset(56),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: helpers_url,
@@ -1479,6 +1623,10 @@ fn test_directives_in_function_body_are_scoped() {
         vec!["filter", "mutate", "select"],
         vec![],
     )]);
+    let db = TestDb {
+        library,
+        sources: HashMap::new(),
+    };
 
     // library() inside f produces a scoped directive
     let directives = script_idx.file_directives();
@@ -1492,12 +1640,12 @@ fn test_directives_in_function_body_are_scoped() {
     // `mutate` inside f (after library()) — resolves via scoped dplyr
     let use_offset = script_source.find("  mutate").unwrap() as u32 + 2;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     // `mutate` inside f (after library()) — resolves via scoped dplyr
     assert!(!targets.is_empty());
@@ -1505,12 +1653,12 @@ fn test_directives_in_function_body_are_scoped() {
     // `helper` at file scope — not resolved (source() had no resolver)
     let use_offset = script_source.find("\nhelper").unwrap() as u32 + 1;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert!(targets.is_empty());
 
@@ -1518,12 +1666,12 @@ fn test_directives_in_function_body_are_scoped() {
     // scoped to f, not visible here)
     let use_offset = script_source.rfind("mutate").unwrap() as u32;
     let targets = goto_definition(
+        &db,
         offset(use_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert!(targets.is_empty());
 }
@@ -1533,46 +1681,49 @@ fn test_source_in_function_body_scoping() {
     // `source(local = FALSE)` inside a function body scopes directives to the
     // function scope, so sourced definitions are NOT visible at file scope.
     let helpers_source = "helper <- function() 1\n";
-    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
+    let (_helpers_root, helpers_idx) = parse_source(helpers_source);
 
     let script_source = "f <- function() {\n  source(\"helpers.R\")\n  helper\n}\nhelper\n";
     let script_url = file_url("script.R");
 
     let helpers_url_clone = helpers_url.clone();
-    let helpers_exports: Vec<FileDefinition> = helpers_idx
+    let helpers_names: Vec<String> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| FileDefinition {
-            name: name.to_string(),
-            file: helpers_url_clone.clone(),
-            range,
-        })
+        .map(|(name, _range)| name.to_string())
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());
     let script_root = parsed.syntax();
-    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), move |_path| {
-        Some(SourceResolution {
-            definitions: helpers_exports.clone(),
-            packages: Vec::new(),
-        })
-    });
+    let script_idx =
+        semantic_index_with_source_resolver(&parsed.tree(), &script_url, move |_path| {
+            Some(SourceResolution {
+                file: helpers_url_clone.clone(),
+                names: helpers_names.clone(),
+                packages: Vec::new(),
+            })
+        });
 
     let dir_layers = directive_layers(script_idx.file_directives());
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
-    let library = empty_library();
+    let mut sources = HashMap::new();
+    sources.insert(helpers_url.clone(), helpers_source.to_string());
+    let db = TestDb {
+        library: empty_library(),
+        sources,
+    };
 
     // `helper` inside the function body — should resolve to helpers.R
     let inner_offset = script_source.find("  helper\n}").unwrap() as u32 + 2;
     let targets = goto_definition(
+        &db,
         offset(inner_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert_eq!(targets, vec![NavigationTarget {
         file: helpers_url,
@@ -1584,12 +1735,12 @@ fn test_source_in_function_body_scoping() {
     // `helper` outside the function — NOT visible
     let outer_offset = script_source.rfind("\nhelper\n").unwrap() as u32 + 1;
     let targets = goto_definition(
+        &db,
         offset(outer_offset),
         &script_url,
         &script_root,
         &script_idx,
         &scope,
-        &library,
     );
     assert!(targets.is_empty());
 }

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -1363,8 +1363,8 @@ fn test_source_directive_resolves_to_sourced_file() {
 
     let helpers_names: Vec<String> = helpers_idx
         .file_exports()
-        .into_iter()
-        .map(|(name, _range)| name.to_string())
+        .keys()
+        .map(|name| name.to_string())
         .collect();
 
     let helpers_url_clone = helpers_url.clone();
@@ -1417,8 +1417,8 @@ fn test_source_directive_resolves_nested_library() {
 
     let helpers_names: Vec<String> = helpers_idx
         .file_exports()
-        .into_iter()
-        .map(|(name, _range)| name.to_string())
+        .keys()
+        .map(|name| name.to_string())
         .collect();
     let helpers_packages: Vec<_> = helpers_idx
         .file_directives()
@@ -1535,8 +1535,8 @@ fn test_directive_not_visible_before_call_site() {
     let helpers_url_clone = helpers_url.clone();
     let helpers_names: Vec<String> = helpers_idx
         .file_exports()
-        .into_iter()
-        .map(|(name, _range)| name.to_string())
+        .keys()
+        .map(|name| name.to_string())
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());
@@ -1690,8 +1690,8 @@ fn test_source_in_function_body_scoping() {
     let helpers_url_clone = helpers_url.clone();
     let helpers_names: Vec<String> = helpers_idx
         .file_exports()
-        .into_iter()
-        .map(|(name, _range)| name.to_string())
+        .keys()
+        .map(|name| name.to_string())
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());
@@ -1743,4 +1743,55 @@ fn test_source_in_function_body_scoping() {
         &scope,
     );
     assert!(targets.is_empty());
+}
+
+// TODO(salsa): This tests `resolve_import` which is slated to move to
+// `oak_index`. Move this test alongside it and call `resolve_import` directly
+// once it becomes pub.
+#[test]
+fn test_resolve_import_last_def_wins() {
+    // If the target file defines the same name twice, resolve_import
+    // should navigate to the last definition.
+    let helpers_url = file_url("helpers.R");
+    let script_url = file_url("script.R");
+
+    let db = TestDb {
+        library: empty_library(),
+        sources: HashMap::from([(
+            helpers_url.clone(),
+            "foo <- function() 'first'\nfoo <- function() 'second'\n".to_string(),
+        )]),
+    };
+
+    let script_source = "source(\"helpers.R\")\nfoo\n";
+    let parsed = parse(script_source, RParserOptions::default());
+    let script_root = parsed.syntax();
+    let script_idx = semantic_index_with_source_resolver(&parsed.tree(), &script_url, |_path| {
+        Some(SourceResolution {
+            file: helpers_url.clone(),
+            names: vec!["foo".to_string()],
+            packages: Vec::new(),
+        })
+    });
+
+    let dir_layers = directive_layers(script_idx.file_directives());
+    let scope = ExternalScope::search_path(dir_layers, Vec::new());
+
+    let use_offset = script_source.rfind("foo").unwrap() as u32;
+    let targets = goto_definition(
+        &db,
+        offset(use_offset),
+        &script_url,
+        &script_root,
+        &script_idx,
+        &scope,
+    );
+
+    // Should resolve to the SECOND definition of `foo` in helpers.R (line 1)
+    assert_eq!(targets, vec![NavigationTarget {
+        file: helpers_url,
+        name: "foo".to_string(),
+        full_range: text_range(26, 29),
+        focus_range: text_range(26, 29),
+    }]);
 }

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -21,6 +21,7 @@ use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::ScopeId;
 use oak_index::SourceResolution;
+use oak_index::FileDefinition;
 use oak_package_metadata::description::Description;
 use oak_package_metadata::namespace::Namespace;
 use oak_sources::test::TestPackageCache;
@@ -1227,10 +1228,14 @@ fn test_source_directive_resolves_to_sourced_file() {
     let script_url = file_url("script.R");
 
     let helpers_url_clone = helpers_url.clone();
-    let helpers_exports: Vec<_> = helpers_idx
+    let helpers_exports: Vec<FileDefinition> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| (name.to_string(), helpers_url_clone.clone(), range))
+        .map(|(name, range)| FileDefinition {
+            name: name.to_string(),
+            file: helpers_url_clone.clone(),
+            range,
+        })
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());
@@ -1273,10 +1278,14 @@ fn test_source_directive_resolves_nested_library() {
     let (_helpers_root, helpers_idx) = parse_source(helpers_source);
     let helpers_url = file_url("helpers.R");
 
-    let helpers_exports: Vec<_> = helpers_idx
+    let helpers_exports: Vec<FileDefinition> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| (name.to_string(), helpers_url.clone(), range))
+        .map(|(name, range)| FileDefinition {
+            name: name.to_string(),
+            file: helpers_url.clone(),
+            range,
+        })
         .collect();
     let helpers_packages: Vec<_> = helpers_idx
         .file_directives()
@@ -1382,10 +1391,14 @@ fn test_directive_not_visible_before_call_site() {
     )]);
 
     let helpers_url_clone = helpers_url.clone();
-    let helpers_exports: Vec<_> = helpers_idx
+    let helpers_exports: Vec<FileDefinition> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| (name.to_string(), helpers_url_clone.clone(), range))
+        .map(|(name, range)| FileDefinition {
+            name: name.to_string(),
+            file: helpers_url_clone.clone(),
+            range,
+        })
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());
@@ -1527,10 +1540,14 @@ fn test_source_in_function_body_scoping() {
     let script_url = file_url("script.R");
 
     let helpers_url_clone = helpers_url.clone();
-    let helpers_exports: Vec<_> = helpers_idx
+    let helpers_exports: Vec<FileDefinition> = helpers_idx
         .file_exports()
         .into_iter()
-        .map(|(name, range)| (name.to_string(), helpers_url_clone.clone(), range))
+        .map(|(name, range)| FileDefinition {
+            name: name.to_string(),
+            file: helpers_url_clone.clone(),
+            range,
+        })
         .collect();
 
     let parsed = parse(script_source, RParserOptions::default());

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -13,7 +13,6 @@ use oak_ide::ExternalScope;
 use oak_ide::NavigationTarget;
 use oak_index::library::Library;
 use oak_index::package::Package;
-use oak_index::scope_layer::directive_layers;
 use oak_index::scope_layer::file_layers;
 use oak_index::scope_layer::ScopeLayer;
 use oak_index::semantic_index;
@@ -1379,7 +1378,7 @@ fn test_source_directive_resolves_to_sourced_file() {
             })
         });
 
-    let dir_layers = directive_layers(script_idx.file_directives());
+    let dir_layers = script_idx.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1452,7 +1451,7 @@ fn test_source_directive_resolves_nested_library() {
             })
         });
 
-    let dir_layers = directive_layers(script_idx.file_directives());
+    let dir_layers = script_idx.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1487,7 +1486,7 @@ fn test_source_directive_resolves_nested_library() {
             })
         });
 
-    let dir_layers = directive_layers(script_idx2.file_directives());
+    let dir_layers = script_idx2.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let use_offset = source_with_helper.rfind("helper").unwrap() as u32;
@@ -1550,7 +1549,7 @@ fn test_directive_not_visible_before_call_site() {
             })
         });
 
-    let dir_layers = directive_layers(script_idx.file_directives());
+    let dir_layers = script_idx.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1634,7 +1633,7 @@ fn test_directives_in_function_body_are_scoped() {
     assert_eq!(directives[0].kind(), &DirectiveKind::Attach("dplyr".into()));
     assert_ne!(directives[0].scope(), ScopeId::from(0));
 
-    let dir_layers = directive_layers(script_idx.file_directives());
+    let dir_layers = script_idx.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     // `mutate` inside f (after library()) — resolves via scoped dplyr
@@ -1705,7 +1704,7 @@ fn test_source_in_function_body_scoping() {
             })
         });
 
-    let dir_layers = directive_layers(script_idx.file_directives());
+    let dir_layers = script_idx.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1774,7 +1773,7 @@ fn test_resolve_import_last_def_wins() {
         })
     });
 
-    let dir_layers = directive_layers(script_idx.file_directives());
+    let dir_layers = script_idx.file_directives().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let use_offset = script_source.rfind("foo").unwrap() as u32;

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -1290,7 +1290,12 @@ fn test_source_directive_resolves_nested_library() {
     let script_source = "source(\"helpers.R\")\nmutate\n";
     let script_url = file_url("script.R");
 
-    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+    let library = test_library(vec![TestPackage::new(
+        "dplyr",
+        "dplyr.R",
+        vec!["filter", "mutate", "select"],
+        vec![],
+    )]);
 
     let exports_clone = helpers_exports.clone();
     let packages_clone = helpers_packages.clone();
@@ -1316,10 +1321,8 @@ fn test_source_directive_resolves_nested_library() {
         &scope,
         &library,
     );
-    // Package symbol, no NavigationTarget
-    assert!(targets.is_empty());
-
-    // `helper` still resolves to helpers.R
+    // `mutate` resolves via dplyr (attached by helpers.R's library() call)
+    assert!(!targets.is_empty());
     let source_with_helper = "source(\"helpers.R\")\nhelper\n";
 
     let exports_clone = helpers_exports.clone();
@@ -1371,7 +1374,12 @@ fn test_directive_not_visible_before_call_site() {
     let script_source = "mutate\nhelper\nlibrary(dplyr)\nsource(\"helpers.R\")\nmutate\nhelper\n";
     let script_url = file_url("script.R");
 
-    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+    let library = test_library(vec![TestPackage::new(
+        "dplyr",
+        "dplyr.R",
+        vec!["filter", "mutate", "select"],
+        vec![],
+    )]);
 
     let helpers_url_clone = helpers_url.clone();
     let helpers_exports: Vec<_> = helpers_idx
@@ -1414,7 +1422,7 @@ fn test_directive_not_visible_before_call_site() {
     );
     assert!(targets.is_empty());
 
-    // `mutate` after library(dplyr) (offset 49) — package symbol, no NavigationTarget yet (FIXME)
+    // `mutate` after library(dplyr) (offset 49) — resolves via dplyr
     let targets = goto_definition(
         offset(49),
         &script_url,
@@ -1423,7 +1431,7 @@ fn test_directive_not_visible_before_call_site() {
         &scope,
         &library,
     );
-    assert!(targets.is_empty());
+    assert!(!targets.is_empty());
 
     // `helper` after source() (offset 56) — should resolve to helpers.R
     let targets = goto_definition(
@@ -1452,7 +1460,12 @@ fn test_directives_in_function_body_are_scoped() {
     let script_url = file_url("script.R");
     let (script_root, script_idx) = parse_source(script_source);
 
-    let library = test_library(vec![("dplyr", vec!["filter", "mutate", "select"])]);
+    let library = test_library(vec![TestPackage::new(
+        "dplyr",
+        "dplyr.R",
+        vec!["filter", "mutate", "select"],
+        vec![],
+    )]);
 
     // library() inside f produces a scoped directive
     let directives = script_idx.file_directives();
@@ -1473,8 +1486,8 @@ fn test_directives_in_function_body_are_scoped() {
         &scope,
         &library,
     );
-    // Package symbol, no NavigationTarget
-    assert!(targets.is_empty());
+    // `mutate` inside f (after library()) — resolves via scoped dplyr
+    assert!(!targets.is_empty());
 
     // `helper` at file scope — not resolved (source() had no resolver)
     let use_offset = script_source.find("\nhelper").unwrap() as u32 + 1;

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -711,12 +711,6 @@ impl<'a> SemanticIndexBuilder<'a> {
             return;
         }
 
-        // library()/require() only at file scope -- in a function body the
-        // attachment is a runtime side effect we can't model statically.
-        if is_attach && self.current_scope != ScopeId::from(0) {
-            return;
-        }
-
         let Ok(args) = call.arguments() else {
             return;
         };
@@ -746,6 +740,7 @@ impl<'a> SemanticIndexBuilder<'a> {
             self.directives.push(Directive {
                 kind: DirectiveKind::Attach(pkg_name),
                 offset: call_offset,
+                scope: self.current_scope,
             });
         } else {
             // source() -- resolve via callback and inject definitions
@@ -773,6 +768,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                         self.directives.push(Directive {
                             kind: DirectiveKind::Attach(pkg),
                             offset: call_offset,
+                            scope: self.current_scope,
                         });
                     }
                 }

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -74,11 +74,22 @@ pub fn semantic_index_with_source_resolver<'a>(
 /// callback passed to the builder.
 pub struct SourceResolution {
     /// Definitions to inject as synthetic bindings in the calling scope.
-    /// Each entry is (name, file_url, range_in_source_file).
-    pub definitions: Vec<(String, Url, TextRange)>,
+    pub definitions: Vec<FileDefinition>,
+
     /// Package names from `library()` directives in the sourced file
     /// (and transitively from files it sources).
     pub packages: Vec<String>,
+}
+
+/// A top-level definition from a file, represented so it can be consumed
+/// outside of that file's [`SemanticIndex`]. Where [`Definition`] refers to
+/// names through a `SymbolId` scoped to a specific symbol table,
+/// `FileDefinition` carries the name inline and is self-contained.
+#[derive(Clone)]
+pub struct FileDefinition {
+    pub name: String,
+    pub file: Url,
+    pub range: TextRange,
 }
 
 type SourceResolver<'a> = Box<dyn FnMut(&str) -> Option<SourceResolution> + 'a>;
@@ -876,13 +887,13 @@ impl<'a> SemanticIndexBuilder<'a> {
         if is_local || !in_nested_scope {
             // `local = TRUE` or at file scope: inject into the
             // use-def map so sourced definitions shadow locals.
-            for (name, file, range) in resolution.definitions {
+            for def in resolution.definitions {
                 self.add_definition(
-                    &name,
+                    &def.name,
                     SymbolFlags::IS_BOUND,
                     DefinitionKind::Sourced,
-                    range,
-                    Some(file),
+                    def.range,
+                    Some(def.file),
                 );
             }
             for pkg in resolution.packages {
@@ -897,8 +908,11 @@ impl<'a> SemanticIndexBuilder<'a> {
             // resolution only via directives, scoped to the current scope
             // instead of the file scope.
             let mut by_file: HashMap<Url, HashMap<String, TextRange>> = HashMap::new();
-            for (name, file, range) in resolution.definitions {
-                by_file.entry(file).or_default().insert(name, range);
+            for def in resolution.definitions {
+                by_file
+                    .entry(def.file)
+                    .or_default()
+                    .insert(def.name, def.range);
             }
             for (file, exports) in by_file {
                 self.directives.push(Directive {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -484,6 +484,12 @@ impl SemanticIndexBuilder {
             // quoting constructs (`~`, `quote()`, `bquote()`) are recorded as
             // uses and bindings. Refining this requires special-casing these
             // forms, which we defer as future work.
+            //
+            // Once quoting is handled, `declare()` and `~declare()` will need
+            // explicit treatment: its arguments are quoted (not evaluated) but
+            // should still be inspected for directives like `source()`.
+            // Currently this works by accident because the generic traversal is
+            // transparent to both `declare()` and `~`.
             _ => {
                 self.collect_descendants(expr.syntax());
             },

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -42,6 +42,8 @@ use crate::semantic_index::Use;
 use crate::semantic_index::UseId;
 use crate::use_def_map::UseDefMapBuilder;
 
+// TODO(salsa): Remove `semantic_index()` and variant, these are too coarse queries.
+
 /// Build a [`SemanticIndex`] from a parsed R file.
 pub fn semantic_index(root: &RRoot, file: &Url) -> SemanticIndex {
     let range = root.syntax().text_trimmed_range();

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+
+use aether_syntax::AnyRArgumentName;
 use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRParameterName;
 use aether_syntax::AnyRValue;
@@ -705,12 +708,22 @@ impl<'a> SemanticIndexBuilder<'a> {
         };
 
         let fn_name = ident.name_text();
-        let is_attach = fn_name == "library" || fn_name == "require";
-        let is_source = fn_name == "source";
-        if !is_attach && !is_source {
-            return;
+        if fn_name == "library" || fn_name == "require" {
+            self.collect_attach_directive(call);
+        } else if fn_name == "source" {
+            self.collect_source_directive(call);
         }
+    }
 
+    // ## `library()` / `require()` scoping
+    //
+    // In R, `library()` always modifies the global search path regardless
+    // of where it's called. Statically, we scope the directive to
+    // `self.current_scope`: at file scope it's visible everywhere (sequential
+    // execution is guaranteed), but inside a function it's only visible
+    // within that function and its children, since the function might never
+    // be called. Same reasoning as `source(local = FALSE)` directives.
+    fn collect_attach_directive(&mut self, call: &aether_syntax::RCall) {
         let Ok(args) = call.arguments() else {
             return;
         };
@@ -726,36 +739,133 @@ impl<'a> SemanticIndexBuilder<'a> {
             return;
         };
 
+        let pkg_name = match &value {
+            AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
+            AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
+            _ => None,
+        };
+        let Some(pkg_name) = pkg_name else {
+            return;
+        };
+
         let call_offset = call.syntax().text_trimmed_range().start();
+        self.directives.push(Directive {
+            kind: DirectiveKind::Attach(pkg_name),
+            offset: call_offset,
+            scope: self.current_scope,
+        });
+    }
 
-        if is_attach {
-            let pkg_name = match &value {
-                AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
-                AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
-                _ => None,
-            };
-            let Some(pkg_name) = pkg_name else {
-                return;
-            };
-            self.directives.push(Directive {
-                kind: DirectiveKind::Attach(pkg_name),
-                offset: call_offset,
-                scope: self.current_scope,
-            });
-        } else {
-            // source() -- resolve via callback and inject definitions
-            let path = match &value {
-                AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
-                _ => None,
-            };
-            let Some(path) = path else {
-                return;
-            };
+    // ## `source()` resolution
+    //
+    // R's `source(file, local = )` evaluates a file in a target
+    // environment. The `local` parameter controls where definitions land:
+    //
+    //   - `local = TRUE`: definitions go into the calling environment.
+    //   - `local = FALSE` (default): definitions go into the global
+    //     environment.
+    //   - `local = <env>`: definitions go into `<env>`.
+    //
+    // We model the boolean case with two mechanisms:
+    //
+    // ### `local = TRUE`, or `source()` at file scope
+    //
+    // Top-level bindings in the sourced file are injected as definitions into
+    // the use-def map as `DefinitionKind::Sourced` via `add_definition`. They
+    // fully participate in local resolution and shadow prior bindings, just
+    // like `<-`. At file scope, `local` doesn't matter because the current
+    // scope IS the global environment, and sequential execution is guaranteed,
+    // so `source()` overwrites like any other assignment:
+    //
+    // ```r
+    // foo <- 1
+    // source("helpers.R")  # also defines foo
+    // foo                  # resolves to sourced foo (shadowed)
+    // ```
+    //
+    // ### `local = FALSE` (default) in a nested scope
+    //
+    // External top-level bindings are reached through `DirectiveKind::Source`
+    // entries, which flow through the `FileScope` scope chain alongside
+    // `library()` / `Attach` directives. They are only consulted when a symbol
+    // is unbound after local + enclosing scope resolution, so they never shadow
+    // local bindings:
+    //
+    // ```r
+    // f <- function() {
+    //     foo <- "local"
+    //     source("helpers.R")  # also defines foo, local = FALSE
+    //     foo                  # resolves to local "local"
+    //     bar                  # no local def → resolves via directive
+    // }
+    // ```
+    //
+    // The directive is scoped to the function (not file scope) because
+    // top-level code should not assume that the sourcing function will be
+    // called. We could refine with call analysis in the future though.
+    // `FileScope::at()` filters by `(offset, scope)`: the directive is visible
+    // only at cursor positions inside the function (or its children) and after
+    // the call site. `FileScope::lazy()` only includes file-scope directives,
+    // so function-scoped ones are conservatively excluded.
+    //
+    // ### Resolution chain
+    //
+    // Goto-definition resolves a use through three layers:
+    //
+    // 1. **Local bindings** (`use_def_map.bindings_at_use`): finds
+    //    `Sourced` definitions from `local = TRUE` / file-scope sources.
+    // 2. **Enclosing bindings** (`enclosing_bindings`): free variables
+    //    in nested scopes reach ancestor definitions.
+    // 3. **Scope chain** (`FileScope::at` → `resolve_external_name`):
+    //    `Source` and `Attach` directive layers, searched in reverse
+    //    order (LIFO, matching R's search path where the last
+    //    `library()` or `source()` wins).
+    fn collect_source_directive(&mut self, call: &aether_syntax::RCall) {
+        let Ok(args) = call.arguments() else {
+            return;
+        };
 
-            // Take the resolver out to avoid borrow conflict with `&mut self`
-            let mut resolver = self.source_resolver.take();
-            if let Some(ref mut resolve) = resolver {
-                if let Some(resolution) = resolve(&path) {
+        let mut path: Option<String> = None;
+        let mut is_local = false;
+
+        for item in args.items().iter() {
+            let Ok(arg) = item else { continue };
+
+            if let Some(name_clause) = arg.name_clause() {
+                let Ok(AnyRArgumentName::RIdentifier(name_ident)) = name_clause.name() else {
+                    continue;
+                };
+                if name_ident.name_text() == "local" {
+                    if let Some(value) = arg.value() {
+                        match value {
+                            AnyRExpression::RTrueExpression(_) => is_local = true,
+                            AnyRExpression::RFalseExpression(_) => is_local = false,
+                            _ => {},
+                        }
+                    }
+                }
+            } else if path.is_none() {
+                // First positional argument: the file path
+                if let Some(AnyRExpression::AnyRValue(AnyRValue::RStringValue(s))) = arg.value() {
+                    path = s.string_text();
+                }
+            }
+        }
+
+        let Some(path) = path else {
+            return;
+        };
+
+        let call_offset = call.syntax().text_trimmed_range().start();
+        let in_nested_scope = self.current_scope != ScopeId::from(0);
+
+        // Take the resolver out to avoid borrow conflict with `&mut self`
+        let mut resolver = self.source_resolver.take();
+        if let Some(ref mut resolve) = resolver {
+            if let Some(resolution) = resolve(&path) {
+                if is_local || !in_nested_scope {
+                    // `local = TRUE` or at file scope: inject into the
+                    // use-def map so sourced definitions shadow locals.
                     for (name, file, range) in resolution.definitions {
                         self.add_definition(
                             &name,
@@ -771,10 +881,33 @@ impl<'a> SemanticIndexBuilder<'a> {
                             scope: self.current_scope,
                         });
                     }
+                } else {
+                    // `local = FALSE` (default) in a nested scope:
+                    // cross-file resolution only via directives, scoped
+                    // to the current scope (not file scope) since the
+                    // function might never be called.
+                    let mut by_file: HashMap<Url, HashMap<String, TextRange>> = HashMap::new();
+                    for (name, file, range) in resolution.definitions {
+                        by_file.entry(file).or_default().insert(name, range);
+                    }
+                    for (file, exports) in by_file {
+                        self.directives.push(Directive {
+                            kind: DirectiveKind::Source { file, exports },
+                            offset: call_offset,
+                            scope: self.current_scope,
+                        });
+                    }
+                    for pkg in resolution.packages {
+                        self.directives.push(Directive {
+                            kind: DirectiveKind::Attach(pkg),
+                            offset: call_offset,
+                            scope: self.current_scope,
+                        });
+                    }
                 }
             }
-            self.source_resolver = resolver;
         }
+        self.source_resolver = resolver;
     }
 
     fn finish(mut self) -> SemanticIndex {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -245,7 +245,7 @@ impl<'a> SemanticIndexBuilder<'a> {
         loop {
             if let Some(id) = self.symbol_tables[scope].id(name) {
                 if self.symbol_tables[scope]
-                    .symbol_id(id)
+                    .symbol(id)
                     .flags()
                     .contains(SymbolFlags::IS_BOUND)
                 {
@@ -291,7 +291,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                 .id(name)
                 .is_some_and(|sym_id| {
                     self.symbol_tables[current_scope]
-                        .symbol_id(sym_id)
+                        .symbol(sym_id)
                         .flags()
                         .contains(SymbolFlags::IS_BOUND)
                 });
@@ -734,7 +734,7 @@ impl<'a> SemanticIndexBuilder<'a> {
     // `self.current_scope`: at file scope it's visible everywhere (sequential
     // execution is guaranteed), but inside a function it's only visible
     // within that function and its children, since the function might never
-    // be called. Same reasoning as `source(local = FALSE)` directives.
+    // be called. Same reasoning as `source()` directives.
     fn collect_attach_directive(&mut self, call: &aether_syntax::RCall) {
         let Ok(args) = call.arguments() else {
             return;

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -182,12 +182,14 @@ impl<'a> SemanticIndexBuilder<'a> {
         flags: SymbolFlags,
         kind: DefinitionKind,
         range: TextRange,
+        file: Option<Url>,
     ) {
         let symbol_id = self.symbol_tables[self.current_scope].intern(name, flags);
         let def_id = self.definitions[self.current_scope].push(Definition {
             symbol: symbol_id,
             kind,
             range,
+            file,
         });
         self.use_def_maps[self.current_scope].ensure_symbol(symbol_id);
         self.use_def_maps[self.current_scope].record_definition(symbol_id, def_id);
@@ -208,6 +210,7 @@ impl<'a> SemanticIndexBuilder<'a> {
             symbol: symbol_id,
             kind: kind.clone(),
             range,
+            file: None,
         });
 
         let target_scope = self.resolve_super_target(name);
@@ -217,6 +220,7 @@ impl<'a> SemanticIndexBuilder<'a> {
             symbol: target_symbol,
             kind,
             range,
+            file: None,
         });
         self.use_def_maps[target_scope].ensure_symbol(target_symbol);
         self.use_def_maps[target_scope].record_deferred_definition(target_symbol, target_def_id);
@@ -422,6 +426,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                         SymbolFlags::IS_BOUND,
                         DefinitionKind::ForVariable(stmt.syntax().clone()),
                         variable.syntax().text_trimmed_range(),
+                        None,
                     );
                 }
                 if let Ok(sequence) = stmt.sequence() {
@@ -628,6 +633,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         ident.syntax().text_trimmed_range(),
+                        None,
                     );
                 },
                 AnyRParameterName::RDots(dots) => {
@@ -636,6 +642,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         dots.syntax().text_trimmed_range(),
+                        None,
                     );
                 },
                 AnyRParameterName::RDotDotI(ddi) => {
@@ -644,6 +651,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         ddi.syntax().text_trimmed_range(),
+                        None,
                     );
                 },
             }
@@ -690,6 +698,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                 SymbolFlags::IS_BOUND,
                 DefinitionKind::Assignment(op.syntax().clone()),
                 range,
+                None,
             );
         }
     }
@@ -871,8 +880,9 @@ impl<'a> SemanticIndexBuilder<'a> {
                 self.add_definition(
                     &name,
                     SymbolFlags::IS_BOUND,
-                    DefinitionKind::Sourced { file },
+                    DefinitionKind::Sourced,
                     range,
+                    Some(file),
                 );
             }
             for pkg in resolution.packages {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -671,7 +671,9 @@ impl SemanticIndexBuilder {
         };
 
         let fn_name = ident.name_text();
-        if fn_name != "library" && fn_name != "require" {
+        let is_attach = fn_name == "library" || fn_name == "require";
+        let is_source = fn_name == "source";
+        if !is_attach && !is_source {
             return;
         }
 
@@ -693,18 +695,29 @@ impl SemanticIndexBuilder {
             return;
         };
 
-        // Extract the package name from identifier or string literal
-        let pkg_name = match &value {
-            AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
-            AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
-            _ => None,
-        };
-        let Some(pkg_name) = pkg_name else {
-            return;
+        let kind = if is_attach {
+            let pkg_name = match &value {
+                AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
+                AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
+                _ => None,
+            };
+            let Some(pkg_name) = pkg_name else {
+                return;
+            };
+            DirectiveKind::Attach(pkg_name)
+        } else {
+            let path = match &value {
+                AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
+                _ => None,
+            };
+            let Some(path) = path else {
+                return;
+            };
+            DirectiveKind::Source(path)
         };
 
         self.directives.push(Directive {
-            kind: DirectiveKind::Attach(pkg_name),
+            kind,
             offset: call.syntax().text_trimmed_range().start(),
         });
     }

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -739,6 +739,9 @@ impl<'a> SemanticIndexBuilder<'a> {
         };
         let mut items = args.items().iter();
 
+        // For now, only recognise exactly one unnamed argument. We'll do
+        // argument matching later (`character.only` unquoting is another
+        // complication).
         let Some(Ok(first_arg)) = items.next() else {
             return;
         };
@@ -856,13 +859,9 @@ impl<'a> SemanticIndexBuilder<'a> {
         }
     }
 
-    /// Call the source resolver for `path`, temporarily taking it out of
-    /// `self` to avoid borrow conflicts.
     fn resolve_source(&mut self, path: &str) -> Option<SourceResolution> {
-        let mut resolver = self.source_resolver.take()?;
-        let result = resolver(path);
-        self.source_resolver = Some(resolver);
-        result
+        let source_resolver = self.source_resolver.as_mut()?;
+        source_resolver(path)
     }
 
     fn finish(mut self) -> SemanticIndex {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -22,6 +22,7 @@ use oak_index_vec::Idx;
 use oak_index_vec::IndexVec;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
+use url::Url;
 
 use crate::semantic_index::Definition;
 use crate::semantic_index::DefinitionId;
@@ -40,19 +41,48 @@ use crate::semantic_index::Use;
 use crate::semantic_index::UseId;
 use crate::use_def_map::UseDefMapBuilder;
 
+/// The result of resolving a `source()` call. Returned by the resolver
+/// callback passed to the builder.
+pub struct SourceResolution {
+    /// Definitions to inject as synthetic bindings in the calling scope.
+    /// Each entry is (name, file_url, range_in_source_file).
+    pub definitions: Vec<(String, Url, TextRange)>,
+    /// Package names from `library()` directives in the sourced file
+    /// (and transitively from files it sources).
+    pub packages: Vec<String>,
+}
+
 /// Build a [`SemanticIndex`] from a parsed R file.
 pub fn semantic_index(root: &RRoot) -> SemanticIndex {
     let range = root.syntax().text_trimmed_range();
-    let mut builder = SemanticIndexBuilder::new(range);
+    let mut builder = SemanticIndexBuilder::new(range, None);
     builder.pre_scan_scope(root.syntax());
     builder.collect_expression_list(&root.expressions());
     builder.finish()
 }
 
+/// Build a [`SemanticIndex`] with cross-file `source()` resolution.
+///
+/// The resolver callback is called when the builder encounters a
+/// `source("path")` call. It should return the sourced file's exported
+/// definitions and any `library()` package attachments.
+pub fn semantic_index_with_source_resolver<'a>(
+    root: &RRoot,
+    resolver: impl FnMut(&str) -> Option<SourceResolution> + 'a,
+) -> SemanticIndex {
+    let range = root.syntax().text_trimmed_range();
+    let mut builder = SemanticIndexBuilder::new(range, Some(Box::new(resolver)));
+    builder.pre_scan_scope(root.syntax());
+    builder.collect_expression_list(&root.expressions());
+    builder.finish()
+}
+
+type SourceResolver<'a> = Box<dyn FnMut(&str) -> Option<SourceResolution> + 'a>;
+
 // Maintains the preorder allocation invariant on `Scope::descendants`. The
 // parallel arrays are pushed in lockstep so they stay indexed by the same
 // `ScopeId`.
-struct SemanticIndexBuilder {
+struct SemanticIndexBuilder<'a> {
     scopes: IndexVec<ScopeId, Scope>,
     symbol_tables: IndexVec<ScopeId, SymbolTableBuilder>,
     definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
@@ -62,10 +92,11 @@ struct SemanticIndexBuilder {
     pre_scans: IndexVec<ScopeId, PreScanScope>,
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
     directives: Vec<Directive>,
+    source_resolver: Option<SourceResolver<'a>>,
 }
 
-impl SemanticIndexBuilder {
-    fn new(range: TextRange) -> Self {
+impl<'a> SemanticIndexBuilder<'a> {
+    fn new(range: TextRange, source_resolver: Option<SourceResolver<'a>>) -> Self {
         let mut scopes = IndexVec::new();
         let mut symbol_tables = IndexVec::new();
         let mut definitions = IndexVec::new();
@@ -102,6 +133,7 @@ impl SemanticIndexBuilder {
             pre_scans,
             enclosing_snapshots: FxHashMap::default(),
             directives: Vec::new(),
+            source_resolver,
         }
     }
 
@@ -344,9 +376,7 @@ impl SemanticIndexBuilder {
                 // also consider nested scopes as long as they're not lazy (e.g.
                 // function definitions or NSE calls that don't evaluate
                 // immediately.
-                if self.current_scope == ScopeId::from(0) {
-                    self.collect_directive(call);
-                }
+                self.collect_directive(call);
             },
             AnyRExpression::RSubset(subset) => {
                 if let Ok(object) = subset.function() {
@@ -669,8 +699,6 @@ impl SemanticIndexBuilder {
         }
     }
 
-    /// Detect directives like `library(pkg)` and `require(pkg)` at the
-    /// file-level scope.
     fn collect_directive(&mut self, call: &aether_syntax::RCall) {
         let Ok(AnyRExpression::RIdentifier(ident)) = call.function() else {
             return;
@@ -683,14 +711,17 @@ impl SemanticIndexBuilder {
             return;
         }
 
+        // library()/require() only at file scope -- in a function body the
+        // attachment is a runtime side effect we can't model statically.
+        if is_attach && self.current_scope != ScopeId::from(0) {
+            return;
+        }
+
         let Ok(args) = call.arguments() else {
             return;
         };
         let mut items = args.items().iter();
 
-        // For now, only recognise exactly one unnamed argument. We'll do
-        // argument matching later (`character.only` unquoting is another
-        // complication).
         let Some(Ok(first_arg)) = items.next() else {
             return;
         };
@@ -701,7 +732,9 @@ impl SemanticIndexBuilder {
             return;
         };
 
-        let kind = if is_attach {
+        let call_offset = call.syntax().text_trimmed_range().start();
+
+        if is_attach {
             let pkg_name = match &value {
                 AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
                 AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
@@ -710,8 +743,12 @@ impl SemanticIndexBuilder {
             let Some(pkg_name) = pkg_name else {
                 return;
             };
-            DirectiveKind::Attach(pkg_name)
+            self.directives.push(Directive {
+                kind: DirectiveKind::Attach(pkg_name),
+                offset: call_offset,
+            });
         } else {
+            // source() -- resolve via callback and inject definitions
             let path = match &value {
                 AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
                 _ => None,
@@ -719,13 +756,29 @@ impl SemanticIndexBuilder {
             let Some(path) = path else {
                 return;
             };
-            DirectiveKind::Source(path)
-        };
 
-        self.directives.push(Directive {
-            kind,
-            offset: call.syntax().text_trimmed_range().start(),
-        });
+            // Take the resolver out to avoid borrow conflict with `&mut self`
+            let mut resolver = self.source_resolver.take();
+            if let Some(ref mut resolve) = resolver {
+                if let Some(resolution) = resolve(&path) {
+                    for (name, file, range) in resolution.definitions {
+                        self.add_definition(
+                            &name,
+                            SymbolFlags::IS_BOUND,
+                            DefinitionKind::Sourced { file },
+                            range,
+                        );
+                    }
+                    for pkg in resolution.packages {
+                        self.directives.push(Directive {
+                            kind: DirectiveKind::Attach(pkg),
+                            offset: call_offset,
+                        });
+                    }
+                }
+            }
+            self.source_resolver = resolver;
+        }
     }
 
     fn finish(mut self) -> SemanticIndex {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -44,17 +44,6 @@ use crate::semantic_index::Use;
 use crate::semantic_index::UseId;
 use crate::use_def_map::UseDefMapBuilder;
 
-/// The result of resolving a `source()` call. Returned by the resolver
-/// callback passed to the builder.
-pub struct SourceResolution {
-    /// Definitions to inject as synthetic bindings in the calling scope.
-    /// Each entry is (name, file_url, range_in_source_file).
-    pub definitions: Vec<(String, Url, TextRange)>,
-    /// Package names from `library()` directives in the sourced file
-    /// (and transitively from files it sources).
-    pub packages: Vec<String>,
-}
-
 /// Build a [`SemanticIndex`] from a parsed R file.
 pub fn semantic_index(root: &RRoot) -> SemanticIndex {
     let range = root.syntax().text_trimmed_range();
@@ -68,7 +57,8 @@ pub fn semantic_index(root: &RRoot) -> SemanticIndex {
 ///
 /// The resolver callback is called when the builder encounters a
 /// `source("path")` call. It should return the sourced file's exported
-/// definitions and any `library()` package attachments.
+/// definitions and any `library()` package attachments. See the design
+/// comment on `collect_source_directive` for how these are handled.
 pub fn semantic_index_with_source_resolver<'a>(
     root: &RRoot,
     resolver: impl FnMut(&str) -> Option<SourceResolution> + 'a,
@@ -78,6 +68,17 @@ pub fn semantic_index_with_source_resolver<'a>(
     builder.pre_scan_scope(root.syntax());
     builder.collect_expression_list(&root.expressions());
     builder.finish()
+}
+
+/// The result of resolving a `source()` call. Returned by the resolver
+/// callback passed to the builder.
+pub struct SourceResolution {
+    /// Definitions to inject as synthetic bindings in the calling scope.
+    /// Each entry is (name, file_url, range_in_source_file).
+    pub definitions: Vec<(String, Url, TextRange)>,
+    /// Package names from `library()` directives in the sourced file
+    /// (and transitively from files it sources).
+    pub packages: Vec<String>,
 }
 
 type SourceResolver<'a> = Box<dyn FnMut(&str) -> Option<SourceResolution> + 'a>;
@@ -859,55 +860,60 @@ impl<'a> SemanticIndexBuilder<'a> {
         let call_offset = call.syntax().text_trimmed_range().start();
         let in_nested_scope = self.current_scope != ScopeId::from(0);
 
-        // Take the resolver out to avoid borrow conflict with `&mut self`
-        let mut resolver = self.source_resolver.take();
-        if let Some(ref mut resolve) = resolver {
-            if let Some(resolution) = resolve(&path) {
-                if is_local || !in_nested_scope {
-                    // `local = TRUE` or at file scope: inject into the
-                    // use-def map so sourced definitions shadow locals.
-                    for (name, file, range) in resolution.definitions {
-                        self.add_definition(
-                            &name,
-                            SymbolFlags::IS_BOUND,
-                            DefinitionKind::Sourced { file },
-                            range,
-                        );
-                    }
-                    for pkg in resolution.packages {
-                        self.directives.push(Directive {
-                            kind: DirectiveKind::Attach(pkg),
-                            offset: call_offset,
-                            scope: self.current_scope,
-                        });
-                    }
-                } else {
-                    // `local = FALSE` (default) in a nested scope:
-                    // cross-file resolution only via directives, scoped
-                    // to the current scope (not file scope) since the
-                    // function might never be called.
-                    let mut by_file: HashMap<Url, HashMap<String, TextRange>> = HashMap::new();
-                    for (name, file, range) in resolution.definitions {
-                        by_file.entry(file).or_default().insert(name, range);
-                    }
-                    for (file, exports) in by_file {
-                        self.directives.push(Directive {
-                            kind: DirectiveKind::Source { file, exports },
-                            offset: call_offset,
-                            scope: self.current_scope,
-                        });
-                    }
-                    for pkg in resolution.packages {
-                        self.directives.push(Directive {
-                            kind: DirectiveKind::Attach(pkg),
-                            offset: call_offset,
-                            scope: self.current_scope,
-                        });
-                    }
-                }
+        let Some(resolution) = self.resolve_source(&path) else {
+            return;
+        };
+
+        if is_local || !in_nested_scope {
+            // `local = TRUE` or at file scope: inject into the
+            // use-def map so sourced definitions shadow locals.
+            for (name, file, range) in resolution.definitions {
+                self.add_definition(
+                    &name,
+                    SymbolFlags::IS_BOUND,
+                    DefinitionKind::Sourced { file },
+                    range,
+                );
+            }
+            for pkg in resolution.packages {
+                self.directives.push(Directive {
+                    kind: DirectiveKind::Attach(pkg),
+                    offset: call_offset,
+                    scope: self.current_scope,
+                });
+            }
+        } else {
+            // `local = FALSE` (default) in a nested scope: cross-file
+            // resolution only via directives, scoped to the current scope
+            // instead of the file scope.
+            let mut by_file: HashMap<Url, HashMap<String, TextRange>> = HashMap::new();
+            for (name, file, range) in resolution.definitions {
+                by_file.entry(file).or_default().insert(name, range);
+            }
+            for (file, exports) in by_file {
+                self.directives.push(Directive {
+                    kind: DirectiveKind::Source { file, exports },
+                    offset: call_offset,
+                    scope: self.current_scope,
+                });
+            }
+            for pkg in resolution.packages {
+                self.directives.push(Directive {
+                    kind: DirectiveKind::Attach(pkg),
+                    offset: call_offset,
+                    scope: self.current_scope,
+                });
             }
         }
-        self.source_resolver = resolver;
+    }
+
+    /// Call the source resolver for `path`, temporarily taking it out of
+    /// `self` to avoid borrow conflicts.
+    fn resolve_source(&mut self, path: &str) -> Option<SourceResolution> {
+        let mut resolver = self.source_resolver.take()?;
+        let result = resolver(path);
+        self.source_resolver = Some(resolver);
+        result
     }
 
     fn finish(mut self) -> SemanticIndex {

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use aether_syntax::AnyRArgumentName;
 use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRParameterName;
@@ -45,9 +43,9 @@ use crate::semantic_index::UseId;
 use crate::use_def_map::UseDefMapBuilder;
 
 /// Build a [`SemanticIndex`] from a parsed R file.
-pub fn semantic_index(root: &RRoot) -> SemanticIndex {
+pub fn semantic_index(root: &RRoot, file: &Url) -> SemanticIndex {
     let range = root.syntax().text_trimmed_range();
-    let mut builder = SemanticIndexBuilder::new(range, None);
+    let mut builder = SemanticIndexBuilder::new(range, file.clone(), None);
     builder.pre_scan_scope(root.syntax());
     builder.collect_expression_list(&root.expressions());
     builder.finish()
@@ -57,14 +55,14 @@ pub fn semantic_index(root: &RRoot) -> SemanticIndex {
 ///
 /// The resolver callback is called when the builder encounters a
 /// `source("path")` call. It should return the sourced file's exported
-/// definitions and any `library()` package attachments. See the design
-/// comment on `collect_source_directive` for how these are handled.
+/// names and any `library()` package attachments.
 pub fn semantic_index_with_source_resolver<'a>(
     root: &RRoot,
+    file: &Url,
     resolver: impl FnMut(&str) -> Option<SourceResolution> + 'a,
 ) -> SemanticIndex {
     let range = root.syntax().text_trimmed_range();
-    let mut builder = SemanticIndexBuilder::new(range, Some(Box::new(resolver)));
+    let mut builder = SemanticIndexBuilder::new(range, file.clone(), Some(Box::new(resolver)));
     builder.pre_scan_scope(root.syntax());
     builder.collect_expression_list(&root.expressions());
     builder.finish()
@@ -73,23 +71,15 @@ pub fn semantic_index_with_source_resolver<'a>(
 /// The result of resolving a `source()` call. Returned by the resolver
 /// callback passed to the builder.
 pub struct SourceResolution {
-    /// Definitions to inject as synthetic bindings in the calling scope.
-    pub definitions: Vec<FileDefinition>,
+    /// The resolved URL of the sourced file.
+    pub file: Url,
+
+    /// Names of top-level definitions in the sourced file.
+    pub names: Vec<String>,
 
     /// Package names from `library()` directives in the sourced file
     /// (and transitively from files it sources).
     pub packages: Vec<String>,
-}
-
-/// A top-level definition from a file, represented so it can be consumed
-/// outside of that file's [`SemanticIndex`]. Where [`Definition`] refers to
-/// names through a `SymbolId` scoped to a specific symbol table,
-/// `FileDefinition` carries the name inline and is self-contained.
-#[derive(Clone)]
-pub struct FileDefinition {
-    pub name: String,
-    pub file: Url,
-    pub range: TextRange,
 }
 
 type SourceResolver<'a> = Box<dyn FnMut(&str) -> Option<SourceResolution> + 'a>;
@@ -107,11 +97,12 @@ struct SemanticIndexBuilder<'a> {
     pre_scans: IndexVec<ScopeId, PreScanScope>,
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
     directives: Vec<Directive>,
+    file: Url,
     source_resolver: Option<SourceResolver<'a>>,
 }
 
 impl<'a> SemanticIndexBuilder<'a> {
-    fn new(range: TextRange, source_resolver: Option<SourceResolver<'a>>) -> Self {
+    fn new(range: TextRange, file: Url, source_resolver: Option<SourceResolver<'a>>) -> Self {
         let mut scopes = IndexVec::new();
         let mut symbol_tables = IndexVec::new();
         let mut definitions = IndexVec::new();
@@ -122,7 +113,7 @@ impl<'a> SemanticIndexBuilder<'a> {
         // The descendants range starts empty (`n+1..n+1`). `pop_scope` later
         // fills in `descendants.end` with the current arena length. Everything
         // allocated between push and pop is a descendant.
-        let file = scopes.push(Scope {
+        let file_scope = scopes.push(Scope {
             parent: None,
             kind: ScopeKind::File,
             range,
@@ -144,10 +135,11 @@ impl<'a> SemanticIndexBuilder<'a> {
             definitions,
             uses,
             use_def_maps,
-            current_scope: file,
+            current_scope: file_scope,
             pre_scans,
             enclosing_snapshots: FxHashMap::default(),
             directives: Vec::new(),
+            file,
             source_resolver,
         }
     }
@@ -193,14 +185,14 @@ impl<'a> SemanticIndexBuilder<'a> {
         flags: SymbolFlags,
         kind: DefinitionKind,
         range: TextRange,
-        file: Option<Url>,
     ) {
         let symbol_id = self.symbol_tables[self.current_scope].intern(name, flags);
         let def_id = self.definitions[self.current_scope].push(Definition {
             symbol: symbol_id,
             kind,
             range,
-            file,
+            file: self.file.clone(),
+            scope: self.current_scope,
         });
         self.use_def_maps[self.current_scope].ensure_symbol(symbol_id);
         self.use_def_maps[self.current_scope].record_definition(symbol_id, def_id);
@@ -221,7 +213,8 @@ impl<'a> SemanticIndexBuilder<'a> {
             symbol: symbol_id,
             kind: kind.clone(),
             range,
-            file: None,
+            file: self.file.clone(),
+            scope: self.current_scope,
         });
 
         let target_scope = self.resolve_super_target(name);
@@ -231,7 +224,8 @@ impl<'a> SemanticIndexBuilder<'a> {
             symbol: target_symbol,
             kind,
             range,
-            file: None,
+            file: self.file.clone(),
+            scope: target_scope,
         });
         self.use_def_maps[target_scope].ensure_symbol(target_symbol);
         self.use_def_maps[target_scope].record_deferred_definition(target_symbol, target_def_id);
@@ -249,7 +243,7 @@ impl<'a> SemanticIndexBuilder<'a> {
         loop {
             if let Some(id) = self.symbol_tables[scope].id(name) {
                 if self.symbol_tables[scope]
-                    .symbol(id)
+                    .symbol_id(id)
                     .flags()
                     .contains(SymbolFlags::IS_BOUND)
                 {
@@ -295,7 +289,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                 .id(name)
                 .is_some_and(|sym_id| {
                     self.symbol_tables[current_scope]
-                        .symbol(sym_id)
+                        .symbol_id(sym_id)
                         .flags()
                         .contains(SymbolFlags::IS_BOUND)
                 });
@@ -391,7 +385,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                 if let Ok(args) = call.arguments() {
                     self.collect_arguments(&args.items());
                 }
-                // TODO: When eager NSE scopes land (e.g. `local()`) we should
+                // TODO(nse): When eager NSE scopes land (e.g. `local()`) we should
                 // also consider nested scopes as long as they're not lazy (e.g.
                 // function definitions or NSE calls that don't evaluate
                 // immediately.
@@ -437,7 +431,6 @@ impl<'a> SemanticIndexBuilder<'a> {
                         SymbolFlags::IS_BOUND,
                         DefinitionKind::ForVariable(stmt.syntax().clone()),
                         variable.syntax().text_trimmed_range(),
-                        None,
                     );
                 }
                 if let Ok(sequence) = stmt.sequence() {
@@ -609,7 +602,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                         let right = is_right_assignment(bin);
                         let target = if right { bin.right() } else { bin.left() };
                         if let Ok(target) = target {
-                            if let Some((name, range)) = assignment_target_name(&target) {
+                            if let Some((name, range)) = assignment_name(&target) {
                                 self.pre_scans[self.current_scope].add(name, range);
                             }
                         }
@@ -644,7 +637,6 @@ impl<'a> SemanticIndexBuilder<'a> {
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         ident.syntax().text_trimmed_range(),
-                        None,
                     );
                 },
                 AnyRParameterName::RDots(dots) => {
@@ -653,7 +645,6 @@ impl<'a> SemanticIndexBuilder<'a> {
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         dots.syntax().text_trimmed_range(),
-                        None,
                     );
                 },
                 AnyRParameterName::RDotDotI(ddi) => {
@@ -662,7 +653,6 @@ impl<'a> SemanticIndexBuilder<'a> {
                         flags,
                         DefinitionKind::Parameter(param.syntax().clone()),
                         ddi.syntax().text_trimmed_range(),
-                        None,
                     );
                 },
             }
@@ -690,7 +680,7 @@ impl<'a> SemanticIndexBuilder<'a> {
         let target = if right { op.right() } else { op.left() };
         let Ok(target) = target else { return };
 
-        let Some((name, range)) = assignment_target_name(&target) else {
+        let Some((name, range)) = assignment_name(&target) else {
             // Complex target (`x$foo <- rhs`, `x[1] <- rhs`, etc.) does
             // not represent a binding. We recurse for uses.
             self.collect_expression(&target);
@@ -709,7 +699,6 @@ impl<'a> SemanticIndexBuilder<'a> {
                 SymbolFlags::IS_BOUND,
                 DefinitionKind::Assignment(op.syntax().clone()),
                 range,
-                None,
             );
         }
     }
@@ -779,75 +768,27 @@ impl<'a> SemanticIndexBuilder<'a> {
 
     // ## `source()` resolution
     //
-    // R's `source(file, local = )` evaluates a file in a target
-    // environment. The `local` parameter controls where definitions land:
+    // `source("file.R")` creates `DefinitionKind::Import` forwarding
+    // bindings in the current scope for each top-level name exported by
+    // the target file. These participate in the use-def map like normal
+    // definitions (shadowing, ordering), but goto-definition chases
+    // through them via `resolve_definition` to reach the actual origin.
     //
-    //   - `local = TRUE`: definitions go into the calling environment.
-    //   - `local = FALSE` (default): definitions go into the global
-    //     environment.
-    //   - `local = <env>`: definitions go into `<env>`.
+    // The `local` argument is inspected only to bail: if it's set to
+    // something other than TRUE/FALSE (e.g., an environment), the call
+    // isn't statically analyzable and we skip it.
     //
-    // We model the boolean case with two mechanisms:
-    //
-    // ### `local = TRUE`, or `source()` at file scope
-    //
-    // Top-level bindings in the sourced file are injected as definitions into
-    // the use-def map as `DefinitionKind::Sourced` via `add_definition`. They
-    // fully participate in local resolution and shadow prior bindings, just
-    // like `<-`. At file scope, `local` doesn't matter because the current
-    // scope IS the global environment, and sequential execution is guaranteed,
-    // so `source()` overwrites like any other assignment:
-    //
-    // ```r
-    // foo <- 1
-    // source("helpers.R")  # also defines foo
-    // foo                  # resolves to sourced foo (shadowed)
-    // ```
-    //
-    // ### `local = FALSE` (default) in a nested scope
-    //
-    // External top-level bindings are reached through `DirectiveKind::Source`
-    // entries, which flow through the `FileScope` scope chain alongside
-    // `library()` / `Attach` directives. They are only consulted when a symbol
-    // is unbound after local + enclosing scope resolution, so they never shadow
-    // local bindings:
-    //
-    // ```r
-    // f <- function() {
-    //     foo <- "local"
-    //     source("helpers.R")  # also defines foo, local = FALSE
-    //     foo                  # resolves to local "local"
-    //     bar                  # no local def → resolves via directive
-    // }
-    // ```
-    //
-    // The directive is scoped to the function (not file scope) because
-    // top-level code should not assume that the sourcing function will be
-    // called. We could refine with call analysis in the future though.
-    // `FileScope::at()` filters by `(offset, scope)`: the directive is visible
-    // only at cursor positions inside the function (or its children) and after
-    // the call site. `FileScope::lazy()` only includes file-scope directives,
-    // so function-scoped ones are conservatively excluded.
-    //
-    // ### Resolution chain
-    //
-    // Goto-definition resolves a use through three layers:
-    //
-    // 1. **Local bindings** (`use_def_map.bindings_at_use`): finds
-    //    `Sourced` definitions from `local = TRUE` / file-scope sources.
-    // 2. **Enclosing bindings** (`enclosing_bindings`): free variables
-    //    in nested scopes reach ancestor definitions.
-    // 3. **Scope chain** (`FileScope::at` → `resolve_external_name`):
-    //    `Source` and `Attach` directive layers, searched in reverse
-    //    order (LIFO, matching R's search path where the last
-    //    `library()` or `source()` wins).
+    // TODO: In nested scopes, `local = FALSE` technically targets the
+    // global environment. We currently inject into the calling scope
+    // regardless to keep the sourcing mechanism simple. A future diagnostic
+    // should suggest `local = TRUE` in nested contexts.
     fn collect_source_directive(&mut self, call: &aether_syntax::RCall) {
         let Ok(args) = call.arguments() else {
             return;
         };
 
         let mut path: Option<String> = None;
-        let mut is_local = false;
+        let mut bail = false;
 
         for item in args.items().iter() {
             let Ok(arg) = item else { continue };
@@ -859,9 +800,14 @@ impl<'a> SemanticIndexBuilder<'a> {
                 if name_ident.name_text() == "local" {
                     if let Some(value) = arg.value() {
                         match value {
-                            AnyRExpression::RTrueExpression(_) => is_local = true,
-                            AnyRExpression::RFalseExpression(_) => is_local = false,
-                            _ => {},
+                            // TRUE/FALSE are fine, we resolve uniformly. For
+                            // the FALSE in nested context case, we'll emit a
+                            // diagnostic.
+                            AnyRExpression::RTrueExpression(_) |
+                            AnyRExpression::RFalseExpression(_) => {},
+                            // With anything else (environment, non-statically
+                            // resolvable expression) is not we need to bail.
+                            _ => bail = true,
                         }
                     }
                 }
@@ -873,61 +819,40 @@ impl<'a> SemanticIndexBuilder<'a> {
             }
         }
 
+        if bail {
+            return;
+        }
+
         let Some(path) = path else {
             return;
         };
 
         let call_offset = call.syntax().text_trimmed_range().start();
-        let in_nested_scope = self.current_scope != ScopeId::from(0);
 
         let Some(resolution) = self.resolve_source(&path) else {
             return;
         };
 
-        if is_local || !in_nested_scope {
-            // `local = TRUE` or at file scope: inject into the
-            // use-def map so sourced definitions shadow locals.
-            for def in resolution.definitions {
-                self.add_definition(
-                    &def.name,
-                    SymbolFlags::IS_BOUND,
-                    DefinitionKind::Sourced,
-                    def.range,
-                    Some(def.file),
-                );
-            }
-            for pkg in resolution.packages {
-                self.directives.push(Directive {
-                    kind: DirectiveKind::Attach(pkg),
-                    offset: call_offset,
-                    scope: self.current_scope,
-                });
-            }
-        } else {
-            // `local = FALSE` (default) in a nested scope: cross-file
-            // resolution only via directives, scoped to the current scope
-            // instead of the file scope.
-            let mut by_file: HashMap<Url, HashMap<String, TextRange>> = HashMap::new();
-            for def in resolution.definitions {
-                by_file
-                    .entry(def.file)
-                    .or_default()
-                    .insert(def.name, def.range);
-            }
-            for (file, exports) in by_file {
-                self.directives.push(Directive {
-                    kind: DirectiveKind::Source { file, exports },
-                    offset: call_offset,
-                    scope: self.current_scope,
-                });
-            }
-            for pkg in resolution.packages {
-                self.directives.push(Directive {
-                    kind: DirectiveKind::Attach(pkg),
-                    offset: call_offset,
-                    scope: self.current_scope,
-                });
-            }
+        let file = resolution.file;
+
+        for name in resolution.names {
+            self.add_definition(
+                &name,
+                SymbolFlags::IS_BOUND,
+                DefinitionKind::Import {
+                    call: call.syntax().clone(),
+                    file: file.clone(),
+                    name: name.clone(),
+                },
+                TextRange::empty(call_offset),
+            );
+        }
+        for pkg in resolution.packages {
+            self.directives.push(Directive {
+                kind: DirectiveKind::Attach(pkg),
+                offset: call_offset,
+                scope: self.current_scope,
+            });
         }
     }
 
@@ -1038,7 +963,7 @@ fn is_right_assignment(bin: &RBinaryExpression) -> bool {
 /// Extract the binding name and range from an assignment target expression.
 /// Returns `None` for complex targets (`x$foo`, `x[1]`, etc.) that don't
 /// represent simple name bindings.
-fn assignment_target_name(target: &AnyRExpression) -> Option<(String, TextRange)> {
+fn assignment_name(target: &AnyRExpression) -> Option<(String, TextRange)> {
     match target {
         AnyRExpression::RIdentifier(ident) => {
             let name = ident.name_text();

--- a/crates/oak_index/src/builder.rs
+++ b/crates/oak_index/src/builder.rs
@@ -839,6 +839,11 @@ impl<'a> SemanticIndexBuilder<'a> {
         let file = resolution.file;
 
         for name in resolution.names {
+            // Empty range: R's `source()` imports names implicitly (unlike
+            // Python's `from x import y` where `y` appears in the text).
+            // There's no text span to assign to these definitions.
+            let range = TextRange::empty(call_offset);
+
             self.add_definition(
                 &name,
                 SymbolFlags::IS_BOUND,
@@ -847,9 +852,10 @@ impl<'a> SemanticIndexBuilder<'a> {
                     file: file.clone(),
                     name: name.clone(),
                 },
-                TextRange::empty(call_offset),
+                range,
             );
         }
+
         for pkg in resolution.packages {
             self.directives.push(Directive {
                 kind: DirectiveKind::Attach(pkg),

--- a/crates/oak_index/src/external.rs
+++ b/crates/oak_index/src/external.rs
@@ -55,10 +55,10 @@ pub fn resolve_external_name(
             ScopeLayer::PackageImports(names) => {
                 if let Some(pkg) = names.get(name) {
                     if let Some(def) = resolve_in_package(
-                        name,
-                        pkg,
-                        PackageDefinitionVisibility::Exported,
                         library,
+                        pkg,
+                        name,
+                        PackageDefinitionVisibility::Exported,
                     ) {
                         return Some(def);
                     }
@@ -67,7 +67,7 @@ pub fn resolve_external_name(
 
             ScopeLayer::PackageExports(pkg) => {
                 if let Some(def) =
-                    resolve_in_package(name, pkg, PackageDefinitionVisibility::Exported, library)
+                    resolve_in_package(library, pkg, name, PackageDefinitionVisibility::Exported)
                 {
                     return Some(def);
                 }
@@ -80,10 +80,10 @@ pub fn resolve_external_name(
 
 /// Resolve a name in a specific package's exported symbols.
 pub fn resolve_in_package(
-    name: &str,
-    package: &str,
-    visibility: PackageDefinitionVisibility,
     library: &Library,
+    package: &str,
+    name: &str,
+    visibility: PackageDefinitionVisibility,
 ) -> Option<ExternalDefinition> {
     // FIXME: Slow without salsa!
     let package_definitions = library.definitions(package)?;

--- a/crates/oak_index/src/lib.rs
+++ b/crates/oak_index/src/lib.rs
@@ -10,7 +10,6 @@ pub mod use_def_map;
 pub use builder::semantic_index;
 pub use builder::semantic_index_with_source_resolver;
 pub use builder::SourceResolution;
-pub use builder::FileDefinition;
 pub use semantic_index::DefinitionId;
 pub use semantic_index::ScopeId;
 pub use semantic_index::UseId;

--- a/crates/oak_index/src/lib.rs
+++ b/crates/oak_index/src/lib.rs
@@ -8,6 +8,8 @@ pub mod semantic_index;
 pub mod use_def_map;
 
 pub use builder::semantic_index;
+pub use builder::semantic_index_with_source_resolver;
+pub use builder::SourceResolution;
 pub use semantic_index::DefinitionId;
 pub use semantic_index::ScopeId;
 pub use semantic_index::UseId;

--- a/crates/oak_index/src/lib.rs
+++ b/crates/oak_index/src/lib.rs
@@ -10,6 +10,7 @@ pub mod use_def_map;
 pub use builder::semantic_index;
 pub use builder::semantic_index_with_source_resolver;
 pub use builder::SourceResolution;
+pub use builder::FileDefinition;
 pub use semantic_index::DefinitionId;
 pub use semantic_index::ScopeId;
 pub use semantic_index::UseId;

--- a/crates/oak_index/src/package_definitions.rs
+++ b/crates/oak_index/src/package_definitions.rs
@@ -84,7 +84,11 @@ fn append_definitions(
         return;
     }
 
-    let index = semantic_index(&parsed.tree());
+    let Some(file_url) = url::Url::from_file_path(&file).ok() else {
+        return;
+    };
+
+    let index = semantic_index(&parsed.tree(), &file_url);
 
     let file_id = files.push(file);
 

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -64,12 +64,6 @@ pub fn directive_layers(directives: &[Directive]) -> Vec<(TextSize, ScopeId, Sco
                     ScopeLayer::PackageExports(pkg.clone()),
                 ));
             },
-            DirectiveKind::Source { file, exports } => {
-                layers.push((offset, directive.scope(), ScopeLayer::FileExports {
-                    file: file.clone(),
-                    exports: exports.clone(),
-                }));
-            },
         }
     }
     layers

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -53,6 +53,27 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     layers
 }
 
+/// The default R search path for scripts: the default packages that R
+/// attaches on startup, in search order (last attached = searched first).
+pub fn default_search_path() -> Vec<ScopeLayer> {
+    // R's default packages, in reverse attachment order (most recently
+    // attached first). These are always on the search path unless
+    // overridden by `R_DEFAULT_PACKAGES`.
+    let default_packages = [
+        "utils",
+        "stats",
+        "datasets",
+        "methods",
+        "grDevices",
+        "graphics",
+        "base",
+    ];
+    default_packages
+        .into_iter()
+        .map(|pkg| ScopeLayer::PackageExports(pkg.to_string()))
+        .collect()
+}
+
 /// Build the root layers for a package from its NAMESPACE.
 ///
 /// These go at the back of every file's scope chain:

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -31,10 +31,8 @@ pub enum ScopeLayer {
 /// scope chain: one `FileExports` layer from its top-level definitions, plus
 /// one `PackageExports` layer per `library()`/`require()` directive.
 ///
-/// `Source` directives are skipped here because resolving them requires the
-/// sourced file's index. Use [`directive_layers`] with a resolver callback
-/// when cross-file resolution is available. Offsets are discarded since
-/// all of a predecessor file's layers are unconditionally visible.
+/// Offsets are discarded since all of a predecessor file's layers are
+/// unconditionally visible.
 pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     let mut layers = Vec::new();
 
@@ -45,7 +43,7 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     }
 
     layers.push(ScopeLayer::FileExports { file, exports });
-    let dir_layers = directive_layers(index.file_directives(), |_| None);
+    let dir_layers = directive_layers(index.file_directives());
     layers.extend(dir_layers.into_iter().map(|(_, l)| l));
 
     layers
@@ -53,18 +51,7 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
 
 /// Convert directives into scope-chain layers, each paired with the offset
 /// of the directive that produced it.
-///
-/// `Attach` directives become `PackageExports` layers. `Source` directives
-/// are resolved via the callback, which returns the full set of layers the
-/// sourced file contributes: its `FileExports`, any `PackageExports` from
-/// `library()` calls it contains, and layers from nested `source()` calls.
-/// The callback receives the raw path string from the `source()` call.
-///
-/// All layers produced by a single directive share that directive's offset.
-pub fn directive_layers(
-    directives: &[Directive],
-    mut resolve_source: impl FnMut(&str) -> Option<Vec<ScopeLayer>>,
-) -> Vec<(TextSize, ScopeLayer)> {
+pub fn directive_layers(directives: &[Directive]) -> Vec<(TextSize, ScopeLayer)> {
     let mut layers = Vec::new();
     for directive in directives {
         let offset = directive.offset();
@@ -72,11 +59,7 @@ pub fn directive_layers(
             DirectiveKind::Attach(pkg) => {
                 layers.push((offset, ScopeLayer::PackageExports(pkg.clone())));
             },
-            DirectiveKind::Source(path) => {
-                if let Some(source_layers) = resolve_source(path) {
-                    layers.extend(source_layers.into_iter().map(|l| (offset, l)));
-                }
-            },
+            DirectiveKind::Source(_) => {},
         }
     }
     layers

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -1,13 +1,10 @@
 use std::collections::HashMap;
 
 use biome_rowan::TextRange;
-use biome_rowan::TextSize;
 use oak_package_metadata::namespace::Namespace;
 use url::Url;
 
-use crate::semantic_index::Directive;
 use crate::semantic_index::DirectiveKind;
-use crate::semantic_index::ScopeId;
 use crate::semantic_index::SemanticIndex;
 
 /// A layer in the scope chain. Layers are ordered most-local-first; resolution
@@ -44,28 +41,15 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
         .collect();
 
     layers.push(ScopeLayer::FileExports { file, exports });
-    let dir_layers = directive_layers(index.file_directives());
-    layers.extend(dir_layers.into_iter().map(|(_, _, l)| l));
 
-    layers
-}
-
-/// Convert directives into scope-chain layers, each paired with the offset
-/// of the directive that produced it.
-pub fn directive_layers(directives: &[Directive]) -> Vec<(TextSize, ScopeId, ScopeLayer)> {
-    let mut layers = Vec::new();
-    for directive in directives {
-        let offset = directive.offset();
+    for directive in index.file_directives() {
         match directive.kind() {
             DirectiveKind::Attach(pkg) => {
-                layers.push((
-                    offset,
-                    directive.scope(),
-                    ScopeLayer::PackageExports(pkg.clone()),
-                ));
+                layers.push(ScopeLayer::PackageExports(pkg.clone()));
             },
         }
     }
+
     layers
 }
 

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 use biome_rowan::TextRange;
+use biome_rowan::TextSize;
 use oak_package_metadata::namespace::Namespace;
 use url::Url;
 
+use crate::semantic_index::Directive;
 use crate::semantic_index::DirectiveKind;
 use crate::semantic_index::SemanticIndex;
 
@@ -28,6 +30,11 @@ pub enum ScopeLayer {
 /// Compute the scope layers that a single file contributes to the
 /// scope chain: one `FileExports` layer from its top-level definitions, plus
 /// one `PackageExports` layer per `library()`/`require()` directive.
+///
+/// `Source` directives are skipped here because resolving them requires the
+/// sourced file's index. Use [`directive_layers`] with a resolver callback
+/// when cross-file resolution is available. Offsets are discarded since
+/// all of a predecessor file's layers are unconditionally visible.
 pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     let mut layers = Vec::new();
 
@@ -38,15 +45,40 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     }
 
     layers.push(ScopeLayer::FileExports { file, exports });
+    let dir_layers = directive_layers(index.file_directives(), |_| None);
+    layers.extend(dir_layers.into_iter().map(|(_, l)| l));
 
-    for directive in index.file_directives() {
+    layers
+}
+
+/// Convert directives into scope-chain layers, each paired with the offset
+/// of the directive that produced it.
+///
+/// `Attach` directives become `PackageExports` layers. `Source` directives
+/// are resolved via the callback, which returns the full set of layers the
+/// sourced file contributes: its `FileExports`, any `PackageExports` from
+/// `library()` calls it contains, and layers from nested `source()` calls.
+/// The callback receives the raw path string from the `source()` call.
+///
+/// All layers produced by a single directive share that directive's offset.
+pub fn directive_layers(
+    directives: &[Directive],
+    resolve_source: impl Fn(&str) -> Option<Vec<ScopeLayer>>,
+) -> Vec<(TextSize, ScopeLayer)> {
+    let mut layers = Vec::new();
+    for directive in directives {
+        let offset = directive.offset();
         match directive.kind() {
             DirectiveKind::Attach(pkg) => {
-                layers.push(ScopeLayer::PackageExports(pkg.clone()));
+                layers.push((offset, ScopeLayer::PackageExports(pkg.clone())));
+            },
+            DirectiveKind::Source(path) => {
+                if let Some(source_layers) = resolve_source(path) {
+                    layers.extend(source_layers.into_iter().map(|l| (offset, l)));
+                }
             },
         }
     }
-
     layers
 }
 

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -63,7 +63,7 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
 /// All layers produced by a single directive share that directive's offset.
 pub fn directive_layers(
     directives: &[Directive],
-    resolve_source: impl Fn(&str) -> Option<Vec<ScopeLayer>>,
+    mut resolve_source: impl FnMut(&str) -> Option<Vec<ScopeLayer>>,
 ) -> Vec<(TextSize, ScopeLayer)> {
     let mut layers = Vec::new();
     for directive in directives {

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::semantic_index::Directive;
 use crate::semantic_index::DirectiveKind;
+use crate::semantic_index::ScopeId;
 use crate::semantic_index::SemanticIndex;
 
 /// A layer in the scope chain. Layers are ordered most-local-first; resolution
@@ -44,20 +45,24 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
 
     layers.push(ScopeLayer::FileExports { file, exports });
     let dir_layers = directive_layers(index.file_directives());
-    layers.extend(dir_layers.into_iter().map(|(_, l)| l));
+    layers.extend(dir_layers.into_iter().map(|(_, _, l)| l));
 
     layers
 }
 
 /// Convert directives into scope-chain layers, each paired with the offset
 /// of the directive that produced it.
-pub fn directive_layers(directives: &[Directive]) -> Vec<(TextSize, ScopeLayer)> {
+pub fn directive_layers(directives: &[Directive]) -> Vec<(TextSize, ScopeId, ScopeLayer)> {
     let mut layers = Vec::new();
     for directive in directives {
         let offset = directive.offset();
         match directive.kind() {
             DirectiveKind::Attach(pkg) => {
-                layers.push((offset, ScopeLayer::PackageExports(pkg.clone())));
+                layers.push((
+                    offset,
+                    directive.scope(),
+                    ScopeLayer::PackageExports(pkg.clone()),
+                ));
             },
             DirectiveKind::Source(_) => {},
         }

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -64,7 +64,12 @@ pub fn directive_layers(directives: &[Directive]) -> Vec<(TextSize, ScopeId, Sco
                     ScopeLayer::PackageExports(pkg.clone()),
                 ));
             },
-            DirectiveKind::Source(_) => {},
+            DirectiveKind::Source { file, exports } => {
+                layers.push((offset, directive.scope(), ScopeLayer::FileExports {
+                    file: file.clone(),
+                    exports: exports.clone(),
+                }));
+            },
         }
     }
     layers

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -37,11 +37,11 @@ pub enum ScopeLayer {
 pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     let mut layers = Vec::new();
 
-    // Last definition of each name wins
-    let mut exports = HashMap::new();
-    for (name, range) in index.file_exports() {
-        exports.insert(name.to_string(), range);
-    }
+    let exports = index
+        .file_exports()
+        .into_iter()
+        .map(|(name, range)| (name.to_string(), range))
+        .collect();
 
     layers.push(ScopeLayer::FileExports { file, exports });
     let dir_layers = directive_layers(index.file_directives());

--- a/crates/oak_index/src/scope_layer.rs
+++ b/crates/oak_index/src/scope_layer.rs
@@ -28,9 +28,6 @@ pub enum ScopeLayer {
 /// Compute the scope layers that a single file contributes to the
 /// scope chain: one `FileExports` layer from its top-level definitions, plus
 /// one `PackageExports` layer per `library()`/`require()` directive.
-///
-/// Offsets are discarded since all of a predecessor file's layers are
-/// unconditionally visible.
 pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     let mut layers = Vec::new();
 

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -577,6 +577,7 @@ impl Ranged for Use {
 pub struct Directive {
     pub(crate) kind: DirectiveKind,
     pub(crate) offset: TextSize,
+    pub(crate) scope: ScopeId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -592,6 +593,10 @@ impl Directive {
 
     pub fn offset(&self) -> TextSize {
         self.offset
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
     }
 }
 

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::ops::Range;
 
 use aether_syntax::RSyntaxNode;
@@ -117,54 +116,25 @@ impl SemanticIndex {
     }
 
     /// Top-level definitions exported by this file (definitions in the file scope).
+    /// Includes `Import`-kind forwarding definitions from `source()` calls.
     pub fn file_exports(&self) -> Vec<(&str, TextRange)> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
         self.definitions[file_scope]
             .iter()
-            .filter(|(_id, def)| def.file().is_none())
             .map(|(_id, def)| {
-                let name = symbols.symbol(def.symbol()).name();
+                let name = symbols.symbol_id(def.symbol()).name();
                 (name, def.range())
             })
             .collect()
-    }
-
-    /// All definitions that a `source()` caller would see from this file:
-    /// own file-scope definitions, `Sourced` definitions injected into the
-    /// use-def map, and exports from `Source` directives (transitive
-    /// `source()` calls with `local = FALSE` in nested scopes).
-    pub fn file_source_exports(&self, file_url: &Url) -> Vec<(&str, Url, TextRange)> {
-        let file_scope = ScopeId::from(0);
-        let symbols = &self.symbol_tables[file_scope];
-
-        let mut defs: Vec<(&str, Url, TextRange)> = self.definitions[file_scope]
-            .iter()
-            .map(|(_id, def)| {
-                let name = symbols.symbol(def.symbol()).name();
-                let url = def.file().cloned().unwrap_or_else(|| file_url.clone());
-                (name, url, def.range())
-            })
-            .collect();
-
-        for directive in &self.directives {
-            if let DirectiveKind::Source { file, exports } = &directive.kind {
-                for (name, range) in exports {
-                    defs.push((name.as_str(), file.clone(), *range));
-                }
-            }
-        }
-
-        defs
     }
 
     /// Package names from `library()` / `require()` directives in this file.
     pub fn file_attached_packages(&self) -> Vec<&str> {
         self.directives
             .iter()
-            .filter_map(|d| match &d.kind {
-                DirectiveKind::Attach(pkg) => Some(pkg.as_str()),
-                _ => None,
+            .map(|d| match &d.kind {
+                DirectiveKind::Attach(pkg) => pkg.as_str(),
             })
             .collect()
     }
@@ -195,7 +165,7 @@ impl SemanticIndex {
         let def_id = self
             .definitions(scope)
             .iter()
-            .filter(|(_id, def)| def.file().is_none())
+            .filter(|(_id, def)| !matches!(def.kind(), DefinitionKind::Import { .. }))
             .find_map(|(id, d)| d.range().contains(offset).then_some(id));
         Some((scope, def_id?))
     }
@@ -233,7 +203,7 @@ impl SemanticIndex {
         for ancestor in self.ancestor_scopes(scope) {
             if let Some(id) = self.symbol_tables[ancestor].id(name) {
                 if self.symbol_tables[ancestor]
-                    .symbol(id)
+                    .symbol_id(id)
                     .flags()
                     .contains(SymbolFlags::IS_BOUND)
                 {
@@ -357,7 +327,7 @@ impl SymbolTable {
         self.by_name.get(name).copied()
     }
 
-    pub fn symbol(&self, id: SymbolId) -> &Symbol {
+    pub fn symbol_id(&self, id: SymbolId) -> &Symbol {
         &self.symbols[id]
     }
 
@@ -524,7 +494,11 @@ impl SymbolFlags {
 #[derive(Debug)]
 pub struct Definition {
     pub(crate) kind: DefinitionKind,
-    pub(crate) file: Option<Url>,
+    /// The file that owns this definition's index.
+    pub(crate) file: Url,
+    /// The scope within the file's index where this definition lives.
+    pub(crate) scope: ScopeId,
+    // TODO(salsa): Should become a PlaceId (like ty's `ScopedPlaceId`).
     pub(crate) symbol: SymbolId,
     pub(crate) range: TextRange,
 }
@@ -535,8 +509,13 @@ pub enum DefinitionKind {
     SuperAssignment(RSyntaxNode),
     Parameter(RSyntaxNode),
     ForVariable(RSyntaxNode),
-    /// Injected from a `source()` call. The range belongs to `Definition::file`.
-    Sourced,
+    /// A forwarding binding that resolves to a definition in another file.
+    /// Consumers must chase the `file`/`name` chain to reach the actual origin.
+    Import {
+        call: RSyntaxNode,
+        file: Url,
+        name: String,
+    },
 }
 
 impl Definition {
@@ -552,8 +531,12 @@ impl Definition {
         self.range
     }
 
-    pub fn file(&self) -> Option<&Url> {
-        self.file.as_ref()
+    pub fn file(&self) -> &Url {
+        &self.file
+    }
+
+    pub fn scope(&self) -> ScopeId {
+        self.scope
     }
 }
 
@@ -602,11 +585,6 @@ pub struct Directive {
 pub enum DirectiveKind {
     /// `library(pkg)` or `require(pkg)`: attaches a package to the search path.
     Attach(String),
-    /// `source(file)`: brings exports from another file into scope.
-    Source {
-        file: Url,
-        exports: HashMap<String, TextRange>,
-    },
 }
 
 impl Directive {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -124,7 +124,7 @@ impl SemanticIndex {
 
         let mut exports = FxHashMap::default();
         for (_id, def) in self.definitions[file_scope].iter() {
-            let name = symbols.symbol_id(def.symbol()).name();
+            let name = symbols.symbol(def.symbol()).name();
             exports.insert(name, def.range());
         }
 
@@ -177,6 +177,7 @@ impl SemanticIndex {
         let (id, use_site) = self.uses(scope).contains(offset)?;
         Some((scope, id, use_site))
     }
+
     /// Iterate direct child scopes of `scope`.
     pub fn child_scopes(&self, scope: ScopeId) -> ChildScopesIter<'_> {
         let descendants = &self.scopes[scope].descendants;
@@ -201,7 +202,7 @@ impl SemanticIndex {
         for ancestor in self.ancestor_scopes(scope) {
             if let Some(id) = self.symbol_tables[ancestor].id(name) {
                 if self.symbol_tables[ancestor]
-                    .symbol_id(id)
+                    .symbol(id)
                     .flags()
                     .contains(SymbolFlags::IS_BOUND)
                 {
@@ -325,7 +326,7 @@ impl SymbolTable {
         self.by_name.get(name).copied()
     }
 
-    pub fn symbol_id(&self, id: SymbolId) -> &Symbol {
+    pub fn symbol(&self, id: SymbolId) -> &Symbol {
         &self.symbols[id]
     }
 
@@ -473,12 +474,11 @@ impl SymbolFlags {
 // definition without invalidating the definition's identity (file + scope +
 // place) or the UseDefMap.
 //
-// Our definitions don't carry file or scope because they live inside the
-// `SemanticIndex` at a known position (`definitions[scope_id][def_id]`).
-// In ty, `Definition<'db>` is a self-contained salsa tracked struct that
-// carries file + scope + place, because it gets passed around independently
-// to type inference queries and cross-file lookups. We'll add those fields
-// when salsa is introduced.
+// Definitions carry `file` and `scope` so they're self-contained when
+// passed around (e.g., through `DefinitionKind::Import` chains during
+// cross-file goto-definition). This mirrors ty's `Definition<'db>`, a
+// salsa tracked struct that carries file + scope + place for the same
+// reason.
 //
 // Type inference will eventually take a definition as input and inspect
 // the syntax node (via the kind) to determine the type.
@@ -493,6 +493,7 @@ impl SymbolFlags {
 pub struct Definition {
     pub(crate) kind: DefinitionKind,
     /// The file that owns this definition's index.
+    // TODO(salsa): Should become a File.
     pub(crate) file: Url,
     /// The scope within the file's index where this definition lives.
     pub(crate) scope: ScopeId,
@@ -571,7 +572,7 @@ impl Ranged for Use {
     }
 }
 
-/// A file-level directive that affects the scope chain (e.g. `library()` calls).
+/// A directive that affects the file's imports (e.g. `library()` calls).
 #[derive(Debug, Clone)]
 pub struct Directive {
     pub(crate) kind: DirectiveKind,

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -7,6 +7,7 @@ use oak_core::range::Ranged;
 use oak_index_vec::define_index;
 use oak_index_vec::IndexVec;
 use rustc_hash::FxHashMap;
+use url::Url;
 
 use crate::use_def_map::Bindings;
 use crate::use_def_map::UseDefMap;
@@ -115,14 +116,38 @@ impl SemanticIndex {
     }
 
     /// Top-level definitions exported by this file (definitions in the file scope).
+    /// Excludes `Sourced` definitions since those belong to other files.
     pub fn file_exports(&self) -> Vec<(&str, TextRange)> {
+        let file_scope = ScopeId::from(0);
+        let symbols = &self.symbol_tables[file_scope];
+        self.definitions[file_scope]
+            .iter()
+            .filter(|(_id, def)| !matches!(def.kind(), DefinitionKind::Sourced { .. }))
+            .map(|(_id, def)| {
+                let name = symbols.symbol(def.symbol()).name();
+                (name, def.range())
+            })
+            .collect()
+    }
+
+    /// All definitions visible at file scope, including sourced ones.
+    ///
+    /// Each entry carries the file URL where the definition lives and
+    /// the range within that file. For own definitions, `file_url` is
+    /// passed through; for `Sourced` definitions, the URL comes from
+    /// the `DefinitionKind`.
+    pub fn file_all_definitions(&self, file_url: &Url) -> Vec<(&str, Url, TextRange)> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
         self.definitions[file_scope]
             .iter()
             .map(|(_id, def)| {
                 let name = symbols.symbol(def.symbol()).name();
-                (name, def.range())
+                let url = match def.kind() {
+                    DefinitionKind::Sourced { file } => file.clone(),
+                    _ => file_url.clone(),
+                };
+                (name, url, def.range())
             })
             .collect()
     }
@@ -147,6 +172,27 @@ impl SemanticIndex {
         }
     }
 
+    /// Find the definition site at `offset`, if any.
+    pub fn definition_at_offset(&self, offset: TextSize) -> Option<(ScopeId, DefinitionId)> {
+        let (scope, _) = self.scope_at(offset);
+        let def_id = self.definitions(scope).iter().find_map(|(id, d)| {
+            if matches!(d.kind(), DefinitionKind::Sourced { .. }) {
+                return None;
+            }
+            d.range().contains(offset).then_some(id)
+        });
+        Some((scope, def_id?))
+    }
+
+    /// Find the use site at `offset`, if any.
+    pub fn use_at_offset(&self, offset: TextSize) -> Option<(ScopeId, UseId)> {
+        let (scope, _) = self.scope_at(offset);
+        let use_id = self
+            .uses(scope)
+            .iter()
+            .find_map(|(id, u)| u.range().contains(offset).then_some(id));
+        Some((scope, use_id?))
+    }
     /// Iterate direct child scopes of `scope`.
     pub fn child_scopes(&self, scope: ScopeId) -> ChildScopesIter<'_> {
         let descendants = &self.scopes[scope].descendants;
@@ -472,6 +518,11 @@ pub enum DefinitionKind {
     SuperAssignment(RSyntaxNode),
     Parameter(RSyntaxNode),
     ForVariable(RSyntaxNode),
+    /// Injected from a `source()` call. The definition lives in an external
+    /// file; `range` on the `Definition` gives the name's range in that file.
+    Sourced {
+        file: Url,
+    },
 }
 
 impl Definition {
@@ -532,9 +583,6 @@ pub struct Directive {
 pub enum DirectiveKind {
     /// `library(pkg)` or `require(pkg)`: attaches a package to the search path.
     Attach(String),
-    /// `source(path)`: splices the sourced file's bindings at this offset.
-    /// Stores the raw path string from the call site.
-    Source(String),
 }
 
 impl Directive {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -162,27 +162,20 @@ impl SemanticIndex {
     }
 
     /// Find the definition site at `offset`, if any.
-    pub fn definition_at_offset(&self, offset: TextSize) -> Option<(ScopeId, DefinitionId)> {
+    pub fn definition_at(&self, offset: TextSize) -> Option<(ScopeId, DefinitionId, &Definition)> {
         let (scope, _) = self.scope_at(offset);
 
         // Definitions with empty ranges (e.g. imports) are naturally excluded
         // here since they can't contain the offset
-        let def_id = self
-            .definitions(scope)
-            .iter()
-            .find_map(|(id, d)| d.range().contains(offset).then_some(id));
-
-        Some((scope, def_id?))
+        let (id, def) = self.definitions(scope).contains(offset)?;
+        Some((scope, id, def))
     }
 
     /// Find the use site at `offset`, if any.
-    pub fn use_at_offset(&self, offset: TextSize) -> Option<(ScopeId, UseId)> {
+    pub fn use_at(&self, offset: TextSize) -> Option<(ScopeId, UseId, &Use)> {
         let (scope, _) = self.scope_at(offset);
-        let use_id = self
-            .uses(scope)
-            .iter()
-            .find_map(|(id, u)| u.range().contains(offset).then_some(id));
-        Some((scope, use_id?))
+        let (id, use_site) = self.uses(scope).contains(offset)?;
+        Some((scope, id, use_site))
     }
     /// Iterate direct child scopes of `scope`.
     pub fn child_scopes(&self, scope: ScopeId) -> ChildScopesIter<'_> {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -528,11 +528,13 @@ pub struct Directive {
     pub(crate) offset: TextSize,
 }
 
-// TODO: `Source()` directives
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DirectiveKind {
     /// `library(pkg)` or `require(pkg)`: attaches a package to the search path.
     Attach(String),
+    /// `source(path)`: splices the sourced file's bindings at this offset.
+    /// Stores the raw path string from the call site.
+    Source(String),
 }
 
 impl Directive {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ops::Range;
 
 use aether_syntax::RSyntaxNode;
@@ -116,7 +117,6 @@ impl SemanticIndex {
     }
 
     /// Top-level definitions exported by this file (definitions in the file scope).
-    /// Excludes `Sourced` definitions since those belong to other files.
     pub fn file_exports(&self) -> Vec<(&str, TextRange)> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
@@ -175,12 +175,11 @@ impl SemanticIndex {
     /// Find the definition site at `offset`, if any.
     pub fn definition_at_offset(&self, offset: TextSize) -> Option<(ScopeId, DefinitionId)> {
         let (scope, _) = self.scope_at(offset);
-        let def_id = self.definitions(scope).iter().find_map(|(id, d)| {
-            if matches!(d.kind(), DefinitionKind::Sourced { .. }) {
-                return None;
-            }
-            d.range().contains(offset).then_some(id)
-        });
+        let def_id = self
+            .definitions(scope)
+            .iter()
+            .filter(|(_id, def)| !matches!(def.kind(), DefinitionKind::Sourced { .. }))
+            .find_map(|(id, d)| d.range().contains(offset).then_some(id));
         Some((scope, def_id?))
     }
 
@@ -584,6 +583,11 @@ pub struct Directive {
 pub enum DirectiveKind {
     /// `library(pkg)` or `require(pkg)`: attaches a package to the search path.
     Attach(String),
+    /// `source(file)`: brings exports from another file into scope.
+    Source {
+        file: Url,
+        exports: HashMap<String, TextRange>,
+    },
 }
 
 impl Directive {

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -164,11 +164,14 @@ impl SemanticIndex {
     /// Find the definition site at `offset`, if any.
     pub fn definition_at_offset(&self, offset: TextSize) -> Option<(ScopeId, DefinitionId)> {
         let (scope, _) = self.scope_at(offset);
+
+        // Definitions with empty ranges (e.g. imports) are naturally excluded
+        // here since they can't contain the offset
         let def_id = self
             .definitions(scope)
             .iter()
-            .filter(|(_id, def)| !matches!(def.kind(), DefinitionKind::Import { .. }))
             .find_map(|(id, d)| d.range().contains(offset).then_some(id));
+
         Some((scope, def_id?))
     }
 

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -130,16 +130,15 @@ impl SemanticIndex {
             .collect()
     }
 
-    /// All definitions visible at file scope, including sourced ones.
-    ///
-    /// Each entry carries the file URL where the definition lives and
-    /// the range within that file. For own definitions, `file_url` is
-    /// passed through; for `Sourced` definitions, the URL comes from
-    /// the `DefinitionKind`.
-    pub fn file_all_definitions(&self, file_url: &Url) -> Vec<(&str, Url, TextRange)> {
+    /// All definitions that a `source()` caller would see from this file:
+    /// own file-scope definitions, `Sourced` definitions injected into the
+    /// use-def map, and exports from `Source` directives (transitive
+    /// `source()` calls with `local = FALSE` in nested scopes).
+    pub fn file_source_exports(&self, file_url: &Url) -> Vec<(&str, Url, TextRange)> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
-        self.definitions[file_scope]
+
+        let mut defs: Vec<(&str, Url, TextRange)> = self.definitions[file_scope]
             .iter()
             .map(|(_id, def)| {
                 let name = symbols.symbol(def.symbol()).name();
@@ -148,6 +147,27 @@ impl SemanticIndex {
                     _ => file_url.clone(),
                 };
                 (name, url, def.range())
+            })
+            .collect();
+
+        for directive in &self.directives {
+            if let DirectiveKind::Source { file, exports } = &directive.kind {
+                for (name, range) in exports {
+                    defs.push((name.as_str(), file.clone(), *range));
+                }
+            }
+        }
+
+        defs
+    }
+
+    /// Package names from `library()` / `require()` directives in this file.
+    pub fn file_attached_packages(&self) -> Vec<&str> {
+        self.directives
+            .iter()
+            .filter_map(|d| match &d.kind {
+                DirectiveKind::Attach(pkg) => Some(pkg.as_str()),
+                _ => None,
             })
             .collect()
     }

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -117,16 +117,18 @@ impl SemanticIndex {
 
     /// Top-level definitions exported by this file (definitions in the file scope).
     /// Includes `Import`-kind forwarding definitions from `source()` calls.
-    pub fn file_exports(&self) -> Vec<(&str, TextRange)> {
+    /// Last definition of each name wins (later assignments shadow earlier ones).
+    pub fn file_exports(&self) -> FxHashMap<&str, TextRange> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
-        self.definitions[file_scope]
-            .iter()
-            .map(|(_id, def)| {
-                let name = symbols.symbol_id(def.symbol()).name();
-                (name, def.range())
-            })
-            .collect()
+
+        let mut exports = FxHashMap::default();
+        for (_id, def) in self.definitions[file_scope].iter() {
+            let name = symbols.symbol_id(def.symbol()).name();
+            exports.insert(name, def.range());
+        }
+
+        exports
     }
 
     /// Package names from `library()` / `require()` directives in this file.

--- a/crates/oak_index/src/semantic_index.rs
+++ b/crates/oak_index/src/semantic_index.rs
@@ -122,7 +122,7 @@ impl SemanticIndex {
         let symbols = &self.symbol_tables[file_scope];
         self.definitions[file_scope]
             .iter()
-            .filter(|(_id, def)| !matches!(def.kind(), DefinitionKind::Sourced { .. }))
+            .filter(|(_id, def)| def.file().is_none())
             .map(|(_id, def)| {
                 let name = symbols.symbol(def.symbol()).name();
                 (name, def.range())
@@ -142,10 +142,7 @@ impl SemanticIndex {
             .iter()
             .map(|(_id, def)| {
                 let name = symbols.symbol(def.symbol()).name();
-                let url = match def.kind() {
-                    DefinitionKind::Sourced { file } => file.clone(),
-                    _ => file_url.clone(),
-                };
+                let url = def.file().cloned().unwrap_or_else(|| file_url.clone());
                 (name, url, def.range())
             })
             .collect();
@@ -198,7 +195,7 @@ impl SemanticIndex {
         let def_id = self
             .definitions(scope)
             .iter()
-            .filter(|(_id, def)| !matches!(def.kind(), DefinitionKind::Sourced { .. }))
+            .filter(|(_id, def)| def.file().is_none())
             .find_map(|(id, d)| d.range().contains(offset).then_some(id));
         Some((scope, def_id?))
     }
@@ -526,8 +523,9 @@ impl SymbolFlags {
 // declarations.
 #[derive(Debug)]
 pub struct Definition {
-    pub(crate) symbol: SymbolId,
     pub(crate) kind: DefinitionKind,
+    pub(crate) file: Option<Url>,
+    pub(crate) symbol: SymbolId,
     pub(crate) range: TextRange,
 }
 
@@ -537,11 +535,8 @@ pub enum DefinitionKind {
     SuperAssignment(RSyntaxNode),
     Parameter(RSyntaxNode),
     ForVariable(RSyntaxNode),
-    /// Injected from a `source()` call. The definition lives in an external
-    /// file; `range` on the `Definition` gives the name's range in that file.
-    Sourced {
-        file: Url,
-    },
+    /// Injected from a `source()` call. The range belongs to `Definition::file`.
+    Sourced,
 }
 
 impl Definition {
@@ -555,6 +550,10 @@ impl Definition {
 
     pub fn range(&self) -> TextRange {
         self.range
+    }
+
+    pub fn file(&self) -> Option<&Url> {
+        self.file.as_ref()
     }
 }
 

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1451,3 +1451,97 @@ fn test_directive_source_mixed_with_library() {
         &DirectiveKind::Attach("tidyr".into()),
     ]);
 }
+
+// --- declare() directives ---
+
+#[test]
+fn test_directive_declare_source() {
+    let index = index("declare(source(\"helpers.R\"))");
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
+        "helpers.R".into()
+    )]);
+}
+
+#[test]
+fn test_directive_declare_source_single_quotes() {
+    let index = index("declare(source('utils.R'))");
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
+        "utils.R".into()
+    )]);
+}
+
+#[test]
+fn test_directive_tilde_declare_source() {
+    let index = index("~declare(source(\"helpers.R\"))");
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
+        "helpers.R".into()
+    )]);
+}
+
+#[test]
+fn test_fimxe_directive_declare_library_transparent() {
+    // `declare()` is transparent: the inner `library(dplyr)` is still
+    // picked up as a directive.
+    // FIXME: We should declare `declare()` as a quoting function.
+    let index = index("declare(library(dplyr))");
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
+        "dplyr".into()
+    )]);
+}
+
+#[test]
+fn test_directive_declare_not_at_file_scope() {
+    let index = index("f <- function() { declare(source(\"helpers.R\")) }");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_tilde_declare_not_at_file_scope() {
+    let index = index("f <- function() { ~declare(source(\"helpers.R\")) }");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_declare_mixed_with_bare() {
+    let index = index("library(dplyr)\ndeclare(source(\"helpers.R\"))\nsource(\"utils.R\")");
+    assert_eq!(directive_kinds(&index), [
+        &DirectiveKind::Attach("dplyr".into()),
+        &DirectiveKind::Source("helpers.R".into()),
+        &DirectiveKind::Source("utils.R".into()),
+    ]);
+}
+
+#[test]
+fn test_directive_declare_preserves_offset() {
+    let index = index("x <- 1\ndeclare(source(\"helpers.R\"))");
+    let directives = index.file_directives();
+    assert_eq!(directives.len(), 1);
+    // Offset of the `source(...)` call inside declare, not the declare call
+    assert_eq!(
+        directives[0].kind(),
+        &DirectiveKind::Source("helpers.R".into())
+    );
+}
+
+#[test]
+fn test_directive_tilde_declare_preserves_offset() {
+    let index = index("x <- 1\n~declare(source(\"helpers.R\"))");
+    let directives = index.file_directives();
+    assert_eq!(directives.len(), 1);
+    assert_eq!(
+        directives[0].kind(),
+        &DirectiveKind::Source("helpers.R".into())
+    );
+}
+
+#[test]
+fn test_directive_declare_non_call_arg_ignored() {
+    let index = index("declare(42)");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_declare_identifier_source_arg_ignored() {
+    let index = index("declare(source(my_file))");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1424,7 +1424,8 @@ fn test_directive_source_named_argument_ignored() {
 }
 
 #[test]
-fn test_directive_source_multiple_arguments_ignored() {
+fn test_directive_source_local_true_without_resolver() {
+    // `source("helpers.R", local = TRUE)` is recognized but no resolver, so no directives
     let index = index("source(\"helpers.R\", local = TRUE)");
     assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
@@ -1436,7 +1437,8 @@ fn test_directive_source_no_arguments_ignored() {
 }
 
 #[test]
-fn test_directive_source_not_at_file_scope() {
+fn test_directive_source_nested_without_resolver() {
+    // Nested `source()` is recognized but no resolver, so no directives
     let index = index("f <- function() { source(\"helpers.R\") }");
     assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
@@ -1560,13 +1562,13 @@ fn helper_resolution() -> SourceResolution {
 
 #[test]
 fn test_source_resolver_injects_definitions() {
+    // At file scope, source() injects Sourced definitions into the use-def map.
     let code = "source(\"helpers.R\")\nhelper\n";
     let index = index_with_resolver(code, |_| Some(helper_resolution()));
     let file = ScopeId::from(0);
 
-    // The use of `helper` resolves to the sourced definition
-    let map = index.use_def_map(file);
     // Use 0 is `source`, use 1 is `helper`
+    let map = index.use_def_map(file);
     let bindings = map.bindings_at_use(UseId::from(1));
     assert!(!bindings.definitions().is_empty());
 
@@ -1618,20 +1620,22 @@ fn test_source_resolver_in_function_scope() {
     let fun = ScopeId::from(1);
     let file = ScopeId::from(0);
 
-    // `helper` inside the function resolves to the sourced definition
-    // Function scope uses: source(0), helper(1)
     let fun_map = index.use_def_map(fun);
     let inner_bindings = fun_map.bindings_at_use(UseId::from(1));
-    assert!(!inner_bindings.definitions().is_empty());
-    let def_id = inner_bindings.definitions()[0];
-    let def = &index.definitions(fun)[def_id];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+    assert!(inner_bindings.definitions().is_empty());
+    assert!(inner_bindings.may_be_unbound());
 
-    // `helper` at file scope does not resolve
     let file_map = index.use_def_map(file);
     let outer_bindings = file_map.bindings_at_use(UseId::from(0));
-    assert!(outer_bindings.may_be_unbound());
     assert!(outer_bindings.definitions().is_empty());
+    assert!(outer_bindings.may_be_unbound());
+
+    let source_directive = index
+        .file_directives()
+        .iter()
+        .find(|d| matches!(d.kind(), DirectiveKind::Source { .. }));
+    assert!(source_directive.is_some());
+    assert_eq!(source_directive.unwrap().scope(), ScopeId::from(1));
 }
 
 #[test]
@@ -1651,6 +1655,8 @@ fn test_source_resolver_packages_become_directives() {
 
 #[test]
 fn test_source_resolver_later_shadows_earlier() {
+    // At file scope, both source() calls inject Sourced definitions
+    // into the use-def map. The later one shadows the earlier.
     let code = "source(\"a.R\")\nsource(\"b.R\")\nfoo\n";
     let parsed = parse(code, RParserOptions::default());
 
@@ -1690,4 +1696,77 @@ fn test_source_resolver_later_shadows_earlier() {
         panic!("expected Sourced definition, got {:?}", def.kind());
     };
     assert_eq!(*url, b_url);
+}
+
+#[test]
+fn test_source_resolver_local_true_in_function_scope() {
+    // `local = TRUE` injects Sourced definitions into the function
+    // scope's use-def map, not into directives.
+    let code = "f <- function() {\n  source(\"helpers.R\", local = TRUE)\n  helper\n}\nhelper\n";
+    let index = index_with_resolver(code, |_| Some(helper_resolution()));
+    let fun = ScopeId::from(1);
+    let file = ScopeId::from(0);
+
+    let fun_map = index.use_def_map(fun);
+    // Function scope uses: source(0), helper(1)
+    let inner_bindings = fun_map.bindings_at_use(UseId::from(1));
+    assert_eq!(inner_bindings.definitions().len(), 1);
+    let def = &index.definitions(fun)[inner_bindings.definitions()[0]];
+    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+
+    // File scope: `helper` does not resolve
+    let file_map = index.use_def_map(file);
+    let outer_bindings = file_map.bindings_at_use(UseId::from(0));
+    assert!(outer_bindings.definitions().is_empty());
+}
+
+#[test]
+fn test_source_resolver_local_true_shadows_local_def() {
+    // `source(local = TRUE)` injects into the use-def map and
+    // shadows a prior local binding.
+    let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\", local = TRUE)\n  foo\n}\n";
+    let index = index_with_resolver(code, |_| {
+        Some(SourceResolution {
+            definitions: vec![(
+                "foo".into(),
+                Url::parse("file:///test/helpers.R").unwrap(),
+                TextRange::new(TextSize::from(0), TextSize::from(3)),
+            )],
+            packages: vec![],
+        })
+    });
+    let fun = ScopeId::from(1);
+
+    let fun_map = index.use_def_map(fun);
+    // Function scope uses: source(0), foo(1)
+    let bindings = fun_map.bindings_at_use(UseId::from(1));
+    assert_eq!(bindings.definitions().len(), 1);
+    let def = &index.definitions(fun)[bindings.definitions()[0]];
+    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+}
+
+#[test]
+fn test_source_resolver_local_false_does_not_shadow_local_def() {
+    // `source(local = FALSE)` (the default) in a function scope does not
+    // shadow a prior local binding: the sourced definition goes to the
+    // file scope, leaving the local one intact.
+    let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\")\n  foo\n}\n";
+    let index = index_with_resolver(code, |_| {
+        Some(SourceResolution {
+            definitions: vec![(
+                "foo".into(),
+                Url::parse("file:///test/helpers.R").unwrap(),
+                TextRange::new(TextSize::from(0), TextSize::from(3)),
+            )],
+            packages: vec![],
+        })
+    });
+    let fun = ScopeId::from(1);
+
+    let fun_map = index.use_def_map(fun);
+    // Function scope uses: source(0), foo(1)
+    let bindings = fun_map.bindings_at_use(UseId::from(1));
+    assert_eq!(bindings.definitions().len(), 1);
+    let def = &index.definitions(fun)[bindings.definitions()[0]];
+    assert!(matches!(def.kind(), DefinitionKind::Assignment(_)));
 }

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1366,9 +1366,14 @@ fn test_directive_no_arguments_ignored() {
 }
 
 #[test]
-fn test_directive_not_at_file_scope() {
+fn test_directive_library_in_function_scope() {
+    // library() in a function body now records a scoped directive
     let index = index("f <- function() { library(dplyr) }");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
+        "dplyr".into()
+    )]);
+    let directives = index.file_directives();
+    assert_ne!(directives[0].scope(), ScopeId::from(0));
 }
 
 #[test]

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -14,6 +14,7 @@ use oak_index::semantic_index::SymbolFlags;
 use oak_index::semantic_index::UseId;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::SourceResolution;
+use oak_index::FileDefinition;
 use url::Url;
 
 fn index(source: &str) -> SemanticIndex {
@@ -1551,11 +1552,11 @@ fn index_with_resolver(
 
 fn helper_resolution() -> SourceResolution {
     SourceResolution {
-        definitions: vec![(
-            "helper".into(),
-            Url::parse("file:///test/helpers.R").unwrap(),
-            TextRange::new(TextSize::from(0), TextSize::from(6)),
-        )],
+        definitions: vec![FileDefinition {
+            name: "helper".into(),
+            file: Url::parse("file:///test/helpers.R").unwrap(),
+            range: TextRange::new(TextSize::from(0), TextSize::from(6)),
+        }],
         packages: vec![],
     }
 }
@@ -1677,7 +1678,11 @@ fn test_source_resolver_later_shadows_earlier() {
             _ => return None,
         };
         Some(SourceResolution {
-            definitions: vec![("foo".to_string(), url, range)],
+            definitions: vec![FileDefinition {
+                name: "foo".to_string(),
+                file: url,
+                range,
+            }],
             packages: Vec::new(),
         })
     });
@@ -1725,11 +1730,11 @@ fn test_source_resolver_local_true_shadows_local_def() {
     let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\", local = TRUE)\n  foo\n}\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {
-            definitions: vec![(
-                "foo".into(),
-                Url::parse("file:///test/helpers.R").unwrap(),
-                TextRange::new(TextSize::from(0), TextSize::from(3)),
-            )],
+            definitions: vec![FileDefinition {
+                name: "foo".into(),
+                file: Url::parse("file:///test/helpers.R").unwrap(),
+                range: TextRange::new(TextSize::from(0), TextSize::from(3)),
+            }],
             packages: vec![],
         })
     });
@@ -1751,11 +1756,11 @@ fn test_source_resolver_local_false_does_not_shadow_local_def() {
     let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\")\n  foo\n}\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {
-            definitions: vec![(
-                "foo".into(),
-                Url::parse("file:///test/helpers.R").unwrap(),
-                TextRange::new(TextSize::from(0), TextSize::from(3)),
-            )],
+            definitions: vec![FileDefinition {
+                name: "foo".into(),
+                file: Url::parse("file:///test/helpers.R").unwrap(),
+                range: TextRange::new(TextSize::from(0), TextSize::from(3)),
+            }],
             packages: vec![],
         })
     });

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1648,3 +1648,46 @@ fn test_source_resolver_packages_become_directives() {
         "dplyr".into()
     )]);
 }
+
+#[test]
+fn test_source_resolver_later_shadows_earlier() {
+    let code = "source(\"a.R\")\nsource(\"b.R\")\nfoo\n";
+    let parsed = parse(code, RParserOptions::default());
+
+    let a_url = Url::parse("file:///test/a.R").unwrap();
+    let b_url = Url::parse("file:///test/b.R").unwrap();
+    let a_url_clone = a_url.clone();
+    let b_url_clone = b_url.clone();
+
+    let index = semantic_index_with_source_resolver(&parsed.tree(), move |path| {
+        let (url, range) = match path {
+            "a.R" => (
+                a_url_clone.clone(),
+                TextRange::new(TextSize::from(0), TextSize::from(3)),
+            ),
+            "b.R" => (
+                b_url_clone.clone(),
+                TextRange::new(TextSize::from(0), TextSize::from(3)),
+            ),
+            _ => return None,
+        };
+        Some(SourceResolution {
+            definitions: vec![("foo".to_string(), url, range)],
+            packages: Vec::new(),
+        })
+    });
+
+    let file = ScopeId::from(0);
+    let map = index.use_def_map(file);
+
+    // Uses: source(0), source(1), foo(2)
+    let bindings = map.bindings_at_use(UseId::from(2));
+    assert_eq!(bindings.definitions().len(), 1);
+
+    let def_id = bindings.definitions()[0];
+    let def = &index.definitions(file)[def_id];
+    let DefinitionKind::Sourced { file: ref url } = def.kind() else {
+        panic!("expected Sourced definition, got {:?}", def.kind());
+    };
+    assert_eq!(*url, b_url);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1,6 +1,8 @@
 use aether_parser::parse;
 use aether_parser::RParserOptions;
 use aether_syntax::RSyntaxKind;
+use biome_rowan::TextRange;
+use biome_rowan::TextSize;
 use oak_index::semantic_index;
 use oak_index::semantic_index::DefinitionId;
 use oak_index::semantic_index::DefinitionKind;
@@ -10,6 +12,9 @@ use oak_index::semantic_index::ScopeKind;
 use oak_index::semantic_index::SemanticIndex;
 use oak_index::semantic_index::SymbolFlags;
 use oak_index::semantic_index::UseId;
+use oak_index::semantic_index_with_source_resolver;
+use oak_index::SourceResolution;
+use url::Url;
 
 fn index(source: &str) -> SemanticIndex {
     let parsed = parse(source, RParserOptions::default());
@@ -1383,19 +1388,16 @@ fn test_directive_preserves_offset() {
 // --- source() directives ---
 
 #[test]
-fn test_directive_source_string() {
+fn test_directive_source_no_resolver() {
+    // Without a resolver, source() produces no directives
     let index = index("source(\"helpers.R\")");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
-        "helpers.R".into()
-    )]);
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
 
 #[test]
-fn test_directive_source_single_quoted_string() {
+fn test_directive_source_single_quoted_no_resolver() {
     let index = index("source('utils/helpers.R')");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
-        "utils/helpers.R".into()
-    )]);
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
 
 #[test]
@@ -1435,11 +1437,10 @@ fn test_directive_source_not_at_file_scope() {
 }
 
 #[test]
-fn test_directive_source_preserves_offset() {
+fn test_directive_source_no_resolver_no_directives() {
     let index = index("x <- 1\nsource(\"helpers.R\")");
     let directives = index.file_directives();
-    assert_eq!(directives.len(), 1);
-    assert_eq!(directives[0].offset(), biome_rowan::TextSize::from(7));
+    assert_eq!(directives.len(), 0);
 }
 
 #[test]
@@ -1447,7 +1448,6 @@ fn test_directive_source_mixed_with_library() {
     let index = index("library(dplyr)\nsource(\"helpers.R\")\nlibrary(tidyr)");
     assert_eq!(directive_kinds(&index), [
         &DirectiveKind::Attach("dplyr".into()),
-        &DirectiveKind::Source("helpers.R".into()),
         &DirectiveKind::Attach("tidyr".into()),
     ]);
 }
@@ -1455,31 +1455,25 @@ fn test_directive_source_mixed_with_library() {
 // --- declare() directives ---
 
 #[test]
-fn test_directive_declare_source() {
+fn test_directive_declare_source_no_resolver() {
     let index = index("declare(source(\"helpers.R\"))");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
-        "helpers.R".into()
-    )]);
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
 
 #[test]
-fn test_directive_declare_source_single_quotes() {
+fn test_directive_declare_source_single_quotes_no_resolver() {
     let index = index("declare(source('utils.R'))");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
-        "utils.R".into()
-    )]);
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
 
 #[test]
-fn test_directive_tilde_declare_source() {
+fn test_directive_tilde_declare_source_no_resolver() {
     let index = index("~declare(source(\"helpers.R\"))");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
-        "helpers.R".into()
-    )]);
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
 }
 
 #[test]
-fn test_fimxe_directive_declare_library_transparent() {
+fn test_fixme_directive_declare_library_transparent() {
     // `declare()` is transparent: the inner `library(dplyr)` is still
     // picked up as a directive.
     // FIXME: We should declare `declare()` as a quoting function.
@@ -1504,34 +1498,23 @@ fn test_directive_tilde_declare_not_at_file_scope() {
 #[test]
 fn test_directive_declare_mixed_with_bare() {
     let index = index("library(dplyr)\ndeclare(source(\"helpers.R\"))\nsource(\"utils.R\")");
-    assert_eq!(directive_kinds(&index), [
-        &DirectiveKind::Attach("dplyr".into()),
-        &DirectiveKind::Source("helpers.R".into()),
-        &DirectiveKind::Source("utils.R".into()),
-    ]);
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
+        "dplyr".into()
+    ),]);
 }
 
 #[test]
-fn test_directive_declare_preserves_offset() {
+fn test_directive_declare_source_no_resolver_no_directives() {
     let index = index("x <- 1\ndeclare(source(\"helpers.R\"))");
     let directives = index.file_directives();
-    assert_eq!(directives.len(), 1);
-    // Offset of the `source(...)` call inside declare, not the declare call
-    assert_eq!(
-        directives[0].kind(),
-        &DirectiveKind::Source("helpers.R".into())
-    );
+    assert_eq!(directives.len(), 0);
 }
 
 #[test]
-fn test_directive_tilde_declare_preserves_offset() {
+fn test_directive_tilde_declare_source_no_resolver_no_directives() {
     let index = index("x <- 1\n~declare(source(\"helpers.R\"))");
     let directives = index.file_directives();
-    assert_eq!(directives.len(), 1);
-    assert_eq!(
-        directives[0].kind(),
-        &DirectiveKind::Source("helpers.R".into())
-    );
+    assert_eq!(directives.len(), 0);
 }
 
 #[test]
@@ -1544,4 +1527,119 @@ fn test_directive_declare_non_call_arg_ignored() {
 fn test_directive_declare_identifier_source_arg_ignored() {
     let index = index("declare(source(my_file))");
     assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+// --- source() with resolver ---
+
+fn index_with_resolver(
+    source: &str,
+    resolver: impl FnMut(&str) -> Option<SourceResolution>,
+) -> SemanticIndex {
+    let parsed = parse(source, RParserOptions::default());
+    if parsed.has_error() {
+        panic!("source has syntax errors: {source}");
+    }
+    semantic_index_with_source_resolver(&parsed.tree(), resolver)
+}
+
+fn helper_resolution() -> SourceResolution {
+    SourceResolution {
+        definitions: vec![(
+            "helper".into(),
+            Url::parse("file:///test/helpers.R").unwrap(),
+            TextRange::new(TextSize::from(0), TextSize::from(6)),
+        )],
+        packages: vec![],
+    }
+}
+
+#[test]
+fn test_source_resolver_injects_definitions() {
+    let code = "source(\"helpers.R\")\nhelper\n";
+    let index = index_with_resolver(code, |_| Some(helper_resolution()));
+    let file = ScopeId::from(0);
+
+    // The use of `helper` resolves to the sourced definition
+    let map = index.use_def_map(file);
+    // Use 0 is `source`, use 1 is `helper`
+    let bindings = map.bindings_at_use(UseId::from(1));
+    assert!(!bindings.definitions().is_empty());
+
+    let def_id = bindings.definitions()[0];
+    let def = &index.definitions(file)[def_id];
+    let DefinitionKind::Sourced { file: ref url } = def.kind() else {
+        panic!("expected Sourced definition, got {:?}", def.kind());
+    };
+    assert_eq!(url.as_str(), "file:///test/helpers.R");
+
+    // file_exports() excludes sourced definitions
+    let exports = index.file_exports();
+    assert!(!exports.iter().any(|(name, _)| *name == "helper"));
+
+    // file_all_definitions() includes sourced definitions
+    let own_url = Url::parse("file:///test/main.R").unwrap();
+    let all_defs = index.file_all_definitions(&own_url);
+    let sourced = all_defs
+        .iter()
+        .find(|(name, _, _)| *name == "helper")
+        .unwrap();
+    assert_eq!(sourced.1.as_str(), "file:///test/helpers.R");
+}
+
+#[test]
+fn test_source_resolver_offset_visibility() {
+    let code = "helper\nsource(\"helpers.R\")\nhelper\n";
+    let index = index_with_resolver(code, |_| Some(helper_resolution()));
+    let file = ScopeId::from(0);
+    let map = index.use_def_map(file);
+
+    // First `helper` (before source call) is unbound
+    let first = map.bindings_at_use(UseId::from(0));
+    assert!(first.may_be_unbound());
+
+    // Second `helper` (after source call) resolves to the sourced definition
+    // Uses: helper(0), source(1), helper(2)
+    let second = map.bindings_at_use(UseId::from(2));
+    assert!(!second.definitions().is_empty());
+    let def_id = second.definitions()[0];
+    let def = &index.definitions(file)[def_id];
+    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+}
+
+#[test]
+fn test_source_resolver_in_function_scope() {
+    let code = "f <- function() {\n  source(\"helpers.R\")\n  helper\n}\nhelper\n";
+    let index = index_with_resolver(code, |_| Some(helper_resolution()));
+    let fun = ScopeId::from(1);
+    let file = ScopeId::from(0);
+
+    // `helper` inside the function resolves to the sourced definition
+    // Function scope uses: source(0), helper(1)
+    let fun_map = index.use_def_map(fun);
+    let inner_bindings = fun_map.bindings_at_use(UseId::from(1));
+    assert!(!inner_bindings.definitions().is_empty());
+    let def_id = inner_bindings.definitions()[0];
+    let def = &index.definitions(fun)[def_id];
+    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+
+    // `helper` at file scope does not resolve
+    let file_map = index.use_def_map(file);
+    let outer_bindings = file_map.bindings_at_use(UseId::from(0));
+    assert!(outer_bindings.may_be_unbound());
+    assert!(outer_bindings.definitions().is_empty());
+}
+
+#[test]
+fn test_source_resolver_packages_become_directives() {
+    let code = "source(\"helpers.R\")\n";
+    let index = index_with_resolver(code, |_| {
+        Some(SourceResolution {
+            definitions: vec![],
+            packages: vec!["dplyr".into()],
+        })
+    });
+
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
+        "dplyr".into()
+    )]);
 }

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1272,8 +1272,8 @@ fn test_file_exports_simple() {
     let index = index("x <- 1\ny <- 2");
     let exports = index.file_exports();
     assert_eq!(exports.len(), 2);
-    assert_eq!(exports[0].0, "x");
-    assert_eq!(exports[1].0, "y");
+    assert!(exports.contains_key("x"));
+    assert!(exports.contains_key("y"));
 }
 
 #[test]
@@ -1281,7 +1281,7 @@ fn test_file_exports_excludes_nested_definitions() {
     let index = index("f <- function(x) { local_var <- x }");
     let exports = index.file_exports();
     assert_eq!(exports.len(), 1);
-    assert_eq!(exports[0].0, "f");
+    assert!(exports.contains_key("f"));
 }
 
 #[test]
@@ -1295,10 +1295,9 @@ fn test_file_exports_empty() {
 fn test_file_exports_multiple_defs_same_symbol() {
     let index = index("x <- 1\nx <- 2");
     let exports = index.file_exports();
-    // Both definition sites are returned
-    assert_eq!(exports.len(), 2);
-    assert_eq!(exports[0].0, "x");
-    assert_eq!(exports[1].0, "x");
+    // Deduplicates: last definition wins
+    assert_eq!(exports.len(), 1);
+    assert!(exports.contains_key("x"));
 }
 
 // --- File directives ---
@@ -1386,6 +1385,18 @@ fn test_directive_preserves_offset() {
     let directives = index.file_directives();
     assert_eq!(directives.len(), 1);
     assert_eq!(directives[0].offset(), biome_rowan::TextSize::from(7));
+}
+
+#[test]
+fn test_file_exports_last_def_wins() {
+    // When the same name is defined multiple times at file scope,
+    // file_exports() returns only the last definition.
+    let index = index("foo <- 1\nfoo <- 2\nbar <- 3\n");
+    let exports = index.file_exports();
+    assert_eq!(exports.len(), 2);
+    // The range should be the second `foo` (offset 9..12)
+    let range = exports.get("foo").unwrap();
+    assert_eq!(range.start(), biome_rowan::TextSize::from(9));
 }
 
 // --- source() directives ---

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1748,8 +1748,8 @@ fn test_source_resolver_local_true_shadows_local_def() {
 #[test]
 fn test_source_resolver_local_false_does_not_shadow_local_def() {
     // `source(local = FALSE)` (the default) in a function scope does not
-    // shadow a prior local binding: the sourced definition goes to the
-    // file scope, leaving the local one intact.
+    // shadow a prior local binding: the sourced definition becomes a
+    // directive scoped to the function, leaving the local one intact.
     let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\")\n  foo\n}\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1583,9 +1583,9 @@ fn test_source_resolver_injects_definitions() {
     let exports = index.file_exports();
     assert!(!exports.iter().any(|(name, _)| *name == "helper"));
 
-    // file_all_definitions() includes sourced definitions
+    // file_source_exports() includes sourced definitions
     let own_url = Url::parse("file:///test/main.R").unwrap();
-    let all_defs = index.file_all_definitions(&own_url);
+    let all_defs = index.file_source_exports(&own_url);
     let sourced = all_defs
         .iter()
         .find(|(name, _, _)| *name == "helper")

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -88,11 +88,11 @@ fn test_rhs_collected_before_lhs() {
     let file = ScopeId::from(0);
 
     let use_site = &index.uses(file)[UseId::from(0)];
-    let use_sym = index.symbols(file).symbol_id(use_site.symbol());
+    let use_sym = index.symbols(file).symbol(use_site.symbol());
     assert_eq!(use_sym.name(), "y");
 
     let def_site = &index.definitions(file)[DefinitionId::from(0)];
-    let def_sym = index.symbols(file).symbol_id(def_site.symbol());
+    let def_sym = index.symbols(file).symbol(def_site.symbol());
     assert_eq!(def_sym.name(), "x");
 }
 
@@ -459,11 +459,11 @@ fn test_right_assignment_rhs_collected_before_lhs() {
     let file = ScopeId::from(0);
 
     let use_site = &index.uses(file)[UseId::from(0)];
-    let use_sym = index.symbols(file).symbol_id(use_site.symbol());
+    let use_sym = index.symbols(file).symbol(use_site.symbol());
     assert_eq!(use_sym.name(), "y");
 
     let def_site = &index.definitions(file)[DefinitionId::from(0)];
-    let def_sym = index.symbols(file).symbol_id(def_site.symbol());
+    let def_sym = index.symbols(file).symbol(def_site.symbol());
     assert_eq!(def_sym.name(), "x");
 }
 
@@ -664,7 +664,7 @@ fn test_super_assignment_does_not_pollute_ancestor() {
     let x_file_defs: Vec<_> = index
         .definitions(file)
         .iter()
-        .filter(|(_, d)| index.symbols(file).symbol_id(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_file_defs.len(), 2);
     assert!(matches!(
@@ -708,7 +708,7 @@ fn test_super_assignment_nested_recorded_in_inner_scope() {
     let x_outer_defs: Vec<_> = index
         .definitions(outer)
         .iter()
-        .filter(|(_, d)| index.symbols(outer).symbol_id(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_outer_defs.len(), 2);
     assert!(matches!(
@@ -748,7 +748,7 @@ fn test_super_assignment_nested_skips_super_bound_scope() {
     let x_file_defs: Vec<_> = index
         .definitions(file)
         .iter()
-        .filter(|(_, d)| index.symbols(file).symbol_id(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_file_defs.len(), 3);
     assert!(matches!(

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1574,9 +1574,8 @@ fn test_source_resolver_injects_definitions() {
 
     let def_id = bindings.definitions()[0];
     let def = &index.definitions(file)[def_id];
-    let DefinitionKind::Sourced { file: ref url } = def.kind() else {
-        panic!("expected Sourced definition, got {:?}", def.kind());
-    };
+    assert!(matches!(def.kind(), DefinitionKind::Sourced));
+    let url = def.file().unwrap();
     assert_eq!(url.as_str(), "file:///test/helpers.R");
 
     // file_exports() excludes sourced definitions
@@ -1610,7 +1609,7 @@ fn test_source_resolver_offset_visibility() {
     assert!(!second.definitions().is_empty());
     let def_id = second.definitions()[0];
     let def = &index.definitions(file)[def_id];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+    assert!(matches!(def.kind(), DefinitionKind::Sourced));
 }
 
 #[test]
@@ -1692,9 +1691,8 @@ fn test_source_resolver_later_shadows_earlier() {
 
     let def_id = bindings.definitions()[0];
     let def = &index.definitions(file)[def_id];
-    let DefinitionKind::Sourced { file: ref url } = def.kind() else {
-        panic!("expected Sourced definition, got {:?}", def.kind());
-    };
+    assert!(matches!(def.kind(), DefinitionKind::Sourced));
+    let url = def.file().unwrap();
     assert_eq!(*url, b_url);
 }
 
@@ -1712,7 +1710,7 @@ fn test_source_resolver_local_true_in_function_scope() {
     let inner_bindings = fun_map.bindings_at_use(UseId::from(1));
     assert_eq!(inner_bindings.definitions().len(), 1);
     let def = &index.definitions(fun)[inner_bindings.definitions()[0]];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+    assert!(matches!(def.kind(), DefinitionKind::Sourced));
 
     // File scope: `helper` does not resolve
     let file_map = index.use_def_map(file);
@@ -1742,7 +1740,7 @@ fn test_source_resolver_local_true_shadows_local_def() {
     let bindings = fun_map.bindings_at_use(UseId::from(1));
     assert_eq!(bindings.definitions().len(), 1);
     let def = &index.definitions(fun)[bindings.definitions()[0]];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced { .. }));
+    assert!(matches!(def.kind(), DefinitionKind::Sourced));
 }
 
 #[test]

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1379,3 +1379,75 @@ fn test_directive_preserves_offset() {
     assert_eq!(directives.len(), 1);
     assert_eq!(directives[0].offset(), biome_rowan::TextSize::from(7));
 }
+
+// --- source() directives ---
+
+#[test]
+fn test_directive_source_string() {
+    let index = index("source(\"helpers.R\")");
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
+        "helpers.R".into()
+    )]);
+}
+
+#[test]
+fn test_directive_source_single_quoted_string() {
+    let index = index("source('utils/helpers.R')");
+    assert_eq!(directive_kinds(&index), [&DirectiveKind::Source(
+        "utils/helpers.R".into()
+    )]);
+}
+
+#[test]
+fn test_directive_source_identifier_ignored() {
+    let index = index("source(my_file)");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_source_non_static_argument_ignored() {
+    let index = index("source(paste0(\"path/\", name))");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_source_named_argument_ignored() {
+    let index = index("source(file = \"helpers.R\")");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_source_multiple_arguments_ignored() {
+    let index = index("source(\"helpers.R\", local = TRUE)");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_source_no_arguments_ignored() {
+    let index = index("source()");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_source_not_at_file_scope() {
+    let index = index("f <- function() { source(\"helpers.R\") }");
+    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+}
+
+#[test]
+fn test_directive_source_preserves_offset() {
+    let index = index("x <- 1\nsource(\"helpers.R\")");
+    let directives = index.file_directives();
+    assert_eq!(directives.len(), 1);
+    assert_eq!(directives[0].offset(), biome_rowan::TextSize::from(7));
+}
+
+#[test]
+fn test_directive_source_mixed_with_library() {
+    let index = index("library(dplyr)\nsource(\"helpers.R\")\nlibrary(tidyr)");
+    assert_eq!(directive_kinds(&index), [
+        &DirectiveKind::Attach("dplyr".into()),
+        &DirectiveKind::Source("helpers.R".into()),
+        &DirectiveKind::Attach("tidyr".into()),
+    ]);
+}

--- a/crates/oak_index/tests/builder.rs
+++ b/crates/oak_index/tests/builder.rs
@@ -1,8 +1,6 @@
 use aether_parser::parse;
 use aether_parser::RParserOptions;
 use aether_syntax::RSyntaxKind;
-use biome_rowan::TextRange;
-use biome_rowan::TextSize;
 use oak_index::semantic_index;
 use oak_index::semantic_index::DefinitionId;
 use oak_index::semantic_index::DefinitionKind;
@@ -14,7 +12,6 @@ use oak_index::semantic_index::SymbolFlags;
 use oak_index::semantic_index::UseId;
 use oak_index::semantic_index_with_source_resolver;
 use oak_index::SourceResolution;
-use oak_index::FileDefinition;
 use url::Url;
 
 fn index(source: &str) -> SemanticIndex {
@@ -24,7 +21,7 @@ fn index(source: &str) -> SemanticIndex {
         panic!("source has syntax errors: {source}");
     }
 
-    semantic_index(&parsed.tree())
+    semantic_index(&parsed.tree(), &Url::parse("file:///test/test.R").unwrap())
 }
 
 fn directive_kinds(index: &SemanticIndex) -> Vec<&DirectiveKind> {
@@ -91,11 +88,11 @@ fn test_rhs_collected_before_lhs() {
     let file = ScopeId::from(0);
 
     let use_site = &index.uses(file)[UseId::from(0)];
-    let use_sym = index.symbols(file).symbol(use_site.symbol());
+    let use_sym = index.symbols(file).symbol_id(use_site.symbol());
     assert_eq!(use_sym.name(), "y");
 
     let def_site = &index.definitions(file)[DefinitionId::from(0)];
-    let def_sym = index.symbols(file).symbol(def_site.symbol());
+    let def_sym = index.symbols(file).symbol_id(def_site.symbol());
     assert_eq!(def_sym.name(), "x");
 }
 
@@ -462,11 +459,11 @@ fn test_right_assignment_rhs_collected_before_lhs() {
     let file = ScopeId::from(0);
 
     let use_site = &index.uses(file)[UseId::from(0)];
-    let use_sym = index.symbols(file).symbol(use_site.symbol());
+    let use_sym = index.symbols(file).symbol_id(use_site.symbol());
     assert_eq!(use_sym.name(), "y");
 
     let def_site = &index.definitions(file)[DefinitionId::from(0)];
-    let def_sym = index.symbols(file).symbol(def_site.symbol());
+    let def_sym = index.symbols(file).symbol_id(def_site.symbol());
     assert_eq!(def_sym.name(), "x");
 }
 
@@ -667,7 +664,7 @@ fn test_super_assignment_does_not_pollute_ancestor() {
     let x_file_defs: Vec<_> = index
         .definitions(file)
         .iter()
-        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(file).symbol_id(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_file_defs.len(), 2);
     assert!(matches!(
@@ -711,7 +708,7 @@ fn test_super_assignment_nested_recorded_in_inner_scope() {
     let x_outer_defs: Vec<_> = index
         .definitions(outer)
         .iter()
-        .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(outer).symbol_id(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_outer_defs.len(), 2);
     assert!(matches!(
@@ -751,7 +748,7 @@ fn test_super_assignment_nested_skips_super_bound_scope() {
     let x_file_defs: Vec<_> = index
         .definitions(file)
         .iter()
-        .filter(|(_, d)| index.symbols(file).symbol(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(file).symbol_id(d.symbol()).name() == "x")
         .collect();
     assert_eq!(x_file_defs.len(), 3);
     assert!(matches!(
@@ -1547,23 +1544,24 @@ fn index_with_resolver(
     if parsed.has_error() {
         panic!("source has syntax errors: {source}");
     }
-    semantic_index_with_source_resolver(&parsed.tree(), resolver)
+    semantic_index_with_source_resolver(
+        &parsed.tree(),
+        &Url::parse("file:///test/test.R").unwrap(),
+        resolver,
+    )
 }
 
 fn helper_resolution() -> SourceResolution {
     SourceResolution {
-        definitions: vec![FileDefinition {
-            name: "helper".into(),
-            file: Url::parse("file:///test/helpers.R").unwrap(),
-            range: TextRange::new(TextSize::from(0), TextSize::from(6)),
-        }],
+        file: Url::parse("file:///test/helpers.R").unwrap(),
+        names: vec!["helper".into()],
         packages: vec![],
     }
 }
 
 #[test]
 fn test_source_resolver_injects_definitions() {
-    // At file scope, source() injects Sourced definitions into the use-def map.
+    // At file scope, source() injects Import definitions into the use-def map.
     let code = "source(\"helpers.R\")\nhelper\n";
     let index = index_with_resolver(code, |_| Some(helper_resolution()));
     let file = ScopeId::from(0);
@@ -1575,22 +1573,20 @@ fn test_source_resolver_injects_definitions() {
 
     let def_id = bindings.definitions()[0];
     let def = &index.definitions(file)[def_id];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced));
-    let url = def.file().unwrap();
-    assert_eq!(url.as_str(), "file:///test/helpers.R");
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
+    // def.file() is the owning file; the target is in the kind
+    assert_eq!(def.file().as_str(), "file:///test/test.R");
+    match def.kind() {
+        DefinitionKind::Import { file, name, .. } => {
+            assert_eq!(file.as_str(), "file:///test/helpers.R");
+            assert_eq!(name, "helper");
+        },
+        _ => panic!("expected Import kind"),
+    }
 
-    // file_exports() excludes sourced definitions
+    // file_exports() includes Import-kind definitions
     let exports = index.file_exports();
-    assert!(!exports.iter().any(|(name, _)| *name == "helper"));
-
-    // file_source_exports() includes sourced definitions
-    let own_url = Url::parse("file:///test/main.R").unwrap();
-    let all_defs = index.file_source_exports(&own_url);
-    let sourced = all_defs
-        .iter()
-        .find(|(name, _, _)| *name == "helper")
-        .unwrap();
-    assert_eq!(sourced.1.as_str(), "file:///test/helpers.R");
+    assert!(exports.iter().any(|(name, _)| *name == "helper"));
 }
 
 #[test]
@@ -1610,32 +1606,30 @@ fn test_source_resolver_offset_visibility() {
     assert!(!second.definitions().is_empty());
     let def_id = second.definitions()[0];
     let def = &index.definitions(file)[def_id];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced));
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
 }
 
 #[test]
 fn test_source_resolver_in_function_scope() {
+    // source() in a function scope injects Import-kind defs into
+    // the function scope's use-def map.
     let code = "f <- function() {\n  source(\"helpers.R\")\n  helper\n}\nhelper\n";
     let index = index_with_resolver(code, |_| Some(helper_resolution()));
     let fun = ScopeId::from(1);
     let file = ScopeId::from(0);
 
+    // Function scope: source(0), helper(1)
     let fun_map = index.use_def_map(fun);
     let inner_bindings = fun_map.bindings_at_use(UseId::from(1));
-    assert!(inner_bindings.definitions().is_empty());
-    assert!(inner_bindings.may_be_unbound());
+    assert_eq!(inner_bindings.definitions().len(), 1);
+    let def = &index.definitions(fun)[inner_bindings.definitions()[0]];
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
 
+    // File scope: `helper` does not resolve
     let file_map = index.use_def_map(file);
     let outer_bindings = file_map.bindings_at_use(UseId::from(0));
     assert!(outer_bindings.definitions().is_empty());
     assert!(outer_bindings.may_be_unbound());
-
-    let source_directive = index
-        .file_directives()
-        .iter()
-        .find(|d| matches!(d.kind(), DirectiveKind::Source { .. }));
-    assert!(source_directive.is_some());
-    assert_eq!(source_directive.unwrap().scope(), ScopeId::from(1));
 }
 
 #[test]
@@ -1643,7 +1637,8 @@ fn test_source_resolver_packages_become_directives() {
     let code = "source(\"helpers.R\")\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {
-            definitions: vec![],
+            file: Url::parse("file:///test/helpers.R").unwrap(),
+            names: vec![],
             packages: vec!["dplyr".into()],
         })
     });
@@ -1655,7 +1650,7 @@ fn test_source_resolver_packages_become_directives() {
 
 #[test]
 fn test_source_resolver_later_shadows_earlier() {
-    // At file scope, both source() calls inject Sourced definitions
+    // At file scope, both source() calls inject Import definitions
     // into the use-def map. The later one shadows the earlier.
     let code = "source(\"a.R\")\nsource(\"b.R\")\nfoo\n";
     let parsed = parse(code, RParserOptions::default());
@@ -1665,27 +1660,22 @@ fn test_source_resolver_later_shadows_earlier() {
     let a_url_clone = a_url.clone();
     let b_url_clone = b_url.clone();
 
-    let index = semantic_index_with_source_resolver(&parsed.tree(), move |path| {
-        let (url, range) = match path {
-            "a.R" => (
-                a_url_clone.clone(),
-                TextRange::new(TextSize::from(0), TextSize::from(3)),
-            ),
-            "b.R" => (
-                b_url_clone.clone(),
-                TextRange::new(TextSize::from(0), TextSize::from(3)),
-            ),
-            _ => return None,
-        };
-        Some(SourceResolution {
-            definitions: vec![FileDefinition {
-                name: "foo".to_string(),
+    let index = semantic_index_with_source_resolver(
+        &parsed.tree(),
+        &Url::parse("file:///test/test.R").unwrap(),
+        move |path| {
+            let url = match path {
+                "a.R" => a_url_clone.clone(),
+                "b.R" => b_url_clone.clone(),
+                _ => return None,
+            };
+            Some(SourceResolution {
                 file: url,
-                range,
-            }],
-            packages: Vec::new(),
-        })
-    });
+                names: vec!["foo".into()],
+                packages: Vec::new(),
+            })
+        },
+    );
 
     let file = ScopeId::from(0);
     let map = index.use_def_map(file);
@@ -1696,15 +1686,17 @@ fn test_source_resolver_later_shadows_earlier() {
 
     let def_id = bindings.definitions()[0];
     let def = &index.definitions(file)[def_id];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced));
-    let url = def.file().unwrap();
-    assert_eq!(*url, b_url);
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
+    match def.kind() {
+        DefinitionKind::Import { file, .. } => assert_eq!(*file, b_url),
+        _ => panic!("expected Import kind"),
+    }
 }
 
 #[test]
 fn test_source_resolver_local_true_in_function_scope() {
-    // `local = TRUE` injects Sourced definitions into the function
-    // scope's use-def map, not into directives.
+    // `local = TRUE` injects Import definitions into the function
+    // scope's use-def map.
     let code = "f <- function() {\n  source(\"helpers.R\", local = TRUE)\n  helper\n}\nhelper\n";
     let index = index_with_resolver(code, |_| Some(helper_resolution()));
     let fun = ScopeId::from(1);
@@ -1715,7 +1707,7 @@ fn test_source_resolver_local_true_in_function_scope() {
     let inner_bindings = fun_map.bindings_at_use(UseId::from(1));
     assert_eq!(inner_bindings.definitions().len(), 1);
     let def = &index.definitions(fun)[inner_bindings.definitions()[0]];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced));
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
 
     // File scope: `helper` does not resolve
     let file_map = index.use_def_map(file);
@@ -1730,11 +1722,8 @@ fn test_source_resolver_local_true_shadows_local_def() {
     let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\", local = TRUE)\n  foo\n}\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {
-            definitions: vec![FileDefinition {
-                name: "foo".into(),
-                file: Url::parse("file:///test/helpers.R").unwrap(),
-                range: TextRange::new(TextSize::from(0), TextSize::from(3)),
-            }],
+            file: Url::parse("file:///test/helpers.R").unwrap(),
+            names: vec!["foo".into()],
             packages: vec![],
         })
     });
@@ -1745,22 +1734,18 @@ fn test_source_resolver_local_true_shadows_local_def() {
     let bindings = fun_map.bindings_at_use(UseId::from(1));
     assert_eq!(bindings.definitions().len(), 1);
     let def = &index.definitions(fun)[bindings.definitions()[0]];
-    assert!(matches!(def.kind(), DefinitionKind::Sourced));
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
 }
 
 #[test]
 fn test_source_resolver_local_false_does_not_shadow_local_def() {
-    // `source(local = FALSE)` (the default) in a function scope does not
-    // shadow a prior local binding: the sourced definition becomes a
-    // directive scoped to the function, leaving the local one intact.
+    // source() without `local = TRUE` in a function scope now also
+    // injects Import definitions, shadowing the local binding.
     let code = "f <- function() {\n  foo <- 1\n  source(\"helpers.R\")\n  foo\n}\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {
-            definitions: vec![FileDefinition {
-                name: "foo".into(),
-                file: Url::parse("file:///test/helpers.R").unwrap(),
-                range: TextRange::new(TextSize::from(0), TextSize::from(3)),
-            }],
+            file: Url::parse("file:///test/helpers.R").unwrap(),
+            names: vec!["foo".into()],
             packages: vec![],
         })
     });
@@ -1771,5 +1756,22 @@ fn test_source_resolver_local_false_does_not_shadow_local_def() {
     let bindings = fun_map.bindings_at_use(UseId::from(1));
     assert_eq!(bindings.definitions().len(), 1);
     let def = &index.definitions(fun)[bindings.definitions()[0]];
-    assert!(matches!(def.kind(), DefinitionKind::Assignment(_)));
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
+}
+
+#[test]
+fn test_source_resolver_local_def_shadowed_by_source() {
+    // A local definition followed by source() at file scope:
+    // the source() shadows the local def.
+    let code = "helper <- 1\nsource(\"helpers.R\")\nhelper\n";
+    let index = index_with_resolver(code, |_| Some(helper_resolution()));
+    let file = ScopeId::from(0);
+    let map = index.use_def_map(file);
+
+    // Uses: source(0), helper(1)
+    let bindings = map.bindings_at_use(UseId::from(1));
+    assert_eq!(bindings.definitions().len(), 1);
+    let def_id = bindings.definitions()[0];
+    let def = &index.definitions(file)[def_id];
+    assert!(matches!(def.kind(), DefinitionKind::Import { .. }));
 }

--- a/crates/oak_index/tests/external.rs
+++ b/crates/oak_index/tests/external.rs
@@ -364,6 +364,22 @@ fn test_file_layers_empty_file() {
     });
 }
 
+#[test]
+fn test_file_layers_source_directive_skipped() {
+    let index = index_source("library(dplyr)\nsource(\"helpers.R\")\nx <- 1");
+    let layers = file_layers(file_url("script.R"), &index);
+
+    // FileExports + PackageExports(dplyr), source() is not emitted as a layer
+    assert_eq!(layers.len(), 2);
+    assert_matches!(&layers[0], ScopeLayer::FileExports { exports, .. } => {
+        assert_eq!(exports.len(), 1);
+        assert!(exports.contains_key("x"));
+    });
+    assert_matches!(&layers[1], ScopeLayer::PackageExports(pkg) => {
+        assert_eq!(pkg, "dplyr");
+    });
+}
+
 // --- Integration: file_layers -> resolve_external_name ---
 
 #[test]

--- a/crates/oak_index/tests/external.rs
+++ b/crates/oak_index/tests/external.rs
@@ -303,7 +303,10 @@ fn test_resolve_file_exports_last_definition_wins() {
 
 fn index_source(source: &str) -> oak_index::semantic_index::SemanticIndex {
     let parsed = parse(source, RParserOptions::default());
-    semantic_index(&parsed.tree())
+    semantic_index(
+        &parsed.tree(),
+        &url::Url::parse("file:///test/test.R").unwrap(),
+    )
 }
 
 #[test]

--- a/crates/oak_index/tests/use_def_map.rs
+++ b/crates/oak_index/tests/use_def_map.rs
@@ -731,7 +731,7 @@ x                                            # file: use 0 -> {def 0} only
     let outer_defs: Vec<_> = index
         .definitions(outer)
         .iter()
-        .filter(|(_, d)| index.symbols(outer).symbol_id(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
         .collect();
     assert_eq!(outer_defs.len(), 2);
 }

--- a/crates/oak_index/tests/use_def_map.rs
+++ b/crates/oak_index/tests/use_def_map.rs
@@ -9,7 +9,10 @@ use stdext::assert_not;
 
 fn index(source: &str) -> SemanticIndex {
     let parsed = parse(source, RParserOptions::default());
-    semantic_index(&parsed.tree())
+    semantic_index(
+        &parsed.tree(),
+        &url::Url::parse("file:///test/test.R").unwrap(),
+    )
 }
 
 // --- Straight-line code ---
@@ -728,7 +731,7 @@ x                                            # file: use 0 -> {def 0} only
     let outer_defs: Vec<_> = index
         .definitions(outer)
         .iter()
-        .filter(|(_, d)| index.symbols(outer).symbol(d.symbol()).name() == "x")
+        .filter(|(_, d)| index.symbols(outer).symbol_id(d.symbol()).name() == "x")
         .collect();
     assert_eq!(outer_defs.len(), 2);
 }


### PR DESCRIPTION
Closes https://github.com/posit-dev/ark/issues/1148
Progress towards https://github.com/posit-dev/positron/issues/11112

I somehow closed https://github.com/posit-dev/ark/pull/1157 by mistake and couldn't reopen it. See PR description there.

I've addressed your first round of review @DavisVaughan. The main change I made follows your remark about ordering with:

```r
helper <- function() {}
source("helpers.R")  # Also defines `helper`
helper # Should resolve to definition in `helpers.R`
```

We really need the imported definitions to shadow any earlier ones. Cross-file resolution only kicks in for unbound symbols, so the cross-file directive approach couldn't work here. To fix this I made the `local = FALSE` case use the same approach as with `local = TRUE`. I.e. we inject actual definitions in the symbol table, so that they can shadow earlier ones.

The cross-file resolution mechanism would still have been useful in nested scopes like:

```r
fn <- function() {
  source("helpers.R")
  helper
}
```

Here the external resolution for unbound symbols _is_ correct because `local = FALSE`. However it didn't feel justified to keep this mechanism just for this case. So I've removed it and `source()` now always injects in the local environment, as if `local = TRUE`. I've added a TODO note about linting this usage of `source()` to guide users toward using `local = TRUE`.

The other change concerns how we represent these imported definitions. You were right to call out how they were represented in the first version of my PR, as definitions copied from the imported file. Although in ty definitions are self-contained and shareable, with a scope and file ID that refer to their original context, there is a major problem to importing a definition this way: it creates a dependency that's not trackable by Salsa in a targeted way. For instance if the sourced file changes in a way that doesn't affect imports (same exported names), we'd be forced to recompute the whole index even though it's not necessary. With a proper Salsa query for imported symbols, the computation will be short-circuited if the imports haven't changed.

So I've revised the approach so it can be resolved via queries. There is a new `DefinitionKind::Import` which references a definition in an external file, and a resolving procedure that looks up the external definition. All stored definitions are local.

One subtlety is that import definitions have an empty range (at the `source()` call offset), since there is no syntactic element in the file that represents them. Thanks to the empty range we can exclude these definitions in a natural way by using `def.contains(offset)`. Their empty range can't contain the offset. So for instance when we look for an actual definition at cursor, e.g. in goto-definition, these import definitions are excluded as expected via their empty range.
