### PR TITLE
Fix namespace generation in `View()` hook

### DIFF
--- a/crates/ark/src/modules/positron/view.R
+++ b/crates/ark/src/modules/positron/view.R
@@ -7,11 +7,15 @@
 
 # `utils::View()` replacement, with exact same arguments
 view_hook <- function(x, title) {
+    # `sys.nframe() == 1` must be evaluated in the hook frame because
+    # `view_hook` adds a frame above `view()`. Gates namespace srcref mutation
+    # in `view_function_info()`, only safe when no user code is on the stack.
     view(
         x = x,
         title = title,
         name = as_label(substitute(x)),
-        env = parent.frame()
+        env = parent.frame(),
+        top_level = sys.nframe() == 1
     )
 }
 
@@ -20,7 +24,13 @@ view_hook <- function(x, title) {
 # the input and if that variable exists in the calling environment. This is used
 # for live updating the objects, if supported (e.g. data frames in the data
 # viewer).
-view <- function(x, title, name = NULL, env = parent.frame()) {
+view <- function(
+    x,
+    title,
+    name = NULL,
+    env = parent.frame(),
+    top_level = sys.nframe() == 1
+) {
     # Derive the name of the object from the expression passed to View()
     name <- name %||% as_label(substitute(x))
     stopifnot(is_string(name))
@@ -49,7 +59,6 @@ view <- function(x, title, name = NULL, env = parent.frame()) {
     }
 
     if (is.function(x)) {
-        top_level <- sys.nframe() == 1
         return(view_function(x, title, var, env, top_level = top_level))
     }
 

--- a/crates/ark/tests/kernel-hooks-view.rs
+++ b/crates/ark/tests/kernel-hooks-view.rs
@@ -1,0 +1,49 @@
+//
+// kernel-hooks-view.rs
+//
+// Copyright (C) 2026 by Posit Software, PBC
+//
+//
+
+use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+use ark_test::DummyArkFrontend;
+
+/// `View()` on a namespace function must materialise the virtual namespace
+/// document at `ark:.../namespace/<pkg>.R` and emit an `open_editor` UI event
+/// pointing at it.
+#[test]
+fn test_view_namespace_function_generates_vdoc() {
+    let frontend = DummyArkFrontend::lock();
+    let comm_id = frontend.open_ui_comm();
+
+    frontend.send_execute_request("View(identity)", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+
+    // `view_function()` ends with `.ps.ui.navigateToFile()`, emitted on the UI
+    // comm before the surrounding `busy(true/false)` / `prompt_state` pair.
+    let open_editor = frontend.recv_iopub_comm_msg();
+    assert_eq!(open_editor.comm_id, comm_id);
+    assert_eq!(
+        open_editor.data.get("method").and_then(|v| v.as_str()),
+        Some("open_editor")
+    );
+
+    // Test runs in the kernel's own process, so `std::process::id()` matches
+    // the pid that `ark_uri()` embeds.
+    let pid = std::process::id();
+    let expected_uri = format!("ark:ark-{pid}/namespace/base.R");
+
+    let params = &open_editor.data["params"];
+    assert_eq!(params["file"], expected_uri);
+    assert_eq!(params["kind"], "uri");
+    // `identity`'s srcref points somewhere inside the generated namespace
+    // file. We only care that it's a real position, not the start.
+    assert!(params["line"].as_i64().unwrap() > 0);
+
+    frontend.recv_ui_busy(&comm_id, true);
+    frontend.recv_ui_busy(&comm_id, false);
+    frontend.recv_ui_prompt_state(&comm_id);
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/ark/pull/1179

The positron-r extension test for `View()` is failing because the top-level check in the hook now incorrectly returns `FALSE`, due to the new hook wrapper. This prevented `View()` from generating virtual namespaces for package functions.