### PR TITLE
Add support for renaming local variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,7 @@ version = "0.1.0"
 dependencies = [
  "air_r_parser",
  "air_r_syntax",
+ "anyhow",
  "assert_matches",
  "biome_rowan",
 ]
@@ -2583,6 +2584,7 @@ version = "0.1.0"
 dependencies = [
  "air_r_parser",
  "air_r_syntax",
+ "anyhow",
  "biome_rowan",
  "oak_core",
  "oak_semantic",

--- a/crates/ark/src/lsp.rs
+++ b/crates/ark/src/lsp.rs
@@ -32,6 +32,7 @@ pub mod main_loop;
 pub mod markdown;
 
 pub mod find_references;
+pub mod rename;
 pub mod selection_range;
 pub mod signature_help;
 pub mod state;

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -81,7 +81,10 @@ macro_rules! cast_response {
             },
             RequestResponse::Result(Err(err)) => match err {
                 LspError::JsonRpc(err) => Err(err),
-                LspError::Anyhow(err) => Err(new_jsonrpc_error(format!("{err:?}"))),
+                // `{err}` (Display) prints just the message. `{err:?}` (Debug)
+                // would include the captured backtrace when `RUST_BACKTRACE`
+                // is set, which then surfaces in the client's error popup.
+                LspError::Anyhow(err) => Err(new_jsonrpc_error(format!("{err}"))),
             },
             RequestResponse::Crashed(err) => {
                 // Notify user that the LSP has crashed and is no longer active

--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -154,6 +154,8 @@ pub(crate) enum LspRequest {
     GotoImplementation(GotoImplementationParams),
     SelectionRange(SelectionRangeParams),
     References(ReferenceParams),
+    PrepareRename(TextDocumentPositionParams),
+    Rename(RenameParams),
     StatementRange(StatementRangeParams),
     HelpTopic(HelpTopicParams),
     OnTypeFormatting(DocumentOnTypeFormattingParams),
@@ -178,6 +180,8 @@ pub(crate) enum LspResponse {
     GotoImplementation(Option<GotoImplementationResponse>),
     SelectionRange(Option<Vec<SelectionRange>>),
     References(Option<Vec<Location>>),
+    PrepareRename(Option<PrepareRenameResponse>),
+    Rename(Option<WorkspaceEdit>),
     StatementRange(Option<StatementRangeResponse>),
     HelpTopic(Option<HelpTopicResponse>),
     OnTypeFormatting(Option<Vec<TextEdit>>),
@@ -429,6 +433,25 @@ impl LanguageServer for Backend {
             self,
             self.request(LspRequest::References(params)).await,
             LspResponse::References
+        )
+    }
+
+    async fn prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        cast_response!(
+            self,
+            self.request(LspRequest::PrepareRename(params)).await,
+            LspResponse::PrepareRename
+        )
+    }
+
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        cast_response!(
+            self,
+            self.request(LspRequest::Rename(params)).await,
+            LspResponse::Rename
         )
     }
 

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -26,13 +26,16 @@ use tower_lsp::lsp_types::HoverContents;
 use tower_lsp::lsp_types::HoverParams;
 use tower_lsp::lsp_types::Location;
 use tower_lsp::lsp_types::MessageType;
+use tower_lsp::lsp_types::PrepareRenameResponse;
 use tower_lsp::lsp_types::ReferenceParams;
 use tower_lsp::lsp_types::Registration;
+use tower_lsp::lsp_types::RenameParams;
 use tower_lsp::lsp_types::SelectionRange;
 use tower_lsp::lsp_types::SelectionRangeParams;
 use tower_lsp::lsp_types::SignatureHelp;
 use tower_lsp::lsp_types::SignatureHelpParams;
 use tower_lsp::lsp_types::SymbolInformation;
+use tower_lsp::lsp_types::TextDocumentPositionParams;
 use tower_lsp::lsp_types::TextEdit;
 use tower_lsp::lsp_types::WorkspaceEdit;
 use tower_lsp::lsp_types::WorkspaceSymbolParams;
@@ -58,6 +61,7 @@ use crate::lsp::indent::indent_edit;
 use crate::lsp::input_boundaries::InputBoundariesParams;
 use crate::lsp::input_boundaries::InputBoundariesResponse;
 use crate::lsp::main_loop::LspState;
+use crate::lsp::rename;
 use crate::lsp::selection_range::convert_selection_range_from_tree_sitter_to_lsp;
 use crate::lsp::selection_range::selection_range;
 use crate::lsp::signature_help::r_signature_help;
@@ -325,6 +329,22 @@ pub(crate) fn handle_references(
     } else {
         Ok(Some(locations))
     }
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn handle_prepare_rename(
+    params: TextDocumentPositionParams,
+    state: &WorldState,
+) -> LspResult<Option<PrepareRenameResponse>> {
+    Ok(rename::prepare_rename(params, state).log_err().flatten())
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn handle_rename(
+    params: RenameParams,
+    state: &WorldState,
+) -> LspResult<Option<WorkspaceEdit>> {
+    Ok(rename::rename(params, state).log_err().flatten())
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -345,8 +345,8 @@ pub(crate) fn handle_rename(
     params: RenameParams,
     state: &WorldState,
 ) -> LspResult<Option<WorkspaceEdit>> {
-    // Propagate error to the frontend (unlike `prepare_rename()`) to give
-    // actionable feedback to the user
+    // Propagate error to the frontend to give actionable feedback to the user.
+    // All errors thrown by `rename()` must be informative for users.
     Ok(rename::rename(params, state)?)
 }
 

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -336,8 +336,7 @@ pub(crate) fn handle_prepare_rename(
     params: TextDocumentPositionParams,
     state: &WorldState,
 ) -> LspResult<Option<PrepareRenameResponse>> {
-    // Don't propagate errors to the frontend
-    Ok(rename::prepare_rename(params, state).log_err().flatten())
+    Ok(rename::prepare_rename(params, state)?)
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -336,6 +336,7 @@ pub(crate) fn handle_prepare_rename(
     params: TextDocumentPositionParams,
     state: &WorldState,
 ) -> LspResult<Option<PrepareRenameResponse>> {
+    // Don't propagate errors to the frontend
     Ok(rename::prepare_rename(params, state).log_err().flatten())
 }
 
@@ -344,7 +345,9 @@ pub(crate) fn handle_rename(
     params: RenameParams,
     state: &WorldState,
 ) -> LspResult<Option<WorkspaceEdit>> {
-    Ok(rename::rename(params, state).log_err().flatten())
+    // Propagate error to the frontend (unlike `prepare_rename()`) to give
+    // actionable feedback to the user
+    Ok(rename::rename(params, state)?)
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -371,6 +371,12 @@ impl GlobalState {
                         LspRequest::References(params) => {
                             respond(tx, || handlers::handle_references(params, &self.world), LspResponse::References)?;
                         },
+                        LspRequest::PrepareRename(params) => {
+                            respond(tx, || handlers::handle_prepare_rename(params, &self.world), LspResponse::PrepareRename)?;
+                        },
+                        LspRequest::Rename(params) => {
+                            respond(tx, || handlers::handle_rename(params, &self.world), LspResponse::Rename)?;
+                        },
                         LspRequest::StatementRange(params) => {
                             respond(tx, || handlers::handle_statement_range(params, &self.world), LspResponse::StatementRange)?;
                         },

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -497,7 +497,12 @@ fn respond<T>(
     let out = match response {
         RequestResponse::Result(Ok(_)) => Ok(()),
         RequestResponse::Result(Err(ref error)) => {
-            Err(anyhow!("Error while handling request:\n{error:?}"))
+            // The error has already been sent to the client on `response_tx`
+            // as a jsonrpc error, so the user sees the popup. Log here at
+            // info level (with `{:?}` for the full debug format including a
+            // backtrace) so server logs keep diagnostic context.
+            lsp::log_info!("Error while handling request:\n{error:?}");
+            Ok(())
         },
         RequestResponse::Crashed(ref error) => {
             Err(anyhow!("Crashed while handling request:\n{error:?}"))

--- a/crates/ark/src/lsp/rename.rs
+++ b/crates/ark/src/lsp/rename.rs
@@ -26,7 +26,7 @@ pub(crate) fn prepare_rename(
     )?;
     let index = document.semantic_index();
     let tree = document.syntax()?;
-    let pos = oak_ide::FileOffset { file: uri, offset };
+    let pos = oak_ide::FilePosition { file: uri, offset };
 
     let Some((range, placeholder)) = oak_ide::prepare_rename(&index, &tree, &pos) else {
         return Ok(None);
@@ -55,7 +55,7 @@ pub(crate) fn rename(
     )?;
     let index = document.semantic_index();
     let root = document.syntax()?;
-    let pos = oak_ide::FileOffset {
+    let pos = oak_ide::FilePosition {
         file: uri.clone(),
         offset,
     };

--- a/crates/ark/src/lsp/rename.rs
+++ b/crates/ark/src/lsp/rename.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+use aether_lsp_utils::proto::from_proto;
+use aether_lsp_utils::proto::to_proto;
+use tower_lsp::lsp_types;
+use tower_lsp::lsp_types::PrepareRenameResponse;
+use tower_lsp::lsp_types::RenameParams;
+use tower_lsp::lsp_types::TextDocumentPositionParams;
+use tower_lsp::lsp_types::TextEdit;
+use tower_lsp::lsp_types::WorkspaceEdit;
+
+use crate::lsp::state::WorldState;
+
+pub(crate) fn prepare_rename(
+    params: TextDocumentPositionParams,
+    state: &WorldState,
+) -> anyhow::Result<Option<PrepareRenameResponse>> {
+    let uri = params.text_document.uri;
+    let position = params.position;
+    let document = state.get_document(&uri)?;
+
+    let offset = from_proto::offset_from_position(
+        position,
+        &document.line_index,
+        document.position_encoding,
+    )?;
+    let index = document.semantic_index();
+    let tree = document.syntax()?;
+    let pos = oak_ide::FileOffset { file: uri, offset };
+
+    let Some((range, placeholder)) = oak_ide::prepare_rename(&index, &tree, &pos) else {
+        return Ok(None);
+    };
+
+    let range = to_proto::range(range, &document.line_index, document.position_encoding)?;
+    Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
+        range,
+        placeholder,
+    }))
+}
+
+pub(crate) fn rename(
+    params: RenameParams,
+    state: &WorldState,
+) -> anyhow::Result<Option<WorkspaceEdit>> {
+    let uri = params.text_document_position.text_document.uri;
+    let position = params.text_document_position.position;
+    let new_name = params.new_name;
+    let document = state.get_document(&uri)?;
+
+    let offset = from_proto::offset_from_position(
+        position,
+        &document.line_index,
+        document.position_encoding,
+    )?;
+    let index = document.semantic_index();
+    let root = document.syntax()?;
+    let pos = oak_ide::FileOffset {
+        file: uri.clone(),
+        offset,
+    };
+
+    let targets = oak_ide::rename(&index, &root, &pos, &new_name)?;
+
+    // All edits target the current file (intra-file rename).
+    let mut edits: Vec<TextEdit> = Vec::with_capacity(targets.ranges.len());
+    for r in targets.ranges {
+        let range = to_proto::range(r.range, &document.line_index, document.position_encoding)?;
+        edits.push(TextEdit {
+            range,
+            new_text: targets.new_text.clone(),
+        });
+    }
+
+    let mut changes: HashMap<lsp_types::Url, Vec<TextEdit>> = HashMap::new();
+    changes.insert(uri, edits);
+
+    Ok(Some(WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    }))
+}

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -32,6 +32,7 @@ use tower_lsp::lsp_types::InitializeParams;
 use tower_lsp::lsp_types::InitializeResult;
 use tower_lsp::lsp_types::OneOf;
 use tower_lsp::lsp_types::RenameFilesParams;
+use tower_lsp::lsp_types::RenameOptions;
 use tower_lsp::lsp_types::SelectionRangeProviderCapability;
 use tower_lsp::lsp_types::ServerCapabilities;
 use tower_lsp::lsp_types::ServerInfo;
@@ -164,6 +165,12 @@ pub(crate) fn initialize(
             type_definition_provider: None,
             implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
             references_provider: Some(OneOf::Left(true)),
+            rename_provider: Some(OneOf::Right(RenameOptions {
+                prepare_provider: Some(true),
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: None,
+                },
+            })),
             document_symbol_provider: Some(OneOf::Left(true)),
             folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
             workspace_symbol_provider: Some(OneOf::Left(true)),

--- a/crates/ark/src/lsp/tests.rs
+++ b/crates/ark/src/lsp/tests.rs
@@ -1,2 +1,4 @@
 mod find_references;
 mod goto_definition;
+mod rename;
+mod utils;

--- a/crates/ark/src/lsp/tests/find_references.rs
+++ b/crates/ark/src/lsp/tests/find_references.rs
@@ -3,9 +3,10 @@ use tower_lsp::lsp_types::Location;
 use tower_lsp::lsp_types::ReferenceContext;
 use tower_lsp::lsp_types::ReferenceParams;
 
+use super::utils::make_state;
+use super::utils::range;
 use crate::lsp::document::Document;
 use crate::lsp::find_references::find_references;
-use crate::lsp::state::WorldState;
 use crate::lsp::util::test_path;
 
 fn make_params(
@@ -24,19 +25,6 @@ fn make_params(
         },
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
-    }
-}
-
-fn make_state(uri: &lsp_types::Url, doc: &Document) -> WorldState {
-    let mut state = WorldState::default();
-    state.documents.insert(uri.clone(), doc.clone());
-    state
-}
-
-fn range(start: (u32, u32), end: (u32, u32)) -> lsp_types::Range {
-    lsp_types::Range {
-        start: lsp_types::Position::new(start.0, start.1),
-        end: lsp_types::Position::new(end.0, end.1),
     }
 }
 

--- a/crates/ark/src/lsp/tests/rename.rs
+++ b/crates/ark/src/lsp/tests/rename.rs
@@ -1,0 +1,129 @@
+use tower_lsp::lsp_types;
+use tower_lsp::lsp_types::PrepareRenameResponse;
+use tower_lsp::lsp_types::RenameParams;
+use tower_lsp::lsp_types::TextDocumentPositionParams;
+use tower_lsp::lsp_types::TextEdit;
+
+use super::utils::make_state;
+use super::utils::range;
+use crate::lsp::document::Document;
+use crate::lsp::rename::prepare_rename;
+use crate::lsp::rename::rename;
+use crate::lsp::util::test_path;
+
+fn make_prepare_params(
+    uri: lsp_types::Url,
+    line: u32,
+    character: u32,
+) -> TextDocumentPositionParams {
+    TextDocumentPositionParams {
+        text_document: lsp_types::TextDocumentIdentifier { uri },
+        position: lsp_types::Position::new(line, character),
+    }
+}
+
+fn make_rename_params(
+    uri: lsp_types::Url,
+    line: u32,
+    character: u32,
+    new_name: &str,
+) -> RenameParams {
+    RenameParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: lsp_types::TextDocumentIdentifier { uri },
+            position: lsp_types::Position::new(line, character),
+        },
+        new_name: new_name.to_string(),
+        work_done_progress_params: Default::default(),
+    }
+}
+
+#[test]
+fn test_prepare_rename_returns_range_and_placeholder() {
+    let code = "foo <- 1\nfoo\n";
+    let doc = Document::new(code, None);
+    let uri = test_path("test.R");
+    let state = make_state(&uri, &doc);
+
+    let params = make_prepare_params(uri, 0, 0);
+    let result = prepare_rename(params, &state).unwrap().unwrap();
+
+    let PrepareRenameResponse::RangeWithPlaceholder {
+        range: r,
+        placeholder,
+    } = result
+    else {
+        panic!("expected RangeWithPlaceholder");
+    };
+    assert_eq!(r, range((0, 0), (0, 3)));
+    assert_eq!(placeholder, "foo");
+}
+
+#[test]
+fn test_prepare_rename_on_namespace_access_returns_none() {
+    let code = "dplyr::mutate\n";
+    let doc = Document::new(code, None);
+    let uri = test_path("test.R");
+    let state = make_state(&uri, &doc);
+
+    let params = make_prepare_params(uri, 0, 7);
+    assert!(prepare_rename(params, &state).unwrap().is_none());
+}
+
+#[test]
+fn test_rename_emits_edits_for_def_and_uses() {
+    let code = "foo <- 1\nfoo + foo\n";
+    let doc = Document::new(code, None);
+    let uri = test_path("test.R");
+    let state = make_state(&uri, &doc);
+
+    let params = make_rename_params(uri.clone(), 0, 0, "bar");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let changes = edit.changes.expect("changes map");
+    assert_eq!(changes.len(), 1);
+    let edits = changes.get(&uri).expect("edits for uri");
+    let expected: Vec<TextEdit> = vec![
+        TextEdit {
+            range: range((0, 0), (0, 3)),
+            new_text: "bar".to_string(),
+        },
+        TextEdit {
+            range: range((1, 0), (1, 3)),
+            new_text: "bar".to_string(),
+        },
+        TextEdit {
+            range: range((1, 6), (1, 9)),
+            new_text: "bar".to_string(),
+        },
+    ];
+    assert_eq!(edits, &expected);
+}
+
+#[test]
+fn test_rename_to_reserved_word_errors() {
+    // Reserved word as new name. `rename` returns an `Err`, which
+    // `handle_rename` propagates to the client so the editor can show
+    // the message inline.
+    let code = "foo <- 1\n";
+    let doc = Document::new(code, None);
+    let uri = test_path("test.R");
+    let state = make_state(&uri, &doc);
+
+    let params = make_rename_params(uri, 0, 0, "if");
+    let err = rename(params, &state).unwrap_err();
+    assert!(err.to_string().contains("reserved"));
+}
+
+#[test]
+fn test_rename_to_name_with_space_wraps_in_backticks() {
+    let code = "foo <- 1\nfoo\n";
+    let doc = Document::new(code, None);
+    let uri = test_path("test.R");
+    let state = make_state(&uri, &doc);
+
+    let params = make_rename_params(uri.clone(), 0, 0, "new name");
+    let edit = rename(params, &state).unwrap().unwrap();
+    let edits = edit.changes.unwrap().remove(&uri).unwrap();
+    assert!(edits.iter().all(|e| e.new_text == "`new name`"));
+}

--- a/crates/ark/src/lsp/tests/utils.rs
+++ b/crates/ark/src/lsp/tests/utils.rs
@@ -1,0 +1,17 @@
+use tower_lsp::lsp_types;
+
+use crate::lsp::document::Document;
+use crate::lsp::state::WorldState;
+
+pub(super) fn make_state(uri: &lsp_types::Url, doc: &Document) -> WorldState {
+    let mut state = WorldState::default();
+    state.documents.insert(uri.clone(), doc.clone());
+    state
+}
+
+pub(super) fn range(start: (u32, u32), end: (u32, u32)) -> lsp_types::Range {
+    lsp_types::Range {
+        start: lsp_types::Position::new(start.0, start.1),
+        end: lsp_types::Position::new(end.0, end.1),
+    }
+}

--- a/crates/ark/tests/lsp.rs
+++ b/crates/ark/tests/lsp.rs
@@ -9,6 +9,7 @@
 // kernel, i.e. LSP features that require dynamic access to the R session.
 
 use ark_test::DummyArkFrontend;
+use serde_json::json;
 
 #[test]
 fn test_lsp_init() {
@@ -17,4 +18,47 @@ fn test_lsp_init() {
 
     // Verify the server reports completion support
     assert!(lsp.server_capabilities().completion_provider.is_some());
+}
+
+// The two cases below test errors that don't depend on the rename
+// implementation's resolution capabilities. New-name validation always
+// applies (R language constraints), so these tests stay valid once
+// cross-file rename lands.
+//
+// They also pin the wire format: an exact `assert_eq!` catches both
+// `Anyhow(...)` wrapping and `Stack backtrace:` blocks that anyhow's
+// `{:?}` formatting would smuggle into the editor popup.
+
+#[test]
+fn test_rename_to_reserved_word_returns_clean_error() {
+    let frontend = DummyArkFrontend::lock();
+    let mut lsp = frontend.start_lsp();
+
+    let uri = lsp.open_document("rename_reserved.R", "foo <- 1\n");
+
+    let params = json!({
+        "textDocument": { "uri": uri },
+        "position": { "line": 0, "character": 0 },
+        "newName": "if",
+    });
+    let message = lsp.send_request_expect_error("textDocument/rename", params);
+
+    assert_eq!(message, "`if` is a reserved word in R");
+}
+
+#[test]
+fn test_rename_to_empty_name_returns_clean_error() {
+    let frontend = DummyArkFrontend::lock();
+    let mut lsp = frontend.start_lsp();
+
+    let uri = lsp.open_document("rename_empty.R", "foo <- 1\n");
+
+    let params = json!({
+        "textDocument": { "uri": uri },
+        "position": { "line": 0, "character": 0 },
+        "newName": "",
+    });
+    let message = lsp.send_request_expect_error("textDocument/rename", params);
+
+    assert_eq!(message, "Identifier cannot be empty");
 }

--- a/crates/ark_test/src/lsp_client.rs
+++ b/crates/ark_test/src/lsp_client.rs
@@ -182,19 +182,7 @@ impl LspClient {
     /// Panics if the response contains an error.
     #[track_caller]
     pub fn send_request(&mut self, method: &str, params: Value) -> Value {
-        self.next_id += 1;
-        let id = self.next_id;
-
-        let mut message = json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": method,
-        });
-        if !params.is_null() {
-            message["params"] = params;
-        }
-
-        self.send_raw(&message);
+        let id = self.send_request_raw(method, params);
         self.recv_response(method, id)
     }
 
@@ -203,6 +191,13 @@ impl LspClient {
     /// `message` field.
     #[track_caller]
     pub fn send_request_expect_error(&mut self, method: &str, params: Value) -> String {
+        let id = self.send_request_raw(method, params);
+        self.recv_error_response(method, id)
+    }
+
+    /// Wire-level request send. Allocates an id, frames the message, ships
+    /// it, and returns the id so the caller can await a matching response.
+    fn send_request_raw(&mut self, method: &str, params: Value) -> i64 {
         self.next_id += 1;
         let id = self.next_id;
 
@@ -216,7 +211,7 @@ impl LspClient {
         }
 
         self.send_raw(&message);
-        self.recv_error_response(method, id)
+        id
     }
 
     /// Send a JSON-RPC notification (no response expected).
@@ -267,6 +262,33 @@ impl LspClient {
     /// `diagnostics()`. Panics on unexpected messages.
     #[track_caller]
     fn recv_response(&mut self, method: &str, id: i64) -> Value {
+        match self.recv_any_response(method, id) {
+            Ok(result) => result,
+            Err(error) => panic!("LSP error response for `{method}`: {error}"),
+        }
+    }
+
+    /// Receive an expected error response for `id`. Returns the error
+    /// `message` field. Panics on success responses or malformed errors.
+    #[track_caller]
+    fn recv_error_response(&mut self, method: &str, id: i64) -> String {
+        match self.recv_any_response(method, id) {
+            Ok(_) => panic!("Expected error response for `{method}`"),
+            Err(error) => error["message"]
+                .as_str()
+                .unwrap_or_else(|| panic!("Error response for `{method}` has no message: {error}"))
+                .to_string(),
+        }
+    }
+
+    /// Receive JSON-RPC messages until we get the response matching `id`,
+    /// then return `Ok(result)` for a success response or `Err(error)` for
+    /// an error response. Caller decides how to handle each case.
+    ///
+    /// Buffers `publishDiagnostics` notifications for later assertion via
+    /// `diagnostics()`. Panics on unexpected messages.
+    #[track_caller]
+    fn recv_any_response(&mut self, method: &str, id: i64) -> Result<Value, Value> {
         loop {
             match self.recv_any() {
                 LspMessage::Response {
@@ -278,50 +300,10 @@ impl LspClient {
                         msg_id, id,
                         "Response id mismatch: expected {id}, got {msg_id}"
                     );
-                    if let Some(error) = error {
-                        panic!("LSP error response for `{method}`: {error}");
-                    }
-                    return result.unwrap_or(Value::Null);
-                },
-                LspMessage::ServerRequest {
-                    method: req_method, ..
-                } => {
-                    panic!(
-                        "Unexpected LSP server request `{req_method}` while waiting for response to `{method}`"
-                    );
-                },
-                LspMessage::Notification { diagnostics } => {
-                    if let Some(params) = diagnostics {
-                        self.diagnostics.insert(params.uri, params.diagnostics);
-                    }
-                },
-            }
-        }
-    }
-
-    /// Receive an expected error response for `id`. Returns the error
-    /// `message` field. Panics on success responses or malformed errors.
-    #[track_caller]
-    fn recv_error_response(&mut self, method: &str, id: i64) -> String {
-        loop {
-            match self.recv_any() {
-                LspMessage::Response {
-                    id: msg_id,
-                    result: _,
-                    error,
-                } => {
-                    assert_eq!(
-                        msg_id, id,
-                        "Response id mismatch: expected {id}, got {msg_id}"
-                    );
-                    let error =
-                        error.unwrap_or_else(|| panic!("Expected error response for `{method}`"));
-                    return error["message"]
-                        .as_str()
-                        .unwrap_or_else(|| {
-                            panic!("Error response for `{method}` has no message: {error}")
-                        })
-                        .to_string();
+                    return match error {
+                        Some(err) => Err(err),
+                        None => Ok(result.unwrap_or(Value::Null)),
+                    };
                 },
                 LspMessage::ServerRequest {
                     method: req_method, ..

--- a/crates/ark_test/src/lsp_client.rs
+++ b/crates/ark_test/src/lsp_client.rs
@@ -198,6 +198,27 @@ impl LspClient {
         self.recv_response(method, id)
     }
 
+    /// Send a JSON-RPC request expecting an error response. Returns the
+    /// error message string. Panics if the response is a success or has no
+    /// `message` field.
+    #[track_caller]
+    pub fn send_request_expect_error(&mut self, method: &str, params: Value) -> String {
+        self.next_id += 1;
+        let id = self.next_id;
+
+        let mut message = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+        });
+        if !params.is_null() {
+            message["params"] = params;
+        }
+
+        self.send_raw(&message);
+        self.recv_error_response(method, id)
+    }
+
     /// Send a JSON-RPC notification (no response expected).
     pub fn send_notification(&mut self, method: &str, params: Value) {
         let mut message = json!({
@@ -261,6 +282,46 @@ impl LspClient {
                         panic!("LSP error response for `{method}`: {error}");
                     }
                     return result.unwrap_or(Value::Null);
+                },
+                LspMessage::ServerRequest {
+                    method: req_method, ..
+                } => {
+                    panic!(
+                        "Unexpected LSP server request `{req_method}` while waiting for response to `{method}`"
+                    );
+                },
+                LspMessage::Notification { diagnostics } => {
+                    if let Some(params) = diagnostics {
+                        self.diagnostics.insert(params.uri, params.diagnostics);
+                    }
+                },
+            }
+        }
+    }
+
+    /// Receive an expected error response for `id`. Returns the error
+    /// `message` field. Panics on success responses or malformed errors.
+    #[track_caller]
+    fn recv_error_response(&mut self, method: &str, id: i64) -> String {
+        loop {
+            match self.recv_any() {
+                LspMessage::Response {
+                    id: msg_id,
+                    result: _,
+                    error,
+                } => {
+                    assert_eq!(
+                        msg_id, id,
+                        "Response id mismatch: expected {id}, got {msg_id}"
+                    );
+                    let error =
+                        error.unwrap_or_else(|| panic!("Expected error response for `{method}`"));
+                    return error["message"]
+                        .as_str()
+                        .unwrap_or_else(|| {
+                            panic!("Error response for `{method}` has no message: {error}")
+                        })
+                        .to_string();
                 },
                 LspMessage::ServerRequest {
                     method: req_method, ..

--- a/crates/oak_core/Cargo.toml
+++ b/crates/oak_core/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 aether_syntax.workspace = true
+anyhow.workspace = true
 biome_rowan.workspace = true
 
 [dev-dependencies]

--- a/crates/oak_core/src/identifier.rs
+++ b/crates/oak_core/src/identifier.rs
@@ -49,14 +49,17 @@ pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
 /// Whether `name` is a valid bare R identifier (no backticks needed).
 ///
 /// R's rule: starts with a letter or `.`, then letters, digits, `.`, or
-/// `_`. A leading `.` followed by a digit is a number literal, not an
-/// identifier (e.g. `.5`).
+/// `_`. "Letter" is Unicode-aware (matching `iswalpha` in R's UTF-8
+/// locale), so non-ASCII identifiers like `μ`, `αβ`, and `文字` are valid.
+/// Digits are ASCII-only (per `?make.names`: "only ASCII digits are
+/// considered to be digits"). A leading `.` followed by an ASCII digit
+/// is a number literal, not an identifier (e.g. `.5`).
 pub fn is_valid_identifier(name: &str) -> bool {
     let mut chars = name.chars();
     let Some(first) = chars.next() else {
         return false;
     };
-    if !(first.is_ascii_alphabetic() || first == '.') {
+    if !(first.is_alphabetic() || first == '.') {
         return false;
     }
     if first == '.' {
@@ -66,7 +69,7 @@ pub fn is_valid_identifier(name: &str) -> bool {
             }
         }
     }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_')
+    chars.all(|c| c.is_alphabetic() || c.is_ascii_digit() || c == '.' || c == '_')
 }
 
 /// R reserved words that cannot be used as identifier names. Source:
@@ -129,6 +132,21 @@ mod tests {
         assert!(!is_valid_identifier(".1foo"));
         assert!(!is_valid_identifier("foo bar"));
         assert!(!is_valid_identifier("foo-bar"));
+    }
+
+    #[test]
+    fn test_non_ascii_identifiers() {
+        // Unicode letters are valid (R's `iswalpha` in UTF-8 locale).
+        assert!(is_valid_identifier("μ"));
+        assert!(is_valid_identifier("αβ"));
+        assert!(is_valid_identifier("文字"));
+        // Mixed with ASCII and continuation chars.
+        assert!(is_valid_identifier("foo_μ"));
+        assert!(is_valid_identifier("μ2"));
+        assert!(is_valid_identifier(".μ"));
+        // `to_identifier_text` should keep these as-is, not wrap them.
+        assert_eq!(to_identifier_text("μ").unwrap(), "μ");
+        assert_eq!(to_identifier_text("αβ").unwrap(), "αβ");
     }
 
     #[test]

--- a/crates/oak_core/src/identifier.rs
+++ b/crates/oak_core/src/identifier.rs
@@ -9,9 +9,11 @@ use anyhow::anyhow;
 /// Convert a semantic name into its canonical R source form.
 ///
 /// A name that parses as a plain R identifier (and isn't a reserved
-/// word) returns as-is. Anything else gets wrapped in backticks. Empty
-/// names, reserved words, and names containing a literal backtick return
-/// `Err` (a backtick can't appear inside a backtick-quoted identifier).
+/// word) returns as-is. A name already wrapped in backticks (e.g.
+/// `` `foo bar` ``) is accepted as-is too. Anything else gets wrapped
+/// in backticks. Empty names, reserved words, and names with stray
+/// backticks return `Err` (a backtick can't appear inside a
+/// backtick-quoted identifier).
 pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
     if name.is_empty() {
         return Err(anyhow!("Identifier cannot be empty"));
@@ -22,9 +24,25 @@ pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
     if is_valid_identifier(name) {
         return Ok(name.to_string());
     }
+
+    // User pre-wrapped the name in backticks (e.g. `foo bar`)? Normalize:
+    // strip unnecessary backticks when the inside is already a valid bare
+    // identifier; otherwise keep the backticks (they're load-bearing for
+    // names with spaces, leading digits, reserved words, etc.).
+    if let Some(inner) = name.strip_prefix('`').and_then(|s| s.strip_suffix('`')) {
+        if !inner.is_empty() && !inner.contains('`') {
+            if is_valid_identifier(inner) && !is_reserved(inner) {
+                return Ok(inner.to_string());
+            } else {
+                return Ok(name.to_string());
+            }
+        }
+    }
+
     if name.contains('`') {
         return Err(anyhow!("Identifier cannot contain a backtick"));
     }
+
     Ok(format!("`{name}`"))
 }
 
@@ -165,5 +183,32 @@ mod tests {
     #[test]
     fn test_to_identifier_text_rejects_backtick() {
         assert!(to_identifier_text("foo`bar").is_err());
+    }
+
+    #[test]
+    fn test_to_identifier_text_keeps_necessary_backticks() {
+        // Names that need backticks stay wrapped as-is.
+        assert_eq!(to_identifier_text("`foo bar`").unwrap(), "`foo bar`");
+        // Reserved-looking word in backticks is fine; the backticks make
+        // it a valid identifier in R.
+        assert_eq!(to_identifier_text("`if`").unwrap(), "`if`");
+    }
+
+    #[test]
+    fn test_to_identifier_text_strips_unnecessary_backticks() {
+        // Pre-wrapped name whose inside is already a valid bare identifier:
+        // canonicalize by dropping the backticks.
+        assert_eq!(to_identifier_text("`bar`").unwrap(), "bar");
+        assert_eq!(to_identifier_text("`foo.bar`").unwrap(), "foo.bar");
+    }
+
+    #[test]
+    fn test_to_identifier_text_rejects_pre_wrapped_edge_cases() {
+        // Single backtick.
+        assert!(to_identifier_text("`").is_err());
+        // Empty-inside ``.
+        assert!(to_identifier_text("``").is_err());
+        // Stray backtick inside the pre-wrapped name.
+        assert!(to_identifier_text("`foo`bar`").is_err());
     }
 }

--- a/crates/oak_core/src/identifier.rs
+++ b/crates/oak_core/src/identifier.rs
@@ -14,7 +14,7 @@ use anyhow::anyhow;
 /// `Err` (a backtick can't appear inside a backtick-quoted identifier).
 pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
     if name.is_empty() {
-        return Err(anyhow!("identifier must not be empty"));
+        return Err(anyhow!("Identifier cannot be empty"));
     }
     if is_reserved(name) {
         return Err(anyhow!("`{name}` is a reserved word in R"));
@@ -23,9 +23,7 @@ pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
         return Ok(name.to_string());
     }
     if name.contains('`') {
-        return Err(anyhow!(
-            "identifier contains a backtick, which can't appear in an R identifier"
-        ));
+        return Err(anyhow!("Identifier cannot contain a backtick"));
     }
     Ok(format!("`{name}`"))
 }

--- a/crates/oak_core/src/identifier.rs
+++ b/crates/oak_core/src/identifier.rs
@@ -1,0 +1,171 @@
+//! R identifier syntax and reserved words.
+//!
+//! Language-level facts about what counts as a valid R identifier. Used
+//! by rename, diagnostics, completions, and anything else that needs to
+//! emit or recognise identifier text.
+
+use anyhow::anyhow;
+
+/// Convert a semantic name into its canonical R source form.
+///
+/// A name that parses as a plain R identifier (and isn't a reserved
+/// word) returns as-is. Anything else gets wrapped in backticks. Empty
+/// names, reserved words, and names containing a literal backtick return
+/// `Err` (a backtick can't appear inside a backtick-quoted identifier).
+pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
+    if name.is_empty() {
+        return Err(anyhow!("identifier must not be empty"));
+    }
+    if is_reserved(name) {
+        return Err(anyhow!("`{name}` is a reserved word in R"));
+    }
+    if is_valid_identifier(name) {
+        return Ok(name.to_string());
+    }
+    if name.contains('`') {
+        return Err(anyhow!(
+            "identifier contains a backtick, which can't appear in an R identifier"
+        ));
+    }
+    Ok(format!("`{name}`"))
+}
+
+/// Whether `name` is a valid bare R identifier (no backticks needed).
+///
+/// R's rule: starts with a letter or `.`, then letters, digits, `.`, or
+/// `_`. A leading `.` followed by a digit is a number literal, not an
+/// identifier (e.g. `.5`).
+pub fn is_valid_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '.') {
+        return false;
+    }
+    if first == '.' {
+        if let Some(second) = name.chars().nth(1) {
+            if second.is_ascii_digit() {
+                return false;
+            }
+        }
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_')
+}
+
+/// R reserved words that cannot be used as identifier names. Source:
+/// `?Reserved` in R. Note that `return` is a function, not a reserved
+/// word, so it's missing from this list (`return <- 1` is valid R).
+/// `_` became reserved in R 4.2 for use as the `|>` pipe placeholder.
+pub fn is_reserved(name: &str) -> bool {
+    matches!(
+        name,
+        "if" | "else" |
+            "for" |
+            "while" |
+            "repeat" |
+            "break" |
+            "next" |
+            "function" |
+            "in" |
+            "TRUE" |
+            "FALSE" |
+            "NULL" |
+            "NA" |
+            "NA_integer_" |
+            "NA_real_" |
+            "NA_complex_" |
+            "NA_character_" |
+            "NaN" |
+            "Inf" |
+            "..." |
+            "_"
+    ) || is_dot_dot_n(name)
+}
+
+/// `..1`, `..2`, ..., the variadic positional accessors. Listed in
+/// `?Reserved` as "..1, ..2 etc.".
+fn is_dot_dot_n(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("..") else {
+        return false;
+    };
+    !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_identifiers() {
+        assert!(is_valid_identifier("foo"));
+        assert!(is_valid_identifier(".foo"));
+        assert!(is_valid_identifier("foo.bar"));
+        assert!(is_valid_identifier("foo_bar"));
+        assert!(is_valid_identifier("foo123"));
+    }
+
+    #[test]
+    fn test_invalid_identifiers() {
+        assert!(!is_valid_identifier(""));
+        assert!(!is_valid_identifier("1foo"));
+        assert!(!is_valid_identifier("_foo"));
+        assert!(!is_valid_identifier(".1foo"));
+        assert!(!is_valid_identifier("foo bar"));
+        assert!(!is_valid_identifier("foo-bar"));
+    }
+
+    #[test]
+    fn test_reserved_words() {
+        for word in [
+            "if", "for", "function", "TRUE", "FALSE", "NULL", "NA", "...", "_",
+        ] {
+            assert!(is_reserved(word));
+        }
+        // `return` is a function, not reserved (`return <- 1` is valid R).
+        assert!(!is_reserved("return"));
+        // `T` / `F` are reassignable aliases for TRUE/FALSE.
+        assert!(!is_reserved("T"));
+        assert!(!is_reserved("F"));
+        assert!(!is_reserved("foo"));
+    }
+
+    #[test]
+    fn test_dot_dot_n_is_reserved() {
+        assert!(is_reserved("..1"));
+        assert!(is_reserved("..2"));
+        assert!(is_reserved("..42"));
+        // `..` alone is just an identifier.
+        assert!(!is_reserved(".."));
+        // `..foo` is not reserved (variadic accessors require digits).
+        assert!(!is_reserved("..foo"));
+        // `.1` is a number literal, not even an identifier.
+        assert!(!is_reserved(".1"));
+    }
+
+    #[test]
+    fn test_to_identifier_text_plain() {
+        assert_eq!(to_identifier_text("foo").unwrap(), "foo");
+    }
+
+    #[test]
+    fn test_to_identifier_text_wraps_non_identifier() {
+        assert_eq!(to_identifier_text("foo bar").unwrap(), "`foo bar`");
+        assert_eq!(to_identifier_text("1foo").unwrap(), "`1foo`");
+    }
+
+    #[test]
+    fn test_to_identifier_text_rejects_empty() {
+        assert!(to_identifier_text("").is_err());
+    }
+
+    #[test]
+    fn test_to_identifier_text_rejects_reserved() {
+        assert!(to_identifier_text("if").is_err());
+    }
+
+    #[test]
+    fn test_to_identifier_text_rejects_backtick() {
+        assert!(to_identifier_text("foo`bar").is_err());
+    }
+}

--- a/crates/oak_core/src/lib.rs
+++ b/crates/oak_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod declaration;
 pub mod file;
+pub mod identifier;
 pub mod range;
 pub mod syntax_ext;

--- a/crates/oak_ide/Cargo.toml
+++ b/crates/oak_ide/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 aether_syntax.workspace = true
+anyhow.workspace = true
 biome_rowan.workspace = true
 oak_core.workspace = true
 oak_semantic.workspace = true

--- a/crates/oak_ide/src/lib.rs
+++ b/crates/oak_ide/src/lib.rs
@@ -1,12 +1,16 @@
 mod find_references;
 mod goto_definition;
 mod identifier;
+mod rename;
 
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 pub use find_references::find_references;
 pub use goto_definition::goto_definition;
 pub use identifier::Identifier;
+pub use rename::prepare_rename;
+pub use rename::rename;
+pub use rename::RenameTargets;
 use url::Url;
 
 /// A cursor location in the workspace: a file and a byte offset into it.

--- a/crates/oak_ide/src/rename.rs
+++ b/crates/oak_ide/src/rename.rs
@@ -5,7 +5,7 @@ use oak_core::identifier::to_identifier_text;
 use oak_semantic::semantic_index::SemanticIndex;
 
 use crate::find_references;
-use crate::FileOffset;
+use crate::FilePosition;
 use crate::FileRange;
 use crate::Identifier;
 
@@ -19,8 +19,8 @@ pub struct RenameTargets {
     pub new_text: String,
 }
 
-/// Identify the renamable identifier at `pos`, returning its range and
-/// current (unquoted) name. Returns `None` when the cursor is on a
+/// Identify the renamable identifier at `position`, returning its range
+/// and current (unquoted) name. Returns `None` when the cursor is on a
 /// non-identifier, a `pkg::sym` namespace access, or a `$`/`@` member
 /// name (TODO(places)).
 ///
@@ -29,9 +29,9 @@ pub struct RenameTargets {
 pub fn prepare_rename(
     index: &SemanticIndex,
     root: &RSyntaxNode,
-    pos: &FileOffset,
+    position: &FilePosition,
 ) -> Option<(TextRange, String)> {
-    let ident = Identifier::classify(index, root, pos.offset)?;
+    let ident = Identifier::classify(index, root, position.offset)?;
     match ident {
         Identifier::Definition { def, name, .. } => Some((def.range(), name.to_string())),
         Identifier::Use { use_site, name, .. } => Some((use_site.range(), name.to_string())),
@@ -59,16 +59,16 @@ pub fn prepare_rename(
 pub fn rename(
     index: &SemanticIndex,
     root: &RSyntaxNode,
-    pos: &FileOffset,
+    position: &FilePosition,
     new_name: &str,
 ) -> anyhow::Result<RenameTargets> {
     let new_text = to_identifier_text(new_name)?;
 
-    if prepare_rename(index, root, pos).is_none() {
+    if prepare_rename(index, root, position).is_none() {
         return Err(anyhow!("No renamable identifier at cursor"));
     }
 
-    let ranges = find_references(index, root, pos, true);
+    let ranges = find_references(index, root, position, true);
     if ranges.is_empty() {
         return Err(anyhow!(
             "Cannot rename: symbol has no local binding in this file"

--- a/crates/oak_ide/src/rename.rs
+++ b/crates/oak_ide/src/rename.rs
@@ -1,0 +1,75 @@
+use aether_syntax::RSyntaxNode;
+use anyhow::anyhow;
+use biome_rowan::TextRange;
+use oak_core::identifier::to_identifier_text;
+use oak_semantic::semantic_index::SemanticIndex;
+
+use crate::find_references;
+use crate::FileOffset;
+use crate::FileRange;
+use crate::Identifier;
+
+/// All edits needed to rename the symbol at the cursor. Each range gets
+/// replaced by `new_text`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameTargets {
+    pub ranges: Vec<FileRange>,
+    /// The canonical syntactic form of the new name (backtick-wrapped if
+    /// needed). Same for every range in `ranges`.
+    pub new_text: String,
+}
+
+/// Identify the renamable identifier at `pos`, returning its range and
+/// current (unquoted) name. Returns `None` when the cursor is on a
+/// non-identifier, a `pkg::sym` namespace access, or a `$`/`@` member
+/// name (TODO(places)).
+///
+/// Equivalent to LSP `textDocument/prepareRename`. Clients use the range
+/// to highlight the editable region and the name as the placeholder.
+pub fn prepare_rename(
+    index: &SemanticIndex,
+    root: &RSyntaxNode,
+    pos: &FileOffset,
+) -> Option<(TextRange, String)> {
+    let ident = Identifier::classify(index, root, pos.offset)?;
+    match ident {
+        Identifier::Definition { def, name, .. } => Some((def.range(), name.to_string())),
+        Identifier::Use { use_site, name, .. } => Some((use_site.range(), name.to_string())),
+        Identifier::NamespaceAccess { .. } => None,
+    }
+}
+
+/// Compute all rename edits within the file.
+///
+/// Returns `Err` when:
+/// - `new_name` is empty, is an R reserved word, or contains a literal
+///   backtick (which can't appear in a backtick-quoted identifier).
+/// - The cursor isn't on a renamable identifier (no `prepare_rename`
+///   target).
+/// - Nothing in the file binds to the cursor's symbol (free variable
+///   from outside the file). Rename would only edit local sites without
+///   touching the external definition, so we refuse rather than produce
+///   a partial result.
+///
+/// TODO(places): renaming a `$`/`@` member name returns `Err` because
+/// the semantic index doesn't track member names.
+///
+/// TODO(salsa): cross-file renames are out of scope until cross-file
+/// resolution lands. For now this is intra-file only.
+pub fn rename(
+    index: &SemanticIndex,
+    root: &RSyntaxNode,
+    pos: &FileOffset,
+    new_name: &str,
+) -> anyhow::Result<RenameTargets> {
+    let new_text = to_identifier_text(new_name)?;
+
+    let ranges = find_references(index, root, pos, true);
+    if ranges.is_empty() {
+        return Err(anyhow!(
+            "no identifier at cursor, or symbol isn't renamable from this file"
+        ));
+    }
+
+    Ok(RenameTargets { ranges, new_text })
+}

--- a/crates/oak_ide/src/rename.rs
+++ b/crates/oak_ide/src/rename.rs
@@ -64,10 +64,14 @@ pub fn rename(
 ) -> anyhow::Result<RenameTargets> {
     let new_text = to_identifier_text(new_name)?;
 
+    if prepare_rename(index, root, pos).is_none() {
+        return Err(anyhow!("No renamable identifier at cursor"));
+    }
+
     let ranges = find_references(index, root, pos, true);
     if ranges.is_empty() {
         return Err(anyhow!(
-            "no identifier at cursor, or symbol isn't renamable from this file"
+            "Cannot rename: symbol has no local binding in this file"
         ));
     }
 

--- a/crates/oak_ide/tests/rename.rs
+++ b/crates/oak_ide/tests/rename.rs
@@ -145,26 +145,27 @@ fn test_rename_reserved_word_errors() {
 
 #[test]
 fn test_rename_non_renamable_errors() {
-    // Cursor on `mutate` in `dplyr::mutate` (NamespaceAccess: returns no
-    // refs, so rename errors). TODO: if package is in the workspace we should
-    // allow renaming.
+    // Cursor on `mutate` in `dplyr::mutate` (NamespaceAccess: not a
+    // renamable identifier). TODO: if package is in the workspace we
+    // should allow renaming.
     let source = "dplyr::mutate\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
 
     let err = rename(&idx, &root, &pos(&file, 7), "x").unwrap_err();
-    assert!(err.to_string().contains("renamable") || err.to_string().contains("identifier"));
+    assert!(err.to_string().contains("renamable identifier"));
 }
 
 #[test]
 fn test_rename_unbound_use_errors() {
-    // Free variable: no local binding to rename.
+    // Free variable: classifies as a Use but has no local binding, so
+    // rename refuses rather than producing a partial edit.
     let source = "foo\n";
     let file = file_url("test.R");
     let (root, idx) = parse_source(source);
 
     let err = rename(&idx, &root, &pos(&file, 0), "bar").unwrap_err();
-    assert!(err.to_string().contains("renamable") || err.to_string().contains("identifier"));
+    assert!(err.to_string().contains("no local binding"));
 }
 
 // --- rename: backtick canonicalization ---

--- a/crates/oak_ide/tests/rename.rs
+++ b/crates/oak_ide/tests/rename.rs
@@ -1,0 +1,224 @@
+use aether_parser::parse;
+use aether_parser::RParserOptions;
+use aether_syntax::RSyntaxNode;
+use biome_rowan::TextRange;
+use biome_rowan::TextSize;
+use oak_ide::prepare_rename;
+use oak_ide::rename;
+use oak_ide::FileOffset;
+use oak_semantic::build_index;
+use oak_semantic::semantic_index::SemanticIndex;
+use oak_semantic::NoopImportsResolver;
+use url::Url;
+
+fn parse_source(source: &str) -> (RSyntaxNode, SemanticIndex) {
+    let parsed = parse(source, RParserOptions::default());
+    let root = parsed.syntax();
+    let index = build_index(&parsed.tree(), NoopImportsResolver);
+    (root, index)
+}
+
+fn text_range(start: u32, end: u32) -> TextRange {
+    TextRange::new(TextSize::from(start), TextSize::from(end))
+}
+
+fn file_url(name: &str) -> Url {
+    Url::parse(&format!("file:///project/R/{name}")).unwrap()
+}
+
+fn pos(file: &Url, n: u32) -> FileOffset {
+    FileOffset {
+        file: file.clone(),
+        offset: TextSize::from(n),
+    }
+}
+
+fn edited_ranges(targets: oak_ide::RenameTargets) -> Vec<TextRange> {
+    targets.ranges.into_iter().map(|r| r.range).collect()
+}
+
+// --- prepare_rename ---
+
+#[test]
+fn test_prepare_rename_on_def() {
+    let source = "foo <- 1\nfoo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    // Cursor on the def `foo` at offset 0
+    let result = prepare_rename(&idx, &root, &pos(&file, 0)).unwrap();
+    assert_eq!(result, (text_range(0, 3), "foo".to_string()));
+}
+
+#[test]
+fn test_prepare_rename_on_use() {
+    let source = "foo <- 1\nfoo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    // Cursor on the use at offset 9
+    let result = prepare_rename(&idx, &root, &pos(&file, 9)).unwrap();
+    assert_eq!(result, (text_range(9, 12), "foo".to_string()));
+}
+
+#[test]
+fn test_prepare_rename_namespace_access_returns_none() {
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    assert!(prepare_rename(&idx, &root, &pos(&file, 7)).is_none());
+}
+
+#[test]
+fn test_prepare_rename_non_identifier_returns_none() {
+    let source = "x <- 1\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    // Cursor on `<-` operator
+    assert!(prepare_rename(&idx, &root, &pos(&file, 3)).is_none());
+}
+
+// --- rename: basic ---
+
+#[test]
+fn test_rename_def_and_use() {
+    let source = "foo <- 1\nfoo + foo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let targets = rename(&idx, &root, &pos(&file, 0), "bar").unwrap();
+    assert_eq!(targets.new_text, "bar");
+    assert_eq!(edited_ranges(targets), vec![
+        text_range(0, 3),
+        text_range(9, 12),
+        text_range(15, 18),
+    ]);
+}
+
+#[test]
+fn test_rename_excludes_shadowed_outer() {
+    // Inner `x` is a different binding from outer `x`. Renaming inner
+    // should not touch outer.
+    let source = "x <- 1\nf <- function() {\n  x <- 2\n  x\n}\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let inner_def = source.find("x <- 2").unwrap() as u32;
+    let targets = rename(&idx, &root, &pos(&file, inner_def), "y").unwrap();
+    assert_eq!(edited_ranges(targets), vec![
+        text_range(inner_def, inner_def + 1),
+        text_range(
+            source.rfind('x').unwrap() as u32,
+            source.rfind('x').unwrap() as u32 + 1
+        ),
+    ]);
+}
+
+// --- rename: validation ---
+
+#[test]
+fn test_rename_empty_name_errors() {
+    let source = "foo <- 1\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let err = rename(&idx, &root, &pos(&file, 0), "").unwrap_err();
+    assert!(err.to_string().contains("empty"));
+}
+
+#[test]
+fn test_rename_reserved_word_errors() {
+    let source = "foo <- 1\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    for word in ["if", "for", "function", "TRUE", "NULL", "NA"] {
+        let err = rename(&idx, &root, &pos(&file, 0), word).unwrap_err();
+        assert!(
+            err.to_string().contains("reserved"),
+            "expected {word} to be rejected"
+        );
+    }
+}
+
+#[test]
+fn test_rename_non_renamable_errors() {
+    // Cursor on `mutate` in `dplyr::mutate` (NamespaceAccess: returns no
+    // refs, so rename errors). TODO: if package is in the workspace we should
+    // allow renaming.
+    let source = "dplyr::mutate\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let err = rename(&idx, &root, &pos(&file, 7), "x").unwrap_err();
+    assert!(err.to_string().contains("renamable") || err.to_string().contains("identifier"));
+}
+
+#[test]
+fn test_rename_unbound_use_errors() {
+    // Free variable: no local binding to rename.
+    let source = "foo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let err = rename(&idx, &root, &pos(&file, 0), "bar").unwrap_err();
+    assert!(err.to_string().contains("renamable") || err.to_string().contains("identifier"));
+}
+
+// --- rename: backtick canonicalization ---
+
+#[test]
+fn test_rename_to_name_with_space_gets_backticked() {
+    let source = "foo <- 1\nfoo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let targets = rename(&idx, &root, &pos(&file, 0), "foo bar").unwrap();
+    assert_eq!(targets.new_text, "`foo bar`");
+}
+
+#[test]
+fn test_rename_to_name_with_starting_digit_gets_backticked() {
+    let source = "foo <- 1\nfoo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let targets = rename(&idx, &root, &pos(&file, 0), "1foo").unwrap();
+    assert_eq!(targets.new_text, "`1foo`");
+}
+
+#[test]
+fn test_rename_to_name_with_backtick_errors() {
+    let source = "foo <- 1\nfoo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let err = rename(&idx, &root, &pos(&file, 0), "foo`bar").unwrap_err();
+    assert!(err.to_string().contains("backtick"));
+}
+
+// --- rename: string definitions ---
+
+#[test]
+fn test_rename_string_def_normalizes_to_identifier_form() {
+    // `"foo" <- 1` defines `foo` using R's rarely-seen string-literal
+    // assignment form. The semantic index records the def's range as
+    // covering the whole `"foo"` token (5 chars), so rename emits an
+    // edit that replaces `"foo"` with the new name in bare identifier
+    // form. The user's quoting style is intentionally not preserved:
+    // `bar <- 1` is valid R, more idiomatic than `"bar" <- 1`, and
+    // preserving it would require per-site `new_text` plus escaping
+    // rules for new names that contain quotes or backslashes.
+    let source = "\"foo\" <- 1\nfoo\n";
+    let file = file_url("test.R");
+    let (root, idx) = parse_source(source);
+
+    let targets = rename(&idx, &root, &pos(&file, 11), "bar").unwrap();
+    assert_eq!(targets.new_text, "bar");
+    assert_eq!(edited_ranges(targets), vec![
+        text_range(0, 5),   // covers `"foo"` (replaced as a whole)
+        text_range(11, 14), // covers `foo` (the use site)
+    ]);
+}

--- a/crates/oak_ide/tests/rename.rs
+++ b/crates/oak_ide/tests/rename.rs
@@ -5,7 +5,7 @@ use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_ide::prepare_rename;
 use oak_ide::rename;
-use oak_ide::FileOffset;
+use oak_ide::FilePosition;
 use oak_semantic::build_index;
 use oak_semantic::semantic_index::SemanticIndex;
 use oak_semantic::NoopImportsResolver;
@@ -26,8 +26,8 @@ fn file_url(name: &str) -> Url {
     Url::parse(&format!("file:///project/R/{name}")).unwrap()
 }
 
-fn pos(file: &Url, n: u32) -> FileOffset {
-    FileOffset {
+fn pos(file: &Url, n: u32) -> FilePosition {
+    FilePosition {
         file: file.clone(),
         offset: TextSize::from(n),
     }


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1231

Addresses https://github.com/posit-dev/positron/issues/13749
Part of https://github.com/posit-dev/ark/issues/1149

Implements rename for local definitions. If a symbol is unbound locally, an error is emitted. Cross-file renaming will come along with the Salsa infrastructure.

See usage in screencast. The most surprising behaviour is with nested lazy contexts where the enclosing snapshot reaches definitions and uses below the context. That's a consequence of the over-approximation we inherit from ty. The alternative would be to perform full call analysis to determine exactly what a nested symbol can reach (intractable in general).

https://github.com/user-attachments/assets/b0f589f3-b28f-47e7-a09f-c3643840c387

See user-facing errors in second screencast, when trying to rename something not renamable, or to an invalid identifier. There should be no backtraces in user visible popups.

https://github.com/user-attachments/assets/82fa38f8-fbfc-4d63-bfe7-4b692479b11b

