### PR TITLE
Introduce `oak_db` and `File`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "reqwest-retry",
  "rust-embed",
  "rustc-hash",
+ "salsa",
  "scraper",
  "serde",
  "serde_json",
@@ -2515,7 +2516,11 @@ dependencies = [
 name = "oak_db"
 version = "0.1.0"
 dependencies = [
+ "air_r_parser",
+ "air_r_syntax",
+ "biome_rowan",
  "oak_semantic",
+ "salsa",
  "url",
 ]
 

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -59,6 +59,7 @@ reqwest-middleware.workspace = true
 reqwest-retry.workspace = true
 rust-embed.workspace = true
 rustc-hash.workspace = true
+salsa.workspace = true
 scraper.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use anyhow::anyhow;
 use oak_core::file::list_r_files;
-use oak_db::Db;
+use oak_db::LegacyDb;
 use oak_ide::ExternalScope;
 use oak_semantic::library::Library;
 use oak_semantic::scope_layer::default_search_path;
@@ -22,7 +22,26 @@ use crate::lsp::config::LspConfig;
 use crate::lsp::document::Document;
 use crate::lsp::inputs::source_root::SourceRoot;
 
-impl Db for WorldState {
+/// Concrete Salsa database that owns the storage for all LSP inputs.
+#[salsa::db]
+#[derive(Clone, Default)]
+pub struct OakDatabase {
+    storage: salsa::Storage<Self>,
+}
+
+impl OakDatabase {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[salsa::db]
+impl salsa::Database for OakDatabase {}
+
+#[salsa::db]
+impl oak_db::Db for OakDatabase {}
+
+impl LegacyDb for WorldState {
     fn semantic_index(&self, file: &Url) -> Option<SemanticIndex> {
         let doc = self.workspace_document(file)?;
         let source_root = self.source_root(file);

--- a/crates/oak_db/Cargo.toml
+++ b/crates/oak_db/Cargo.toml
@@ -14,5 +14,9 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aether_parser.workspace = true
+aether_syntax.workspace = true
+biome_rowan.workspace = true
 oak_semantic.workspace = true
+salsa.workspace = true
 url.workspace = true

--- a/crates/oak_db/Cargo.toml
+++ b/crates/oak_db/Cargo.toml
@@ -17,6 +17,6 @@ workspace = true
 aether_parser.workspace = true
 aether_syntax.workspace = true
 biome_rowan.workspace = true
-oak_semantic.workspace = true
+oak_semantic = { workspace = true, features = ["salsa"] }
 salsa.workspace = true
 url.workspace = true

--- a/crates/oak_db/Cargo.toml
+++ b/crates/oak_db/Cargo.toml
@@ -20,3 +20,6 @@ biome_rowan.workspace = true
 oak_semantic = { workspace = true, features = ["salsa"] }
 salsa.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+oak_semantic = { workspace = true, features = ["salsa", "testing"] }

--- a/crates/oak_db/src/db.rs
+++ b/crates/oak_db/src/db.rs
@@ -1,0 +1,6 @@
+/// Salsa Database trait.
+///
+/// Queries take a `dyn Db` rather than the concrete database owned by
+/// the LSP layer.
+#[salsa::db]
+pub trait Db: salsa::Database {}

--- a/crates/oak_db/src/file.rs
+++ b/crates/oak_db/src/file.rs
@@ -51,7 +51,7 @@ impl File {
     /// The full index re-runs typically on every edit (e.g. the `AstPtr` ranges
     /// inside `Definition`s shift, so it rarely backdates).
     #[cfg(not(test))]
-    #[salsa::tracked(returns(ref))]
+    #[salsa::tracked(returns(ref), no_eq)]
     fn semantic_index(self, db: &dyn Db) -> SemanticIndex {
         build_semantic_index(self, db)
     }
@@ -59,7 +59,7 @@ impl File {
     /// Tests use the `pub(crate)` variant gated behind `cfg(test)` so they can
     /// call into `semantic_index` directly to verify salsa caching behaviour.
     #[cfg(test)]
-    #[salsa::tracked(returns(ref))]
+    #[salsa::tracked(returns(ref), no_eq)]
     pub(crate) fn semantic_index(self, db: &dyn Db) -> SemanticIndex {
         build_semantic_index(self, db)
     }

--- a/crates/oak_db/src/file.rs
+++ b/crates/oak_db/src/file.rs
@@ -1,0 +1,45 @@
+use oak_semantic::semantic_index::SemanticIndex;
+use url::Url;
+
+use crate::parse::OakParse;
+use crate::Db;
+
+/// A source file tracked by Salsa.
+///
+/// Content is pushed into Salsa by the LSP layer, the database never does I/O.
+/// This matches rust-analyzer's push model and avoids tying parsing to
+/// disk/network I/O inside a Salsa query.
+#[salsa::input]
+pub struct File {
+    #[returns(ref)]
+    pub url: Url,
+    #[returns(ref)]
+    pub contents: String,
+}
+
+#[salsa::tracked]
+impl File {
+    /// Parse this file's contents into an R syntax tree.
+    ///
+    /// Crate-internal: kept `pub(crate)` so downstream crates can't take a
+    /// dependency on a full parse tree. They reach the tree only through
+    /// narrower public queries.
+    #[salsa::tracked(returns(ref))]
+    pub(crate) fn parse(self, db: &dyn Db) -> OakParse {
+        OakParse::new(aether_parser::parse(
+            self.contents(db),
+            aether_parser::RParserOptions::default(),
+        ))
+    }
+
+    /// Build this file's `SemanticIndex` from the parse tree.
+    ///
+    /// Crate-internal: cross-file consumers must use narrower public queries
+    /// (`exports`, `external_scope`) to avoid depending on the full index,
+    /// which would invalidate on every internal edit.
+    #[salsa::tracked(returns(ref))]
+    pub(crate) fn semantic_index(self, db: &dyn Db) -> SemanticIndex {
+        let parsed = self.parse(db);
+        oak_semantic::semantic_index(&parsed.tree(), self.url(db))
+    }
+}

--- a/crates/oak_db/src/file.rs
+++ b/crates/oak_db/src/file.rs
@@ -1,4 +1,9 @@
+use std::sync::Arc;
+
+use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::SemanticIndex;
+use oak_semantic::semantic_index::SymbolTable;
+use oak_semantic::use_def_map::UseDefMap;
 use url::Url;
 
 use crate::parse::OakParse;
@@ -40,12 +45,39 @@ impl File {
 
     /// Build this file's `SemanticIndex` from the parse tree.
     ///
-    /// Crate-internal: cross-file consumers must use narrower public queries
-    /// (`exports`, `external_scope`) to avoid depending on the full index,
-    /// which would invalidate on every internal edit.
+    /// Private to this file to prevent coarse Salsa queries. Consumers should
+    /// go through the narrow tracked queries below.
+    ///
+    /// The full index re-runs typically on every edit (e.g. the `AstPtr` ranges
+    /// inside `Definition`s shift, so it rarely backdates).
+    #[cfg(not(test))]
+    #[salsa::tracked(returns(ref))]
+    fn semantic_index(self, db: &dyn Db) -> SemanticIndex {
+        build_semantic_index(self, db)
+    }
+
+    /// Tests use the `pub(crate)` variant gated behind `cfg(test)` so they can
+    /// call into `semantic_index` directly to verify salsa caching behaviour.
+    #[cfg(test)]
     #[salsa::tracked(returns(ref))]
     pub(crate) fn semantic_index(self, db: &dyn Db) -> SemanticIndex {
-        let parsed = self.parse(db);
-        oak_semantic::semantic_index(&parsed.tree(), self.url(db))
+        build_semantic_index(self, db)
     }
+
+    /// The symbol table for one scope of this file.
+    #[salsa::tracked]
+    pub fn symbol_table(self, db: &dyn Db, scope: ScopeId) -> Arc<SymbolTable> {
+        Arc::clone(self.semantic_index(db).symbols(scope))
+    }
+
+    /// The use-def map for one scope of this file.
+    #[salsa::tracked]
+    pub fn use_def_map(self, db: &dyn Db, scope: ScopeId) -> Arc<UseDefMap> {
+        Arc::clone(self.semantic_index(db).use_def_map(scope))
+    }
+}
+
+fn build_semantic_index(file: File, db: &dyn Db) -> SemanticIndex {
+    let parsed = file.parse(db);
+    oak_semantic::semantic_index(&parsed.tree(), file.url(db))
 }

--- a/crates/oak_db/src/file.rs
+++ b/crates/oak_db/src/file.rs
@@ -24,7 +24,13 @@ impl File {
     /// Crate-internal: kept `pub(crate)` so downstream crates can't take a
     /// dependency on a full parse tree. They reach the tree only through
     /// narrower public queries.
-    #[salsa::tracked(returns(ref))]
+    ///
+    /// `lru = 128` caps the number of live parse trees to 128. Matches
+    /// rust-analyzer's default for its analogous `parse(file_id)` query.
+    /// Rowan's green tree shares structure across edits, so eviction frees
+    /// memory cleanly. Derived queries (e.g. `semantic_index`) store
+    /// `AstPtr`s rather than tree nodes, so they don't pin an evicted tree.
+    #[salsa::tracked(returns(ref), lru = 128)]
     pub(crate) fn parse(self, db: &dyn Db) -> OakParse {
         OakParse::new(aether_parser::parse(
             self.contents(db),

--- a/crates/oak_db/src/legacy.rs
+++ b/crates/oak_db/src/legacy.rs
@@ -1,0 +1,14 @@
+use oak_semantic::library::Library;
+use oak_semantic::semantic_index::SemanticIndex;
+use url::Url;
+
+/// Legacy database trait used by the tree-sitter backed code path.
+///
+/// Exists only during the Salsa migration.
+pub trait LegacyDb {
+    /// `None` means the file disappeared between index-build and query time,
+    /// which is an edge case, not a normal path. With Salsa inputs this
+    /// becomes infallible.
+    fn semantic_index(&self, file: &Url) -> Option<SemanticIndex>;
+    fn library(&self) -> &Library;
+}

--- a/crates/oak_db/src/lib.rs
+++ b/crates/oak_db/src/lib.rs
@@ -1,15 +1,11 @@
-use oak_semantic::library::Library;
-use oak_semantic::semantic_index::SemanticIndex;
-use url::Url;
+mod db;
+mod file;
+mod legacy;
+mod parse;
 
-/// Database trait for cross-file queries.
-///
-/// This will become a Salsa `#[salsa::db]` trait. For now it's a plain
-/// trait that abstracts over how other files' semantic indexes are obtained.
-pub trait Db {
-    /// TODO(salsa): With tracked file inputs this becomes infallible in
-    /// practice. `None` means the file disappeared between index-build
-    /// and query time, which is an edge case, not a normal path.
-    fn semantic_index(&self, file: &Url) -> Option<SemanticIndex>;
-    fn library(&self) -> &Library;
-}
+#[cfg(test)]
+mod tests;
+
+pub use db::Db;
+pub use file::File;
+pub use legacy::LegacyDb;

--- a/crates/oak_db/src/parse.rs
+++ b/crates/oak_db/src/parse.rs
@@ -1,0 +1,34 @@
+use aether_syntax::RRoot;
+use aether_syntax::RSyntaxNode;
+use biome_rowan::AstNode;
+use biome_rowan::SendNode;
+
+/// Thread-safe handle to a parsed R syntax tree.
+///
+/// Wraps biome_rowan's `SendNode` (a shareable language-agnostic root handle).
+/// Equality is structural (delegated to `GreenNode`'s recursive compare) which
+/// is what lets Salsa backdate equal re-parses and skip downstream queries.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OakParse(SendNode);
+
+impl OakParse {
+    pub(crate) fn new(parse: aether_parser::Parse) -> Self {
+        Self(
+            parse
+                .syntax()
+                .as_send()
+                .expect("`Parse::syntax()` returns the root node"),
+        )
+    }
+
+    pub(crate) fn syntax(&self) -> RSyntaxNode {
+        self.0
+            .clone()
+            .into_node()
+            .expect("Aether's parser produces R-language trees")
+    }
+
+    pub(crate) fn tree(&self) -> RRoot {
+        RRoot::unwrap_cast(self.syntax())
+    }
+}

--- a/crates/oak_db/src/tests.rs
+++ b/crates/oak_db/src/tests.rs
@@ -1,0 +1,1 @@
+mod file;

--- a/crates/oak_db/src/tests/file.rs
+++ b/crates/oak_db/src/tests/file.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use url::Url;
+
+use crate::Db;
+use crate::File;
+
+type Events = Arc<Mutex<Vec<salsa::Event>>>;
+
+#[salsa::db]
+#[derive(Clone)]
+struct TestDb {
+    storage: salsa::Storage<Self>,
+    events: Events,
+}
+
+impl TestDb {
+    fn new() -> Self {
+        let events = Events::default();
+        let storage = salsa::Storage::new(Some(Box::new({
+            let events = events.clone();
+            move |event| {
+                events.lock().unwrap().push(event);
+            }
+        })));
+        Self { storage, events }
+    }
+
+    /// Count `WillExecute` events whose `database_key`'s Debug form
+    /// contains `name`. Salsa's `DatabaseKeyIndex::fmt` resolves the
+    /// underlying function name only when a database is attached to the
+    /// current thread, so we wrap the scan in `salsa::attach`.
+    fn executions(&self, name: &str) -> usize {
+        salsa::attach(self, || {
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|event| match &event.kind {
+                    salsa::EventKind::WillExecute { database_key } => {
+                        format!("{database_key:?}").contains(name)
+                    },
+                    _ => false,
+                })
+                .count()
+        })
+    }
+}
+
+#[salsa::db]
+impl salsa::Database for TestDb {}
+
+#[salsa::db]
+impl Db for TestDb {}
+
+fn file_url(name: &str) -> Url {
+    Url::parse(&format!("file:///{name}")).unwrap()
+}
+
+#[test]
+fn parse_is_cached_across_calls() {
+    let db = TestDb::new();
+    let file = File::new(&db, file_url("a.R"), "x <- 1\n".to_string());
+
+    let _ = file.parse(&db);
+    assert_eq!(db.executions("parse"), 1);
+
+    let _ = file.parse(&db);
+    assert_eq!(db.executions("parse"), 1);
+}
+
+#[test]
+fn semantic_index_is_cached_across_calls() {
+    let db = TestDb::new();
+    let file = File::new(&db, file_url("a.R"), "x <- 1\n".to_string());
+
+    let _ = file.semantic_index(&db);
+    let _ = file.semantic_index(&db);
+    assert_eq!(db.executions("parse"), 1);
+    assert_eq!(db.executions("semantic_index"), 1);
+}
+
+#[test]
+fn changing_contents_reparses() {
+    use salsa::Setter;
+
+    let mut db = TestDb::new();
+    let file = File::new(&db, file_url("a.R"), "x <- 1\n".to_string());
+
+    let _ = file.semantic_index(&db);
+    assert_eq!(db.executions("parse"), 1);
+    assert_eq!(db.executions("semantic_index"), 1);
+
+    file.set_contents(&mut db).to("x <- 2\n".to_string());
+    let _ = file.semantic_index(&db);
+
+    assert_eq!(db.executions("parse"), 2);
+    assert_eq!(db.executions("semantic_index"), 2);
+}
+
+#[test]
+fn semantic_index_matches_oak_semantic() {
+    let db = TestDb::new();
+    let source = "x <- 1\nx\n";
+    let url = file_url("a.R");
+    let file = File::new(&db, url.clone(), source.to_string());
+
+    let via_salsa = file.semantic_index(&db);
+
+    let parse = aether_parser::parse(source, aether_parser::RParserOptions::default());
+    let direct = oak_semantic::semantic_index(&parse.tree(), &url);
+
+    assert_eq!(*via_salsa, direct);
+}
+
+#[test]
+fn semantic_index_backdates_on_equivalent_reparse() {
+    use salsa::Setter;
+
+    let mut db = TestDb::new();
+    let file = File::new(&db, file_url("a.R"), "x <- 1\n".to_string());
+
+    let _ = file.semantic_index(&db);
+    assert_eq!(db.executions("parse"), 1);
+    assert_eq!(db.executions("semantic_index"), 1);
+
+    // Setting identical contents bumps the revision, so Salsa must
+    // re-validate `parse`. But the result is structurally equal to the
+    // previous one, so `SendNode`'s `PartialEq` lets Salsa backdate and
+    // skip re-executing the downstream `semantic_index`.
+    file.set_contents(&mut db).to("x <- 1\n".to_string());
+    let _ = file.semantic_index(&db);
+
+    assert_eq!(db.executions("parse"), 2);
+    assert_eq!(db.executions("semantic_index"), 1);
+}
+
+#[test]
+fn editing_one_file_does_not_invalidate_another() {
+    use salsa::Setter;
+
+    let mut db = TestDb::new();
+    let file_a = File::new(&db, file_url("a.R"), "x <- 1\n".to_string());
+    let file_b = File::new(&db, file_url("b.R"), "y <- 2\n".to_string());
+
+    let _ = file_a.semantic_index(&db);
+    let _ = file_b.semantic_index(&db);
+    assert_eq!(db.executions("parse"), 2);
+    assert_eq!(db.executions("semantic_index"), 2);
+
+    // Mutate `file_b` to an unrelated value. `file_a`'s queries depend
+    // only on `file_a.contents`, so they must not re-execute.
+    file_b.set_contents(&mut db).to("y <- 99\n".to_string());
+    let _ = file_a.semantic_index(&db);
+
+    assert_eq!(db.executions("parse"), 2);
+    assert_eq!(db.executions("semantic_index"), 2);
+
+    // Re-querying `file_b` does re-run its pipeline.
+    let _ = file_b.semantic_index(&db);
+    assert_eq!(db.executions("parse"), 3);
+    assert_eq!(db.executions("semantic_index"), 3);
+}
+
+#[test]
+fn distinct_files_have_distinct_semantic_indexes() {
+    let db = TestDb::new();
+    let file_a = File::new(&db, file_url("a.R"), "x <- 1\n".to_string());
+    let file_b = File::new(&db, file_url("b.R"), "x <- 1\n".to_string());
+
+    // Same contents, different `File` inputs: separate cache entries.
+    assert!(file_a != file_b);
+
+    let idx_a = file_a.semantic_index(&db);
+    let idx_b = file_b.semantic_index(&db);
+
+    // Each index records its own file URL, so they are not structurally
+    // equal even though the source text matches.
+    assert_ne!(*idx_a, *idx_b);
+    assert_eq!(db.executions("parse"), 2);
+    assert_eq!(db.executions("semantic_index"), 2);
+}

--- a/crates/oak_ide/src/goto_definition.rs
+++ b/crates/oak_ide/src/goto_definition.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use aether_syntax::RSyntaxNode;
 use biome_rowan::TextSize;
-use oak_db::Db;
+use oak_db::LegacyDb;
 use oak_semantic::external::resolve_external_name;
 use oak_semantic::external::resolve_in_package;
 use oak_semantic::package_definitions::PackageDefinitionVisibility;
@@ -39,7 +39,7 @@ use crate::NavigationTarget;
 /// Returns an empty `Vec` if the offset doesn't point at a known
 /// identifier, or if the symbol cannot be resolved.
 pub fn goto_definition(
-    db: &dyn Db,
+    db: &dyn LegacyDb,
     offset: TextSize,
     file: &Url,
     root: &RSyntaxNode,
@@ -83,7 +83,7 @@ pub fn goto_definition(
 }
 
 fn resolve_use(
-    db: &dyn Db,
+    db: &dyn LegacyDb,
     index: &SemanticIndex,
     scope_id: ScopeId,
     use_id: UseId,
@@ -151,13 +151,13 @@ fn resolve_use(
 /// definitions (e.g., a.R sources b.R sources c.R).
 ///
 /// TODO(salsa): Move to `oak_semantic` once it depends on `oak_db`.
-fn resolve_import(db: &dyn Db, file: &Url, name: &str) -> Option<NavigationTarget> {
+fn resolve_import(db: &dyn LegacyDb, file: &Url, name: &str) -> Option<NavigationTarget> {
     let mut visited = HashSet::new();
     resolve_import_inner(db, file, name, &mut visited)
 }
 
 fn resolve_import_inner(
-    db: &dyn Db,
+    db: &dyn LegacyDb,
     file: &Url,
     name: &str,
     visited: &mut HashSet<(Url, String)>,
@@ -194,7 +194,7 @@ fn resolve_import_inner(
 }
 
 fn resolve_namespace_access(
-    db: &dyn Db,
+    db: &dyn LegacyDb,
     symbol: &str,
     package: &str,
     visibility: PackageDefinitionVisibility,
@@ -206,7 +206,7 @@ fn resolve_namespace_access(
 }
 
 fn resolve_external(
-    db: &dyn Db,
+    db: &dyn LegacyDb,
     symbol: &str,
     scope_chain: &[ScopeLayer],
 ) -> Vec<NavigationTarget> {

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -7,7 +7,7 @@ use aether_parser::RParserOptions;
 use aether_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
-use oak_db::Db;
+use oak_db::LegacyDb;
 use oak_ide::goto_definition;
 use oak_ide::ExternalScope;
 use oak_ide::NavigationTarget;
@@ -39,7 +39,7 @@ struct TestDb {
     sources: HashMap<Url, String>,
 }
 
-impl Db for TestDb {
+impl LegacyDb for TestDb {
     fn semantic_index(&self, file: &Url) -> Option<SemanticIndex> {
         // Rebuild from source for tests. We store the source instead.
         self.sources.get(file).map(|source| {

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -43,6 +43,7 @@ define_index!(EnclosingSnapshotId);
 // introduced).
 #[derive(Debug)]
 #[cfg_attr(feature = "salsa", derive(salsa::Update))]
+#[cfg_attr(feature = "testing", derive(PartialEq, Eq))]
 pub struct SemanticIndex {
     scopes: IndexVec<ScopeId, Scope>,
 


### PR DESCRIPTION
Branched from #1211 

Closes https://github.com/posit-dev/ark/issues/1141
Progress towards https://github.com/posit-dev/ark/issues/1212

This PR introduces

- The `oak_db` crate which hosts a Salsa database containing all LSP inputs.
- The `File` data structure that represents an R file (similar to `Document` in the legacy LSP). It holds the parse tree and semantic index for a file.
- Dependency on `salsa` (latest version).
- The parse tree is now a Salsa query on file contents, and the semantic index is a query on the parse tree.

The cache holds at most 128 parse trees at any time (following Rust-Analyser) to spare memory.

Higher level consumers should depend on narrow Salsa queries, to reduce the risk of being invalidated by unrelated edits. For this reason, although `File` contains the parse tree and semantic index, they are kept `pub(crate)` so they are not reachable from outside `oak_db` (e.g. from `oak_ide`).

For context we're working our way up towards:

- A file tree starting from roots (workspace roots and lib path folders) and indexing all R files wrapped up in `File`
- A Source Graph (#1183) relating scripts, workspace packages, and installed packages. The nodes point to `File` handles from the file tree.
