### PR TITLE
Track `source()` calls as `SemanticCall` items on the index

### DIFF
--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -281,10 +281,10 @@ impl WorldState {
             self.resolve_source(dir, path, &mut stack)
         });
 
-        let directives = index.file_directives().to_vec();
+        let semantic_calls = index.semantic_calls().to_vec();
         (
             index,
-            ExternalScope::search_path(directives, default_search_path()),
+            ExternalScope::search_path(semantic_calls, default_search_path()),
         )
     }
 

--- a/crates/oak_ide/src/external_scope.rs
+++ b/crates/oak_ide/src/external_scope.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use biome_rowan::TextSize;
 use oak_semantic::scope_layer::ScopeLayer;
-use oak_semantic::semantic_index::Directive;
-use oak_semantic::semantic_index::DirectiveKind;
 use oak_semantic::semantic_index::ScopeKind;
+use oak_semantic::semantic_index::SemanticCall;
+use oak_semantic::semantic_index::SemanticCallKind;
 use oak_semantic::semantic_index::SemanticIndex;
 use oak_semantic::ScopeId;
 
@@ -26,13 +26,14 @@ pub enum ExternalScope {
     /// search path: `library()` attachments from the file itself,
     /// default packages (stats, graphics, etc.), and base.
     ///
-    /// At top-level, only directives that appear before the cursor are
-    /// visible (R executes scripts sequentially). Inside function bodies
-    /// all directives are visible because the function will typically be
-    /// called after the full script has been sourced.
+    /// At top-level, only `Attach` semantic calls that appear before
+    /// the cursor are visible (R executes scripts sequentially).
+    /// Inside function bodies all visible attachments are exposed
+    /// because the function will typically be called after the full
+    /// script has been sourced.
     SearchPath {
         base: Vec<ScopeLayer>,
-        directives: Vec<Directive>,
+        semantic_calls: Vec<SemanticCall>,
     },
 }
 
@@ -40,7 +41,7 @@ impl Default for ExternalScope {
     fn default() -> Self {
         Self::SearchPath {
             base: Vec::new(),
-            directives: Vec::new(),
+            semantic_calls: Vec::new(),
         }
     }
 }
@@ -50,15 +51,18 @@ impl ExternalScope {
         Self::Package { top_level, lazy }
     }
 
-    pub fn search_path(directives: Vec<Directive>, base: Vec<ScopeLayer>) -> Self {
-        Self::SearchPath { base, directives }
+    pub fn search_path(semantic_calls: Vec<SemanticCall>, base: Vec<ScopeLayer>) -> Self {
+        Self::SearchPath {
+            base,
+            semantic_calls,
+        }
     }
 
     /// Return the scope chain appropriate for the given offset. For
     /// packages, top-level scope uses predecessors only while lazy
     /// (function) scopes see all files. For scripts, top-level code
     /// only sees `library()` calls that precede the cursor while
-    /// function bodies see all directives.
+    /// function bodies see all attachments.
     pub fn at(&self, index: &SemanticIndex, offset: TextSize) -> Cow<'_, [ScopeLayer]> {
         match self {
             Self::Package { top_level, lazy } => {
@@ -68,26 +72,32 @@ impl ExternalScope {
                     ScopeKind::Function => Cow::Borrowed(lazy),
                 }
             },
-            Self::SearchPath { base, directives } => {
+            Self::SearchPath {
+                base,
+                semantic_calls,
+            } => {
                 let (cursor_scope, _) = index.scope_at(offset);
                 let file_scope = ScopeId::from(0);
                 let in_function = cursor_scope != file_scope;
-                let layers: Vec<_> = directives
+                let layers: Vec<_> = semantic_calls
                     .iter()
                     .rev()
-                    .filter(|d| {
-                        let dir_scope = d.scope();
-                        // File-scope directives are always visible inside
+                    .filter(|c| {
+                        let call_scope = c.scope();
+                        // File-scope attachments are always visible inside
                         // function bodies (the function is typically called
                         // after the full script has been sourced).
-                        if in_function && dir_scope == file_scope {
+                        if in_function && call_scope == file_scope {
                             return true;
                         }
-                        d.offset() < offset &&
-                            index.ancestor_scopes(cursor_scope).any(|s| s == dir_scope)
+                        c.offset() < offset &&
+                            index.ancestor_scopes(cursor_scope).any(|s| s == call_scope)
                     })
-                    .map(|d| match d.kind() {
-                        DirectiveKind::Attach(pkg) => ScopeLayer::PackageExports(pkg.clone()),
+                    .filter_map(|c| match c.kind() {
+                        SemanticCallKind::Attach { package } => {
+                            Some(ScopeLayer::PackageExports(package.clone()))
+                        },
+                        SemanticCallKind::Source { .. } => None,
                     })
                     .chain(base.iter().cloned())
                     .collect();
@@ -102,15 +112,20 @@ impl ExternalScope {
         match self {
             Self::Package { lazy, .. } => Cow::Borrowed(lazy),
             Self::SearchPath {
-                directives, base, ..
+                semantic_calls,
+                base,
+                ..
             } => {
                 let file_scope = ScopeId::from(0);
-                let mut layers: Vec<ScopeLayer> = directives
+                let mut layers: Vec<ScopeLayer> = semantic_calls
                     .iter()
                     .rev()
-                    .filter(|d| d.scope() == file_scope)
-                    .map(|d| match d.kind() {
-                        DirectiveKind::Attach(pkg) => ScopeLayer::PackageExports(pkg.clone()),
+                    .filter(|c| c.scope() == file_scope)
+                    .filter_map(|c| match c.kind() {
+                        SemanticCallKind::Attach { package } => {
+                            Some(ScopeLayer::PackageExports(package.clone()))
+                        },
+                        SemanticCallKind::Source { .. } => None,
                     })
                     .collect();
                 layers.extend(base.iter().cloned());

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -1634,7 +1634,8 @@ fn test_directives_in_function_body_are_scoped() {
     let semantic_calls = script_idx.semantic_calls();
     assert_eq!(semantic_calls.len(), 2);
     assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     });
     assert_eq!(semantic_calls[1].kind(), &SemanticCallKind::Attach {
         package: "dplyr".into()

--- a/crates/oak_ide/tests/goto_definition.rs
+++ b/crates/oak_ide/tests/goto_definition.rs
@@ -18,7 +18,7 @@ use oak_semantic::package::Package;
 use oak_semantic::scope_layer::file_layers;
 use oak_semantic::scope_layer::ScopeLayer;
 use oak_semantic::semantic_index;
-use oak_semantic::semantic_index::DirectiveKind;
+use oak_semantic::semantic_index::SemanticCallKind;
 use oak_semantic::semantic_index::SemanticIndex;
 use oak_semantic::semantic_index_with_source_resolver;
 use oak_semantic::ScopeId;
@@ -1378,7 +1378,7 @@ fn test_source_directive_resolves_to_sourced_file() {
             })
         });
 
-    let dir_layers = script_idx.file_directives().to_vec();
+    let dir_layers = script_idx.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1420,10 +1420,11 @@ fn test_source_directive_resolves_nested_library() {
         .map(|name| name.to_string())
         .collect();
     let helpers_packages: Vec<_> = helpers_idx
-        .file_directives()
+        .semantic_calls()
         .iter()
-        .map(|d| match d.kind() {
-            DirectiveKind::Attach(pkg) => pkg.clone(),
+        .filter_map(|c| match c.kind() {
+            SemanticCallKind::Attach { package } => Some(package.clone()),
+            SemanticCallKind::Source { .. } => None,
         })
         .collect();
 
@@ -1451,7 +1452,7 @@ fn test_source_directive_resolves_nested_library() {
             })
         });
 
-    let dir_layers = script_idx.file_directives().to_vec();
+    let dir_layers = script_idx.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1486,7 +1487,7 @@ fn test_source_directive_resolves_nested_library() {
             })
         });
 
-    let dir_layers = script_idx2.file_directives().to_vec();
+    let dir_layers = script_idx2.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let use_offset = source_with_helper.rfind("helper").unwrap() as u32;
@@ -1549,7 +1550,7 @@ fn test_directive_not_visible_before_call_site() {
             })
         });
 
-    let dir_layers = script_idx.file_directives().to_vec();
+    let dir_layers = script_idx.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1608,9 +1609,10 @@ fn test_directive_not_visible_before_call_site() {
 
 #[test]
 fn test_directives_in_function_body_are_scoped() {
-    // `library()` inside a function body produces a scoped directive:
-    // visible inside the function but not at file scope.
-    // `source()` without a resolver is still a no-op.
+    // `library()` inside a function body produces a scoped Attach
+    // semantic call: visible inside the function but not at file scope.
+    // The `source()` call is recorded as a Source semantic call,
+    // independent of the legacy resolver path.
     let script_source =
         "f <- function() {\n  source(\"helpers.R\")\n  library(dplyr)\n  mutate\n}\nhelper\nmutate\n";
     let script_url = file_url("script.R");
@@ -1627,13 +1629,20 @@ fn test_directives_in_function_body_are_scoped() {
         sources: HashMap::new(),
     };
 
-    // library() inside f produces a scoped directive
-    let directives = script_idx.file_directives();
-    assert_eq!(directives.len(), 1);
-    assert_eq!(directives[0].kind(), &DirectiveKind::Attach("dplyr".into()));
-    assert_ne!(directives[0].scope(), ScopeId::from(0));
+    // Both source() and library() inside f are recorded as scoped
+    // semantic calls, in source order.
+    let semantic_calls = script_idx.semantic_calls();
+    assert_eq!(semantic_calls.len(), 2);
+    assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
+        path: "helpers.R".into()
+    });
+    assert_eq!(semantic_calls[1].kind(), &SemanticCallKind::Attach {
+        package: "dplyr".into()
+    });
+    assert_ne!(semantic_calls[0].scope(), ScopeId::from(0));
+    assert_ne!(semantic_calls[1].scope(), ScopeId::from(0));
 
-    let dir_layers = script_idx.file_directives().to_vec();
+    let dir_layers = script_idx.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     // `mutate` inside f (after library()) — resolves via scoped dplyr
@@ -1704,7 +1713,7 @@ fn test_source_in_function_body_scoping() {
             })
         });
 
-    let dir_layers = script_idx.file_directives().to_vec();
+    let dir_layers = script_idx.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let mut sources = HashMap::new();
@@ -1773,7 +1782,7 @@ fn test_resolve_import_last_def_wins() {
         })
     });
 
-    let dir_layers = script_idx.file_directives().to_vec();
+    let dir_layers = script_idx.semantic_calls().to_vec();
     let scope = ExternalScope::search_path(dir_layers, Vec::new());
 
     let use_offset = script_source.rfind("foo").unwrap() as u32;

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -836,22 +836,28 @@ impl<'a> SemanticIndexBuilder<'a> {
         };
 
         let call_offset = call.syntax().text_trimmed_range().start();
+        let resolution = self.resolve_source(&path);
 
-        // Always record the source() call site. Downstream consumers
-        // (oak_db's `exports` query) translate the path to a `Script`
-        // and inject the target's exports into this file's exports.
+        // Record every `source()` call site, independent of whether the resolver
+        // below resolves it. `resolved` pins the canonical URL when resolution
+        // succeeded so reflective queries (diagnostics for unresolved `source()`,
+        // file-dependency views) read the outcome without re-resolving.
         self.semantic_calls.push(SemanticCall {
-            kind: SemanticCallKind::Source { path: path.clone() },
+            kind: SemanticCallKind::Source {
+                path: path.clone(),
+                resolved: resolution.as_ref().map(|r| r.file.clone()),
+            },
             offset: call_offset,
             scope: self.current_scope,
         });
 
-        // Legacy `_with_source_resolver` path: when a resolver is
-        // present and resolves, eagerly synthesise `Import` definitions
-        // and transitive `Attach` semantic calls for the resolved
-        // names/packages. Retires once the new pipeline takes over
-        // (PR 3/4).
-        let Some(resolution) = self.resolve_source(&path) else {
+        // Eagerly inject `Import` definitions and transitive `Attach` calls
+        // via the caller-provided resolver callback.
+        //
+        // TODO(salsa): the resolver callback generalises to a
+        // `CrossFileResolver` trait. oak_db will provide a salsa-backed
+        // implementation. The injection logic stays here.
+        let Some(resolution) = resolution else {
             return;
         };
 

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -838,10 +838,11 @@ impl<'a> SemanticIndexBuilder<'a> {
         let call_offset = call.syntax().text_trimmed_range().start();
         let resolution = self.resolve_source(&path);
 
-        // Record every `source()` call site, independent of whether the resolver
-        // below resolves it. `resolved` pins the canonical URL when resolution
-        // succeeded so reflective queries (diagnostics for unresolved `source()`,
-        // file-dependency views) read the outcome without re-resolving.
+        // Record every `source()` call site, independent of whether the
+        // resolution was successful. `resolved` pins the canonical URL when
+        // resolution succeeded so reflective queries (diagnostics for
+        // unresolved `source()`, file-dependency views) read the outcome
+        // without re-resolving.
         self.semantic_calls.push(SemanticCall {
             kind: SemanticCallKind::Source {
                 path: path.clone(),

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -31,13 +31,13 @@ use url::Url;
 use crate::semantic_index::Definition;
 use crate::semantic_index::DefinitionId;
 use crate::semantic_index::DefinitionKind;
-use crate::semantic_index::Directive;
-use crate::semantic_index::DirectiveKind;
 use crate::semantic_index::EnclosingSnapshotId;
 use crate::semantic_index::EnclosingSnapshotKey;
 use crate::semantic_index::Scope;
 use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
+use crate::semantic_index::SemanticCall;
+use crate::semantic_index::SemanticCallKind;
 use crate::semantic_index::SemanticIndex;
 use crate::semantic_index::SymbolFlags;
 use crate::semantic_index::SymbolTableBuilder;
@@ -101,7 +101,7 @@ struct SemanticIndexBuilder<'a> {
     current_scope: ScopeId,
     pre_scans: IndexVec<ScopeId, PreScanScope>,
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
-    directives: Vec<Directive>,
+    semantic_calls: Vec<SemanticCall>,
     file: Url,
     source_resolver: Option<SourceResolver<'a>>,
 }
@@ -143,7 +143,7 @@ impl<'a> SemanticIndexBuilder<'a> {
             current_scope: file_scope,
             pre_scans,
             enclosing_snapshots: FxHashMap::default(),
-            directives: Vec::new(),
+            semantic_calls: Vec::new(),
             file,
             source_resolver,
         }
@@ -394,7 +394,7 @@ impl<'a> SemanticIndexBuilder<'a> {
                 // also consider nested scopes as long as they're not lazy (e.g.
                 // function definitions or NSE calls that don't evaluate
                 // immediately.
-                self.collect_directive(call);
+                self.collect_semantic_call(call);
             },
             AnyRExpression::RSubset(subset) => {
                 if let Ok(object) = subset.function() {
@@ -717,28 +717,28 @@ impl<'a> SemanticIndexBuilder<'a> {
         }
     }
 
-    fn collect_directive(&mut self, call: &aether_syntax::RCall) {
+    fn collect_semantic_call(&mut self, call: &aether_syntax::RCall) {
         let Ok(AnyRExpression::RIdentifier(ident)) = call.function() else {
             return;
         };
 
         let fn_name = ident.name_text();
         if fn_name == "library" || fn_name == "require" {
-            self.collect_attach_directive(call);
+            self.collect_attach_call(call);
         } else if fn_name == "source" {
-            self.collect_source_directive(call);
+            self.collect_source_call(call);
         }
     }
 
     // ## `library()` / `require()` scoping
     //
     // In R, `library()` always modifies the global search path regardless
-    // of where it's called. Statically, we scope the directive to
+    // of where it's called. Statically, we scope the call to
     // `self.current_scope`: at file scope it's visible everywhere (sequential
     // execution is guaranteed), but inside a function it's only visible
     // within that function and its children, since the function might never
-    // be called. Same reasoning as `source()` directives.
-    fn collect_attach_directive(&mut self, call: &aether_syntax::RCall) {
+    // be called. Same reasoning as `source()` calls.
+    fn collect_attach_call(&mut self, call: &aether_syntax::RCall) {
         let Ok(args) = call.arguments() else {
             return;
         };
@@ -767,8 +767,8 @@ impl<'a> SemanticIndexBuilder<'a> {
         };
 
         let call_offset = call.syntax().text_trimmed_range().start();
-        self.directives.push(Directive {
-            kind: DirectiveKind::Attach(pkg_name),
+        self.semantic_calls.push(SemanticCall {
+            kind: SemanticCallKind::Attach { package: pkg_name },
             offset: call_offset,
             scope: self.current_scope,
         });
@@ -790,7 +790,7 @@ impl<'a> SemanticIndexBuilder<'a> {
     // global environment. We currently inject into the calling scope
     // regardless to keep the sourcing mechanism simple. A future diagnostic
     // should suggest `local = TRUE` in nested contexts.
-    fn collect_source_directive(&mut self, call: &aether_syntax::RCall) {
+    fn collect_source_call(&mut self, call: &aether_syntax::RCall) {
         let Ok(args) = call.arguments() else {
             return;
         };
@@ -837,6 +837,20 @@ impl<'a> SemanticIndexBuilder<'a> {
 
         let call_offset = call.syntax().text_trimmed_range().start();
 
+        // Always record the source() call site. Downstream consumers
+        // (oak_db's `exports` query) translate the path to a `Script`
+        // and inject the target's exports into this file's exports.
+        self.semantic_calls.push(SemanticCall {
+            kind: SemanticCallKind::Source { path: path.clone() },
+            offset: call_offset,
+            scope: self.current_scope,
+        });
+
+        // Legacy `_with_source_resolver` path: when a resolver is
+        // present and resolves, eagerly synthesise `Import` definitions
+        // and transitive `Attach` semantic calls for the resolved
+        // names/packages. Retires once the new pipeline takes over
+        // (PR 3/4).
         let Some(resolution) = self.resolve_source(&path) else {
             return;
         };
@@ -862,8 +876,8 @@ impl<'a> SemanticIndexBuilder<'a> {
         }
 
         for pkg in resolution.packages {
-            self.directives.push(Directive {
-                kind: DirectiveKind::Attach(pkg),
+            self.semantic_calls.push(SemanticCall {
+                kind: SemanticCallKind::Attach { package: pkg },
                 offset: call_offset,
                 scope: self.current_scope,
             });
@@ -897,7 +911,7 @@ impl<'a> SemanticIndexBuilder<'a> {
             self.uses,
             use_def_maps,
             self.enclosing_snapshots,
-            self.directives,
+            self.semantic_calls,
         )
     }
 }

--- a/crates/oak_semantic/src/scope_layer.rs
+++ b/crates/oak_semantic/src/scope_layer.rs
@@ -4,7 +4,7 @@ use biome_rowan::TextRange;
 use oak_package_metadata::namespace::Namespace;
 use url::Url;
 
-use crate::semantic_index::DirectiveKind;
+use crate::semantic_index::SemanticCallKind;
 use crate::semantic_index::SemanticIndex;
 
 /// A layer in the scope chain. Layers are ordered most-local-first; resolution
@@ -27,7 +27,7 @@ pub enum ScopeLayer {
 
 /// Compute the scope layers that a single file contributes to the
 /// scope chain: one `FileExports` layer from its top-level definitions, plus
-/// one `PackageExports` layer per `library()`/`require()` directive.
+/// one `PackageExports` layer per `library()`/`require()` semantic call.
 pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
     let mut layers = Vec::new();
 
@@ -39,10 +39,14 @@ pub fn file_layers(file: Url, index: &SemanticIndex) -> Vec<ScopeLayer> {
 
     layers.push(ScopeLayer::FileExports { file, exports });
 
-    for directive in index.file_directives() {
-        match directive.kind() {
-            DirectiveKind::Attach(pkg) => {
-                layers.push(ScopeLayer::PackageExports(pkg.clone()));
+    for call in index.semantic_calls() {
+        match call.kind() {
+            SemanticCallKind::Attach { package } => {
+                layers.push(ScopeLayer::PackageExports(package.clone()));
+            },
+            SemanticCallKind::Source { .. } => {
+                // `source()` injects into local scope, not the search path;
+                // not a scope-chain layer.
             },
         }
     }

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -600,7 +600,11 @@ pub enum SemanticCallKind {
     /// `source("path")`: injects the sourced file's top-level
     /// bindings into the current scope. Local-scope semantics, not
     /// search-path semantics.
-    Source { path: String },
+    ///
+    /// `resolved` is the canonical URL the resolver mapped `path` to,
+    /// or `None` if no resolver was provided or the resolver couldn't
+    /// resolve the path.
+    Source { path: String, resolved: Option<Url> },
 }
 
 impl SemanticCall {

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -77,8 +77,9 @@ pub struct SemanticIndex {
     // snapshot where that symbol is bound.
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
 
-    // Scope-chain directives called at top-level, such as `library()` or `require()`.
-    directives: Vec<Directive>,
+    // Cross-file call sites recorded during indexing, such as `library()`
+    // attachments or `source()` injections.
+    semantic_calls: Vec<SemanticCall>,
 }
 
 impl SemanticIndex {
@@ -89,7 +90,7 @@ impl SemanticIndex {
         uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
         use_def_maps: IndexVec<ScopeId, Arc<UseDefMap>>,
         enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
-        directives: Vec<Directive>,
+        semantic_calls: Vec<SemanticCall>,
     ) -> Self {
         Self {
             scopes,
@@ -98,7 +99,7 @@ impl SemanticIndex {
             uses,
             use_def_maps,
             enclosing_snapshots,
-            directives,
+            semantic_calls,
         }
     }
 
@@ -138,19 +139,21 @@ impl SemanticIndex {
         exports
     }
 
-    /// Package names from `library()` / `require()` directives in this file.
+    /// Package names from `library()` / `require()` calls in this file.
     pub fn file_attached_packages(&self) -> Vec<&str> {
-        self.directives
+        self.semantic_calls
             .iter()
-            .map(|d| match &d.kind {
-                DirectiveKind::Attach(pkg) => pkg.as_str(),
+            .filter_map(|c| match &c.kind {
+                SemanticCallKind::Attach { package } => Some(package.as_str()),
+                SemanticCallKind::Source { .. } => None,
             })
             .collect()
     }
 
-    /// File-level directives (e.g. `library()` calls) recorded during indexing.
-    pub fn file_directives(&self) -> &[Directive] {
-        &self.directives
+    /// Cross-file call sites (`library()`, `source()`, …) recorded
+    /// during indexing.
+    pub fn semantic_calls(&self) -> &[SemanticCall] {
+        &self.semantic_calls
     }
 
     /// Find the innermost scope containing `offset`.
@@ -579,22 +582,29 @@ impl Ranged for Use {
     }
 }
 
-/// A directive that affects the file's imports (e.g. `library()` calls).
+/// A cross-file call site recorded at parse time (`library()`,
+/// `source()`, ...). Different kinds carry different downstream
+/// semantics, see [`SemanticCallKind`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Directive {
-    pub(crate) kind: DirectiveKind,
+pub struct SemanticCall {
+    pub(crate) kind: SemanticCallKind,
     pub(crate) offset: TextSize,
     pub(crate) scope: ScopeId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DirectiveKind {
-    /// `library(pkg)` or `require(pkg)`: attaches a package to the search path.
-    Attach(String),
+pub enum SemanticCallKind {
+    /// `library(pkg)` or `require(pkg)`: attaches a package to the
+    /// search path. Contributes a fallback layer for unbound symbols.
+    Attach { package: String },
+    /// `source("path")`: injects the sourced file's top-level
+    /// bindings into the current scope. Local-scope semantics, not
+    /// search-path semantics.
+    Source { path: String },
 }
 
-impl Directive {
-    pub fn kind(&self) -> &DirectiveKind {
+impl SemanticCall {
+    pub fn kind(&self) -> &SemanticCallKind {
         &self.kind
     }
 

--- a/crates/oak_semantic/tests/builder.rs
+++ b/crates/oak_semantic/tests/builder.rs
@@ -4,9 +4,9 @@ use aether_syntax::RSyntaxKind;
 use oak_semantic::semantic_index;
 use oak_semantic::semantic_index::DefinitionId;
 use oak_semantic::semantic_index::DefinitionKind;
-use oak_semantic::semantic_index::DirectiveKind;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::ScopeKind;
+use oak_semantic::semantic_index::SemanticCallKind;
 use oak_semantic::semantic_index::SemanticIndex;
 use oak_semantic::semantic_index::SymbolFlags;
 use oak_semantic::semantic_index::UseId;
@@ -24,8 +24,8 @@ fn index(source: &str) -> SemanticIndex {
     semantic_index(&parsed.tree(), &Url::parse("file:///test/test.R").unwrap())
 }
 
-fn directive_kinds(index: &SemanticIndex) -> Vec<&DirectiveKind> {
-    index.file_directives().iter().map(|d| d.kind()).collect()
+fn semantic_call_kinds(index: &SemanticIndex) -> Vec<&SemanticCallKind> {
+    index.semantic_calls().iter().map(|c| c.kind()).collect()
 }
 
 #[test]
@@ -1308,86 +1308,194 @@ fn test_file_exports_multiple_defs_same_symbol() {
 #[test]
 fn test_directive_library_identifier() {
     let index = index("library(dplyr)");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "dplyr".into()
-    )]);
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "dplyr".into()
+    }]);
 }
 
 #[test]
 fn test_directive_library_string() {
     let index = index("library(\"tidyr\")");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "tidyr".into()
-    )]);
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "tidyr".into()
+    }]);
 }
 
 #[test]
 fn test_directive_library_single_quoted_string() {
     let index = index("library('ggplot2')");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "ggplot2".into()
-    )]);
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "ggplot2".into()
+    }]);
 }
 
 #[test]
 fn test_directive_require() {
     let index = index("require(data.table)");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "data.table".into()
-    )]);
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "data.table".into()
+    }]);
 }
 
 #[test]
 fn test_directive_multiple_libraries() {
     let index = index("library(dplyr)\nlibrary(tidyr)\nrequire(ggplot2)");
-    assert_eq!(directive_kinds(&index), [
-        &DirectiveKind::Attach("dplyr".into()),
-        &DirectiveKind::Attach("tidyr".into()),
-        &DirectiveKind::Attach("ggplot2".into()),
+    assert_eq!(semantic_call_kinds(&index), [
+        &SemanticCallKind::Attach {
+            package: "dplyr".into()
+        },
+        &SemanticCallKind::Attach {
+            package: "tidyr".into()
+        },
+        &SemanticCallKind::Attach {
+            package: "ggplot2".into()
+        },
     ]);
 }
 
 #[test]
 fn test_directive_named_argument_ignored() {
     let index = index("library(package = dplyr)");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_multiple_arguments_ignored() {
     let index = index("library(dplyr, warn.conflicts = FALSE)");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_no_arguments_ignored() {
     let index = index("library()");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_library_in_function_scope() {
     // library() in a function body now records a scoped directive
     let index = index("f <- function() { library(dplyr) }");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "dplyr".into()
-    )]);
-    let directives = index.file_directives();
-    assert_ne!(directives[0].scope(), ScopeId::from(0));
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "dplyr".into()
+    }]);
+    let semantic_calls = index.semantic_calls();
+    assert_ne!(semantic_calls[0].scope(), ScopeId::from(0));
 }
 
 #[test]
 fn test_directive_non_static_argument_ignored() {
     let index = index("library(get_pkg())");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_preserves_offset() {
     let index = index("x <- 1\nlibrary(dplyr)");
-    let directives = index.file_directives();
-    assert_eq!(directives.len(), 1);
-    assert_eq!(directives[0].offset(), biome_rowan::TextSize::from(7));
+    let semantic_calls = index.semantic_calls();
+    assert_eq!(semantic_calls.len(), 1);
+    assert_eq!(semantic_calls[0].offset(), biome_rowan::TextSize::from(7));
+}
+
+// --- source() semantic calls ---
+//
+// The no-resolver `semantic_index` (used by `oak_db`) always records
+// a `Source` semantic call for every `source(...)` site, even when
+// the path can't be resolved cross-file. Downstream queries in
+// `oak_db` translate the path to a `Script` and inject the target's
+// exports.
+
+#[test]
+fn test_source_call_records_path() {
+    let index = index("source(\"helpers.R\")");
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
+}
+
+#[test]
+fn test_source_call_single_quoted_string() {
+    let index = index("source('helpers.R')");
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
+}
+
+#[test]
+fn test_source_call_preserves_offset() {
+    let index = index("x <- 1\nsource(\"helpers.R\")");
+    let semantic_calls = index.semantic_calls();
+    assert_eq!(semantic_calls.len(), 1);
+    assert_eq!(semantic_calls[0].offset(), biome_rowan::TextSize::from(7));
+}
+
+#[test]
+fn test_source_call_records_file_scope() {
+    let index = index("source(\"helpers.R\")");
+    let semantic_calls = index.semantic_calls();
+    assert_eq!(semantic_calls.len(), 1);
+    assert_eq!(semantic_calls[0].scope(), ScopeId::from(0));
+}
+
+#[test]
+fn test_source_call_in_function_body_records_inner_scope() {
+    let index = index("f <- function() { source(\"helpers.R\") }");
+    let semantic_calls = index.semantic_calls();
+    assert_eq!(semantic_calls.len(), 1);
+    assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
+        path: "helpers.R".into()
+    });
+    assert_ne!(semantic_calls[0].scope(), ScopeId::from(0));
+}
+
+#[test]
+fn test_source_call_non_static_path_ignored() {
+    let index = index("source(get_path())");
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
+}
+
+#[test]
+fn test_source_call_non_static_local_ignored() {
+    // `local = some_env()` isn't statically resolvable; we bail rather
+    // than record the call.
+    let index = index("source(\"helpers.R\", local = some_env())");
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
+}
+
+#[test]
+fn test_source_call_local_true_recorded() {
+    let index = index("source(\"helpers.R\", local = TRUE)");
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
+}
+
+#[test]
+fn test_source_and_library_calls_coexist() {
+    let index = index("library(dplyr)\nsource(\"helpers.R\")\nrequire(tidyr)");
+    assert_eq!(semantic_call_kinds(&index), [
+        &SemanticCallKind::Attach {
+            package: "dplyr".into()
+        },
+        &SemanticCallKind::Source {
+            path: "helpers.R".into()
+        },
+        &SemanticCallKind::Attach {
+            package: "tidyr".into()
+        },
+    ]);
+}
+
+#[test]
+fn test_source_call_emitted_without_resolver() {
+    // The pure `semantic_index` (no resolver) doesn't produce
+    // `DefinitionKind::Import` for sourced names — those come from
+    // the legacy `_with_source_resolver` path. But the `Source`
+    // semantic call IS recorded, so downstream queries in `oak_db`
+    // can still chase the forwarding chain.
+    let index = index("source(\"helpers.R\")");
+    let file_scope = ScopeId::from(0);
+    assert_eq!(index.definitions(file_scope).iter().count(), 0);
+    assert_eq!(index.semantic_calls().len(), 1);
 }
 
 #[test]
@@ -1402,73 +1510,34 @@ fn test_file_exports_last_def_wins() {
     assert_eq!(range.start(), biome_rowan::TextSize::from(9));
 }
 
-// --- source() directives ---
+// --- source() semantic calls: bail paths ---
+//
+// Cases where the builder can't extract a statically-resolvable
+// path, so no `Source` semantic call is emitted. The valid-path
+// cases live above ("source() semantic calls").
 
 #[test]
-fn test_directive_source_no_resolver() {
-    // Without a resolver, source() produces no directives
-    let index = index("source(\"helpers.R\")");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
-}
-
-#[test]
-fn test_directive_source_single_quoted_no_resolver() {
-    let index = index("source('utils/helpers.R')");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
-}
-
-#[test]
-fn test_directive_source_identifier_ignored() {
+fn test_source_call_identifier_path_ignored() {
     let index = index("source(my_file)");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
-fn test_directive_source_non_static_argument_ignored() {
+fn test_source_call_paste0_argument_ignored() {
     let index = index("source(paste0(\"path/\", name))");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
-fn test_directive_source_named_argument_ignored() {
+fn test_source_call_named_file_argument_ignored() {
     let index = index("source(file = \"helpers.R\")");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
-fn test_directive_source_local_true_without_resolver() {
-    // `source("helpers.R", local = TRUE)` is recognized but no resolver, so no directives
-    let index = index("source(\"helpers.R\", local = TRUE)");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
-}
-
-#[test]
-fn test_directive_source_no_arguments_ignored() {
+fn test_source_call_no_arguments_ignored() {
     let index = index("source()");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
-}
-
-#[test]
-fn test_directive_source_nested_without_resolver() {
-    // Nested `source()` is recognized but no resolver, so no directives
-    let index = index("f <- function() { source(\"helpers.R\") }");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
-}
-
-#[test]
-fn test_directive_source_no_resolver_no_directives() {
-    let index = index("x <- 1\nsource(\"helpers.R\")");
-    let directives = index.file_directives();
-    assert_eq!(directives.len(), 0);
-}
-
-#[test]
-fn test_directive_source_mixed_with_library() {
-    let index = index("library(dplyr)\nsource(\"helpers.R\")\nlibrary(tidyr)");
-    assert_eq!(directive_kinds(&index), [
-        &DirectiveKind::Attach("dplyr".into()),
-        &DirectiveKind::Attach("tidyr".into()),
-    ]);
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 // --- declare() directives ---
@@ -1476,19 +1545,25 @@ fn test_directive_source_mixed_with_library() {
 #[test]
 fn test_directive_declare_source_no_resolver() {
     let index = index("declare(source(\"helpers.R\"))");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
 }
 
 #[test]
 fn test_directive_declare_source_single_quotes_no_resolver() {
     let index = index("declare(source('utils.R'))");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "utils.R".into()
+    }]);
 }
 
 #[test]
 fn test_directive_tilde_declare_source_no_resolver() {
     let index = index("~declare(source(\"helpers.R\"))");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
 }
 
 #[test]
@@ -1497,55 +1572,75 @@ fn test_fixme_directive_declare_library_transparent() {
     // picked up as a directive.
     // FIXME: We should declare `declare()` as a quoting function.
     let index = index("declare(library(dplyr))");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "dplyr".into()
-    )]);
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "dplyr".into()
+    }]);
 }
 
 #[test]
 fn test_directive_declare_not_at_file_scope() {
+    // declare()'s argument is walked into regardless of position, so a
+    // nested source() inside a function body is still recorded.
     let index = index("f <- function() { declare(source(\"helpers.R\")) }");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
 }
 
 #[test]
 fn test_directive_tilde_declare_not_at_file_scope() {
     let index = index("f <- function() { ~declare(source(\"helpers.R\")) }");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
+        path: "helpers.R".into()
+    }]);
 }
 
 #[test]
 fn test_directive_declare_mixed_with_bare() {
     let index = index("library(dplyr)\ndeclare(source(\"helpers.R\"))\nsource(\"utils.R\")");
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "dplyr".into()
-    ),]);
+    assert_eq!(semantic_call_kinds(&index), [
+        &SemanticCallKind::Attach {
+            package: "dplyr".into()
+        },
+        &SemanticCallKind::Source {
+            path: "helpers.R".into()
+        },
+        &SemanticCallKind::Source {
+            path: "utils.R".into()
+        },
+    ]);
 }
 
 #[test]
-fn test_directive_declare_source_no_resolver_no_directives() {
+fn test_directive_declare_source_no_resolver_records_call() {
     let index = index("x <- 1\ndeclare(source(\"helpers.R\"))");
-    let directives = index.file_directives();
-    assert_eq!(directives.len(), 0);
+    let semantic_calls = index.semantic_calls();
+    assert_eq!(semantic_calls.len(), 1);
+    assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
+        path: "helpers.R".into()
+    });
 }
 
 #[test]
-fn test_directive_tilde_declare_source_no_resolver_no_directives() {
+fn test_directive_tilde_declare_source_no_resolver_records_call() {
     let index = index("x <- 1\n~declare(source(\"helpers.R\"))");
-    let directives = index.file_directives();
-    assert_eq!(directives.len(), 0);
+    let semantic_calls = index.semantic_calls();
+    assert_eq!(semantic_calls.len(), 1);
+    assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
+        path: "helpers.R".into()
+    });
 }
 
 #[test]
 fn test_directive_declare_non_call_arg_ignored() {
     let index = index("declare(42)");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_declare_identifier_source_arg_ignored() {
     let index = index("declare(source(my_file))");
-    assert_eq!(directive_kinds(&index), Vec::<&DirectiveKind>::new());
+    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 // --- source() with resolver ---
@@ -1647,7 +1742,11 @@ fn test_source_resolver_in_function_scope() {
 }
 
 #[test]
-fn test_source_resolver_packages_become_directives() {
+fn test_source_resolver_packages_become_attach_calls() {
+    // The source() call is always recorded as a `Source` semantic call.
+    // With a resolver, packages attached transitively by the sourced
+    // file are *additionally* recorded as `Attach` semantic calls (the
+    // legacy "library() in a sourced file propagates to caller" path).
     let code = "source(\"helpers.R\")\n";
     let index = index_with_resolver(code, |_| {
         Some(SourceResolution {
@@ -1657,9 +1756,14 @@ fn test_source_resolver_packages_become_directives() {
         })
     });
 
-    assert_eq!(directive_kinds(&index), [&DirectiveKind::Attach(
-        "dplyr".into()
-    )]);
+    assert_eq!(semantic_call_kinds(&index), [
+        &SemanticCallKind::Source {
+            path: "helpers.R".into()
+        },
+        &SemanticCallKind::Attach {
+            package: "dplyr".into()
+        },
+    ]);
 }
 
 #[test]

--- a/crates/oak_semantic/tests/builder.rs
+++ b/crates/oak_semantic/tests/builder.rs
@@ -1408,7 +1408,8 @@ fn test_directive_preserves_offset() {
 fn test_source_call_records_path() {
     let index = index("source(\"helpers.R\")");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1416,7 +1417,8 @@ fn test_source_call_records_path() {
 fn test_source_call_single_quoted_string() {
     let index = index("source('helpers.R')");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1442,7 +1444,8 @@ fn test_source_call_in_function_body_records_inner_scope() {
     let semantic_calls = index.semantic_calls();
     assert_eq!(semantic_calls.len(), 1);
     assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     });
     assert_ne!(semantic_calls[0].scope(), ScopeId::from(0));
 }
@@ -1465,7 +1468,8 @@ fn test_source_call_non_static_local_ignored() {
 fn test_source_call_local_true_recorded() {
     let index = index("source(\"helpers.R\", local = TRUE)");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1477,7 +1481,8 @@ fn test_source_and_library_calls_coexist() {
             package: "dplyr".into()
         },
         &SemanticCallKind::Source {
-            path: "helpers.R".into()
+            path: "helpers.R".into(),
+            resolved: None,
         },
         &SemanticCallKind::Attach {
             package: "tidyr".into()
@@ -1546,7 +1551,8 @@ fn test_source_call_no_arguments_ignored() {
 fn test_directive_declare_source_no_resolver() {
     let index = index("declare(source(\"helpers.R\"))");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1554,7 +1560,8 @@ fn test_directive_declare_source_no_resolver() {
 fn test_directive_declare_source_single_quotes_no_resolver() {
     let index = index("declare(source('utils.R'))");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "utils.R".into()
+        path: "utils.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1562,7 +1569,8 @@ fn test_directive_declare_source_single_quotes_no_resolver() {
 fn test_directive_tilde_declare_source_no_resolver() {
     let index = index("~declare(source(\"helpers.R\"))");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1583,7 +1591,8 @@ fn test_directive_declare_not_at_file_scope() {
     // nested source() inside a function body is still recorded.
     let index = index("f <- function() { declare(source(\"helpers.R\")) }");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1591,7 +1600,8 @@ fn test_directive_declare_not_at_file_scope() {
 fn test_directive_tilde_declare_not_at_file_scope() {
     let index = index("f <- function() { ~declare(source(\"helpers.R\")) }");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     }]);
 }
 
@@ -1603,10 +1613,12 @@ fn test_directive_declare_mixed_with_bare() {
             package: "dplyr".into()
         },
         &SemanticCallKind::Source {
-            path: "helpers.R".into()
+            path: "helpers.R".into(),
+            resolved: None,
         },
         &SemanticCallKind::Source {
-            path: "utils.R".into()
+            path: "utils.R".into(),
+            resolved: None,
         },
     ]);
 }
@@ -1617,7 +1629,8 @@ fn test_directive_declare_source_no_resolver_records_call() {
     let semantic_calls = index.semantic_calls();
     assert_eq!(semantic_calls.len(), 1);
     assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     });
 }
 
@@ -1627,7 +1640,8 @@ fn test_directive_tilde_declare_source_no_resolver_records_call() {
     let semantic_calls = index.semantic_calls();
     assert_eq!(semantic_calls.len(), 1);
     assert_eq!(semantic_calls[0].kind(), &SemanticCallKind::Source {
-        path: "helpers.R".into()
+        path: "helpers.R".into(),
+        resolved: None,
     });
 }
 
@@ -1758,7 +1772,8 @@ fn test_source_resolver_packages_become_attach_calls() {
 
     assert_eq!(semantic_call_kinds(&index), [
         &SemanticCallKind::Source {
-            path: "helpers.R".into()
+            path: "helpers.R".into(),
+            resolved: Some(Url::parse("file:///test/helpers.R").unwrap()),
         },
         &SemanticCallKind::Attach {
             package: "dplyr".into()


### PR DESCRIPTION
Branched from #1214 
Progress towards #1212

This PR does two things:

- Renames `Directive` to `SemanticCall`. Better reflects what they are: calls that impact cross-file resolution.

- Stores `source()` calls as `SemanticCall::Source { path, resolved }`

I was originally going to use that for a downstream query, but I won't be needing it in the end.

I kept these changes because it seems useful to keep track of source calls and their resolution for reflective queries, e.g. for diagnostics (unresolved source path) or debugging.