### PR TITLE
Derive Equality on the semantic index after all

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: 'false'
 
       - name: Install nextest
         uses: taiki-e/install-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "amalthea"
 version = "0.1.0"
 dependencies = [
@@ -723,6 +729,12 @@ checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
@@ -1685,6 +1697,20 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -2050,6 +2076,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2596,7 @@ dependencies = [
  "oak_semantic",
  "oak_sources",
  "rustc-hash",
+ "salsa",
  "smallvec",
  "stdext",
  "tempfile",
@@ -3190,6 +3244,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4612ff789805e65c87e9b38cb749a293212a615af065bed8a2001086801498c3"
+dependencies = [
+ "boxcar",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "hashbrown 0.17.0",
+ "hashlink 0.10.0",
+ "indexmap 2.14.0",
+ "intrusive-collections",
+ "inventory",
+ "parking_lot",
+ "portable-atomic",
+ "rayon",
+ "rustc-hash",
+ "salsa-macro-rules",
+ "salsa-macros",
+ "smallvec",
+ "thin-vec",
+ "tracing",
+ "typeid",
+]
+
+[[package]]
+name = "salsa-macro-rules"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e354cbac6939b9b09cd9c11fb419a53e64b4a0f755d929f56a09f4cc752e41"
+
+[[package]]
+name = "salsa-macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3067861075c2b80608f84ad49fb88f2c7610b94cdf8b4201e79ddee87f8980c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,6 +3803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4230,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -4861,7 +4971,7 @@ checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ reqwest-middleware = "0.5.1"
 reqwest-retry = "0.9.1"
 rust-embed = "8.11.0"
 rustc-hash = "2.1.2"
+salsa = "0.26.2"
 scraper = "0.26.0"
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/oak_semantic/Cargo.toml
+++ b/crates/oak_semantic/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [features]
+salsa = ["dep:salsa"]
 testing = ["dep:tempfile"]
 
 [lints]
@@ -33,6 +34,10 @@ rustc-hash.workspace = true
 smallvec.workspace = true
 stdext.workspace = true
 url.workspace = true
+
+[dependencies.salsa]
+workspace = true
+optional = true
 
 [dependencies.tempfile]
 workspace = true

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use aether_syntax::AnyRArgumentName;
 use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRParameterName;
@@ -876,12 +878,16 @@ impl<'a> SemanticIndexBuilder<'a> {
     fn finish(mut self) -> SemanticIndex {
         self.scopes[ScopeId::from(0)].descendants.end = self.scopes.next_id();
 
-        let symbol_tables = self.symbol_tables.into_iter().map(|b| b.build()).collect();
+        let symbol_tables = self
+            .symbol_tables
+            .into_iter()
+            .map(|b| Arc::new(b.build()))
+            .collect();
         let use_def_maps: IndexVec<ScopeId, _> = self
             .use_def_maps
             .into_iter()
             .zip(self.uses.iter())
-            .map(|(b, (_, uses))| b.finish(uses))
+            .map(|(b, (_, uses))| Arc::new(b.finish(uses)))
             .collect();
 
         SemanticIndex::new(

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -41,7 +41,8 @@ define_index!(EnclosingSnapshotId);
 // (all indexed by `ScopeId`) rather than bundled into a single struct, so
 // that each can be cached and invalidated independently (when salsa is
 // introduced).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
+#[cfg_attr(feature = "salsa", derive(salsa::Update))]
 pub struct SemanticIndex {
     scopes: IndexVec<ScopeId, Scope>,
 

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -40,7 +40,7 @@ define_index!(EnclosingSnapshotId);
 // (all indexed by `ScopeId`) rather than bundled into a single struct, so
 // that each can be cached and invalidated independently (when salsa is
 // introduced).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SemanticIndex {
     scopes: IndexVec<ScopeId, Scope>,
 
@@ -269,7 +269,7 @@ pub struct EnclosingSnapshotKey {
 // Currently only `function()` creates a new scope. In the future, constructs
 // like `local()`, `with()`, `within()` may also create scopes (determined
 // by function declarations resolved via salsa queries).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Scope {
     pub(crate) parent: Option<ScopeId>,
     pub(crate) kind: ScopeKind,
@@ -312,7 +312,7 @@ impl Ranged for Scope {
 // --- Symbol table (per scope) ---
 
 // Read-only after construction. The builder uses `SymbolTableBuilder`.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct SymbolTable {
     symbols: IndexVec<SymbolId, Symbol>,
 
@@ -399,7 +399,7 @@ impl std::ops::Deref for SymbolTableBuilder {
 // access like `x.y`). `resolve_symbol()` walks the scope chain looking for a
 // symbol with `IS_BOUND`. Future type inference will look up the symbol's
 // definitions and infer a type from them.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Symbol {
     pub(crate) name: String,
     pub(crate) flags: SymbolFlags,
@@ -493,7 +493,7 @@ impl SymbolFlags {
 // implicitly declarations (they declare a name as a function with a specific
 // signature). Future `declare()` annotations will also produce pure
 // declarations.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Definition {
     pub(crate) kind: DefinitionKind,
     /// The file that owns this definition's index.
@@ -506,7 +506,7 @@ pub struct Definition {
     pub(crate) range: TextRange,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DefinitionKind {
     Assignment(AstPtr<RBinaryExpression>),
     SuperAssignment(AstPtr<RBinaryExpression>),
@@ -554,7 +554,7 @@ impl Ranged for Definition {
 // node positions to use IDs). Our flat list serves the same purpose: the
 // `UseDefMap` will reference `UseId` indices into this list to connect each
 // use to its reaching definitions.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Use {
     pub(crate) symbol: SymbolId,
     pub(crate) range: TextRange,
@@ -577,7 +577,7 @@ impl Ranged for Use {
 }
 
 /// A directive that affects the file's imports (e.g. `library()` calls).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Directive {
     pub(crate) kind: DirectiveKind,
     pub(crate) offset: TextSize,

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::sync::Arc;
 
 use aether_syntax::RBinaryExpression;
 use aether_syntax::RCall;
@@ -44,12 +45,11 @@ define_index!(EnclosingSnapshotId);
 pub struct SemanticIndex {
     scopes: IndexVec<ScopeId, Scope>,
 
-    // ty wraps per-scope tables in `Arc` so they can be returned from
-    // individual salsa tracked queries (e.g. `place_table(db, scope) ->
-    // Arc<PlaceTable>`). Salsa compares the returned `Arc` by `Eq` to skip
-    // re-running downstream queries when a scope's table hasn't changed.
-    // We defer that until salsa is introduced.
-    symbol_tables: IndexVec<ScopeId, SymbolTable>,
+    // Heavy per-scope tables are `Arc`-wrapped so narrow tracked queries
+    // (e.g. `symbol_table(db, file, scope) -> Arc<SymbolTable>`) can
+    // return them cheaply, and salsa's storage uses `Arc::ptr_eq` as a
+    // fast path during update comparisons. Matches ty's pattern.
+    symbol_tables: IndexVec<ScopeId, Arc<SymbolTable>>,
 
     // Flat per-scope lists of definition and use sites. These support rename
     // and go-to-definition by letting us find all sites for a given symbol
@@ -66,9 +66,10 @@ pub struct SemanticIndex {
     definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
     uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
 
-    // Per-scope flow-sensitive map from each use site to the set of definitions
-    // that can reach it. Built alongside the other arrays during the tree walk.
-    use_def_maps: IndexVec<ScopeId, UseDefMap>,
+    // Per-scope flow-sensitive map from each use site to the set of
+    // definitions that can reach it. Built alongside the other arrays
+    // during the tree walk. `Arc`-wrapped for fast Salsa comparisons.
+    use_def_maps: IndexVec<ScopeId, Arc<UseDefMap>>,
 
     // For each free variable in a nested scope, maps to the enclosing scope and
     // snapshot where that symbol is bound.
@@ -81,10 +82,10 @@ pub struct SemanticIndex {
 impl SemanticIndex {
     pub(crate) fn new(
         scopes: IndexVec<ScopeId, Scope>,
-        symbol_tables: IndexVec<ScopeId, SymbolTable>,
+        symbol_tables: IndexVec<ScopeId, Arc<SymbolTable>>,
         definitions: IndexVec<ScopeId, IndexVec<DefinitionId, Definition>>,
         uses: IndexVec<ScopeId, IndexVec<UseId, Use>>,
-        use_def_maps: IndexVec<ScopeId, UseDefMap>,
+        use_def_maps: IndexVec<ScopeId, Arc<UseDefMap>>,
         enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
         directives: Vec<Directive>,
     ) -> Self {
@@ -103,7 +104,7 @@ impl SemanticIndex {
         &self.scopes[id]
     }
 
-    pub fn symbols(&self, scope: ScopeId) -> &SymbolTable {
+    pub fn symbols(&self, scope: ScopeId) -> &Arc<SymbolTable> {
         &self.symbol_tables[scope]
     }
 
@@ -115,7 +116,7 @@ impl SemanticIndex {
         &self.uses[scope]
     }
 
-    pub fn use_def_map(&self, scope: ScopeId) -> &UseDefMap {
+    pub fn use_def_map(&self, scope: ScopeId) -> &Arc<UseDefMap> {
         &self.use_def_maps[scope]
     }
 

--- a/crates/oak_semantic/src/use_def_map.rs
+++ b/crates/oak_semantic/src/use_def_map.rs
@@ -197,7 +197,7 @@ use crate::semantic_index::UseId;
 /// Also stores enclosing snapshots: the bindings that lazy nested scopes
 /// (i.e. nested functions) see when they reference a symbol defined in this
 /// scope. Looked up via `SemanticIndex::enclosing_bindings()`.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UseDefMap {
     bindings_by_use: IndexVec<UseId, Bindings>,
 


### PR DESCRIPTION
@DavisVaughan I thought we could use `no_eq` _instead_ of the Eq/PartialEq derivation, but that's not the case. You still need either Eq, or derive/implement `salsa::Update` for updating the value in the Salsa storage. The latter also does deep comparisons. 

I think Eq/PartialEq is better for oak_semantic because it feels useful to keep it completely independent of salsa.

One thing I've learned from ty is that they wrap symbol tables and use-def maps in `Arc` so that the comparisons are cheap. We now do the same, hopefully that addresses your concern about performance.

Also note that ty uses a `no_eq` attribute on their AST pointer in `Definition`. This needs `Definition` to be `#[salsa::tracked]` (the attribute only applies inside salsa-managed structs) and an Update derive. In our case we don't need all this complexity since our AST pointer type is very cheap to compare (a kind and a range).