### PR TITLE
Bump synced biome and air dependencies enough for `SyntaxNodePtr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aether_lsp_utils"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1#4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1"
+source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
 dependencies = [
  "anyhow",
  "biome_line_index",
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "air_r_factory"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1#4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1"
+source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
 dependencies = [
  "air_r_syntax",
  "biome_rowan",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "air_r_parser"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1#4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1"
+source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
 dependencies = [
  "air_r_factory",
  "air_r_syntax",
@@ -252,7 +252,7 @@ dependencies = [
 [[package]]
 name = "air_r_syntax"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1#4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1"
+source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
 dependencies = [
  "biome_rowan",
  "serde",
@@ -551,7 +551,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "biome_console"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "biome_markup",
  "biome_text_size",
@@ -564,7 +564,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "backtrace",
  "biome_console",
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_categories"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "quote",
  "serde",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_macros"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "biome_line_index"
 version = "0.1.0"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "biome_text_size",
  "rustc-hash",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "biome_markup"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "biome_parser"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "biome_rowan"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "biome_text_edit",
  "biome_text_size",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "biome_text_edit"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "biome_text_size",
  "serde",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "biome_text_size"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 dependencies = [
  "serde",
 ]
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "biome_unicode_table"
 version = "0.5.7"
-source = "git+https://github.com/lionel-/biome?rev=41d799cfa4cedd25625fc3f6bd7898532873f051#41d799cfa4cedd25625fc3f6bd7898532873f051"
+source = "git+https://github.com/lionel-/biome?rev=a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9#a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9"
 
 [[package]]
 name = "bitflags"
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "line_ending"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1#4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1"
+source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
 dependencies = [
  "memchr",
  "settings",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "settings"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1#4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1"
+source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
 
 [[package]]
 name = "sha1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aether_lsp_utils"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
+source = "git+https://github.com/posit-dev/air?rev=d2659d5b158374bf486b594625ca50abbd0ac879#d2659d5b158374bf486b594625ca50abbd0ac879"
 dependencies = [
  "anyhow",
  "biome_line_index",
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "air_r_factory"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
+source = "git+https://github.com/posit-dev/air?rev=d2659d5b158374bf486b594625ca50abbd0ac879#d2659d5b158374bf486b594625ca50abbd0ac879"
 dependencies = [
  "air_r_syntax",
  "biome_rowan",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "air_r_parser"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
+source = "git+https://github.com/posit-dev/air?rev=d2659d5b158374bf486b594625ca50abbd0ac879#d2659d5b158374bf486b594625ca50abbd0ac879"
 dependencies = [
  "air_r_factory",
  "air_r_syntax",
@@ -252,7 +252,7 @@ dependencies = [
 [[package]]
 name = "air_r_syntax"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
+source = "git+https://github.com/posit-dev/air?rev=d2659d5b158374bf486b594625ca50abbd0ac879#d2659d5b158374bf486b594625ca50abbd0ac879"
 dependencies = [
  "biome_rowan",
  "serde",
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "line_ending"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
+source = "git+https://github.com/posit-dev/air?rev=d2659d5b158374bf486b594625ca50abbd0ac879#d2659d5b158374bf486b594625ca50abbd0ac879"
 dependencies = [
  "memchr",
  "settings",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "settings"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=58b1a8fc651d9106c9989f4250c690bdf7c4004b#58b1a8fc651d9106c9989f4250c690bdf7c4004b"
+source = "git+https://github.com/posit-dev/air?rev=d2659d5b158374bf486b594625ca50abbd0ac879#d2659d5b158374bf486b594625ca50abbd0ac879"
 
 [[package]]
 name = "sha1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ too_many_arguments = "allow"
 
 [workspace.dependencies]
 actix-web = "4.13.0"
-aether_factory = { git = "https://github.com/posit-dev/air", package = "air_r_factory", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
-aether_lsp_utils = { git = "https://github.com/posit-dev/air", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
-aether_parser = { git = "https://github.com/posit-dev/air", package = "air_r_parser", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
-aether_syntax = { git = "https://github.com/posit-dev/air", package = "air_r_syntax", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
+aether_factory = { git = "https://github.com/posit-dev/air", package = "air_r_factory", rev = "d2659d5b158374bf486b594625ca50abbd0ac879" }
+aether_lsp_utils = { git = "https://github.com/posit-dev/air", rev = "d2659d5b158374bf486b594625ca50abbd0ac879" }
+aether_parser = { git = "https://github.com/posit-dev/air", package = "air_r_parser", rev = "d2659d5b158374bf486b594625ca50abbd0ac879" }
+aether_syntax = { git = "https://github.com/posit-dev/air", package = "air_r_syntax", rev = "d2659d5b158374bf486b594625ca50abbd0ac879" }
 amalthea = { path = "crates/amalthea" }
 anyhow = "1.0.102"
 ark = { path = "crates/ark" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ too_many_arguments = "allow"
 
 [workspace.dependencies]
 actix-web = "4.13.0"
-aether_factory = { git = "https://github.com/posit-dev/air", package = "air_r_factory", rev = "4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1" }
-aether_lsp_utils = { git = "https://github.com/posit-dev/air", rev = "4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1" }
-aether_parser = { git = "https://github.com/posit-dev/air", package = "air_r_parser", rev = "4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1" }
-aether_syntax = { git = "https://github.com/posit-dev/air", package = "air_r_syntax", rev = "4cbd36d552e27d8930cff1602d56bfd9ce4c1ed1" }
+aether_factory = { git = "https://github.com/posit-dev/air", package = "air_r_factory", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
+aether_lsp_utils = { git = "https://github.com/posit-dev/air", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
+aether_parser = { git = "https://github.com/posit-dev/air", package = "air_r_parser", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
+aether_syntax = { git = "https://github.com/posit-dev/air", package = "air_r_syntax", rev = "58b1a8fc651d9106c9989f4250c690bdf7c4004b" }
 amalthea = { path = "crates/amalthea" }
 anyhow = "1.0.102"
 ark = { path = "crates/ark" }
@@ -36,9 +36,9 @@ ark_test = { path = "crates/ark_test" }
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
 base64 = "0.22.1"
-biome_line_index = { git = "https://github.com/lionel-/biome", rev = "41d799cfa4cedd25625fc3f6bd7898532873f051" }
-biome_rowan = { git = "https://github.com/lionel-/biome", rev = "41d799cfa4cedd25625fc3f6bd7898532873f051" }
-biome_text_size = { git = "https://github.com/lionel-/biome", rev = "41d799cfa4cedd25625fc3f6bd7898532873f051" }
+biome_line_index = { git = "https://github.com/lionel-/biome", rev = "a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9" }
+biome_rowan = { git = "https://github.com/lionel-/biome", rev = "a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9" }
+biome_text_size = { git = "https://github.com/lionel-/biome", rev = "a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9" }
 blake3 = "1.8.5"
 bus = "2.4.1"
 cc = "1.2.61"


### PR DESCRIPTION
- [x] The air commit literally points at https://github.com/posit-dev/air/pull/488 which will disappear after we merge that, so we need to come back here and change the SHA to the merged commit

Bumps both air and biome in sync _just enough_ to get `SyntaxNodePtr`, which wasn't far at all actually! Just 3 commits on the Biome side. Easily unblocks us for the moment.

See also https://github.com/posit-dev/air/pull/488
See also https://github.com/lionel-/biome/tree/feature/post-visit-2


