### PR TITLE
Normalize versions to `package_version`s before comparison

### DIFF
--- a/crates/oak_sources/scripts/srcrefs.R
+++ b/crates/oak_sources/scripts/srcrefs.R
@@ -33,7 +33,9 @@ if (length(path) == 0L) {
     quit(status = 1L)
 }
 
-# Make sure installed version matches the requested version
+# Make sure installed version matches the requested version.
+# Normalize both to `package_version`s to handle versions like sf's 1.1-1.
+version <- as.character(package_version(version))
 installed_version <- as.character(packageVersion(package))
 if (installed_version != version) {
     message(paste0(


### PR DESCRIPTION
Closes https://github.com/posit-dev/ark/issues/1189

To handle sf 1.1-1 and convert it to 1.1.1, which is the form `packageVersion()` returns

A bit tricky to actually write a test for this, as I don't really want to install sf on every test run. But a manual check confirms that you can goto definition on `sf::as_Spatial()` now