### PR TITLE
Return latest version from `.ps.rpc.pkg_outdated`

### DIFF
--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -98,13 +98,21 @@
     as.list(version)
 }
 
-# Return the list of outdated pacakages.
+# Return the list of outdated packages with their latest available versions.
+#
+# `utils::old.packages()` queries the user's configured repositories, so
+# `ReposVer` is the authoritative latest version for this session -- it reflects
+# what an upgrade would actually fetch, which P3M (a generic upstream mirror)
+# cannot guarantee.
 #' @export
 .ps.rpc.pkg_outdated <- function() {
     outdated <- utils::old.packages()
     if (is.null(outdated) || nrow(outdated) == 0) {
         return(list())
     }
-    # Return as list to ensure it serializes as an array
-    as.list(outdated[, "Package"])
+    unname(Map(
+        list,
+        name = outdated[, "Package"],
+        latestVersion = outdated[, "ReposVer"]
+    ))
 }


### PR DESCRIPTION
`utils::old.packages()` already returns `ReposVer` (the latest version
in the user's configured repositories), so surface it alongside the
package name.

The Positron R extension uses this to prefer ark's session-resolved
`latestVersion` over P3M's generic upstream mirror in the packages pane
-- mirroring the pip/uv approach in
[positron#13453](https://github.com/posit-dev/positron/issues/13453).

### Shape change

`pkg_outdated` now returns:

```json
[{"name": "dplyr", "latestVersion": "1.1.5"}, ...]
```

This will break the packages pane in Positron until this PR lands https://github.com/posit-dev/positron/pull/13696 so we should merge this PR, update #13696 to use the new commit hash, and then merge it maybe.