### PR TITLE
Use `AstPtr` in `DefinitionKind`

### DIFF
--- a/crates/oak_index_vec/src/lib.rs
+++ b/crates/oak_index_vec/src/lib.rs
@@ -9,7 +9,7 @@ pub trait Idx: Copy + fmt::Debug + Eq {
 
 /// A `Vec<V>` indexed by a strongly-typed newtype `I` instead of `usize`,
 /// so that indices from different vectors can't be mixed up.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct IndexVec<I: Idx, V> {
     raw: Vec<V>,
     _phantom: PhantomData<I>,

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -13,6 +13,7 @@ use aether_syntax::RSyntaxKind;
 use aether_syntax::RSyntaxNode;
 use biome_rowan::AstNode;
 use biome_rowan::AstNodeList;
+use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
 use biome_rowan::SyntaxNodeCast;
 use biome_rowan::TextRange;
@@ -431,7 +432,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                     self.add_definition(
                         &variable.name_text(),
                         SymbolFlags::IS_BOUND,
-                        DefinitionKind::ForVariable(stmt.syntax().clone()),
+                        DefinitionKind::ForVariable(AstPtr::new(stmt)),
                         variable.syntax().text_trimmed_range(),
                     );
                 }
@@ -637,7 +638,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                     self.add_definition(
                         &ident.name_text(),
                         flags,
-                        DefinitionKind::Parameter(param.syntax().clone()),
+                        DefinitionKind::Parameter(AstPtr::new(param)),
                         ident.syntax().text_trimmed_range(),
                     );
                 },
@@ -645,7 +646,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                     self.add_definition(
                         "...",
                         flags,
-                        DefinitionKind::Parameter(param.syntax().clone()),
+                        DefinitionKind::Parameter(AstPtr::new(param)),
                         dots.syntax().text_trimmed_range(),
                     );
                 },
@@ -653,7 +654,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                     self.add_definition(
                         &ddi.syntax().text_trimmed().to_string(),
                         flags,
-                        DefinitionKind::Parameter(param.syntax().clone()),
+                        DefinitionKind::Parameter(AstPtr::new(param)),
                         ddi.syntax().text_trimmed_range(),
                     );
                 },
@@ -692,14 +693,14 @@ impl<'a> SemanticIndexBuilder<'a> {
         if super_assign {
             self.add_super_definition(
                 &name,
-                DefinitionKind::SuperAssignment(op.syntax().clone()),
+                DefinitionKind::SuperAssignment(AstPtr::new(op)),
                 range,
             );
         } else {
             self.add_definition(
                 &name,
                 SymbolFlags::IS_BOUND,
-                DefinitionKind::Assignment(op.syntax().clone()),
+                DefinitionKind::Assignment(AstPtr::new(op)),
                 range,
             );
         }
@@ -850,7 +851,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                 &name,
                 SymbolFlags::IS_BOUND,
                 DefinitionKind::Import {
-                    call: call.syntax().clone(),
+                    call: AstPtr::new(call),
                     file: file.clone(),
                     name: name.clone(),
                 },

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -1,6 +1,10 @@
 use std::ops::Range;
 
-use aether_syntax::RSyntaxNode;
+use aether_syntax::RBinaryExpression;
+use aether_syntax::RCall;
+use aether_syntax::RForStatement;
+use aether_syntax::RParameter;
+use biome_rowan::AstPtr;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_core::range::Ranged;
@@ -36,7 +40,7 @@ define_index!(EnclosingSnapshotId);
 // (all indexed by `ScopeId`) rather than bundled into a single struct, so
 // that each can be cached and invalidated independently (when salsa is
 // introduced).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SemanticIndex {
     scopes: IndexVec<ScopeId, Scope>,
 
@@ -265,7 +269,7 @@ pub struct EnclosingSnapshotKey {
 // Currently only `function()` creates a new scope. In the future, constructs
 // like `local()`, `with()`, `within()` may also create scopes (determined
 // by function declarations resolved via salsa queries).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Scope {
     pub(crate) parent: Option<ScopeId>,
     pub(crate) kind: ScopeKind,
@@ -308,7 +312,7 @@ impl Ranged for Scope {
 // --- Symbol table (per scope) ---
 
 // Read-only after construction. The builder uses `SymbolTableBuilder`.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct SymbolTable {
     symbols: IndexVec<SymbolId, Symbol>,
 
@@ -395,7 +399,7 @@ impl std::ops::Deref for SymbolTableBuilder {
 // access like `x.y`). `resolve_symbol()` walks the scope chain looking for a
 // symbol with `IS_BOUND`. Future type inference will look up the symbol's
 // definitions and infer a type from them.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Symbol {
     pub(crate) name: String,
     pub(crate) flags: SymbolFlags,
@@ -489,7 +493,7 @@ impl SymbolFlags {
 // implicitly declarations (they declare a name as a function with a specific
 // signature). Future `declare()` annotations will also produce pure
 // declarations.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Definition {
     pub(crate) kind: DefinitionKind,
     /// The file that owns this definition's index.
@@ -502,16 +506,16 @@ pub struct Definition {
     pub(crate) range: TextRange,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DefinitionKind {
-    Assignment(RSyntaxNode),
-    SuperAssignment(RSyntaxNode),
-    Parameter(RSyntaxNode),
-    ForVariable(RSyntaxNode),
+    Assignment(AstPtr<RBinaryExpression>),
+    SuperAssignment(AstPtr<RBinaryExpression>),
+    Parameter(AstPtr<RParameter>),
+    ForVariable(AstPtr<RForStatement>),
     /// A forwarding binding that resolves to a definition in another file.
     /// Consumers must chase the `file`/`name` chain to reach the actual origin.
     Import {
-        call: RSyntaxNode,
+        call: AstPtr<RCall>,
         file: Url,
         name: String,
     },
@@ -550,7 +554,7 @@ impl Ranged for Definition {
 // node positions to use IDs). Our flat list serves the same purpose: the
 // `UseDefMap` will reference `UseId` indices into this list to connect each
 // use to its reaching definitions.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Use {
     pub(crate) symbol: SymbolId,
     pub(crate) range: TextRange,
@@ -573,7 +577,7 @@ impl Ranged for Use {
 }
 
 /// A directive that affects the file's imports (e.g. `library()` calls).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Directive {
     pub(crate) kind: DirectiveKind,
     pub(crate) offset: TextSize,

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -40,7 +40,7 @@ define_index!(EnclosingSnapshotId);
 // (all indexed by `ScopeId`) rather than bundled into a single struct, so
 // that each can be cached and invalidated independently (when salsa is
 // introduced).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct SemanticIndex {
     scopes: IndexVec<ScopeId, Scope>,
 
@@ -269,7 +269,7 @@ pub struct EnclosingSnapshotKey {
 // Currently only `function()` creates a new scope. In the future, constructs
 // like `local()`, `with()`, `within()` may also create scopes (determined
 // by function declarations resolved via salsa queries).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Scope {
     pub(crate) parent: Option<ScopeId>,
     pub(crate) kind: ScopeKind,
@@ -312,7 +312,7 @@ impl Ranged for Scope {
 // --- Symbol table (per scope) ---
 
 // Read-only after construction. The builder uses `SymbolTableBuilder`.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct SymbolTable {
     symbols: IndexVec<SymbolId, Symbol>,
 
@@ -399,7 +399,7 @@ impl std::ops::Deref for SymbolTableBuilder {
 // access like `x.y`). `resolve_symbol()` walks the scope chain looking for a
 // symbol with `IS_BOUND`. Future type inference will look up the symbol's
 // definitions and infer a type from them.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Symbol {
     pub(crate) name: String,
     pub(crate) flags: SymbolFlags,
@@ -493,7 +493,7 @@ impl SymbolFlags {
 // implicitly declarations (they declare a name as a function with a specific
 // signature). Future `declare()` annotations will also produce pure
 // declarations.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Definition {
     pub(crate) kind: DefinitionKind,
     /// The file that owns this definition's index.
@@ -506,7 +506,7 @@ pub struct Definition {
     pub(crate) range: TextRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum DefinitionKind {
     Assignment(AstPtr<RBinaryExpression>),
     SuperAssignment(AstPtr<RBinaryExpression>),
@@ -554,7 +554,7 @@ impl Ranged for Definition {
 // node positions to use IDs). Our flat list serves the same purpose: the
 // `UseDefMap` will reference `UseId` indices into this list to connect each
 // use to its reaching definitions.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Use {
     pub(crate) symbol: SymbolId,
     pub(crate) range: TextRange,
@@ -577,7 +577,7 @@ impl Ranged for Use {
 }
 
 /// A directive that affects the file's imports (e.g. `library()` calls).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Directive {
     pub(crate) kind: DirectiveKind,
     pub(crate) offset: TextSize,

--- a/crates/oak_semantic/src/use_def_map.rs
+++ b/crates/oak_semantic/src/use_def_map.rs
@@ -197,7 +197,7 @@ use crate::semantic_index::UseId;
 /// Also stores enclosing snapshots: the bindings that lazy nested scopes
 /// (i.e. nested functions) see when they reference a symbol defined in this
 /// scope. Looked up via `SemanticIndex::enclosing_bindings()`.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UseDefMap {
     bindings_by_use: IndexVec<UseId, Bindings>,
 

--- a/crates/oak_semantic/src/use_def_map.rs
+++ b/crates/oak_semantic/src/use_def_map.rs
@@ -197,7 +197,7 @@ use crate::semantic_index::UseId;
 /// Also stores enclosing snapshots: the bindings that lazy nested scopes
 /// (i.e. nested functions) see when they reference a symbol defined in this
 /// scope. Looked up via `SemanticIndex::enclosing_bindings()`.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct UseDefMap {
     bindings_by_use: IndexVec<UseId, Bindings>,
 

--- a/crates/oak_semantic/tests/builder.rs
+++ b/crates/oak_semantic/tests/builder.rs
@@ -51,7 +51,10 @@ fn test_simple_assignment() {
     else {
         panic!("expected Assignment");
     };
-    assert_eq!(node.kind(), RSyntaxKind::R_BINARY_EXPRESSION);
+    assert_eq!(
+        node.syntax_node_ptr().kind(),
+        RSyntaxKind::R_BINARY_EXPRESSION
+    );
     assert_eq!(index.uses(file).len(), 0);
 }
 
@@ -138,7 +141,7 @@ fn test_function_creates_scope() {
     else {
         panic!("expected Parameter");
     };
-    assert_eq!(node.kind(), RSyntaxKind::R_PARAMETER);
+    assert_eq!(node.syntax_node_ptr().kind(), RSyntaxKind::R_PARAMETER);
     assert_eq!(index.uses(fun_scope).len(), 1);
 }
 
@@ -302,7 +305,7 @@ fn test_for_loop_body() {
     else {
         panic!("expected ForVariable");
     };
-    assert_eq!(node.kind(), RSyntaxKind::R_FOR_STATEMENT);
+    assert_eq!(node.syntax_node_ptr().kind(), RSyntaxKind::R_FOR_STATEMENT);
 }
 
 #[test]


### PR DESCRIPTION
Branched from #1210
Progress towards https://github.com/posit-dev/ark/issues/1212

Replaces the syntax node in `DefinitionSync` by an AST pointer to gain Send/Sync/PartialEq, which are needed for Salsa caching.

The pointer is just an offset + an AST type so we can recover the node from the original parse tree, or even a fresh parse tree. For context, it's common in Salsa-based LSPs to throw away entire parse trees until they are needed again, to spare memory usage.