### PR TITLE
Fix regression in find-references handler

### DIFF
--- a/crates/ark/src/lsp/find_references.rs
+++ b/crates/ark/src/lsp/find_references.rs
@@ -53,6 +53,7 @@ pub(crate) fn find_references(
         offset,
     };
     let intra = oak_ide::find_references(&index, &root, &pos, include_declaration);
+    let intra_resolved = !intra.is_empty();
 
     for file_range in intra {
         let Some(range) = to_proto::range(
@@ -66,22 +67,29 @@ pub(crate) fn find_references(
         locations.push(Location::new(file_range.file, range));
     }
 
-    if !locations.is_empty() {
-        // If the intra-file pass resolved cleanly, we have the precise answer.
-        // The textual cross-file walk can only add unrefined external matches
-        // which, for a locally-bound symbol, would just be unrelated noise.
-        return Ok(locations);
-    }
-
-    // Truly free variable: no within-file binding. Fall back to a textual walk
-    // over workspace folders (including the current file: intra-file gave
-    // nothing, so no dedup needed). No semantic refinement yet, so unrelated
-    // same-name symbols in other files leak through.
+    // Always run the textual walk to pick up cross-file references. When
+    // intra-file resolved cleanly, skip the current file (intra-file is
+    // authoritative there). When it didn't, include the current file so
+    // an unbound symbol still surfaces its own occurrences. Cross-file
+    // results are textual candidates only, so until proper imports
+    // resolution lands they may include false positives (other bindings
+    // that happen to share the name).
+    let skip_current = if intra_resolved {
+        uri.to_file_path().ok()
+    } else {
+        None
+    };
     if let Ok(context) = build_context(&uri, position, state) {
         for folder in state.workspace.folders.iter() {
             if let Ok(path) = folder.to_file_path() {
                 lsp::log_info!("searching references in folder {}", path.display());
-                find_references_in_folder(&context, &path, &mut locations, state);
+                find_references_in_folder(
+                    &context,
+                    &path,
+                    skip_current.as_deref(),
+                    &mut locations,
+                    state,
+                );
             }
         }
     }
@@ -215,6 +223,7 @@ fn build_context(uri: &Url, position: Position, state: &WorldState) -> anyhow::R
 fn find_references_in_folder(
     context: &Context,
     path: &Path,
+    skip_path: Option<&Path>,
     locations: &mut Vec<Location>,
     state: &WorldState,
 ) {
@@ -224,6 +233,10 @@ fn find_references_in_folder(
         let path = entry.path();
         let ext = unwrap!(path.extension(), None => { continue; });
         if ext != "r" && ext != "R" {
+            continue;
+        }
+        if skip_path.is_some_and(|p| p == path) {
+            // Caller's intra-file pass already produced refs for this file.
             continue;
         }
 

--- a/crates/ark/src/lsp/find_references.rs
+++ b/crates/ark/src/lsp/find_references.rs
@@ -53,9 +53,10 @@ pub(crate) fn find_references(
         offset,
     };
     let intra = oak_ide::find_references(&index, &root, &pos, include_declaration);
-    let intra_resolved = !intra.is_empty();
+    let intra_resolved = !intra.ranges.is_empty();
+    let target_locally_scoped = intra.locally_scoped;
 
-    for file_range in intra {
+    for file_range in intra.ranges {
         let Some(range) = to_proto::range(
             file_range.range,
             &document.line_index,
@@ -67,13 +68,21 @@ pub(crate) fn find_references(
         locations.push(Location::new(file_range.file, range));
     }
 
-    // Always run the textual walk to pick up cross-file references. When
-    // intra-file resolved cleanly, skip the current file (intra-file is
-    // authoritative there). When it didn't, include the current file so
-    // an unbound symbol still surfaces its own occurrences. Cross-file
-    // results are textual candidates only, so until proper imports
-    // resolution lands they may include false positives (other bindings
-    // that happen to share the name).
+    // Skip the cross-file textual walk when the target is function-scoped.
+    // Local bindings aren't visible to other files, so any same-name match
+    // elsewhere is by definition a different binding. TODO(salsa): the
+    // short-circuit moves inside `oak_ide::find_references` once cross-file
+    // resolution lands; the `locally_scoped` flag goes away.
+    if target_locally_scoped {
+        return Ok(locations);
+    }
+
+    // Run the textual walk to pick up cross-file references. When intra-file
+    // resolved cleanly, skip the current file (intra-file is authoritative
+    // there). When it didn't, include the current file so an unbound symbol
+    // still surfaces its own occurrences. Cross-file results are textual
+    // candidates only, so until proper imports resolution lands they may
+    // include false positives (other bindings that happen to share the name).
     let skip_current = if intra_resolved {
         uri.to_file_path().ok()
     } else {

--- a/crates/ark/src/lsp/tests/find_references.rs
+++ b/crates/ark/src/lsp/tests/find_references.rs
@@ -247,11 +247,13 @@ fn test_fixme_cross_file_walk_on_namespace_access() {
 }
 
 #[test]
-fn test_intra_file_match_skips_cross_file_walk() {
+fn test_intra_file_match_merges_with_cross_file_walk() {
     // file1 defines + uses `foo` locally. file2 has unrelated `foo`s.
-    // Cursor on file1's def -- intra-file resolves cleanly, so the
-    // textual walk is skipped and file2's `foo`s don't pollute the
-    // result.
+    // Cursor on file1's def: intra-file resolves precisely for file1
+    // (def + use), and the cross-file textual walk picks up file2's
+    // same-name occurrences. Until cross-file resolution lands those
+    // file2 hits are unrefined and they may belong to a different
+    // binding. TODO(salsa)
     let dir = tempfile::tempdir().unwrap();
 
     let file1_path = dir.path().join("a.R");
@@ -269,8 +271,16 @@ fn test_intra_file_match_skips_cross_file_walk() {
     let params = make_params(file1_uri.clone(), 0, 0, true);
     let locs = find_references(params, &state).unwrap();
 
-    // Exactly the two file1 refs. None from file2.
-    assert_eq!(locs.len(), 2);
-    assert!(locs.iter().all(|l| l.uri == file1_uri));
-    assert!(locs.iter().all(|l| l.uri != file2_uri));
+    // file1's two precise refs from intra-file, plus file2's two textual
+    // matches. Sort for a deterministic comparison: WalkDir traversal
+    // order isn't guaranteed across platforms.
+    let mut actual = locs;
+    actual.sort_by_key(|l| (l.uri.to_string(), l.range.start));
+    let expected = vec![
+        Location::new(file1_uri.clone(), range((0, 0), (0, 3))),
+        Location::new(file1_uri, range((1, 0), (1, 3))),
+        Location::new(file2_uri.clone(), range((0, 0), (0, 3))),
+        Location::new(file2_uri, range((1, 0), (1, 3))),
+    ];
+    assert_eq!(actual, expected);
 }

--- a/crates/ark/src/lsp/tests/find_references.rs
+++ b/crates/ark/src/lsp/tests/find_references.rs
@@ -284,3 +284,37 @@ fn test_intra_file_match_merges_with_cross_file_walk() {
     ];
     assert_eq!(actual, expected);
 }
+
+#[test]
+fn test_function_scope_target_skips_cross_file_walk() {
+    // file1 defines `x` as a function parameter. `x` is function-scoped --
+    // it cannot be referenced from any other file. file2 has same-name
+    // matches that happen to use `x`, but they bind to a different (file2)
+    // context. The cross-file walk should be skipped entirely so file2's
+    // `x` doesn't appear in the result.
+    let dir = tempfile::tempdir().unwrap();
+
+    let file1_path = dir.path().join("a.R");
+    let file1_code = "f <- function(x) {\n  x + 1\n}\n";
+    std::fs::write(&file1_path, file1_code).unwrap();
+    let file1_uri = lsp_types::Url::from_file_path(&file1_path).unwrap();
+
+    let file2_path = dir.path().join("b.R");
+    std::fs::write(&file2_path, "x <- 99\nx\n").unwrap();
+
+    let doc1 = Document::new(file1_code, None);
+    let mut state = make_state(&file1_uri, &doc1);
+    state.workspace.folders = vec![lsp_types::Url::from_directory_path(dir.path()).unwrap()];
+
+    // Cursor on the parameter `x` at line 0, column 14.
+    let params = make_params(file1_uri.clone(), 0, 14, true);
+    let locs = find_references(params, &state).unwrap();
+
+    // Only file1's two `x` occurrences (the parameter and its use). No
+    // file2 hits.
+    let expected = vec![
+        Location::new(file1_uri.clone(), range((0, 14), (0, 15))),
+        Location::new(file1_uri, range((1, 2), (1, 3))),
+    ];
+    assert_eq!(locs, expected);
+}

--- a/crates/oak_ide/src/find_references.rs
+++ b/crates/oak_ide/src/find_references.rs
@@ -9,13 +9,35 @@ use crate::FilePosition;
 use crate::FileRange;
 use crate::Identifier;
 
+/// Result of [`find_references`].
+///
+/// TODO(salsa): the `locally_scoped` flag is temporary infrastructure. It
+/// exists today because cross-file references are handled outside the semantic
+/// index by a separate textual workspace scan, and the caller needs to know
+/// whether to run that scan. When cross-file resolution lands,
+/// [`find_references`] becomes a single salsa-aware query and the
+/// locally-scoped optimization moves inside it as an internal short-circuit, at
+/// which point this field disappears.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct References {
+    /// In-file occurrences of the target binding, in source order.
+    pub ranges: Vec<FileRange>,
+    /// Whether the target binding is entirely locally scoped. When `true`, no
+    /// cross-file references are possible (function-local bindings aren't
+    /// visible to other files) so callers can skip any workspace-wide candidate
+    /// scan. When `false` the target is at file scope, the symbol is unbound,
+    /// or the cursor doesn't resolve to a binding at all: all cases where
+    /// cross-file matches are possible.
+    pub locally_scoped: bool,
+}
+
 /// Find all in-file references to the symbol at offset.
 ///
 /// The target is usually a single def. It grows when a use is reached by
 /// conditional defs, or when a free variable picks up multiple visible
 /// defs from an enclosing scope.
 ///
-/// Returns an empty vec for:
+/// Returns empty ranges for:
 /// - Non-identifier cursors (no `Identifier::classify` match).
 /// - `pkg::sym` namespace access. TODO(salsa).
 /// - Truly free variables. These are handled by the ark-layer cross-file
@@ -32,9 +54,12 @@ pub fn find_references(
     root: &RSyntaxNode,
     position: &FilePosition,
     include_declaration: bool,
-) -> Vec<FileRange> {
+) -> References {
     let Some(ident) = Identifier::classify(index, root, position.offset) else {
-        return Vec::new();
+        return References {
+            ranges: Vec::new(),
+            locally_scoped: false,
+        };
     };
 
     // Compute the cursor's reaching defs. Same operation we'll run on
@@ -58,12 +83,25 @@ pub fn find_references(
             index.reaching_definitions(scope_id, use_id).collect(),
             name.to_string(),
         ),
-        Identifier::NamespaceAccess { .. } => return Vec::new(),
+        Identifier::NamespaceAccess { .. } => {
+            return References {
+                ranges: Vec::new(),
+                locally_scoped: false,
+            };
+        },
     };
 
     if target_defs.is_empty() {
-        return Vec::new();
+        return References {
+            ranges: Vec::new(),
+            locally_scoped: false,
+        };
     }
+
+    // All target defs in scopes other than the file scope means the
+    // binding can only be referenced from within this file.
+    let file_scope = ScopeId::from(0);
+    let locally_scoped = target_defs.iter().all(|(scope, _)| *scope != file_scope);
 
     let mut results: Vec<FileRange> = Vec::new();
 
@@ -114,5 +152,8 @@ pub fn find_references(
     // preserved within each file.
     results.sort_by_key(|r| r.range.start());
 
-    results
+    References {
+        ranges: results,
+        locally_scoped,
+    }
 }

--- a/crates/oak_ide/src/lib.rs
+++ b/crates/oak_ide/src/lib.rs
@@ -6,6 +6,7 @@ mod rename;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 pub use find_references::find_references;
+pub use find_references::References;
 pub use goto_definition::goto_definition;
 pub use identifier::Identifier;
 pub use rename::prepare_rename;

--- a/crates/oak_ide/src/rename.rs
+++ b/crates/oak_ide/src/rename.rs
@@ -68,7 +68,7 @@ pub fn rename(
         return Err(anyhow!("No renamable identifier at cursor"));
     }
 
-    let ranges = find_references(index, root, position, true);
+    let ranges = find_references(index, root, position, true).ranges;
     if ranges.is_empty() {
         return Err(anyhow!(
             "Cannot rename: symbol has no local binding in this file"

--- a/crates/oak_ide/tests/find_references.rs
+++ b/crates/oak_ide/tests/find_references.rs
@@ -5,7 +5,6 @@ use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use oak_ide::find_references;
 use oak_ide::FilePosition;
-use oak_ide::FileRange;
 use oak_semantic::build_index;
 use oak_semantic::semantic_index::SemanticIndex;
 use oak_semantic::NoopImportsResolver;
@@ -37,8 +36,8 @@ fn pos(file: &Url, n: u32) -> FilePosition {
     }
 }
 
-fn ranges(refs: Vec<FileRange>) -> Vec<TextRange> {
-    refs.into_iter().map(|r| r.range).collect()
+fn ranges(refs: oak_ide::References) -> Vec<TextRange> {
+    refs.ranges.into_iter().map(|r| r.range).collect()
 }
 
 // --- Local resolution ---
@@ -260,7 +259,7 @@ fn test_no_identifier_at_offset() {
 
     // Cursor on `<-` operator
     let refs = find_references(&idx, &root, &pos(&file, 3), true);
-    assert!(refs.is_empty());
+    assert!(refs.ranges.is_empty());
 }
 
 #[test]
@@ -273,7 +272,7 @@ fn test_unbound_use_returns_empty() {
     let (root, idx) = parse_source(source);
 
     let refs = find_references(&idx, &root, &pos(&file, 0), true);
-    assert!(refs.is_empty());
+    assert!(refs.ranges.is_empty());
 }
 
 #[test]
@@ -284,7 +283,7 @@ fn test_fixme_namespace_access_returns_empty() {
 
     // Cursor on `mutate` - NamespaceAccess, returns empty.
     let refs = find_references(&idx, &root, &pos(&file, 7), true);
-    assert!(refs.is_empty());
+    assert!(refs.ranges.is_empty());
 }
 
 // --- Dollar/at member access (places TODO) ---
@@ -312,7 +311,7 @@ fn test_fixme_dollar_rhs_returns_empty() {
     let (root, idx) = parse_source(source);
 
     let refs = find_references(&idx, &root, &pos(&file, 18), true);
-    assert!(refs.is_empty());
+    assert!(refs.ranges.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Fixes:

```
  [***-electron] › test/***/tests/references/references.test.ts:26:6 › References › R - Verify References Pane Lists All Function References Across Files @:references @:web @:win @:ark 
```

The compatibility mechanism for cross-file references wasn't quite right. If there were any intra-file results, cross-file lookup was skipped entirely. Instead cross-file results should be included for both unbound symbols _and_ symbols bound to a top-level definition, since it might be validly sourced by another file. For locally bound symbols though, we should keep excluding cross-file references since those may not be validly referenced from another file.