### PR TITLE
Return Description in `.ps.rpc.pkg_list`

### DIFF
--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -16,7 +16,7 @@
 # active project, so the same call works for pak/base/renv callers.
 #' @export
 .ps.rpc.pkg_list <- function(method = c("pak", "base", "renv")) {
-    ip <- utils::installed.packages()
+    ip <- utils::installed.packages(fields = "Description")
     name <- ip[, "Package"]
     version <- ip[, "Version"]
     id <- paste0(name, "-", version)
@@ -24,6 +24,16 @@
     # "loaded" here since loadedNamespaces() is a strict superset (a
     # package can be loaded as a dependency without being attached).
     attached <- paste0("package:", name) %in% search()
+    # DESCRIPTION wraps Description across lines; R's DCF parser preserves
+    # the embedded newlines and runs of spaces. Collapse all whitespace
+    # runs to a single space and strip the edges so the card renders as
+    # one flowing string. NA (missing field) becomes "".
+    description <- trimws(gsub(
+        "\\s+",
+        " ",
+        ifelse(is.na(ip[, "Description"]), "", ip[, "Description"]),
+        perl = TRUE
+    ))
     # `Map(list, id = ...)` would name the output list by `id`'s values
     # (mapply USE.NAMES semantics for a character first arg), and a named
     # list serializes to a JSON object instead of the array the frontend
@@ -34,7 +44,8 @@
         name = name,
         displayName = name,
         version = version,
-        attached = attached
+        attached = attached,
+        description = description
     ))
 }
 


### PR DESCRIPTION
Read each installed package's DESCRIPTION Description column via `installed.packages(fields = "Description")` and include it in the per-package list. DESCRIPTION wraps the field across lines with indented continuations; R's DCF parser preserves those embedded newlines and runs of spaces, so collapse all whitespace runs to a single space and trim the edges. NA (missing field) becomes "".

The Positron Packages card view renders this as the description line under each package's name.

Example:

<img width="317" height="980" alt="Screenshot 2026-05-19 at 3 25 33 PM" src="https://github.com/user-attachments/assets/950fb363-1a1f-432a-894b-77f53388f5a9" />

Each package does have a Title property that is supposed to be a short one-liner. Visually, we're going for 2 rows, so it kind of backfired. I also compared the two for the list of packages I have installed and it didn't seem to make a big difference. Until we add extra metadata to the 3rd row and stop wrapping the description, I want to go ahead and use the longer Description field.


See posit-dev/positron#12925