### PR TITLE
Add workspace scanning to `oak_scan` and wire it to the LSP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,3 +211,5 @@ If changes are needed in these files, that must happen in the separate Positron 
 - Don't let comments drift from the code. If behaviour changes, update nearby comments. If a file is renamed, update its header comment.
 
 - Use the new async closure syntax, e.g. `async move || { ... }` instead of `|| async move { ... }`.
+
+- Name closure and pattern bindings after what they hold, not by a single letter. Still use short names if possible, but disambiguate if needed. E.g. write `|root| root.path(db)` and `|(root_path, _)| path.starts_with(root_path)`, not `|r|` / `|(p, _)|`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2062,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2627,6 +2656,7 @@ name = "oak_scan"
 version = "0.1.0"
 dependencies = [
  "aether_url",
+ "ignore",
  "log",
  "oak_core",
  "oak_db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "oak_db",
  "oak_ide",
  "oak_package_metadata",
+ "oak_scan",
  "oak_semantic",
  "oak_sources",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ harp_macros = { path = "crates/harp_macros" }
 hex = "0.4.3"
 hmac = "0.13.0"
 home = "0.5.12"
+ignore = "0.4.23"
 insta = "1.47.2"
 itertools = "0.14.0"
 libc = "0.2.186"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -52,6 +52,7 @@ oak_core.workspace = true
 oak_db.workspace = true
 oak_ide.workspace = true
 oak_package_metadata.workspace = true
+oak_scan.workspace = true
 oak_semantic.workspace = true
 oak_sources.workspace = true
 once_cell.workspace = true

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1130,7 +1130,6 @@ fn check_symbol_in_scope(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-
     use std::sync::Mutex;
     use std::sync::OnceLock;
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1131,13 +1131,15 @@ fn check_symbol_in_scope(
 mod tests {
     use std::path::PathBuf;
 
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
     use harp::eval::RParseEvalOptions;
     use oak_package_metadata::dcf::Dcf;
     use oak_package_metadata::description::Description;
     use oak_package_metadata::namespace::Namespace;
     use oak_semantic::library::Library;
     use oak_semantic::package::Package;
-    use once_cell::sync::Lazy;
     use stdext::SortedVec;
     use tower_lsp::lsp_types;
     use tower_lsp::lsp_types::Position;
@@ -1147,8 +1149,18 @@ mod tests {
     use crate::lsp::state::WorldState;
     use crate::r_task;
 
-    // Default state that includes installed packages and default scopes.
-    static DEFAULT_STATE: Lazy<WorldState> = Lazy::new(current_state);
+    // `WorldState` contains `OakDatabase`, which is `Send` but not `Sync`
+    // (salsa stores thread-local query state). That rules out `Lazy<WorldState>`
+    // in a static, since `Lazy` requires `Sync`. Wrap in a mutex and hand out
+    // fresh clones so each caller gets its own copy.
+    fn default_state() -> WorldState {
+        static CACHE: OnceLock<Mutex<WorldState>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| Mutex::new(current_state()))
+            .lock()
+            .unwrap()
+            .clone()
+    }
 
     fn generate_diagnostics(doc: Document, state: WorldState) -> Vec<lsp_types::Diagnostic> {
         super::generate_diagnostics(doc, state, false)
@@ -1174,7 +1186,7 @@ foo
 
 1 }";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document, default_state());
             assert_eq!(diagnostics.len(), 2);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1198,7 +1210,7 @@ foo
                 2 # hi there
             )";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document, default_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1208,7 +1220,7 @@ foo
         r_task(|| {
             let text = "base::";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document, default_state());
             assert_eq!(diagnostics.len(), 1);
             let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
@@ -1221,7 +1233,7 @@ foo
             let text = "..1 + ..2 + 3";
             let document = Document::new(text, None);
 
-            let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document, default_state());
 
             assert!(diagnostics.is_empty());
         })
@@ -1264,7 +1276,7 @@ foo
                 y + x + z
             ";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1278,7 +1290,7 @@ foo
                 y + x
             ";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1293,7 +1305,7 @@ foo
             ";
             let document = Document::new(text, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 1);
 
             // Only marks the `x` before the `x <- 1`
@@ -1312,7 +1324,7 @@ foo
                 identity(~foo)
             ";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document, default_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1329,7 +1341,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1349,7 +1361,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1370,7 +1382,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1390,7 +1402,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1408,7 +1420,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 0);
         })
     }
@@ -1423,7 +1435,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), DEFAULT_STATE.clone());
+            let diagnostics = generate_diagnostics(document.clone(), default_state());
             assert_eq!(diagnostics.len(), 0);
         })
     }
@@ -1444,7 +1456,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1454,7 +1466,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
         });
@@ -1468,7 +1480,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1479,7 +1491,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
         });
@@ -1493,7 +1505,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1504,7 +1516,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
         });
@@ -1523,7 +1535,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1535,7 +1547,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1546,7 +1558,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 1
             );
         });
@@ -1563,7 +1575,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1576,7 +1588,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
         });
@@ -1589,7 +1601,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
         });
@@ -1605,7 +1617,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1617,7 +1629,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
 
@@ -1628,7 +1640,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), DEFAULT_STATE.clone()).len(),
+                generate_diagnostics(document.clone(), default_state()).len(),
                 0
             );
         })
@@ -1659,7 +1671,8 @@ foo
             // Simulate a search path with `library` in scope
             let console_scopes = vec![vec!["library".to_string()]];
 
-            // Whereas `DEFAULT_STATE` contains base package attached, this world state
+            // Whereas `default_state()` returns a state with the base package
+            // attached, this world state
             // only contains `mockpkg` as installed package and `library()` on
             // the search path.
             let state = WorldState {
@@ -1861,7 +1874,7 @@ foo
             let library = Library::new(vec![]).insert("penguins", palmerpenguins_pkg);
 
             // Simulate a world state with the penguins package installed and attached
-            let mut state = DEFAULT_STATE.clone();
+            let mut state = default_state();
             state.library = library;
             state.console_scopes = vec![vec!["library".to_string()]];
 

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1130,8 +1130,6 @@ fn check_symbol_in_scope(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::Mutex;
-    use std::sync::OnceLock;
 
     use harp::eval::RParseEvalOptions;
     use oak_package_metadata::dcf::Dcf;
@@ -1147,19 +1145,6 @@ mod tests {
     use crate::lsp::document::Document;
     use crate::lsp::state::WorldState;
     use crate::r_task;
-
-    // `WorldState` contains `OakDatabase`, which is `Send` but not `Sync`
-    // (salsa stores thread-local query state). That rules out `Lazy<WorldState>`
-    // in a static, since `Lazy` requires `Sync`. Wrap in a mutex and hand out
-    // fresh clones so each caller gets its own copy.
-    fn default_state() -> WorldState {
-        static CACHE: OnceLock<Mutex<WorldState>> = OnceLock::new();
-        CACHE
-            .get_or_init(|| Mutex::new(current_state()))
-            .lock()
-            .unwrap()
-            .clone()
-    }
 
     fn generate_diagnostics(doc: Document, state: WorldState) -> Vec<lsp_types::Diagnostic> {
         super::generate_diagnostics(doc, state, false)
@@ -1185,7 +1170,7 @@ foo
 
 1 }";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, default_state());
+            let diagnostics = generate_diagnostics(document, current_state());
             assert_eq!(diagnostics.len(), 2);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1209,7 +1194,7 @@ foo
                 2 # hi there
             )";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, default_state());
+            let diagnostics = generate_diagnostics(document, current_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1219,7 +1204,7 @@ foo
         r_task(|| {
             let text = "base::";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, default_state());
+            let diagnostics = generate_diagnostics(document, current_state());
             assert_eq!(diagnostics.len(), 1);
             let diagnostic = diagnostics.first().unwrap();
             insta::assert_snapshot!(diagnostic.message);
@@ -1232,7 +1217,7 @@ foo
             let text = "..1 + ..2 + 3";
             let document = Document::new(text, None);
 
-            let diagnostics = generate_diagnostics(document, default_state());
+            let diagnostics = generate_diagnostics(document, current_state());
 
             assert!(diagnostics.is_empty());
         })
@@ -1275,7 +1260,7 @@ foo
                 y + x + z
             ";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1289,7 +1274,7 @@ foo
                 y + x
             ";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1304,7 +1289,7 @@ foo
             ";
             let document = Document::new(text, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 1);
 
             // Only marks the `x` before the `x <- 1`
@@ -1323,7 +1308,7 @@ foo
                 identity(~foo)
             ";
             let document = Document::new(text, None);
-            let diagnostics = generate_diagnostics(document, default_state());
+            let diagnostics = generate_diagnostics(document, current_state());
             assert!(diagnostics.is_empty());
         })
     }
@@ -1340,7 +1325,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1360,7 +1345,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1381,7 +1366,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1401,7 +1386,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 1);
 
             let diagnostic = diagnostics.first().unwrap();
@@ -1419,7 +1404,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 0);
         })
     }
@@ -1434,7 +1419,7 @@ foo
 
             let document = Document::new(code, None);
 
-            let diagnostics = generate_diagnostics(document.clone(), default_state());
+            let diagnostics = generate_diagnostics(document.clone(), current_state());
             assert_eq!(diagnostics.len(), 0);
         })
     }
@@ -1455,7 +1440,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1465,7 +1450,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
         });
@@ -1479,7 +1464,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1490,7 +1475,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
         });
@@ -1504,7 +1489,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1515,7 +1500,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
         });
@@ -1534,7 +1519,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1546,7 +1531,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1557,7 +1542,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 1
             );
         });
@@ -1574,7 +1559,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1587,7 +1572,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
         });
@@ -1600,7 +1585,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
         });
@@ -1616,7 +1601,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1628,7 +1613,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
 
@@ -1639,7 +1624,7 @@ foo
             ";
             let document = Document::new(code, None);
             assert_eq!(
-                generate_diagnostics(document.clone(), default_state()).len(),
+                generate_diagnostics(document.clone(), current_state()).len(),
                 0
             );
         })
@@ -1670,7 +1655,7 @@ foo
             // Simulate a search path with `library` in scope
             let console_scopes = vec![vec!["library".to_string()]];
 
-            // Whereas `default_state()` returns a state with the base package
+            // Whereas `current_state()` returns a state with the base package
             // attached, this world state
             // only contains `mockpkg` as installed package and `library()` on
             // the search path.
@@ -1873,7 +1858,7 @@ foo
             let library = Library::new(vec![]).insert("penguins", palmerpenguins_pkg);
 
             // Simulate a world state with the penguins package installed and attached
-            let mut state = default_state();
+            let mut state = current_state();
             state.library = library;
             state.console_scopes = vec![vec!["library".to_string()]];
 

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -14,11 +14,14 @@ use tower_lsp::lsp_types::CodeActionResponse;
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::CompletionParams;
 use tower_lsp::lsp_types::CompletionResponse;
+use tower_lsp::lsp_types::DidChangeWatchedFilesRegistrationOptions;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingParams;
 use tower_lsp::lsp_types::DocumentSymbolParams;
 use tower_lsp::lsp_types::DocumentSymbolResponse;
+use tower_lsp::lsp_types::FileSystemWatcher;
 use tower_lsp::lsp_types::FoldingRange;
 use tower_lsp::lsp_types::FoldingRangeParams;
+use tower_lsp::lsp_types::GlobPattern;
 use tower_lsp::lsp_types::GotoDefinitionParams;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::lsp_types::Hover;
@@ -93,6 +96,27 @@ pub(crate) async fn handle_initialized(
 
     // Register capabilities to the client
     let mut regs: Vec<Registration> = vec![];
+
+    // Watch R files and DESCRIPTION across the workspace. The client
+    // sends `workspace/didChangeWatchedFiles` on disk changes that the
+    // editor itself didn't make (git checkouts, external edits, etc.).
+    let watchers = vec![
+        FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/*.{R,r}".to_string()),
+            kind: None,
+        },
+        FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/DESCRIPTION".to_string()),
+            kind: None,
+        },
+    ];
+    regs.push(Registration {
+        id: uuid::Uuid::new_v4().to_string(),
+        method: String::from("workspace/didChangeWatchedFiles"),
+        register_options: Some(
+            serde_json::to_value(DidChangeWatchedFilesRegistrationOptions { watchers }).unwrap(),
+        ),
+    });
 
     if lsp_state
         .capabilities

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -197,7 +197,11 @@ pub(crate) fn handle_completion(
     let context = DocumentContext::new(document, point, trigger);
     lsp::log_info!("Completion context: {:#?}", context);
 
-    let completions = r_task(|| provide_completions(&context, state))?;
+    // TODO(oak/completions): Clone so the closure captures by value. `r_task()`
+    // sends the closure across threads, and `&WorldState` isn't `Send` because
+    // `OakDatabase`'s salsa storage keeps thread-local query state.
+    let state = state.clone();
+    let completions = r_task(move || provide_completions(&context, &state))?;
 
     if !completions.is_empty() {
         Ok(Some(CompletionResponse::Array(completions)))

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -97,9 +97,9 @@ pub(crate) async fn handle_initialized(
     // Register capabilities to the client
     let mut regs: Vec<Registration> = vec![];
 
-    // Watch R files and DESCRIPTION across the workspace. The client
-    // sends `workspace/didChangeWatchedFiles` on disk changes that the
-    // editor itself didn't make (git checkouts, external edits, etc.).
+    // Watch R files and DESCRIPTION. We get notified on any disk change;
+    // the handler skips editor-owned URLs since those are tracked via
+    // `textDocument/did*` instead.
     let watchers = vec![
         FileSystemWatcher {
             glob_pattern: GlobPattern::String("**/*.{R,r}".to_string()),

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -18,6 +18,8 @@ use std::sync::RwLock;
 use anyhow::anyhow;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use oak_db::OakDatabase;
+use oak_scan::DbExt;
 use oak_semantic::library::Library;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::unbounded_channel as tokio_unbounded_channel;
@@ -216,10 +218,13 @@ impl GlobalState {
 
         let library_paths: Vec<PathBuf> = library_paths.into_iter().map(PathBuf::from).collect();
 
+        let mut oak = OakDatabase::new();
+        oak.scan_library_paths(&library_paths);
+
         let library = Library::new(library_paths);
 
         Self {
-            world: WorldState::new(library),
+            world: WorldState::new(library, oak),
             lsp_state,
             client,
             events_tx,

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -219,7 +219,7 @@ impl GlobalState {
         let library_paths: Vec<PathBuf> = library_paths.into_iter().map(PathBuf::from).collect();
 
         let mut oak = OakDatabase::new();
-        oak.scan_library_paths(&library_paths);
+        oak.set_library_paths(&library_paths);
 
         let library = Library::new(library_paths);
 
@@ -304,8 +304,8 @@ impl GlobalState {
                         LspNotification::DidChangeConfiguration(params) => {
                             state_handlers::did_change_configuration(params, &self.client, &mut self.world).await?;
                         },
-                        LspNotification::DidChangeWatchedFiles(_params) => {
-                            // TODO: Re-index the changed files.
+                        LspNotification::DidChangeWatchedFiles(params) => {
+                            state_handlers::did_change_watched_files(params, &mut self.world)?;
                         },
                         LspNotification::DidOpenTextDocument(params) => {
                             state_handlers::did_open(params, &mut self.lsp_state, &mut self.world)?;

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -647,21 +647,12 @@ fn send_auxiliary(event: AuxiliaryEvent) {
 ///
 /// Production wires the sender during `AuxiliaryState::start`. Tests don't
 /// run that path, so `with_auxiliary_tx` would panic. This sets a sender
-/// into the static and keeps the receiver alive in a process-lifetime
-/// `OnceLock` so sends don't error. Nobody drains the receiver: events
-/// accumulate for the test process, which is fine in practice.
-///
-/// Idempotent and parallel-test-safe: only the first caller initialises;
-/// the rest no-op.
+/// into the static and returns the receiver so tests can assert on events.
 #[cfg(test)]
-pub(crate) fn init_aux_for_test() {
-    use std::sync::OnceLock;
-    static RX_GUARD: OnceLock<TokioUnboundedReceiver<AuxiliaryEvent>> = OnceLock::new();
-    RX_GUARD.get_or_init(|| {
-        let (tx, rx) = tokio_unbounded_channel::<AuxiliaryEvent>();
-        *AUXILIARY_EVENT_TX.write().unwrap() = Some(tx);
-        rx
-    });
+pub(crate) fn init_aux_for_test() -> TokioUnboundedReceiver<AuxiliaryEvent> {
+    let (tx, rx) = tokio_unbounded_channel::<AuxiliaryEvent>();
+    *AUXILIARY_EVENT_TX.write().unwrap() = Some(tx);
+    rx
 }
 
 /// Send a message to the LSP client. This is non-blocking and treated on a

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -19,7 +19,7 @@ use anyhow::anyhow;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use oak_db::OakDatabase;
-use oak_scan::DbExt;
+use oak_scan::DbScan;
 use oak_semantic::library::Library;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::unbounded_channel as tokio_unbounded_channel;

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -298,8 +298,8 @@ impl GlobalState {
                         LspNotification::Initialized(_params) => {
                             handlers::handle_initialized(&self.client, &self.lsp_state).await?;
                         },
-                        LspNotification::DidChangeWorkspaceFolders(_params) => {
-                            // TODO: Restart indexer with new folders.
+                        LspNotification::DidChangeWorkspaceFolders(params) => {
+                            state_handlers::did_change_workspace_folders(params, &mut self.world)?;
                         },
                         LspNotification::DidChangeConfiguration(params) => {
                             state_handlers::did_change_configuration(params, &self.client, &mut self.world).await?;

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -218,13 +218,13 @@ impl GlobalState {
 
         let library_paths: Vec<PathBuf> = library_paths.into_iter().map(PathBuf::from).collect();
 
-        let mut oak = OakDatabase::new();
-        oak.set_library_paths(&library_paths);
+        let mut db = OakDatabase::new();
+        db.set_library_paths(&library_paths);
 
         let library = Library::new(library_paths);
 
         Self {
-            world: WorldState::new(library, oak),
+            world: WorldState::new(db, library),
             lsp_state,
             client,
             events_tx,

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -642,6 +642,28 @@ fn send_auxiliary(event: AuxiliaryEvent) {
     })
 }
 
+/// Initialise the auxiliary channel for unit tests that exercise LSP
+/// handlers calling `publish_diagnostics` / `log` / similar.
+///
+/// Production wires the sender during `AuxiliaryState::start`. Tests don't
+/// run that path, so `with_auxiliary_tx` would panic. This sets a sender
+/// into the static and keeps the receiver alive in a process-lifetime
+/// `OnceLock` so sends don't error. Nobody drains the receiver: events
+/// accumulate for the test process, which is fine in practice.
+///
+/// Idempotent and parallel-test-safe: only the first caller initialises;
+/// the rest no-op.
+#[cfg(test)]
+pub(crate) fn init_aux_for_test() {
+    use std::sync::OnceLock;
+    static RX_GUARD: OnceLock<TokioUnboundedReceiver<AuxiliaryEvent>> = OnceLock::new();
+    RX_GUARD.get_or_init(|| {
+        let (tx, rx) = tokio_unbounded_channel::<AuxiliaryEvent>();
+        *AUXILIARY_EVENT_TX.write().unwrap() = Some(tx);
+        rx
+    });
+}
+
 /// Send a message to the LSP client. This is non-blocking and treated on a
 /// latency-sensitive task.
 pub(crate) fn log(level: lsp_types::MessageType, message: String) {

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::anyhow;
+use oak_db::OakDatabase;
 use oak_semantic::library::Library;
 use url::Url;
 
@@ -57,6 +58,9 @@ pub(crate) struct WorldState {
     /// libraries. Lazily populated.
     pub(crate) library: Library,
 
+    /// Salsa input tree for Oak queries.
+    pub(crate) oak: OakDatabase,
+
     pub(crate) config: LspConfig,
 }
 
@@ -66,9 +70,10 @@ pub(crate) struct Workspace {
 }
 
 impl WorldState {
-    pub(crate) fn new(library: Library) -> Self {
+    pub(crate) fn new(library: Library, oak: OakDatabase) -> Self {
         Self {
             library,
+            oak,
             ..Default::default()
         }
     }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -15,6 +15,9 @@ use crate::lsp::inputs::source_root::SourceRoot;
 /// code. This is a pure value. There is no interior mutability in this data
 /// structure. It can be cloned and safely sent to other threads.
 pub(crate) struct WorldState {
+    /// Salsa input tree for Oak queries.
+    pub(crate) db: OakDatabase,
+
     /// Watched documents
     pub(crate) documents: HashMap<Url, Document>,
 
@@ -58,9 +61,6 @@ pub(crate) struct WorldState {
     /// libraries. Lazily populated.
     pub(crate) library: Library,
 
-    /// Salsa input tree for Oak queries.
-    pub(crate) oak: OakDatabase,
-
     pub(crate) config: LspConfig,
 }
 
@@ -70,10 +70,10 @@ pub(crate) struct Workspace {
 }
 
 impl WorldState {
-    pub(crate) fn new(library: Library, oak: OakDatabase) -> Self {
+    pub(crate) fn new(db: OakDatabase, library: Library) -> Self {
         Self {
+            db,
             library,
-            oak,
             ..Default::default()
         }
     }

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -94,47 +94,46 @@ pub(crate) fn initialize(
     lsp_state: &mut LspState,
     state: &mut WorldState,
 ) -> LspResult<InitializeResult> {
+    let workspace_uris = effective_workspace_uris(&params);
     lsp_state.capabilities = Capabilities::new(params.capabilities);
 
     // Initialize the workspace folders
     let mut folders: Vec<String> = Vec::new();
     let mut workspace_paths: Vec<PathBuf> = Vec::new();
 
-    if let Some(workspace_folders) = params.workspace_folders {
-        for folder in workspace_folders.iter() {
-            state.workspace.folders.push(folder.uri.clone());
-            if let Ok(path) = folder.uri.to_file_path() {
-                workspace_paths.push(path.clone());
-                // Try to load package from this workspace folder and set as
-                // root if found. This means we're dealing with a package
-                // source.
-                if state.root.is_none() {
-                    match Package::load_from_folder(&path) {
-                        Ok(Some(pkg)) => {
-                            log::info!(
-                                "Root: Loaded package `{pkg}` from {path} as project root",
-                                pkg = pkg.description().name,
-                                path = path.display()
-                            );
-                            state.root = Some(SourceRoot::Package(pkg));
-                        },
-                        Ok(None) => {
-                            log::info!(
-                                "Root: No package found at {path}, treating as folder of scripts",
-                                path = path.display()
-                            );
-                        },
-                        Err(err) => {
-                            log::warn!(
-                                "Root: Error loading package at {path}: {err}",
-                                path = path.display()
-                            );
-                        },
-                    }
+    for uri in workspace_uris {
+        state.workspace.folders.push(uri.clone());
+        if let Ok(path) = uri.to_file_path() {
+            workspace_paths.push(path.clone());
+            // Try to load package from this workspace folder and set as
+            // root if found. This means we're dealing with a package
+            // source.
+            if state.root.is_none() {
+                match Package::load_from_folder(&path) {
+                    Ok(Some(pkg)) => {
+                        log::info!(
+                            "Root: Loaded package `{pkg}` from {path} as project root",
+                            pkg = pkg.description().name,
+                            path = path.display()
+                        );
+                        state.root = Some(SourceRoot::Package(pkg));
+                    },
+                    Ok(None) => {
+                        log::info!(
+                            "Root: No package found at {path}, treating as folder of scripts",
+                            path = path.display()
+                        );
+                    },
+                    Err(err) => {
+                        log::warn!(
+                            "Root: Error loading package at {path}: {err}",
+                            path = path.display()
+                        );
+                    },
                 }
-                if let Some(path_str) = path.to_str() {
-                    folders.push(path_str.to_string());
-                }
+            }
+            if let Some(path_str) = path.to_str() {
+                folders.push(path_str.to_string());
             }
         }
     }
@@ -226,6 +225,21 @@ pub(crate) fn initialize(
             ..ServerCapabilities::default()
         },
     })
+}
+
+/// Resolve the effective workspace folders from `InitializeParams`.
+///
+/// `workspaceFolders` takes precedence when present and non-empty.
+/// Falls back to the legacy `rootUri` for clients that don't send
+/// multi-root workspaces. The returned vector is empty when neither
+/// produces a folder, i.e. the server is running in single-file mode.
+pub(super) fn effective_workspace_uris(params: &InitializeParams) -> Vec<Url> {
+    if let Some(folders) = params.workspace_folders.as_ref() {
+        if !folders.is_empty() {
+            return folders.iter().map(|f| f.uri.clone()).collect();
+        }
+    }
+    params.root_uri.iter().cloned().collect()
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -264,8 +264,9 @@ pub(crate) fn did_open(
     lsp_state.parsers.insert(uri.clone(), parser);
     state.documents.insert(uri.clone(), document.clone());
 
-    let url_id = UrlId::from_url(uri.clone());
-    state.db.upsert_editor(url_id, contents.to_string());
+    state
+        .db
+        .upsert_editor(UrlId::from_url(uri.clone()), contents.to_string());
 
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
@@ -292,8 +293,9 @@ pub(crate) fn did_change(
     document.on_did_change(parser, &params);
 
     let new_contents = document.contents.to_string();
-    let url_id = UrlId::from_url(uri.clone());
-    state.db.upsert_editor(url_id, new_contents);
+    state
+        .db
+        .upsert_editor(UrlId::from_url(uri.clone()), new_contents);
 
     lsp::main_loop::index_update(vec![uri.clone()], state.clone());
 
@@ -329,8 +331,7 @@ pub(crate) fn did_close(
         .remove(&uri)
         .ok_or(anyhow!("Failed to remove parser for URI: {uri}"))?;
 
-    let url_id = UrlId::from_url(uri.clone());
-    state.db.close_editor(&url_id);
+    state.db.close_editor(&UrlId::from_url(uri.clone()));
 
     lsp::log_info!("did_close(): closed document with URI: '{uri}'.");
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -139,17 +139,11 @@ pub(crate) fn initialize(
         }
     }
 
-    // Start first round of indexing. `state.documents` is empty at init since
-    // no `didOpen` has fired yet, but build the set through the same shape we
-    // use elsewhere so the call site reads consistently.
-    let editor_owned: HashSet<UrlId> = state
-        .documents
-        .keys()
-        .map(|url| UrlId::from_url(url.clone()))
-        .collect();
+    // Start first round of indexing. We are initializing, so no documents have
+    // been opened yet and nothing is editor-owned.
     state
         .db
-        .set_workspace_paths(&workspace_paths, &editor_owned);
+        .set_workspace_paths(&workspace_paths, &HashSet::new());
     lsp::main_loop::index_start(folders, state.clone());
 
     Ok(InitializeResult {

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use aether_url::UrlId;
 use anyhow::anyhow;
-use oak_scan::DbExt;
+use oak_scan::DbScan;
 use oak_scan::FileEvent;
 use oak_scan::FileEventKind;
 use oak_semantic::package::Package;

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -23,6 +23,7 @@ use tower_lsp::lsp_types::DeleteFilesParams;
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 use tower_lsp::lsp_types::DidChangeTextDocumentParams;
 use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
+use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingOptions;
@@ -414,6 +415,31 @@ pub(crate) fn did_change_watched_files(
         .collect();
 
     state.oak.apply_watcher_events(events, &editor_owned);
+    Ok(())
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn did_change_workspace_folders(
+    params: DidChangeWorkspaceFoldersParams,
+    state: &mut WorldState,
+) -> anyhow::Result<()> {
+    let removed: HashSet<Url> = params.event.removed.iter().map(|f| f.uri.clone()).collect();
+    state.workspace.folders.retain(|uri| !removed.contains(uri));
+
+    for folder in params.event.added {
+        if !state.workspace.folders.contains(&folder.uri) {
+            state.workspace.folders.push(folder.uri);
+        }
+    }
+
+    let workspace_paths: Vec<PathBuf> = state
+        .workspace
+        .folders
+        .iter()
+        .filter_map(|uri| uri.to_file_path().ok())
+        .collect();
+    state.oak.scan_workspace_paths(&workspace_paths);
+
     Ok(())
 }
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -273,7 +273,7 @@ pub(crate) fn did_open(
     state.documents.insert(uri.clone(), document.clone());
 
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.set_editor_contents(url_id, contents.to_string());
+    state.oak.upsert_editor(url_id, contents.to_string());
 
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
@@ -301,7 +301,7 @@ pub(crate) fn did_change(
 
     let new_contents = document.contents.to_string();
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.set_editor_contents(url_id, new_contents);
+    state.oak.upsert_editor(url_id, new_contents);
 
     lsp::main_loop::index_update(vec![uri.clone()], state.clone());
 
@@ -336,6 +336,9 @@ pub(crate) fn did_close(
         .parsers
         .remove(&uri)
         .ok_or(anyhow!("Failed to remove parser for URI: {uri}"))?;
+
+    let url_id = UrlId::from_url(uri.clone());
+    state.oak.close_editor(&url_id);
 
     lsp::log_info!("did_close(): closed document with URI: '{uri}'.");
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -5,11 +5,14 @@
 //
 //
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use aether_url::UrlId;
 use anyhow::anyhow;
 use oak_scan::DbExt;
+use oak_scan::FileEvent;
+use oak_scan::FileEventKind;
 use oak_semantic::package::Package;
 use stdext::result::ResultExt;
 use tower_lsp::lsp_types;
@@ -19,10 +22,12 @@ use tower_lsp::lsp_types::CreateFilesParams;
 use tower_lsp::lsp_types::DeleteFilesParams;
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 use tower_lsp::lsp_types::DidChangeTextDocumentParams;
+use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingOptions;
 use tower_lsp::lsp_types::ExecuteCommandOptions;
+use tower_lsp::lsp_types::FileChangeType;
 use tower_lsp::lsp_types::FileOperationFilter;
 use tower_lsp::lsp_types::FileOperationPattern;
 use tower_lsp::lsp_types::FileOperationPatternKind;
@@ -134,10 +139,8 @@ pub(crate) fn initialize(
         }
     }
 
-    // Drive `WorkspaceRoots` in oak_db from the editor's open folders.
-    state.oak.scan_workspace_paths(&workspace_paths);
-
     // Start first round of indexing
+    state.oak.scan_workspace_paths(&workspace_paths);
     lsp::main_loop::index_start(folders, state.clone());
 
     Ok(InitializeResult {
@@ -246,7 +249,7 @@ pub(crate) fn did_open(
     state.documents.insert(uri.clone(), document.clone());
 
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.set_file_contents(url_id, contents.to_string());
+    state.oak.set_editor_contents(url_id, contents.to_string());
 
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
@@ -274,7 +277,7 @@ pub(crate) fn did_change(
 
     let new_contents = document.contents.to_string();
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.set_file_contents(url_id, new_contents);
+    state.oak.set_editor_contents(url_id, new_contents);
 
     lsp::main_loop::index_update(vec![uri.clone()], state.clone());
 
@@ -363,6 +366,40 @@ pub(crate) fn did_rename_files(
         .collect();
 
     lsp::main_loop::index_rename(uri_pairs, state.clone());
+    Ok(())
+}
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) fn did_change_watched_files(
+    params: DidChangeWatchedFilesParams,
+    state: &mut WorldState,
+) -> anyhow::Result<()> {
+    // Editor owns the contents of files it has open: Oak should ignore
+    // disk-side events for those URLs.
+    let editor_owned: HashSet<UrlId> = state
+        .documents
+        .keys()
+        .map(|url| UrlId::from_url(url.clone()))
+        .collect();
+
+    let events: Vec<FileEvent> = params
+        .changes
+        .into_iter()
+        .filter_map(|e| {
+            let kind = match e.typ {
+                FileChangeType::CREATED => FileEventKind::Created,
+                FileChangeType::CHANGED => FileEventKind::Changed,
+                FileChangeType::DELETED => FileEventKind::Deleted,
+                _ => return None,
+            };
+            Some(FileEvent {
+                url: UrlId::from_url(e.uri),
+                kind,
+            })
+        })
+        .collect();
+
+    state.oak.apply_watcher_events(events, &editor_owned);
     Ok(())
 }
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -148,7 +148,7 @@ pub(crate) fn initialize(
         .map(|url| UrlId::from_url(url.clone()))
         .collect();
     state
-        .oak
+        .db
         .set_workspace_paths(&workspace_paths, &editor_owned);
     lsp::main_loop::index_start(folders, state.clone());
 
@@ -271,7 +271,7 @@ pub(crate) fn did_open(
     state.documents.insert(uri.clone(), document.clone());
 
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.upsert_editor(url_id, contents.to_string());
+    state.db.upsert_editor(url_id, contents.to_string());
 
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
@@ -299,7 +299,7 @@ pub(crate) fn did_change(
 
     let new_contents = document.contents.to_string();
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.upsert_editor(url_id, new_contents);
+    state.db.upsert_editor(url_id, new_contents);
 
     lsp::main_loop::index_update(vec![uri.clone()], state.clone());
 
@@ -336,7 +336,7 @@ pub(crate) fn did_close(
         .ok_or(anyhow!("Failed to remove parser for URI: {uri}"))?;
 
     let url_id = UrlId::from_url(uri.clone());
-    state.oak.close_editor(&url_id);
+    state.db.close_editor(&url_id);
 
     lsp::log_info!("did_close(): closed document with URI: '{uri}'.");
 
@@ -424,7 +424,7 @@ pub(crate) fn did_change_watched_files(
         })
         .collect();
 
-    state.oak.apply_watcher_events(events, &editor_owned);
+    state.db.apply_watcher_events(events, &editor_owned);
     Ok(())
 }
 
@@ -459,7 +459,7 @@ pub(crate) fn did_change_workspace_folders(
         .collect();
 
     state
-        .oak
+        .db
         .set_workspace_paths(&workspace_paths, &editor_owned);
     Ok(())
 }

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -139,8 +139,17 @@ pub(crate) fn initialize(
         }
     }
 
-    // Start first round of indexing
-    state.oak.scan_workspace_paths(&workspace_paths);
+    // Start first round of indexing. `state.documents` is empty at init since
+    // no `didOpen` has fired yet, but build the set through the same shape we
+    // use elsewhere so the call site reads consistently.
+    let editor_owned: HashSet<UrlId> = state
+        .documents
+        .keys()
+        .map(|url| UrlId::from_url(url.clone()))
+        .collect();
+    state
+        .oak
+        .set_workspace_paths(&workspace_paths, &editor_owned);
     lsp::main_loop::index_start(folders, state.clone());
 
     Ok(InitializeResult {
@@ -438,8 +447,19 @@ pub(crate) fn did_change_workspace_folders(
         .iter()
         .filter_map(|uri| uri.to_file_path().ok())
         .collect();
-    state.oak.scan_workspace_paths(&workspace_paths);
 
+    // Editor-owned URLs survive eviction in `OrphanRoot` so the user's
+    // open buffers keep getting analysed even when their workspace
+    // folder goes away.
+    let editor_owned: HashSet<UrlId> = state
+        .documents
+        .keys()
+        .map(|url| UrlId::from_url(url.clone()))
+        .collect();
+
+    state
+        .oak
+        .set_workspace_paths(&workspace_paths, &editor_owned);
     Ok(())
 }
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -239,17 +239,15 @@ pub(crate) fn initialize(
 
 /// Resolve the effective workspace folders from `InitializeParams`.
 ///
-/// `workspaceFolders` takes precedence when present and non-empty.
-/// Falls back to the legacy `rootUri` for clients that don't send
-/// multi-root workspaces. The returned vector is empty when neither
-/// produces a folder, i.e. the server is running in single-file mode.
+/// We read only `workspaceFolders`, the modern field , without falling back to
+/// the deprecated `rootUri`. An empty or absent list means single-file mode.
 pub(super) fn effective_workspace_uris(params: &InitializeParams) -> Vec<Url> {
-    if let Some(folders) = params.workspace_folders.as_ref() {
-        if !folders.is_empty() {
-            return folders.iter().map(|f| f.uri.clone()).collect();
-        }
-    }
-    params.root_uri.iter().cloned().collect()
+    params
+        .workspace_folders
+        .iter()
+        .flatten()
+        .map(|folder| folder.uri.clone())
+        .collect()
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -5,8 +5,11 @@
 //
 //
 
+use std::path::PathBuf;
+
 use aether_url::UrlId;
 use anyhow::anyhow;
+use oak_scan::DbExt;
 use oak_semantic::package::Package;
 use stdext::result::ResultExt;
 use tower_lsp::lsp_types;
@@ -90,10 +93,13 @@ pub(crate) fn initialize(
 
     // Initialize the workspace folders
     let mut folders: Vec<String> = Vec::new();
+    let mut workspace_paths: Vec<PathBuf> = Vec::new();
+
     if let Some(workspace_folders) = params.workspace_folders {
         for folder in workspace_folders.iter() {
             state.workspace.folders.push(folder.uri.clone());
             if let Ok(path) = folder.uri.to_file_path() {
+                workspace_paths.push(path.clone());
                 // Try to load package from this workspace folder and set as
                 // root if found. This means we're dealing with a package
                 // source.
@@ -127,6 +133,9 @@ pub(crate) fn initialize(
             }
         }
     }
+
+    // Drive `WorkspaceRoots` in oak_db from the editor's open folders.
+    state.oak.scan_workspace_paths(&workspace_paths);
 
     // Start first round of indexing
     lsp::main_loop::index_start(folders, state.clone());
@@ -236,6 +245,9 @@ pub(crate) fn did_open(
     lsp_state.parsers.insert(uri.clone(), parser);
     state.documents.insert(uri.clone(), document.clone());
 
+    let url_id = UrlId::from_url(uri.clone());
+    state.oak.set_file_contents(url_id, contents.to_string());
+
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
 
@@ -259,6 +271,10 @@ pub(crate) fn did_change(
         .ok_or(anyhow!("No parser for {uri}"))?;
 
     document.on_did_change(parser, &params);
+
+    let new_contents = document.contents.to_string();
+    let url_id = UrlId::from_url(uri.clone());
+    state.oak.set_file_contents(url_id, new_contents);
 
     lsp::main_loop::index_update(vec![uri.clone()], state.clone());
 

--- a/crates/ark/src/lsp/tests.rs
+++ b/crates/ark/src/lsp/tests.rs
@@ -1,4 +1,5 @@
 mod find_references;
 mod goto_definition;
 mod rename;
+mod state_handlers;
 mod utils;

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -311,10 +311,9 @@ fn folder(uri: &str) -> WorkspaceFolder {
 }
 
 #[test]
-fn test_effective_workspace_uris_prefers_workspace_folders() {
+fn test_effective_workspace_uris_reads_workspace_folders() {
     let params = InitializeParams {
         workspace_folders: Some(vec![folder("file:///a"), folder("file:///b")]),
-        root_uri: Some(Url::parse("file:///legacy").unwrap()),
         ..Default::default()
     };
     let uris = effective_workspace_uris(&params);
@@ -324,30 +323,23 @@ fn test_effective_workspace_uris_prefers_workspace_folders() {
 }
 
 #[test]
-fn test_effective_workspace_uris_falls_back_to_root_uri() {
-    let params = InitializeParams {
+fn test_effective_workspace_uris_ignores_legacy_root_uri() {
+    // We dropped the `root_uri` fallback, so a client sending only the
+    // deprecated field gets single-file mode (empty), whether
+    // `workspace_folders` is absent or an empty list.
+    let absent = InitializeParams {
         workspace_folders: None,
         root_uri: Some(Url::parse("file:///legacy").unwrap()),
         ..Default::default()
     };
-    let uris = effective_workspace_uris(&params);
-    assert_eq!(uris.len(), 1);
-    assert_eq!(uris[0].as_str(), "file:///legacy");
-}
+    assert!(effective_workspace_uris(&absent).is_empty());
 
-#[test]
-fn test_effective_workspace_uris_falls_back_when_workspace_folders_empty() {
-    // Some clients send an empty `workspace_folders` list alongside a
-    // legacy `root_uri`. Treat the empty list as "no folders" and use
-    // the legacy field, rather than init-ing with zero workspaces.
-    let params = InitializeParams {
+    let empty = InitializeParams {
         workspace_folders: Some(vec![]),
         root_uri: Some(Url::parse("file:///legacy").unwrap()),
         ..Default::default()
     };
-    let uris = effective_workspace_uris(&params);
-    assert_eq!(uris.len(), 1);
-    assert_eq!(uris[0].as_str(), "file:///legacy");
+    assert!(effective_workspace_uris(&empty).is_empty());
 }
 
 #[test]

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -4,6 +4,7 @@
 //! regression in either the translation step or the state.documents → skip set
 //! conversion.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -51,7 +52,9 @@ fn workspace_state(workspace: &Path) -> WorldState {
         .workspace
         .folders
         .push(Url::from_file_path(workspace).unwrap());
-    state.oak.scan_workspace_paths(&[workspace.to_path_buf()]);
+    state
+        .oak
+        .set_workspace_paths(&[workspace.to_path_buf()], &HashSet::new());
     state
 }
 
@@ -396,12 +399,18 @@ fn test_did_change_workspace_folders_removes_folder() {
     write_package(&second.path().join("pkg2"), "pkg2", &[]);
 
     let mut state = WorldState::default();
-    state.workspace.folders.push(Url::from_file_path(first.path()).unwrap());
-    state.workspace.folders.push(Url::from_file_path(second.path()).unwrap());
-    state.oak.scan_workspace_paths(&[
-        first.path().to_path_buf(),
-        second.path().to_path_buf(),
-    ]);
+    state
+        .workspace
+        .folders
+        .push(Url::from_file_path(first.path()).unwrap());
+    state
+        .workspace
+        .folders
+        .push(Url::from_file_path(second.path()).unwrap());
+    state.oak.set_workspace_paths(
+        &[first.path().to_path_buf(), second.path().to_path_buf()],
+        &HashSet::new(),
+    );
     assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 2);
 
     let params = folders_change(vec![], vec![folder_for(first.path())]);
@@ -439,14 +448,71 @@ fn test_did_change_workspace_folders_handles_add_and_remove_in_one_event() {
     write_package(&second.path().join("pkg2"), "pkg2", &[]);
     let mut state = workspace_state(first.path());
 
-    let params = folders_change(
-        vec![folder_for(second.path())],
-        vec![folder_for(first.path())],
-    );
+    let params = folders_change(vec![folder_for(second.path())], vec![folder_for(
+        first.path(),
+    )]);
     did_change_workspace_folders(params, &mut state).unwrap();
 
     assert_eq!(state.workspace.folders.len(), 1);
     let roots = state.oak.workspace_roots().roots(&state.oak).clone();
     assert_eq!(roots.len(), 1);
     assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg2");
+}
+
+#[test]
+fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
+    // End-to-end check that `did_change_workspace_folders` threads
+    // `state.documents` URLs through as `editor_owned` so an open buffer
+    // survives its workspace folder being removed and re-added: same
+    // `File` entity, editor contents preserved, file findable through
+    // both phases.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut state = workspace_state(tmp.path());
+
+    // Simulate `didOpen` on the package file with editor-side content.
+    let r_path = tmp.path().join("pkg/R/a.R");
+    let url = Url::from_file_path(&r_path).unwrap();
+    let url_id = UrlId::from_url(url.clone());
+    state
+        .documents
+        .insert(url.clone(), Document::new("editor <- 2\n", None));
+    state
+        .oak
+        .set_editor_contents(url_id.clone(), "editor <- 2\n".to_string());
+
+    let file_before = state.oak.file_by_url(&url_id).unwrap();
+
+    // Remove the workspace folder. The handler builds the editor_owned set
+    // from state.documents.keys() and passes it to oak; the buffer's file
+    // routes to OrphanRoot rather than StaleRoot.
+    let params = folders_change(vec![], vec![folder_for(tmp.path())]);
+    did_change_workspace_folders(params, &mut state).unwrap();
+
+    let after_remove = state.oak.file_by_url(&url_id).unwrap();
+    assert_eq!(file_before, after_remove);
+    assert_eq!(after_remove.package(&state.oak), None);
+    assert!(state
+        .oak
+        .orphan_root()
+        .files(&state.oak)
+        .contains(&after_remove));
+    assert_eq!(after_remove.contents(&state.oak), "editor <- 2\n");
+
+    // Re-add the same folder. The file snaps back into pkg.files with
+    // the same entity and the editor content carries over (the scan's
+    // disk snapshot doesn't overwrite).
+    let params = folders_change(vec![folder_for(tmp.path())], vec![]);
+    did_change_workspace_folders(params, &mut state).unwrap();
+
+    let after_readd = state.oak.file_by_url(&url_id).unwrap();
+    assert_eq!(file_before, after_readd);
+    assert!(after_readd.package(&state.oak).is_some());
+    assert_eq!(after_readd.contents(&state.oak), "editor <- 2\n");
+    // `upsert_root_file` cleaned the orphan reference.
+    assert!(!state
+        .oak
+        .orphan_root()
+        .files(&state.oak)
+        .contains(&after_readd));
 }

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -522,7 +522,7 @@ fn test_did_close_releases_orphan_file_to_stale() {
     // to orphan, editor-owned) → close → file leaves orphan, lands in
     // stale. Without the `close_editor` hook in `did_close`, the file
     // would zombie in orphan with the editor's last content.
-    init_aux_for_test();
+    let _aux_rx = init_aux_for_test();
 
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -1,0 +1,173 @@
+//! Smoke tests for the LSP -> oak translator in [`crate::lsp::state_handlers`].
+//! Dispatch behaviour itself is covered by `oak_scan/tests/watch.rs`. The tests
+//! here go through [`did_change_watched_files`] end-to-end so they catch a
+//! regression in either the translation step or the state.documents → skip set
+//! conversion.
+
+use std::fs;
+use std::path::Path;
+
+use aether_url::UrlId;
+use oak_db::Db;
+use oak_db::DbInputs;
+use oak_scan::DbExt;
+use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
+use tower_lsp::lsp_types::FileChangeType;
+use tower_lsp::lsp_types::FileEvent;
+use url::Url;
+
+use crate::lsp::document::Document;
+use crate::lsp::state::WorldState;
+use crate::lsp::state_handlers::did_change_watched_files;
+
+fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
+    fs::create_dir_all(dir.join("R")).unwrap();
+    fs::write(
+        dir.join("DESCRIPTION"),
+        format!("Package: {name}\nVersion: 0.0.0\n"),
+    )
+    .unwrap();
+    for (basename, contents) in r_files {
+        fs::write(dir.join("R").join(basename), contents).unwrap();
+    }
+}
+
+fn event(path: &Path, typ: FileChangeType) -> FileEvent {
+    FileEvent {
+        uri: Url::from_file_path(path).unwrap(),
+        typ,
+    }
+}
+
+fn workspace_state(workspace: &Path) -> WorldState {
+    let mut state = WorldState::default();
+    state.oak.scan_workspace_paths(&[workspace.to_path_buf()]);
+    state
+}
+
+#[test]
+fn test_description_created_triggers_root_rescan() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
+    fs::write(tmp.path().join("pkg/R/a.R"), "x <- 1\n").unwrap();
+    let mut state = workspace_state(tmp.path());
+
+    // No DESCRIPTION yet, so `a.R` registers as a workspace script.
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert!(root.packages(&state.oak).is_empty());
+
+    // Now write DESCRIPTION and fire the watcher.
+    fs::write(
+        tmp.path().join("pkg/DESCRIPTION"),
+        "Package: pkg\nVersion: 0.0.0\n",
+    )
+    .unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(
+            &tmp.path().join("pkg/DESCRIPTION"),
+            FileChangeType::CREATED,
+        )],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert_eq!(root.packages(&state.oak).len(), 1);
+    assert_eq!(root.packages(&state.oak)[0].name(&state.oak), "pkg");
+}
+
+#[test]
+fn test_multiple_descriptions_under_same_root_dedup_to_one_rescan() {
+    // Two DESCRIPTION events in the same root should not double-scan.
+    // We can't observe the dedup directly, but we can check the end
+    // state is consistent and the call doesn't error.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg1"), "pkg1", &[]);
+    write_package(&tmp.path().join("pkg2"), "pkg2", &[]);
+    let mut state = workspace_state(tmp.path());
+
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![
+            event(
+                &tmp.path().join("pkg1/DESCRIPTION"),
+                FileChangeType::CHANGED,
+            ),
+            event(
+                &tmp.path().join("pkg2/DESCRIPTION"),
+                FileChangeType::CHANGED,
+            ),
+        ],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert_eq!(root.packages(&state.oak).len(), 2);
+}
+
+#[test]
+fn test_r_file_created_routes_through_add_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut state = workspace_state(tmp.path());
+
+    let path = tmp.path().join("new.R");
+    fs::write(&path, "x <- 1\n").unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(&path, FileChangeType::CREATED)],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert_eq!(root.scripts(&state.oak).len(), 1);
+    let url = UrlId::from_file_path(&path).unwrap();
+    let file = state.oak.file_by_url(&url).unwrap();
+    assert_eq!(file.contents(&state.oak), "x <- 1\n");
+}
+
+#[test]
+fn test_r_file_changed_for_editor_open_file_is_skipped() {
+    // The editor is the source of truth for files it has open.
+    // A disk-side `Changed` event that races against `didChange`
+    // must not overwrite the editor's content.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("a.R");
+    fs::write(&path, "disk_v1\n").unwrap();
+    let mut state = workspace_state(tmp.path());
+
+    let url = Url::from_file_path(&path).unwrap();
+    state
+        .documents
+        .insert(url.clone(), Document::new("editor_v2\n", None));
+    // Pretend the editor pushed its content into oak too.
+    let url_id = UrlId::from_url(url.clone());
+    state
+        .oak
+        .set_editor_contents(url_id.clone(), "editor_v2\n".to_string());
+
+    // Now disk-side `Changed` fires with stale disk content.
+    fs::write(&path, "disk_v3\n").unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(&path, FileChangeType::CHANGED)],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let file = state.oak.file_by_url(&url_id).unwrap();
+    assert_eq!(file.contents(&state.oak), "editor_v2\n");
+}
+
+#[test]
+fn test_r_file_deleted_routes_through_remove_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
+    fs::write(tmp.path().join("b.R"), "y <- 2\n").unwrap();
+    let mut state = workspace_state(tmp.path());
+
+    let path = tmp.path().join("a.R");
+    let url_id = UrlId::from_file_path(&path).unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(&path, FileChangeType::DELETED)],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert_eq!(root.scripts(&state.oak).len(), 1);
+    assert!(state.oak.file_by_url(&url_id).is_none());
+}

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -4,6 +4,7 @@
 //! regression in either the translation step or the state.documents → skip set
 //! conversion.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -14,17 +15,23 @@ use oak_db::DbInputs;
 use oak_scan::DbExt;
 use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
 use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
+use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tower_lsp::lsp_types::FileChangeType;
 use tower_lsp::lsp_types::FileEvent;
 use tower_lsp::lsp_types::InitializeParams;
+use tower_lsp::lsp_types::TextDocumentIdentifier;
 use tower_lsp::lsp_types::WorkspaceFolder;
 use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
 use url::Url;
 
+use crate::lsp::capabilities::Capabilities;
 use crate::lsp::document::Document;
+use crate::lsp::main_loop::init_aux_for_test;
+use crate::lsp::main_loop::LspState;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers::did_change_watched_files;
 use crate::lsp::state_handlers::did_change_workspace_folders;
+use crate::lsp::state_handlers::did_close;
 use crate::lsp::state_handlers::effective_workspace_uris;
 
 fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
@@ -153,7 +160,7 @@ fn test_r_file_changed_for_editor_open_file_is_skipped() {
     let url_id = UrlId::from_url(url.clone());
     state
         .oak
-        .set_editor_contents(url_id.clone(), "editor_v2\n".to_string());
+        .upsert_editor(url_id.clone(), "editor_v2\n".to_string());
 
     // Now disk-side `Changed` fires with stale disk content.
     fs::write(&path, "disk_v3\n").unwrap();
@@ -245,7 +252,7 @@ fn test_r_file_deleted_for_editor_open_file_is_skipped() {
     let url_id = UrlId::from_url(url.clone());
     state
         .oak
-        .set_editor_contents(url_id.clone(), "editor_v2\n".to_string());
+        .upsert_editor(url_id.clone(), "editor_v2\n".to_string());
 
     fs::remove_file(&path).unwrap();
     let params = DidChangeWatchedFilesParams {
@@ -479,7 +486,7 @@ fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
         .insert(url.clone(), Document::new("editor <- 2\n", None));
     state
         .oak
-        .set_editor_contents(url_id.clone(), "editor <- 2\n".to_string());
+        .upsert_editor(url_id.clone(), "editor <- 2\n".to_string());
 
     let file_before = state.oak.file_by_url(&url_id).unwrap();
 
@@ -515,4 +522,56 @@ fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
         .orphan_root()
         .files(&state.oak)
         .contains(&after_readd));
+}
+
+#[test]
+fn test_did_close_releases_orphan_file_to_stale() {
+    // End-to-end: open buffer → remove its workspace folder (file goes
+    // to orphan, editor-owned) → close → file leaves orphan, lands in
+    // stale. Without the `close_editor` hook in `did_close`, the file
+    // would zombie in orphan with the editor's last content.
+    init_aux_for_test();
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut state = workspace_state(tmp.path());
+    let mut lsp_state = LspState {
+        parsers: HashMap::new(),
+        capabilities: Capabilities::default(),
+        console_notification_tx: tokio::sync::mpsc::unbounded_channel().0,
+    };
+
+    let r_path = tmp.path().join("pkg/R/a.R");
+    let url = Url::from_file_path(&r_path).unwrap();
+    let url_id = UrlId::from_url(url.clone());
+
+    // Simulate `didOpen` via state mutation (matches the rest of the file's
+    // pattern).
+    state
+        .documents
+        .insert(url.clone(), Document::new("edited\n", None));
+    lsp_state
+        .parsers
+        .insert(url.clone(), tree_sitter::Parser::new());
+    state
+        .oak
+        .upsert_editor(url_id.clone(), "edited\n".to_string());
+
+    // Remove the workspace folder; file goes to orphan (editor-owned).
+    did_change_workspace_folders(
+        folders_change(vec![], vec![folder_for(tmp.path())]),
+        &mut state,
+    )
+    .unwrap();
+    let file = state.oak.file_by_url(&url_id).unwrap();
+    assert!(state.oak.orphan_root().files(&state.oak).contains(&file));
+
+    // Now close the buffer. File should move from orphan to stale.
+    let params = DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: url.clone() },
+    };
+    did_close(params, &mut lsp_state, &mut state).unwrap();
+
+    assert!(!state.oak.orphan_root().files(&state.oak).contains(&file));
+    assert!(state.oak.stale_root().files(&state.oak).contains(&file));
 }

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -14,11 +14,14 @@ use oak_scan::DbExt;
 use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
 use tower_lsp::lsp_types::FileChangeType;
 use tower_lsp::lsp_types::FileEvent;
+use tower_lsp::lsp_types::InitializeParams;
+use tower_lsp::lsp_types::WorkspaceFolder;
 use url::Url;
 
 use crate::lsp::document::Document;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers::did_change_watched_files;
+use crate::lsp::state_handlers::effective_workspace_uris;
 
 fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
     fs::create_dir_all(dir.join("R")).unwrap();
@@ -281,4 +284,61 @@ fn test_description_deleted_demotes_package_to_scripts() {
     let a_url = UrlId::from_file_path(tmp.path().join("pkg/R/a.R")).unwrap();
     let file = state.oak.file_by_url(&a_url).unwrap();
     assert_eq!(file.package(&state.oak), None);
+}
+
+fn folder(uri: &str) -> WorkspaceFolder {
+    WorkspaceFolder {
+        uri: Url::parse(uri).unwrap(),
+        name: String::new(),
+    }
+}
+
+#[test]
+fn test_effective_workspace_uris_prefers_workspace_folders() {
+    let params = InitializeParams {
+        workspace_folders: Some(vec![folder("file:///a"), folder("file:///b")]),
+        root_uri: Some(Url::parse("file:///legacy").unwrap()),
+        ..Default::default()
+    };
+    let uris = effective_workspace_uris(&params);
+    assert_eq!(uris.len(), 2);
+    assert_eq!(uris[0].as_str(), "file:///a");
+    assert_eq!(uris[1].as_str(), "file:///b");
+}
+
+#[test]
+fn test_effective_workspace_uris_falls_back_to_root_uri() {
+    let params = InitializeParams {
+        workspace_folders: None,
+        root_uri: Some(Url::parse("file:///legacy").unwrap()),
+        ..Default::default()
+    };
+    let uris = effective_workspace_uris(&params);
+    assert_eq!(uris.len(), 1);
+    assert_eq!(uris[0].as_str(), "file:///legacy");
+}
+
+#[test]
+fn test_effective_workspace_uris_falls_back_when_workspace_folders_empty() {
+    // Some clients send an empty `workspace_folders` list alongside a
+    // legacy `root_uri`. Treat the empty list as "no folders" and use
+    // the legacy field, rather than init-ing with zero workspaces.
+    let params = InitializeParams {
+        workspace_folders: Some(vec![]),
+        root_uri: Some(Url::parse("file:///legacy").unwrap()),
+        ..Default::default()
+    };
+    let uris = effective_workspace_uris(&params);
+    assert_eq!(uris.len(), 1);
+    assert_eq!(uris[0].as_str(), "file:///legacy");
+}
+
+#[test]
+fn test_effective_workspace_uris_single_file_mode() {
+    let params = InitializeParams {
+        workspace_folders: None,
+        root_uri: None,
+        ..Default::default()
+    };
+    assert!(effective_workspace_uris(&params).is_empty());
 }

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -12,15 +12,18 @@ use oak_db::Db;
 use oak_db::DbInputs;
 use oak_scan::DbExt;
 use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
+use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp::lsp_types::FileChangeType;
 use tower_lsp::lsp_types::FileEvent;
 use tower_lsp::lsp_types::InitializeParams;
 use tower_lsp::lsp_types::WorkspaceFolder;
+use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
 use url::Url;
 
 use crate::lsp::document::Document;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers::did_change_watched_files;
+use crate::lsp::state_handlers::did_change_workspace_folders;
 use crate::lsp::state_handlers::effective_workspace_uris;
 
 fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
@@ -44,6 +47,10 @@ fn event(path: &Path, typ: FileChangeType) -> FileEvent {
 
 fn workspace_state(workspace: &Path) -> WorldState {
     let mut state = WorldState::default();
+    state
+        .workspace
+        .folders
+        .push(Url::from_file_path(workspace).unwrap());
     state.oak.scan_workspace_paths(&[workspace.to_path_buf()]);
     state
 }
@@ -341,4 +348,105 @@ fn test_effective_workspace_uris_single_file_mode() {
         ..Default::default()
     };
     assert!(effective_workspace_uris(&params).is_empty());
+}
+
+fn folders_change(
+    added: Vec<WorkspaceFolder>,
+    removed: Vec<WorkspaceFolder>,
+) -> DidChangeWorkspaceFoldersParams {
+    DidChangeWorkspaceFoldersParams {
+        event: WorkspaceFoldersChangeEvent { added, removed },
+    }
+}
+
+fn folder_for(path: &Path) -> WorkspaceFolder {
+    WorkspaceFolder {
+        uri: Url::from_file_path(path).unwrap(),
+        name: String::new(),
+    }
+}
+
+#[test]
+fn test_did_change_workspace_folders_adds_new_folder() {
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_package(&first.path().join("pkg1"), "pkg1", &[]);
+    write_package(&second.path().join("pkg2"), "pkg2", &[]);
+
+    let mut state = workspace_state(first.path());
+    assert_eq!(state.workspace.folders.len(), 1);
+    assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 1);
+
+    let params = folders_change(vec![folder_for(second.path())], vec![]);
+    did_change_workspace_folders(params, &mut state).unwrap();
+
+    assert_eq!(state.workspace.folders.len(), 2);
+    let roots = state.oak.workspace_roots().roots(&state.oak).clone();
+    assert_eq!(roots.len(), 2);
+    // Existing root stays first, new one appended.
+    assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg1");
+    assert_eq!(roots[1].packages(&state.oak)[0].name(&state.oak), "pkg2");
+}
+
+#[test]
+fn test_did_change_workspace_folders_removes_folder() {
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_package(&first.path().join("pkg1"), "pkg1", &[]);
+    write_package(&second.path().join("pkg2"), "pkg2", &[]);
+
+    let mut state = WorldState::default();
+    state.workspace.folders.push(Url::from_file_path(first.path()).unwrap());
+    state.workspace.folders.push(Url::from_file_path(second.path()).unwrap());
+    state.oak.scan_workspace_paths(&[
+        first.path().to_path_buf(),
+        second.path().to_path_buf(),
+    ]);
+    assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 2);
+
+    let params = folders_change(vec![], vec![folder_for(first.path())]);
+    did_change_workspace_folders(params, &mut state).unwrap();
+
+    assert_eq!(state.workspace.folders.len(), 1);
+    let roots = state.oak.workspace_roots().roots(&state.oak).clone();
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg2");
+}
+
+#[test]
+fn test_did_change_workspace_folders_ignores_duplicate_add() {
+    // A client that re-announces a folder that's already tracked
+    // shouldn't end up with two copies in `state.workspace.folders`
+    // or two `Root` entries in oak.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[]);
+    let mut state = workspace_state(tmp.path());
+
+    let params = folders_change(vec![folder_for(tmp.path())], vec![]);
+    did_change_workspace_folders(params, &mut state).unwrap();
+
+    assert_eq!(state.workspace.folders.len(), 1);
+    assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 1);
+}
+
+#[test]
+fn test_did_change_workspace_folders_handles_add_and_remove_in_one_event() {
+    // The LSP sends both `added` and `removed` in a single event when the
+    // user swaps one folder for another.
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_package(&first.path().join("pkg1"), "pkg1", &[]);
+    write_package(&second.path().join("pkg2"), "pkg2", &[]);
+    let mut state = workspace_state(first.path());
+
+    let params = folders_change(
+        vec![folder_for(second.path())],
+        vec![folder_for(first.path())],
+    );
+    did_change_workspace_folders(params, &mut state).unwrap();
+
+    assert_eq!(state.workspace.folders.len(), 1);
+    let roots = state.oak.workspace_roots().roots(&state.oak).clone();
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg2");
 }

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -27,6 +27,7 @@ use url::Url;
 use crate::lsp::capabilities::Capabilities;
 use crate::lsp::document::Document;
 use crate::lsp::main_loop::init_aux_for_test;
+use crate::lsp::main_loop::AuxiliaryEvent;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers::did_change_watched_files;
@@ -522,7 +523,7 @@ fn test_did_close_releases_orphan_file_to_stale() {
     // to orphan, editor-owned) → close → file leaves orphan, lands in
     // stale. Without the `close_editor` hook in `did_close`, the file
     // would zombie in orphan with the editor's last content.
-    let _aux_rx = init_aux_for_test();
+    let mut aux_rx = init_aux_for_test();
 
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
@@ -566,4 +567,11 @@ fn test_did_close_releases_orphan_file_to_stale() {
 
     assert!(!state.db.orphan_root().files(&state.db).contains(&file));
     assert!(state.db.stale_root().files(&state.db).contains(&file));
+
+    // did_close() clears diagnostics for the closed file.
+    let event = aux_rx.try_recv().unwrap();
+    assert!(matches!(
+        event,
+        AuxiliaryEvent::PublishDiagnostics(u, diags, _) if u == url && diags.is_empty()
+    ));
 }

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -171,3 +171,114 @@ fn test_r_file_deleted_routes_through_remove_file() {
     assert_eq!(root.scripts(&state.oak).len(), 1);
     assert!(state.oak.file_by_url(&url_id).is_none());
 }
+
+#[test]
+fn test_r_file_changed_for_unopened_file_updates_contents() {
+    // No editor buffer, so the watcher's disk content is authoritative
+    // and should land in `file.contents()`. Complements the open-file
+    // skip test above.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("a.R");
+    fs::write(&path, "v1\n").unwrap();
+    let mut state = workspace_state(tmp.path());
+
+    let url_id = UrlId::from_file_path(&path).unwrap();
+    assert_eq!(
+        state.oak.file_by_url(&url_id).unwrap().contents(&state.oak),
+        "v1\n"
+    );
+
+    fs::write(&path, "v2\n").unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(&path, FileChangeType::CHANGED)],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    assert_eq!(
+        state.oak.file_by_url(&url_id).unwrap().contents(&state.oak),
+        "v2\n"
+    );
+}
+
+#[test]
+#[ignore = "blocked by UrlId canonicalization gap for missing paths"]
+fn test_r_file_deleted_for_editor_open_file_is_skipped() {
+    // Mirror of `test_r_file_changed_for_editor_open_file_is_skipped`
+    // for the Deleted kind. The skip check in `apply_watcher_events`
+    // sits before the kind match, so editor-owned URLs should be
+    // protected from deletion too: the buffer stays visible to the
+    // user and queries keep resolving against the editor's
+    // last-pushed content.
+    //
+    // The assertion passes today, but only incidentally: the same
+    // canonicalization gap that blocks the DESCRIPTION test below also
+    // breaks the skip lookup here. The event URL canonicalizes to the
+    // raw `/var/...` path (the file is gone, canonicalize fails),
+    // so the skip set (built from open documents while the file
+    // existed, i.e. `/private/var/...`) does not contain it. The event
+    // therefore reaches `remove_watched_file`, which also fails to find
+    // the file by URL and bails out. Net: file survives, but the skip
+    // mechanism is never actually exercised. Marked ignore until the
+    // canonicalization gap is fixed.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("a.R");
+    fs::write(&path, "disk_v1\n").unwrap();
+    let mut state = workspace_state(tmp.path());
+
+    let url = Url::from_file_path(&path).unwrap();
+    state
+        .documents
+        .insert(url.clone(), Document::new("editor_v2\n", None));
+    let url_id = UrlId::from_url(url.clone());
+    state
+        .oak
+        .set_editor_contents(url_id.clone(), "editor_v2\n".to_string());
+
+    fs::remove_file(&path).unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(&path, FileChangeType::DELETED)],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let file = state.oak.file_by_url(&url_id).unwrap();
+    assert_eq!(file.contents(&state.oak), "editor_v2\n");
+}
+
+#[test]
+#[ignore = "blocked by UrlId canonicalization gap for missing paths; see dev-notes/notes/oak/2026-05-22-0846-watcher-test-gaps.md"]
+fn test_description_deleted_demotes_package_to_scripts() {
+    // Inverse of `test_description_created_triggers_root_rescan`: a
+    // DESCRIPTION removed mid-session triggers a root rescan and the
+    // former package's R/ files surface as workspace scripts.
+    //
+    // Currently fails because `UrlId::from_url` canonicalizes via
+    // `std::fs::canonicalize`, which fails for paths that no longer
+    // exist and falls back to the raw path. On macOS this means the
+    // Deleted event's URL keeps the `/var/...` prefix while the
+    // workspace root URL uses `/private/var/...`, and the routing in
+    // `apply_watcher_events` misses.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut state = workspace_state(tmp.path());
+
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert_eq!(root.packages(&state.oak).len(), 1);
+    assert!(root.scripts(&state.oak).is_empty());
+
+    fs::remove_file(tmp.path().join("pkg/DESCRIPTION")).unwrap();
+    let params = DidChangeWatchedFilesParams {
+        changes: vec![event(
+            &tmp.path().join("pkg/DESCRIPTION"),
+            FileChangeType::DELETED,
+        )],
+    };
+    did_change_watched_files(params, &mut state).unwrap();
+
+    let root = state.oak.workspace_roots().roots(&state.oak)[0];
+    assert!(root.packages(&state.oak).is_empty());
+    assert_eq!(root.scripts(&state.oak).len(), 1);
+
+    let a_url = UrlId::from_file_path(tmp.path().join("pkg/R/a.R")).unwrap();
+    let file = state.oak.file_by_url(&a_url).unwrap();
+    assert_eq!(file.package(&state.oak), None);
+}

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use aether_url::UrlId;
 use oak_db::Db;
 use oak_db::DbInputs;
-use oak_scan::DbExt;
+use oak_scan::DbScan;
 use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
 use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -60,7 +60,7 @@ fn workspace_state(workspace: &Path) -> WorldState {
         .folders
         .push(Url::from_file_path(workspace).unwrap());
     state
-        .oak
+        .db
         .set_workspace_paths(&[workspace.to_path_buf()], &HashSet::new());
     state
 }
@@ -73,8 +73,8 @@ fn test_description_created_triggers_root_rescan() {
     let mut state = workspace_state(tmp.path());
 
     // No DESCRIPTION yet, so `a.R` registers as a workspace script.
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert!(root.packages(&state.oak).is_empty());
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert!(root.packages(&state.db).is_empty());
 
     // Now write DESCRIPTION and fire the watcher.
     fs::write(
@@ -90,9 +90,9 @@ fn test_description_created_triggers_root_rescan() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert_eq!(root.packages(&state.oak).len(), 1);
-    assert_eq!(root.packages(&state.oak)[0].name(&state.oak), "pkg");
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert_eq!(root.packages(&state.db).len(), 1);
+    assert_eq!(root.packages(&state.db)[0].name(&state.db), "pkg");
 }
 
 #[test]
@@ -119,8 +119,8 @@ fn test_multiple_descriptions_under_same_root_dedup_to_one_rescan() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert_eq!(root.packages(&state.oak).len(), 2);
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert_eq!(root.packages(&state.db).len(), 2);
 }
 
 #[test]
@@ -135,11 +135,11 @@ fn test_r_file_created_routes_through_add_file() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert_eq!(root.scripts(&state.oak).len(), 1);
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert_eq!(root.scripts(&state.db).len(), 1);
     let url = UrlId::from_file_path(&path).unwrap();
-    let file = state.oak.file_by_url(&url).unwrap();
-    assert_eq!(file.contents(&state.oak), "x <- 1\n");
+    let file = state.db.file_by_url(&url).unwrap();
+    assert_eq!(file.contents(&state.db), "x <- 1\n");
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn test_r_file_changed_for_editor_open_file_is_skipped() {
     // Pretend the editor pushed its content into oak too.
     let url_id = UrlId::from_url(url.clone());
     state
-        .oak
+        .db
         .upsert_editor(url_id.clone(), "editor_v2\n".to_string());
 
     // Now disk-side `Changed` fires with stale disk content.
@@ -169,8 +169,8 @@ fn test_r_file_changed_for_editor_open_file_is_skipped() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let file = state.oak.file_by_url(&url_id).unwrap();
-    assert_eq!(file.contents(&state.oak), "editor_v2\n");
+    let file = state.db.file_by_url(&url_id).unwrap();
+    assert_eq!(file.contents(&state.db), "editor_v2\n");
 }
 
 #[test]
@@ -187,9 +187,9 @@ fn test_r_file_deleted_routes_through_remove_file() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert_eq!(root.scripts(&state.oak).len(), 1);
-    assert!(state.oak.file_by_url(&url_id).is_none());
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert_eq!(root.scripts(&state.db).len(), 1);
+    assert!(state.db.file_by_url(&url_id).is_none());
 }
 
 #[test]
@@ -204,7 +204,7 @@ fn test_r_file_changed_for_unopened_file_updates_contents() {
 
     let url_id = UrlId::from_file_path(&path).unwrap();
     assert_eq!(
-        state.oak.file_by_url(&url_id).unwrap().contents(&state.oak),
+        state.db.file_by_url(&url_id).unwrap().contents(&state.db),
         "v1\n"
     );
 
@@ -215,7 +215,7 @@ fn test_r_file_changed_for_unopened_file_updates_contents() {
     did_change_watched_files(params, &mut state).unwrap();
 
     assert_eq!(
-        state.oak.file_by_url(&url_id).unwrap().contents(&state.oak),
+        state.db.file_by_url(&url_id).unwrap().contents(&state.db),
         "v2\n"
     );
 }
@@ -251,7 +251,7 @@ fn test_r_file_deleted_for_editor_open_file_is_skipped() {
         .insert(url.clone(), Document::new("editor_v2\n", None));
     let url_id = UrlId::from_url(url.clone());
     state
-        .oak
+        .db
         .upsert_editor(url_id.clone(), "editor_v2\n".to_string());
 
     fs::remove_file(&path).unwrap();
@@ -260,8 +260,8 @@ fn test_r_file_deleted_for_editor_open_file_is_skipped() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let file = state.oak.file_by_url(&url_id).unwrap();
-    assert_eq!(file.contents(&state.oak), "editor_v2\n");
+    let file = state.db.file_by_url(&url_id).unwrap();
+    assert_eq!(file.contents(&state.db), "editor_v2\n");
 }
 
 #[test]
@@ -281,9 +281,9 @@ fn test_description_deleted_demotes_package_to_scripts() {
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     let mut state = workspace_state(tmp.path());
 
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert_eq!(root.packages(&state.oak).len(), 1);
-    assert!(root.scripts(&state.oak).is_empty());
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert_eq!(root.packages(&state.db).len(), 1);
+    assert!(root.scripts(&state.db).is_empty());
 
     fs::remove_file(tmp.path().join("pkg/DESCRIPTION")).unwrap();
     let params = DidChangeWatchedFilesParams {
@@ -294,13 +294,13 @@ fn test_description_deleted_demotes_package_to_scripts() {
     };
     did_change_watched_files(params, &mut state).unwrap();
 
-    let root = state.oak.workspace_roots().roots(&state.oak)[0];
-    assert!(root.packages(&state.oak).is_empty());
-    assert_eq!(root.scripts(&state.oak).len(), 1);
+    let root = state.db.workspace_roots().roots(&state.db)[0];
+    assert!(root.packages(&state.db).is_empty());
+    assert_eq!(root.scripts(&state.db).len(), 1);
 
     let a_url = UrlId::from_file_path(tmp.path().join("pkg/R/a.R")).unwrap();
-    let file = state.oak.file_by_url(&a_url).unwrap();
-    assert_eq!(file.package(&state.oak), None);
+    let file = state.db.file_by_url(&a_url).unwrap();
+    assert_eq!(file.package(&state.db), None);
 }
 
 fn folder(uri: &str) -> WorkspaceFolder {
@@ -377,17 +377,17 @@ fn test_did_change_workspace_folders_adds_new_folder() {
 
     let mut state = workspace_state(first.path());
     assert_eq!(state.workspace.folders.len(), 1);
-    assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 1);
+    assert_eq!(state.db.workspace_roots().roots(&state.db).len(), 1);
 
     let params = folders_change(vec![folder_for(second.path())], vec![]);
     did_change_workspace_folders(params, &mut state).unwrap();
 
     assert_eq!(state.workspace.folders.len(), 2);
-    let roots = state.oak.workspace_roots().roots(&state.oak).clone();
+    let roots = state.db.workspace_roots().roots(&state.db).clone();
     assert_eq!(roots.len(), 2);
     // Existing root stays first, new one appended.
-    assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg1");
-    assert_eq!(roots[1].packages(&state.oak)[0].name(&state.oak), "pkg2");
+    assert_eq!(roots[0].packages(&state.db)[0].name(&state.db), "pkg1");
+    assert_eq!(roots[1].packages(&state.db)[0].name(&state.db), "pkg2");
 }
 
 #[test]
@@ -406,19 +406,19 @@ fn test_did_change_workspace_folders_removes_folder() {
         .workspace
         .folders
         .push(Url::from_file_path(second.path()).unwrap());
-    state.oak.set_workspace_paths(
+    state.db.set_workspace_paths(
         &[first.path().to_path_buf(), second.path().to_path_buf()],
         &HashSet::new(),
     );
-    assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 2);
+    assert_eq!(state.db.workspace_roots().roots(&state.db).len(), 2);
 
     let params = folders_change(vec![], vec![folder_for(first.path())]);
     did_change_workspace_folders(params, &mut state).unwrap();
 
     assert_eq!(state.workspace.folders.len(), 1);
-    let roots = state.oak.workspace_roots().roots(&state.oak).clone();
+    let roots = state.db.workspace_roots().roots(&state.db).clone();
     assert_eq!(roots.len(), 1);
-    assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg2");
+    assert_eq!(roots[0].packages(&state.db)[0].name(&state.db), "pkg2");
 }
 
 #[test]
@@ -434,7 +434,7 @@ fn test_did_change_workspace_folders_ignores_duplicate_add() {
     did_change_workspace_folders(params, &mut state).unwrap();
 
     assert_eq!(state.workspace.folders.len(), 1);
-    assert_eq!(state.oak.workspace_roots().roots(&state.oak).len(), 1);
+    assert_eq!(state.db.workspace_roots().roots(&state.db).len(), 1);
 }
 
 #[test]
@@ -453,9 +453,9 @@ fn test_did_change_workspace_folders_handles_add_and_remove_in_one_event() {
     did_change_workspace_folders(params, &mut state).unwrap();
 
     assert_eq!(state.workspace.folders.len(), 1);
-    let roots = state.oak.workspace_roots().roots(&state.oak).clone();
+    let roots = state.db.workspace_roots().roots(&state.db).clone();
     assert_eq!(roots.len(), 1);
-    assert_eq!(roots[0].packages(&state.oak)[0].name(&state.oak), "pkg2");
+    assert_eq!(roots[0].packages(&state.db)[0].name(&state.db), "pkg2");
 }
 
 #[test]
@@ -477,10 +477,10 @@ fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
         .documents
         .insert(url.clone(), Document::new("editor <- 2\n", None));
     state
-        .oak
+        .db
         .upsert_editor(url_id.clone(), "editor <- 2\n".to_string());
 
-    let file_before = state.oak.file_by_url(&url_id).unwrap();
+    let file_before = state.db.file_by_url(&url_id).unwrap();
 
     // Remove the workspace folder. The handler builds the editor_owned set
     // from state.documents.keys() and passes it to oak; the buffer's file
@@ -488,15 +488,15 @@ fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
     let params = folders_change(vec![], vec![folder_for(tmp.path())]);
     did_change_workspace_folders(params, &mut state).unwrap();
 
-    let after_remove = state.oak.file_by_url(&url_id).unwrap();
+    let after_remove = state.db.file_by_url(&url_id).unwrap();
     assert_eq!(file_before, after_remove);
-    assert_eq!(after_remove.package(&state.oak), None);
+    assert_eq!(after_remove.package(&state.db), None);
     assert!(state
-        .oak
+        .db
         .orphan_root()
-        .files(&state.oak)
+        .files(&state.db)
         .contains(&after_remove));
-    assert_eq!(after_remove.contents(&state.oak), "editor <- 2\n");
+    assert_eq!(after_remove.contents(&state.db), "editor <- 2\n");
 
     // Re-add the same folder. The file snaps back into pkg.files with
     // the same entity and the editor content carries over (the scan's
@@ -504,15 +504,15 @@ fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
     let params = folders_change(vec![folder_for(tmp.path())], vec![]);
     did_change_workspace_folders(params, &mut state).unwrap();
 
-    let after_readd = state.oak.file_by_url(&url_id).unwrap();
+    let after_readd = state.db.file_by_url(&url_id).unwrap();
     assert_eq!(file_before, after_readd);
-    assert!(after_readd.package(&state.oak).is_some());
-    assert_eq!(after_readd.contents(&state.oak), "editor <- 2\n");
+    assert!(after_readd.package(&state.db).is_some());
+    assert_eq!(after_readd.contents(&state.db), "editor <- 2\n");
     // `upsert_root_file` cleaned the orphan reference.
     assert!(!state
-        .oak
+        .db
         .orphan_root()
-        .files(&state.oak)
+        .files(&state.db)
         .contains(&after_readd));
 }
 
@@ -546,7 +546,7 @@ fn test_did_close_releases_orphan_file_to_stale() {
         .parsers
         .insert(url.clone(), tree_sitter::Parser::new());
     state
-        .oak
+        .db
         .upsert_editor(url_id.clone(), "edited\n".to_string());
 
     // Remove the workspace folder; file goes to orphan (editor-owned).
@@ -555,8 +555,8 @@ fn test_did_close_releases_orphan_file_to_stale() {
         &mut state,
     )
     .unwrap();
-    let file = state.oak.file_by_url(&url_id).unwrap();
-    assert!(state.oak.orphan_root().files(&state.oak).contains(&file));
+    let file = state.db.file_by_url(&url_id).unwrap();
+    assert!(state.db.orphan_root().files(&state.db).contains(&file));
 
     // Now close the buffer. File should move from orphan to stale.
     let params = DidCloseTextDocumentParams {
@@ -564,6 +564,6 @@ fn test_did_close_releases_orphan_file_to_stale() {
     };
     did_close(params, &mut lsp_state, &mut state).unwrap();
 
-    assert!(!state.oak.orphan_root().files(&state.oak).contains(&file));
-    assert!(state.oak.stale_root().files(&state.oak).contains(&file));
+    assert!(!state.db.orphan_root().files(&state.db).contains(&file));
+    assert!(state.db.stale_root().files(&state.db).contains(&file));
 }

--- a/crates/oak_db/src/db.rs
+++ b/crates/oak_db/src/db.rs
@@ -172,8 +172,8 @@ fn root_depth(db: &dyn Db, root: Root) -> usize {
 }
 
 /// Per-root URL -> File index. Salsa caches one map per `Root`;
-/// reads only `root.scripts`, `root.packages`, and each
-/// `pkg.files` reachable from this root. Adding or removing a file
+/// reads `root.scripts`, `root.packages`, each `pkg.files`, and each
+/// `pkg.scripts` reachable from this root. Adding or removing a file
 /// in *this* root invalidates this entry; other roots stay cached.
 #[salsa::tracked(returns(ref))]
 fn root_url_index(db: &dyn Db, root: Root) -> FxHashMap<UrlId, File> {
@@ -183,6 +183,9 @@ fn root_url_index(db: &dyn Db, root: Root) -> FxHashMap<UrlId, File> {
     }
     for &pkg in root.packages(db) {
         for &file in pkg.files(db) {
+            map.insert(file.url(db).clone(), file);
+        }
+        for &file in pkg.scripts(db) {
             map.insert(file.url(db).clone(), file);
         }
     }

--- a/crates/oak_db/src/inputs.rs
+++ b/crates/oak_db/src/inputs.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use aether_url::UrlId;
 use oak_package_metadata::namespace::Namespace;
 
@@ -124,13 +126,16 @@ pub struct OrphanRoot {
     /// **Placement invariant.** Files here must have `package(db) ==
     /// None`. Call this setter only through `oak_scan`'s helpers,
     /// which keep the back-pointer and the container in sync.
+    ///
+    /// Unordered: these are unanchored files looked up by URL, with no
+    /// collation chain among them, so membership is all that matters.
     #[returns(ref)]
-    pub files: Vec<File>,
+    pub files: HashSet<File>,
 }
 
 impl OrphanRoot {
     pub fn empty(db: &dyn Db) -> Self {
-        Self::new(db, vec![])
+        Self::new(db, HashSet::new())
     }
 }
 
@@ -161,15 +166,17 @@ impl OrphanRoot {
 /// of them gets pulled back into a live container.
 #[salsa::input]
 pub struct StaleRoot {
+    /// Unordered: entity-reuse storage looked up by URL, no collation chain,
+    /// so membership is all that matters.
     #[returns(ref)]
-    pub files: Vec<File>,
+    pub files: HashSet<File>,
     #[returns(ref)]
     pub packages: Vec<Package>,
 }
 
 impl StaleRoot {
     pub fn empty(db: &dyn Db) -> Self {
-        Self::new(db, vec![], vec![])
+        Self::new(db, HashSet::new(), vec![])
     }
 }
 

--- a/crates/oak_db/src/inputs.rs
+++ b/crates/oak_db/src/inputs.rs
@@ -211,12 +211,11 @@ pub struct Package {
     /// the back-pointer and the container in sync.
     #[returns(ref)]
     pub files: Vec<File>,
-    /// Other R files inside the package directory that aren't part of
-    /// the loadable namespace: `tests/`, `inst/`, `vignettes/`,
-    /// `data-raw/`, etc. These get LSP analysis (parse, semantic index)
-    /// but aren't loaded with the package, so name resolution treats
-    /// them as standalone scripts that just happen to live next to the
-    /// package's code.
+    /// Other R files inside the package directory that aren't part of the
+    /// loadable namespace: `tests/`, `inst/`, `data-raw/`, etc. These get LSP
+    /// analysis (parse, semantic index) but aren't loaded with the package, so
+    /// name resolution treats them as standalone scripts that just happen to
+    /// live next to the package's code.
     ///
     /// **Placement invariant.** Same as [`Self::files`]: backpointer
     /// stays `Some(self)`, file lives in one of the two containers.

--- a/crates/oak_db/src/inputs.rs
+++ b/crates/oak_db/src/inputs.rs
@@ -205,11 +205,23 @@ pub struct Package {
     /// package's files.
     ///
     /// **Placement invariant.** A file present here must have
-    /// `package(db) == Some(self)`. Call this setter only through
-    /// `oak_scan`'s helpers, which keep the back-pointer and the
-    /// container in sync.
+    /// `package(db) == Some(self)`, and a file with
+    /// `package == Some(self)` must live here or in [`Self::scripts`].
+    /// Call this setter only through `oak_scan`'s helpers, which keep
+    /// the back-pointer and the container in sync.
     #[returns(ref)]
     pub files: Vec<File>,
+    /// Other R files inside the package directory that aren't part of
+    /// the loadable namespace: `tests/`, `inst/`, `vignettes/`,
+    /// `data-raw/`, etc. These get LSP analysis (parse, semantic index)
+    /// but aren't loaded with the package, so name resolution treats
+    /// them as standalone scripts that just happen to live next to the
+    /// package's code.
+    ///
+    /// **Placement invariant.** Same as [`Self::files`]: backpointer
+    /// stays `Some(self)`, file lives in one of the two containers.
+    #[returns(ref)]
+    pub scripts: Vec<File>,
     /// The basename ordering from `DESCRIPTION`'s `Collate` field, if
     /// present. `None` when the field is absent (R defaults to
     /// alphabetical load order). Changes only when `DESCRIPTION`

--- a/crates/oak_db/src/storage.rs
+++ b/crates/oak_db/src/storage.rs
@@ -31,6 +31,12 @@ impl OakDatabase {
 #[salsa::db]
 impl salsa::Database for OakDatabase {}
 
+impl std::fmt::Debug for OakDatabase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OakDatabase").finish_non_exhaustive()
+    }
+}
+
 #[salsa::db]
 impl DbInputs for OakDatabase {
     fn workspace_roots(&self) -> WorkspaceRoots {

--- a/crates/oak_db/src/tests/db.rs
+++ b/crates/oak_db/src/tests/db.rs
@@ -36,6 +36,7 @@ fn test_file_by_url_finds_workspace_package_file() {
         None,
         Namespace::default(),
         vec![],
+        Vec::new(),
         None,
     );
     let file = File::new(&db, file_url("proj/R/foo.R"), String::new(), Some(pkg));
@@ -57,6 +58,7 @@ fn test_file_by_url_finds_library_package_file() {
         Some("1.0.0".to_string()),
         Namespace::default(),
         vec![],
+        Vec::new(),
         None,
     );
     let file = File::new(&db, file_url("libs/foo/R/a.R"), String::new(), Some(pkg));

--- a/crates/oak_db/src/tests/db.rs
+++ b/crates/oak_db/src/tests/db.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
 
@@ -73,7 +75,9 @@ fn test_file_by_url_finds_library_package_file() {
 fn test_file_by_url_finds_orphan_file() {
     let mut db = TestDb::new();
     let file = File::new(&db, file_url("untitled.R"), String::new(), None);
-    db.orphan_root().set_files(&mut db).to(vec![file]);
+    db.orphan_root()
+        .set_files(&mut db)
+        .to(HashSet::from([file]));
 
     assert_eq!(db.file_by_url(&file_url("untitled.R")), Some(file));
 }

--- a/crates/oak_db/src/tests/file_imports.rs
+++ b/crates/oak_db/src/tests/file_imports.rs
@@ -24,6 +24,7 @@ fn make_installed(db: &mut TestDb, name: &str) -> (crate::Root, Package) {
         Some("1.0.0".to_string()),
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     root.set_packages(db).to(vec![pkg]);
@@ -129,6 +130,7 @@ fn test_package_file_emits_namespace_and_collation_layers() {
         "pkg".to_string(),
         None,
         namespace,
+        Vec::new(),
         Vec::new(),
         None,
     );

--- a/crates/oak_db/src/tests/file_imports_at.rs
+++ b/crates/oak_db/src/tests/file_imports_at.rs
@@ -33,6 +33,7 @@ fn install_packages(db: &mut TestDb, names: &[&str]) -> Vec<Package> {
             Some("1.0.0".to_string()),
             Namespace::default(),
             Vec::new(),
+            Vec::new(),
             None,
         );
         root.set_packages(db).to(vec![pkg]);
@@ -53,6 +54,7 @@ fn install_workspace_package(db: &mut TestDb, name: &str) -> Package {
         name.to_string(),
         None,
         Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -286,6 +286,7 @@ fn test_resolve_unbound_name_in_package_does_not_cycle() {
         None,
         oak_package_metadata::namespace::Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
 
@@ -324,6 +325,7 @@ fn test_resolve_walks_package_files_for_lazy_lookups() {
         "pkg".to_string(),
         None,
         oak_package_metadata::namespace::Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );

--- a/crates/oak_db/src/tests/file_resolve_at.rs
+++ b/crates/oak_db/src/tests/file_resolve_at.rs
@@ -45,6 +45,7 @@ fn install_workspace_package(db: &mut TestDb, name: &str) -> (Root, Package) {
         None,
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     root.set_packages(db).to(vec![pkg]);

--- a/crates/oak_db/src/tests/file_root.rs
+++ b/crates/oak_db/src/tests/file_root.rs
@@ -54,6 +54,7 @@ fn test_root_dispatches_through_library_package_when_set() {
         Some("1.0.0".to_string()),
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     pkg_root.set_packages(&mut db).to(vec![pkg]);
@@ -84,6 +85,7 @@ fn test_root_dispatches_through_workspace_package_when_set() {
         "mypkg".to_string(),
         None,
         Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );

--- a/crates/oak_db/src/tests/inputs.rs
+++ b/crates/oak_db/src/tests/inputs.rs
@@ -20,6 +20,7 @@ fn make_workspace_package(db: &mut OakDatabase, name: &str) -> (Root, Package) {
         None,
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     root.set_packages(db).to(vec![pkg]);
@@ -34,6 +35,7 @@ fn make_installed_package(db: &mut OakDatabase, name: &str) -> (Root, Package) {
         name.to_string(),
         Some("1.0.0".to_string()),
         Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );

--- a/crates/oak_db/src/tests/resolver.rs
+++ b/crates/oak_db/src/tests/resolver.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use oak_semantic::semantic_index::DefinitionKind;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::SemanticCallKind;
@@ -350,7 +352,9 @@ fn test_source_anchors_to_parent_dir_when_no_workspace() {
         None,
     );
     let b = File::new(&db, file_url("dir/b.R"), "x <- 1\n".to_string(), None);
-    db.orphan_root().set_files(&mut db).to(vec![a, b]);
+    db.orphan_root()
+        .set_files(&mut db)
+        .to(HashSet::from([a, b]));
 
     let index = a.semantic_index(&db);
     assert!(index.exports().contains_key("x"));
@@ -368,7 +372,9 @@ fn test_source_path_with_parent_dir_segments() {
         None,
     );
     let b = File::new(&db, file_url("dir/b.R"), "x <- 1\n".to_string(), None);
-    db.orphan_root().set_files(&mut db).to(vec![a, b]);
+    db.orphan_root()
+        .set_files(&mut db)
+        .to(HashSet::from([a, b]));
 
     let index = a.semantic_index(&db);
     assert!(index.exports().contains_key("x"));

--- a/crates/oak_scan/Cargo.toml
+++ b/crates/oak_scan/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 aether_url.workspace = true
+ignore.workspace = true
 log.workspace = true
 oak_core.workspace = true
 oak_db.workspace = true

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -240,6 +240,7 @@ pub trait RootExt {
         version: Option<String>,
         namespace: Namespace,
         files: Vec<FileEntry>,
+        scripts: Vec<FileEntry>,
         collation: Option<Vec<String>>,
     ) -> Package;
 
@@ -272,6 +273,7 @@ impl RootExt for Root {
         version: Option<String>,
         namespace: Namespace,
         files: Vec<FileEntry>,
+        scripts: Vec<FileEntry>,
         collation: Option<Vec<String>>,
     ) -> Package {
         // `package_by_url()` finds the existing entity whether it's already
@@ -294,6 +296,7 @@ impl RootExt for Root {
                 version,
                 namespace,
                 Vec::new(),
+                Vec::new(),
                 collation,
             ),
         };
@@ -302,8 +305,13 @@ impl RootExt for Root {
             .into_iter()
             .map(|entry| upsert_root_file(db, Some(pkg), entry))
             .collect();
+        let script_entities: Vec<File> = scripts
+            .into_iter()
+            .map(|entry| upsert_root_file(db, Some(pkg), entry))
+            .collect();
 
         pkg.set_files(db).to(file_entities);
+        pkg.set_scripts(db).to(script_entities);
         pkg
     }
 
@@ -376,13 +384,24 @@ pub(crate) fn upsert_root_file<DB: Db + DbInputs>(
     File::new(db, entry.url, entry.contents, package)
 }
 
-fn remove_from_pkg_files<DB: Db + DbInputs>(db: &mut DB, pkg: Package, file: File) {
-    if !pkg.files(db).contains(&file) {
+/// Remove `file` from whichever of `pkg.files` / `pkg.scripts` holds it.
+/// Used during cross-package moves: if a file's owning package changed,
+/// the old package's containers still reference it until we drop the
+/// entry. Also used by [`watch::remove_watched_file`] when a file
+/// disappears from disk.
+pub(crate) fn remove_from_pkg_files<DB: Db + DbInputs>(db: &mut DB, pkg: Package, file: File) {
+    if pkg.files(db).contains(&file) {
+        let mut files = pkg.files(db).clone();
+        files.retain(|f| *f != file);
+        pkg.set_files(db).to(files);
         return;
     }
-    let mut files = pkg.files(db).clone();
-    files.retain(|f| *f != file);
-    pkg.set_files(db).to(files);
+
+    if pkg.scripts(db).contains(&file) {
+        let mut scripts = pkg.scripts(db).clone();
+        scripts.retain(|f| *f != file);
+        pkg.set_scripts(db).to(scripts);
+    }
 }
 
 fn remove_from_orphan<DB: Db + DbInputs>(db: &mut DB, file: File) {

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -17,6 +17,7 @@
 //! input structs.
 
 use std::collections::HashSet;
+use std::hash::Hash;
 use std::path::PathBuf;
 
 use aether_url::UrlId;
@@ -178,7 +179,7 @@ impl<DB: Db + DbInputs> DbScan for DB {
         };
 
         let orphan = self.orphan_root();
-        let Some(orphan_files) = with_removed(orphan.files(self), file) else {
+        let Some(orphan_files) = with_cow_remove(orphan.files(self), file) else {
             // A workspace or library root holds it, nothing to do.
             return;
         };
@@ -187,7 +188,7 @@ impl<DB: Db + DbInputs> DbScan for DB {
         orphan.set_files(self).to(orphan_files);
 
         let stale = self.stale_root();
-        if let Some(stale_files) = with_appended(stale.files(self), file) {
+        if let Some(stale_files) = with_cow_insert(stale.files(self), file) {
             stale.set_files(self).to(stale_files);
         }
     }
@@ -384,36 +385,37 @@ pub(crate) fn upsert_root_file<DB: Db + DbInputs>(
 /// entry. Also used by [`watch::remove_watched_file`] when a file
 /// disappears from disk.
 pub(crate) fn remove_from_pkg_files<DB: Db + DbInputs>(db: &mut DB, pkg: Package, file: File) {
-    if let Some(files) = with_removed(pkg.files(db), file) {
+    if let Some(files) = with_cow_filter(pkg.files(db), file) {
         pkg.set_files(db).to(files);
         return;
     }
-    if let Some(scripts) = with_removed(pkg.scripts(db), file) {
+    if let Some(scripts) = with_cow_filter(pkg.scripts(db), file) {
         pkg.set_scripts(db).to(scripts);
     }
 }
 
 pub(crate) fn remove_from_orphan<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let orphan = db.orphan_root();
-    if let Some(files) = with_removed(orphan.files(db), file) {
+    if let Some(files) = with_cow_remove(orphan.files(db), file) {
         orphan.set_files(db).to(files);
     }
 }
 
 fn add_to_orphan_files<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let orphan = db.orphan_root();
-    if let Some(files) = with_appended(orphan.files(db), file) {
+    if let Some(files) = with_cow_insert(orphan.files(db), file) {
         orphan.set_files(db).to(files);
     }
 }
 
-/// The container with `file` appended, or `None` if it's already there.
+/// The ordered container with `file` appended, or `None` if it's already there.
 ///
 /// `None` means nothing would change, so the caller skips the salsa write and
-/// the clone. This keeps the "clone only when the field actually changes"
-/// rule in one place, shared by every container update on `Root` / `Package` /
-/// `OrphanRoot`.
-pub(crate) fn with_appended<T: Clone + PartialEq>(files: &[T], file: T) -> Option<Vec<T>> {
+/// the clone. This keeps the "clone only when the field actually changes" rule
+/// in one place, shared by the ordered container updates on `Root` and
+/// `Package`. See [`with_inserted`] / [`with_discarded`] for the unordered
+/// `OrphanRoot` / `StaleRoot` sets.
+pub(crate) fn with_cow_push<T: Clone + PartialEq>(files: &[T], file: T) -> Option<Vec<T>> {
     if files.contains(&file) {
         return None;
     }
@@ -422,11 +424,40 @@ pub(crate) fn with_appended<T: Clone + PartialEq>(files: &[T], file: T) -> Optio
     Some(updated)
 }
 
-/// The container with `file` removed, or `None` if it wasn't there. `None`
-/// means nothing would change, see [`with_file_appended`].
-pub(crate) fn with_removed<T: Clone + PartialEq>(files: &[T], file: T) -> Option<Vec<T>> {
+/// The ordered container with `file` removed, or `None` if it wasn't there.
+/// `None` means nothing would change, see [`with_appended`].
+pub(crate) fn with_cow_filter<T: Clone + PartialEq>(files: &[T], file: T) -> Option<Vec<T>> {
     if !files.contains(&file) {
         return None;
     }
     Some(files.iter().filter(|f| **f != file).cloned().collect())
+}
+
+/// The set with `item` inserted, or `None` if it's already present. The
+/// unordered counterpart of [`with_appended`], used for the `OrphanRoot` /
+/// `StaleRoot` sets where membership is all that matters.
+pub(crate) fn with_cow_insert<T: Clone + Eq + Hash>(
+    set: &HashSet<T>,
+    item: T,
+) -> Option<HashSet<T>> {
+    if set.contains(&item) {
+        return None;
+    }
+    let mut updated = set.clone();
+    updated.insert(item);
+    Some(updated)
+}
+
+/// The set with `item` removed, or `None` if it wasn't present. The unordered
+/// counterpart of [`with_removed`].
+pub(crate) fn with_cow_remove<T: Clone + Eq + Hash>(
+    set: &HashSet<T>,
+    item: T,
+) -> Option<HashSet<T>> {
+    if !set.contains(&item) {
+        return None;
+    }
+    let mut updated = set.clone();
+    updated.remove(&item);
+    Some(updated)
 }

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -178,21 +178,18 @@ impl<DB: Db + DbInputs> DbScan for DB {
         };
 
         let orphan = self.orphan_root();
-        if !orphan.files(self).contains(&file) {
-            // A workspace or library root holds it
+        let Some(orphan_files) = with_removed(orphan.files(self), file) else {
+            // A workspace or library root holds it, nothing to do.
             return;
-        }
-        // If the opened editor was in the orphan root, the file is now stale
+        };
+        // The opened editor was in the orphan root, so the file is now stale
         // and unreachable. Move it to the stale root.
-
-        let mut orphan_files = orphan.files(self).clone();
-        orphan_files.retain(|f| *f != file);
         orphan.set_files(self).to(orphan_files);
 
         let stale = self.stale_root();
-        let mut stale_files = stale.files(self).clone();
-        stale_files.push(file);
-        stale.set_files(self).to(stale_files);
+        if let Some(stale_files) = with_appended(stale.files(self), file) {
+            stale.set_files(self).to(stale_files);
+        }
     }
 
     fn add_watched_file(&mut self, url: UrlId, contents: String) {
@@ -387,36 +384,49 @@ pub(crate) fn upsert_root_file<DB: Db + DbInputs>(
 /// entry. Also used by [`watch::remove_watched_file`] when a file
 /// disappears from disk.
 pub(crate) fn remove_from_pkg_files<DB: Db + DbInputs>(db: &mut DB, pkg: Package, file: File) {
-    if pkg.files(db).contains(&file) {
-        let mut files = pkg.files(db).clone();
-        files.retain(|f| *f != file);
+    if let Some(files) = with_removed(pkg.files(db), file) {
         pkg.set_files(db).to(files);
         return;
     }
-
-    if pkg.scripts(db).contains(&file) {
-        let mut scripts = pkg.scripts(db).clone();
-        scripts.retain(|f| *f != file);
+    if let Some(scripts) = with_removed(pkg.scripts(db), file) {
         pkg.set_scripts(db).to(scripts);
     }
 }
 
-fn remove_from_orphan<DB: Db + DbInputs>(db: &mut DB, file: File) {
+pub(crate) fn remove_from_orphan<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let orphan = db.orphan_root();
-    if !orphan.files(db).contains(&file) {
-        return;
+    if let Some(files) = with_removed(orphan.files(db), file) {
+        orphan.set_files(db).to(files);
     }
-    let mut files = orphan.files(db).clone();
-    files.retain(|f| *f != file);
-    orphan.set_files(db).to(files);
 }
 
 fn add_to_orphan_files<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let orphan = db.orphan_root();
-    if orphan.files(db).contains(&file) {
-        return;
+    if let Some(files) = with_appended(orphan.files(db), file) {
+        orphan.set_files(db).to(files);
     }
-    let mut files = orphan.files(db).clone();
-    files.push(file);
-    orphan.set_files(db).to(files);
+}
+
+/// The container with `file` appended, or `None` if it's already there.
+///
+/// `None` means nothing would change, so the caller skips the salsa write and
+/// the clone. This keeps the "clone only when the field actually changes"
+/// rule in one place, shared by every container update on `Root` / `Package` /
+/// `OrphanRoot`.
+pub(crate) fn with_appended<T: Clone + PartialEq>(files: &[T], file: T) -> Option<Vec<T>> {
+    if files.contains(&file) {
+        return None;
+    }
+    let mut updated = files.to_vec();
+    updated.push(file);
+    Some(updated)
+}
+
+/// The container with `file` removed, or `None` if it wasn't there. `None`
+/// means nothing would change, see [`with_file_appended`].
+pub(crate) fn with_removed<T: Clone + PartialEq>(files: &[T], file: T) -> Option<Vec<T>> {
+    if !files.contains(&file) {
+        return None;
+    }
+    Some(files.iter().filter(|f| **f != file).cloned().collect())
 }

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -90,20 +90,38 @@ pub trait DbScan: Db + DbInputs {
     /// `DESCRIPTION` events change the package classification of a directory.
     fn rescan_workspace_root(&mut self, root: Root);
 
-    /// Upsert a file's content. Used by the LSP layer to apply `didOpen` /
-    /// `didChange` content for any URL the editor touches.
+    /// Upsert the editor's view of a file. Used by the LSP layer to apply
+    /// `didOpen` / `didChange` content for any URL the editor touches.
     ///
-    /// If a `File` already exists at this URL, only its contents are updated.
-    /// Classification is left as-is: a file the scanner had previously placed
-    /// in a package stays in that package, since `didOpen` is a content event,
-    /// not a reclassification.
+    /// If a `File` already exists at this URL (in a live root or orphan),
+    /// only its contents are updated. Classification is left as-is: a file
+    /// the scanner had previously placed in a package stays in that package
+    /// (`didOpen` is a content event, not a reclassification).
     ///
-    /// If no `File` exists yet, one is created in `orphan_root().files`. It
-    /// stays there until another handler reclassifies it. Untitled buffers and
-    /// files that do not belong to any workspace stay orphan for the session.
-    /// Files inside a workspace folder get reclassified the next time the
-    /// workspace scanner runs, at which point the orphan reference is dropped.
-    fn set_editor_contents(&mut self, url: UrlId, contents: String) -> File;
+    /// If no live `File` exists but one is in [`StaleRoot`] from a prior
+    /// [`Self::close_editor`], it gets resurrected into `orphan_root` with
+    /// the new content. This ways, reopening a previously-closed buffer reuses
+    /// the same `File` input entity in the Salsa cache.
+    ///
+    /// If no `File` exists at all, one is created in `orphan_root().files`.
+    /// It stays there until another handler reclassifies it. Untitled
+    /// buffers and files outside every workspace stay orphan for the
+    /// session. Files inside a workspace folder get reclassified the next
+    /// time the workspace scanner runs.
+    fn upsert_editor(&mut self, url: UrlId, contents: String) -> File;
+
+    /// Mark the editor as no longer holding a buffer for this URL.
+    ///
+    /// If the file lives in [`OrphanRoot`] (placed there by
+    /// [`Self::upsert_editor`] because the URL didn't belong to a live root, or
+    /// by `set_workspace_paths()` eviction routing for an open buffer in a
+    /// removed workspace), it gets moved to [`StaleRoot`]. Future
+    /// [`Self::upsert_editor`] for the same URL resurrects the entity from
+    /// stale instead of minting a fresh one.
+    ///
+    /// If the file is in a live workspace / library container, the call is a
+    /// no-op.
+    fn close_editor(&mut self, url: &UrlId);
 
     /// React to a Created or Changed watcher event on an R file. Classifies the
     /// URL against the current workspace tree and either creates a new `File`
@@ -136,20 +154,48 @@ impl<DB: Db + DbInputs> DbScan for DB {
         workspace::rescan_workspace_root(self, root);
     }
 
-    fn set_editor_contents(&mut self, url: UrlId, contents: String) -> File {
+    fn upsert_editor(&mut self, url: UrlId, contents: String) -> File {
         if let Some(existing) = self.file_by_url(&url) {
             existing.set_contents(self).to(contents);
             return existing;
         }
 
+        // Resurrect a previously-closed buffer from stale. The didOpen
+        // content overwrites whatever the stale entity carried.
+        if let Some(stale) = stale_file_by_url(self, &url) {
+            stale.set_contents(self).to(contents);
+            stale.set_package(self).to(None);
+            remove_from_stale_files(self, stale);
+            add_to_orphan_files(self, stale);
+            return stale;
+        }
+
         let file = File::new(self, url, contents, None);
-        let orphan = self.orphan_root();
-
-        let mut files = orphan.files(self).clone();
-        files.push(file);
-        orphan.set_files(self).to(files);
-
+        add_to_orphan_files(self, file);
         file
+    }
+
+    fn close_editor(&mut self, url: &UrlId) {
+        let Some(file) = self.file_by_url(url) else {
+            return;
+        };
+
+        let orphan = self.orphan_root();
+        if !orphan.files(self).contains(&file) {
+            // A workspace or library root holds it
+            return;
+        }
+        // If the opened editor was in the orphan root, the file is now stale
+        // and unreachable. Move it to the stale root.
+
+        let mut orphan_files = orphan.files(self).clone();
+        orphan_files.retain(|f| *f != file);
+        orphan.set_files(self).to(orphan_files);
+
+        let stale = self.stale_root();
+        let mut stale_files = stale.files(self).clone();
+        stale_files.push(file);
+        stale.set_files(self).to(stale_files);
     }
 
     fn add_watched_file(&mut self, url: UrlId, contents: String) {
@@ -347,4 +393,13 @@ fn remove_from_orphan<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let mut files = orphan.files(db).clone();
     files.retain(|f| *f != file);
     orphan.set_files(db).to(files);
+}
+
+fn add_to_orphan_files<DB: Db + DbInputs>(db: &mut DB, file: File) {
+    let orphan = db.orphan_root();
+    let mut files = orphan.files(db).clone();
+    if !files.contains(&file) {
+        files.push(file);
+        orphan.set_files(db).to(files);
+    }
 }

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -413,9 +413,10 @@ fn remove_from_orphan<DB: Db + DbInputs>(db: &mut DB, file: File) {
 
 fn add_to_orphan_files<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let orphan = db.orphan_root();
-    let mut files = orphan.files(db).clone();
-    if !files.contains(&file) {
-        files.push(file);
-        orphan.set_files(db).to(files);
+    if orphan.files(db).contains(&file) {
+        return;
     }
+    let mut files = orphan.files(db).clone();
+    files.push(file);
+    orphan.set_files(db).to(files);
 }

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -104,10 +104,7 @@ pub trait DbScan: Db + DbInputs {
     /// the same `File` input entity in the Salsa cache.
     ///
     /// If no `File` exists at all, one is created in `orphan_root().files`.
-    /// It stays there until another handler reclassifies it. Untitled
-    /// buffers and files outside every workspace stay orphan for the
-    /// session. Files inside a workspace folder get reclassified the next
-    /// time the workspace scanner runs.
+    /// It stays there until another handler reclassifies it.
     fn upsert_editor(&mut self, url: UrlId, contents: String) -> File;
 
     /// Mark the editor as no longer holding a buffer for this URL.

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -66,11 +66,56 @@ pub trait DbScan: Db + DbInputs {
     /// Order in `LibraryRoots.roots` follows `paths`, matching R's
     /// `.libPaths()` precedence.
     fn set_library_paths(&mut self, paths: &[PathBuf]);
+
+    /// Scan each workspace path and register the result under
+    /// `WorkspaceRoots`. Each path becomes a `Workspace` root with
+    /// its discovered packages (`DESCRIPTION` files at any depth,
+    /// honouring `.gitignore`) and top-level R scripts. Existing
+    /// `Root` entities at each path are reused.
+    ///
+    /// TODO(scan): rename to `set_workspace_paths` and adopt the diff-
+    /// based reconciliation pattern that `set_library_paths` uses
+    /// (untouched / scanned / evicted-to-stale).
+    fn scan_workspace_paths(&mut self, paths: &[PathBuf]);
+
+    /// Upsert a file from the VFS. Used by the LSP layer to apply
+    /// `didOpen` / `didChange` content for any URL the editor touches.
+    ///
+    /// If a `File` already exists at this URL, its contents are
+    /// updated. Classification is left as-is: a file the scanner had
+    /// previously placed in a package stays in that package, since
+    /// `didOpen` is a content event, not a reclassification.
+    ///
+    /// If no `File` exists yet, one is created in
+    /// `orphan_root().files`. It stays there until something
+    /// explicitly reclassifies it. Untitled buffers and files outside
+    /// every workspace stay orphan for the session. Files that should
+    /// belong to a workspace scan's output land in their proper
+    /// container when the workspace scanner next runs.
+    fn set_file_contents(&mut self, url: UrlId, contents: String) -> File;
 }
 
 impl<DB: Db + DbInputs> DbScan for DB {
     fn set_library_paths(&mut self, paths: &[PathBuf]) {
         crate::library::set_library_paths(self, paths);
+    }
+
+    fn scan_workspace_paths(&mut self, paths: &[PathBuf]) {
+        crate::workspace::scan_workspace_paths(self, paths);
+    }
+
+    fn set_file_contents(&mut self, url: UrlId, contents: String) -> File {
+        if let Some(existing) = self.file_by_url(&url) {
+            existing.set_contents(self).to(contents);
+            return existing;
+        }
+
+        let file = File::new(self, url, contents, None);
+        let orphan = self.orphan_root();
+        let mut files = orphan.files(self).clone();
+        files.push(file);
+        orphan.set_files(self).to(files);
+        file
     }
 }
 
@@ -119,6 +164,12 @@ pub trait RootExt {
     /// Doesn't touch `LibraryRoots` / `WorkspaceRoots`. The caller is
     /// responsible for rebuilding those Vec inputs with `self` excluded.
     fn set_stale<DB: Db + DbInputs>(self, db: &mut DB, editor_owned: Option<&HashSet<UrlId>>);
+
+    /// Replace `self.scripts` with `File` entities for `files`. Same
+    /// identity rules as [`set_package`](Self::set_package): existing
+    /// `File` entities at the given URLs are reused and have their
+    /// `package` field cleared.
+    fn set_workspace_scripts<DB: Db + DbInputs>(self, db: &mut DB, files: Vec<FileEntry>);
 }
 
 impl RootExt for Root {
@@ -167,6 +218,14 @@ impl RootExt for Root {
 
     fn set_stale<DB: Db + DbInputs>(self, db: &mut DB, editor_owned: Option<&HashSet<UrlId>>) {
         crate::stale::set_root_stale(db, self, editor_owned);
+    }
+
+    fn set_workspace_scripts<DB: Db + DbInputs>(self, db: &mut DB, files: Vec<FileEntry>) {
+        let scripts: Vec<File> = files
+            .into_iter()
+            .map(|entry| upsert_file(db, None, entry))
+            .collect();
+        self.set_scripts(db).to(scripts);
     }
 }
 

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -135,10 +135,10 @@ pub trait DbScan: Db + DbInputs {
 
     /// Apply a batch of file-watcher events. Routes DESCRIPTION events to a
     /// coarse rescan of the containing workspace root (deduped within the
-    /// batch), and R-file events to per-file add / remove. URLs in `skip` are
+    /// batch), and R-file events to per-file add / remove. URLs in `editor_owned` are
     /// left alone, so callers can defer to an in-memory source of truth (e.g.
     /// the editor's open buffers).
-    fn apply_watcher_events(&mut self, events: Vec<FileEvent>, skip: &HashSet<UrlId>);
+    fn apply_watcher_events(&mut self, events: Vec<FileEvent>, editor_owned: &HashSet<UrlId>);
 }
 
 impl<DB: Db + DbInputs> DbScan for DB {
@@ -206,8 +206,8 @@ impl<DB: Db + DbInputs> DbScan for DB {
         watch::remove_watched_file(self, url);
     }
 
-    fn apply_watcher_events(&mut self, events: Vec<FileEvent>, skip: &HashSet<UrlId>) {
-        watch::apply_watcher_events(self, events, skip);
+    fn apply_watcher_events(&mut self, events: Vec<FileEvent>, editor_owned: &HashSet<UrlId>) {
+        watch::apply_watcher_events(self, events, editor_owned);
     }
 }
 

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -60,7 +60,9 @@ pub trait DbScan: Db + DbInputs {
     ///
     /// - Paths already present as a `Root`: untouched. No fs walk, no
     ///   salsa churn.
+    ///
     /// - New paths: scanned and added.
+    ///
     /// - Removed paths: their `Root` is dropped and the contained `File`
     ///   and `Package` entities move to [`oak_db::StaleRoot`] so that
     ///   a later call that brings the same path back reuses the same
@@ -70,15 +72,19 @@ pub trait DbScan: Db + DbInputs {
     /// `.libPaths()` precedence.
     fn set_library_paths(&mut self, paths: &[PathBuf]);
 
-    /// Scan each workspace path and register the result under `WorkspaceRoots`.
-    /// Each path becomes a `Workspace` root with its discovered packages
-    /// (`DESCRIPTION` files at any depth, honouring `.gitignore`) and top-level
-    /// R scripts. Existing `Root` entities at each path are reused.
+    /// Reconcile `WorkspaceRoots` to exactly `paths`.
     ///
-    /// TODO(scan): rename to `set_workspace_paths` and adopt the diff-based
-    /// reconciliation pattern that `set_library_paths` uses (untouched /
-    /// scanned / evicted-to-stale).
-    fn scan_workspace_paths(&mut self, paths: &[PathBuf]);
+    /// - Paths already present as a `Root`: untouched. No fs walk, no salsa
+    ///   churn. The file watcher handles in-folder changes.
+    ///
+    /// - New paths: scanned (`DESCRIPTION` files at any depth, honouring
+    ///   `.gitignore`, plus top-level R scripts) and added.
+    ///
+    /// - Removed paths: their `Root` is evicted. Files whose URLs are in
+    ///   `editor_owned` move to [`oak_db::OrphanRoot`] (analysis-visible: the
+    ///   buffer is still open). Everything else moves to [`oak_db::StaleRoot`]
+    ///   for entity reuse if the path comes back.
+    fn set_workspace_paths(&mut self, paths: &[PathBuf], editor_owned: &HashSet<UrlId>);
 
     /// Rescan one workspace root. Used as the coarse fallback when
     /// `DESCRIPTION` events change the package classification of a directory.
@@ -122,8 +128,8 @@ impl<DB: Db + DbInputs> DbScan for DB {
         crate::library::set_library_paths(self, paths);
     }
 
-    fn scan_workspace_paths(&mut self, paths: &[PathBuf]) {
-        crate::workspace::scan_workspace_paths(self, paths);
+    fn set_workspace_paths(&mut self, paths: &[PathBuf], editor_owned: &HashSet<UrlId>) {
+        crate::workspace::set_workspace_paths(self, paths, editor_owned);
     }
 
     fn rescan_workspace_root(&mut self, root: Root) {

--- a/crates/oak_scan/src/inputs.rs
+++ b/crates/oak_scan/src/inputs.rs
@@ -32,6 +32,9 @@ use crate::lookup::package_by_url;
 use crate::stale::remove_from_stale_files;
 use crate::stale::remove_from_stale_packages;
 use crate::stale::stale_file_by_url;
+use crate::watch;
+use crate::watch::FileEvent;
+use crate::workspace;
 
 /// Description of one R file the scanner wants to register.
 ///
@@ -67,32 +70,51 @@ pub trait DbScan: Db + DbInputs {
     /// `.libPaths()` precedence.
     fn set_library_paths(&mut self, paths: &[PathBuf]);
 
-    /// Scan each workspace path and register the result under
-    /// `WorkspaceRoots`. Each path becomes a `Workspace` root with
-    /// its discovered packages (`DESCRIPTION` files at any depth,
-    /// honouring `.gitignore`) and top-level R scripts. Existing
-    /// `Root` entities at each path are reused.
+    /// Scan each workspace path and register the result under `WorkspaceRoots`.
+    /// Each path becomes a `Workspace` root with its discovered packages
+    /// (`DESCRIPTION` files at any depth, honouring `.gitignore`) and top-level
+    /// R scripts. Existing `Root` entities at each path are reused.
     ///
-    /// TODO(scan): rename to `set_workspace_paths` and adopt the diff-
-    /// based reconciliation pattern that `set_library_paths` uses
-    /// (untouched / scanned / evicted-to-stale).
+    /// TODO(scan): rename to `set_workspace_paths` and adopt the diff-based
+    /// reconciliation pattern that `set_library_paths` uses (untouched /
+    /// scanned / evicted-to-stale).
     fn scan_workspace_paths(&mut self, paths: &[PathBuf]);
 
-    /// Upsert a file from the VFS. Used by the LSP layer to apply
-    /// `didOpen` / `didChange` content for any URL the editor touches.
+    /// Rescan one workspace root. Used as the coarse fallback when
+    /// `DESCRIPTION` events change the package classification of a directory.
+    fn rescan_workspace_root(&mut self, root: Root);
+
+    /// Upsert a file's content. Used by the LSP layer to apply `didOpen` /
+    /// `didChange` content for any URL the editor touches.
     ///
-    /// If a `File` already exists at this URL, its contents are
-    /// updated. Classification is left as-is: a file the scanner had
-    /// previously placed in a package stays in that package, since
-    /// `didOpen` is a content event, not a reclassification.
+    /// If a `File` already exists at this URL, only its contents are updated.
+    /// Classification is left as-is: a file the scanner had previously placed
+    /// in a package stays in that package, since `didOpen` is a content event,
+    /// not a reclassification.
     ///
-    /// If no `File` exists yet, one is created in
-    /// `orphan_root().files`. It stays there until something
-    /// explicitly reclassifies it. Untitled buffers and files outside
-    /// every workspace stay orphan for the session. Files that should
-    /// belong to a workspace scan's output land in their proper
-    /// container when the workspace scanner next runs.
-    fn set_file_contents(&mut self, url: UrlId, contents: String) -> File;
+    /// If no `File` exists yet, one is created in `orphan_root().files`. It
+    /// stays there until another handler reclassifies it. Untitled buffers and
+    /// files that do not belong to any workspace stay orphan for the session.
+    /// Files inside a workspace folder get reclassified the next time the
+    /// workspace scanner runs, at which point the orphan reference is dropped.
+    fn set_editor_contents(&mut self, url: UrlId, contents: String) -> File;
+
+    /// React to a Created or Changed watcher event on an R file. Classifies the
+    /// URL against the current workspace tree and either creates a new `File`
+    /// or updates an existing one's content. Files outside every workspace, or
+    /// inside a package's non-`R/` subdir, are skipped.
+    fn add_watched_file(&mut self, url: UrlId, contents: String);
+
+    /// React to a Deleted watcher event. Unlinks the file from whichever
+    /// container holds it (package files, root scripts, or orphan).
+    fn remove_watched_file(&mut self, url: UrlId);
+
+    /// Apply a batch of file-watcher events. Routes DESCRIPTION events to a
+    /// coarse rescan of the containing workspace root (deduped within the
+    /// batch), and R-file events to per-file add / remove. URLs in `skip` are
+    /// left alone, so callers can defer to an in-memory source of truth (e.g.
+    /// the editor's open buffers).
+    fn apply_watcher_events(&mut self, events: Vec<FileEvent>, skip: &HashSet<UrlId>);
 }
 
 impl<DB: Db + DbInputs> DbScan for DB {
@@ -104,7 +126,11 @@ impl<DB: Db + DbInputs> DbScan for DB {
         crate::workspace::scan_workspace_paths(self, paths);
     }
 
-    fn set_file_contents(&mut self, url: UrlId, contents: String) -> File {
+    fn rescan_workspace_root(&mut self, root: Root) {
+        workspace::rescan_workspace_root(self, root);
+    }
+
+    fn set_editor_contents(&mut self, url: UrlId, contents: String) -> File {
         if let Some(existing) = self.file_by_url(&url) {
             existing.set_contents(self).to(contents);
             return existing;
@@ -112,10 +138,24 @@ impl<DB: Db + DbInputs> DbScan for DB {
 
         let file = File::new(self, url, contents, None);
         let orphan = self.orphan_root();
+
         let mut files = orphan.files(self).clone();
         files.push(file);
         orphan.set_files(self).to(files);
+
         file
+    }
+
+    fn add_watched_file(&mut self, url: UrlId, contents: String) {
+        watch::add_watched_file(self, url, contents);
+    }
+
+    fn remove_watched_file(&mut self, url: UrlId) {
+        watch::remove_watched_file(self, url);
+    }
+
+    fn apply_watcher_events(&mut self, events: Vec<FileEvent>, skip: &HashSet<UrlId>) {
+        watch::apply_watcher_events(self, events, skip);
     }
 }
 
@@ -165,10 +205,9 @@ pub trait RootExt {
     /// responsible for rebuilding those Vec inputs with `self` excluded.
     fn set_stale<DB: Db + DbInputs>(self, db: &mut DB, editor_owned: Option<&HashSet<UrlId>>);
 
-    /// Replace `self.scripts` with `File` entities for `files`. Same
-    /// identity rules as [`set_package`](Self::set_package): existing
-    /// `File` entities at the given URLs are reused and have their
-    /// `package` field cleared.
+    /// Replace `self.scripts` with `File` entities for `files`. Same identity
+    /// rules as [`set_package`](Self::set_package): existing `File` entities at
+    /// the given URLs are reused and have their `package` field cleared.
     fn set_workspace_scripts<DB: Db + DbInputs>(self, db: &mut DB, files: Vec<FileEntry>);
 }
 
@@ -209,7 +248,7 @@ impl RootExt for Root {
 
         let file_entities: Vec<File> = files
             .into_iter()
-            .map(|entry| upsert_file(db, Some(pkg), entry))
+            .map(|entry| upsert_root_file(db, Some(pkg), entry))
             .collect();
 
         pkg.set_files(db).to(file_entities);
@@ -223,35 +262,53 @@ impl RootExt for Root {
     fn set_workspace_scripts<DB: Db + DbInputs>(self, db: &mut DB, files: Vec<FileEntry>) {
         let scripts: Vec<File> = files
             .into_iter()
-            .map(|entry| upsert_file(db, None, entry))
+            .map(|entry| upsert_root_file(db, None, entry))
             .collect();
         self.set_scripts(db).to(scripts);
     }
 }
 
-fn upsert_file<DB: Db + DbInputs>(db: &mut DB, package: Option<Package>, entry: FileEntry) -> File {
-    if let Some(old) = db.file_by_url(&entry.url) {
-        // Two cleanups before handing the file to the caller, which will place
-        // it in a new container:
+/// Upsert a `File` for `entry`, set its `package` backpointer, and clean up
+/// stale references in old containers.
+///
+/// **Caller invariant.** The caller must atomically place the returned `File`
+/// in some `Root` container (`pkg.files` or `root.scripts`) before returning.
+/// Three callers:
+///
+/// - [`RootExt::set_package`] (both library and workspace scanners)
+/// - [`RootExt::set_workspace_scripts`] (workspace scanner)
+/// - [`watch::add_watched_file`] (watcher dispatch)
+///
+/// The orphan cleanup below relies on this contract. A future caller that
+/// invoked `upsert_root_file()` without then placing the file would leave it
+/// with no container, and `file_by_url()` would return `None`.
+pub(crate) fn upsert_root_file<DB: Db + DbInputs>(
+    db: &mut DB,
+    package: Option<Package>,
+    entry: FileEntry,
+) -> File {
+    if let Some(existing) = db.file_by_url(&entry.url) {
+        // The new container is owned by the caller. What needs active cleanup
+        // is the OLD container:
         //
         // - If the package backpointer changed and the old package was Some,
-        //   the old package's `files` vec still references this file. Drop it,
-        //   otherwise that `Package` would carry a stale entry until its next
-        //   wholesale rescan.
+        //   that package's `files` vec still references this file. Drop it,
+        //   otherwise the old `Package` would carry a stale entry until its
+        //   next wholesale rescan.
         //
-        // - If the file was in `OrphanRoot.files` (typically because the editor
-        //   had it open before a scan classified it), remove it. The placement
-        //   invariant for orphan says `file.package == None`, and we're about
-        //   to set the package.
-        let old_package = old.package(db);
-        old.set_package(db).to(package);
+        // - If the file was in `OrphanRoot.files` (e.g. the editor had it open
+        //   before a scan classified it), drop it. Per the caller invariant
+        //   the file is about to land in a `Root` container, so the orphan
+        //   reference is stale by the time this returns.
+        let old_package = existing.package(db);
+        existing.set_package(db).to(package);
         if old_package != package {
             if let Some(old_pkg) = old_package {
-                remove_from_pkg_files(db, old_pkg, old);
+                remove_from_pkg_files(db, old_pkg, existing);
             }
         }
-        remove_from_orphan(db, old);
-        return old;
+        remove_from_orphan(db, existing);
+        return existing;
     }
 
     if let Some(stale) = stale_file_by_url(db, &entry.url) {

--- a/crates/oak_scan/src/lib.rs
+++ b/crates/oak_scan/src/lib.rs
@@ -27,6 +27,7 @@ mod library;
 mod lookup;
 mod packages;
 mod stale;
+mod workspace;
 
 #[cfg(test)]
 mod tests;

--- a/crates/oak_scan/src/lib.rs
+++ b/crates/oak_scan/src/lib.rs
@@ -27,6 +27,7 @@ mod library;
 mod lookup;
 mod packages;
 mod stale;
+mod watch;
 mod workspace;
 
 #[cfg(test)]
@@ -35,3 +36,5 @@ mod tests;
 pub use inputs::DbScan;
 pub use inputs::FileEntry;
 pub use inputs::RootExt;
+pub use watch::FileEvent;
+pub use watch::FileEventKind;

--- a/crates/oak_scan/src/library.rs
+++ b/crates/oak_scan/src/library.rs
@@ -25,7 +25,7 @@ use salsa::Setter;
 use walkdir::WalkDir;
 
 use crate::inputs::RootExt;
-use crate::packages::read_package;
+use crate::packages::read_package_metadata;
 
 /// Reconcile `LibraryRoots` to exactly `paths`. Called through
 /// [`crate::DbScan::set_library_paths`]. Order in `LibraryRoots.roots`
@@ -82,7 +82,7 @@ fn scan_new_library_path<DB: Db + DbInputs>(db: &mut DB, path: &Path, url: UrlId
         if !entry.file_type().is_dir() {
             continue;
         }
-        let Some(pkg) = read_package(entry.path()) else {
+        let Some(pkg) = read_package_metadata(entry.path()) else {
             continue;
         };
         packages.push(root.set_package(

--- a/crates/oak_scan/src/library.rs
+++ b/crates/oak_scan/src/library.rs
@@ -92,6 +92,7 @@ fn scan_new_library_path<DB: Db + DbInputs>(db: &mut DB, path: &Path, url: UrlId
             pkg.version,
             pkg.namespace,
             pkg.files,
+            pkg.scripts,
             pkg.collation,
         ));
     }

--- a/crates/oak_scan/src/library.rs
+++ b/crates/oak_scan/src/library.rs
@@ -28,7 +28,7 @@ use crate::inputs::RootExt;
 use crate::packages::read_package;
 
 /// Reconcile `LibraryRoots` to exactly `paths`. Called through
-/// [`crate::DbExt::set_library_paths`]. Order in `LibraryRoots.roots`
+/// [`crate::DbScan::set_library_paths`]. Order in `LibraryRoots.roots`
 /// follows `paths`, matching R's `.libPaths()` precedence.
 pub(crate) fn set_library_paths<DB: Db + DbInputs>(db: &mut DB, paths: &[PathBuf]) {
     let new: Vec<(PathBuf, UrlId)> = paths

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -3,6 +3,7 @@
 //! directory) and the workspace scanner (which walks the workspace tree looking
 //! for `DESCRIPTION` files at any depth).
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -107,38 +108,86 @@ fn scan_r_files(r_dir: &Path) -> Vec<FileEntry> {
         .collect()
 }
 
-fn is_r_file(path: &Path) -> bool {
+pub(crate) fn is_r_file(path: &Path) -> bool {
     path.is_file() && oak_core::is_r_file(path)
+}
+
+/// Read just the package name from `dir/DESCRIPTION`. Cheaper than
+/// [`read_package`] when the caller only needs to look up an existing
+/// `Package` by name.
+pub(crate) fn read_description_name(dir: &Path) -> Option<String> {
+    let text = fs::read_to_string(dir.join("DESCRIPTION")).ok()?;
+    Description::parse(&text).log_err().map(|d| d.name)
 }
 
 /// Walk a workspace root, returning every discovered package and every
 /// top-level R script that isn't inside a package directory.
 ///
-/// `DESCRIPTION` files are looked up at any depth, honouring `.gitignore`
-/// and `.ignore` and skipping hidden directories. A package's R/ files
-/// are scoped to `{pkg_dir}/R/*.R`. R files that fall inside any
-/// discovered package directory but outside its `R/` (e.g. tests/,
-/// vignettes/, inst/) are excluded from `scripts`. Everything else with
-/// an `.R` extension becomes a top-level script on the workspace root.
+/// A package's R/ files are scoped to `{pkg_dir}/R/*.R`. R files that fall
+/// inside any discovered package directory but outside its `R/` (e.g. tests/,
+/// vignettes/, inst/) are excluded from `scripts`. Everything else with an `.R`
+/// extension becomes a top-level script on the workspace root.
+///
+/// TODO(scan): Package-internal R files outside `R/` (tests/, vignettes/,
+/// inst/, data-raw/) are currently dropped on the floor. Plan: add
+/// `Package.scripts: Vec<File>` to oak_db so they get LSP analysis. Placement
+/// invariant becomes "file.package = Some(pkg) -> file in pkg.files OR
+/// pkg.scripts"; `file_by_url` walks both. Later refinement: a `Script::kind`
+/// enum (testthat / vignette / ...) so analyses don't path-match.
+///
+/// If two `DESCRIPTION` files in the workspace declare the same `Package:`
+/// name, the one whose directory sorts first wins and the rest are dropped with
+/// a warn log. See [`dedup_packages_by_name`] for the rationale and the
+/// long-term plan.
 pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageDescriptor>, Vec<FileEntry>) {
-    let description_dirs = collect_description_dirs(root);
+    let mut description_dirs = collect_description_dirs(root);
+    description_dirs.sort();
 
-    let packages: Vec<PackageDescriptor> = description_dirs
+    let pairs: Vec<(PathBuf, PackageDescriptor)> = description_dirs
         .iter()
-        .filter_map(|dir| read_package(dir))
+        .filter_map(|dir| read_package(dir).map(|pkg| (dir.clone(), pkg)))
         .collect();
 
+    let packages = dedup_packages_by_name(pairs);
     let scripts = collect_scripts(root, &description_dirs);
 
     (packages, scripts)
 }
 
+/// Keep the first occurrence of each `Package:` name, dropping duplicates with
+/// a warn log naming both directories.
+///
+/// `Package` identity in oak is keyed on `(root, name)`, so two same-name
+/// DESCRIPTIONs in one workspace would otherwise collapse into one `Package`
+/// entity with the loser's files clobbering the winner's and the duplicate
+/// appearing twice in `root.packages`. First-wins gives a stable, predictable
+/// outcome at the cost of ignoring one of the two.
+fn dedup_packages_by_name(pairs: Vec<(PathBuf, PackageDescriptor)>) -> Vec<PackageDescriptor> {
+    let mut winners: HashMap<String, PathBuf> = HashMap::new();
+    let mut packages: Vec<PackageDescriptor> = Vec::with_capacity(pairs.len());
+
+    for (dir, pkg) in pairs {
+        if let Some(existing) = winners.get(&pkg.name) {
+            log::warn!(
+                "Duplicate package name `{name}` in workspace: keeping {first}, skipping {dup}",
+                name = pkg.name,
+                first = existing.display(),
+                dup = dir.display(),
+            );
+            continue;
+        }
+        winners.insert(pkg.name.clone(), dir);
+        packages.push(pkg);
+    }
+
+    packages
+}
+
 /// Walk `root` and return every directory that contains a `DESCRIPTION`
-/// file. Honours `.gitignore` / `.ignore` / hidden-file conventions via
-/// the `ignore` crate's standard filters.
+/// file.
 fn collect_description_dirs(root: &Path) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    for entry in WalkBuilder::new(root).build().flatten() {
+    for entry in workspace_walker(root).flatten() {
         let Some(file_type) = entry.file_type() else {
             continue;
         };
@@ -155,14 +204,13 @@ fn collect_description_dirs(root: &Path) -> Vec<PathBuf> {
     dirs
 }
 
-/// Collect `*.R` files anywhere under `root` that aren't inside any
-/// package directory. Files inside `pkg_dir/R/` are owned by that
-/// package; files elsewhere in `pkg_dir` (tests/, inst/, etc.) are
-/// skipped entirely to avoid double-registering package-internal R
-/// sources as workspace scripts.
+/// Collect `*.R` files anywhere under `root` that aren't inside any package
+/// directory. Files inside `pkg_dir/R/` are owned by that package; files
+/// elsewhere in `pkg_dir` (tests/, inst/, etc.) are skipped entirely to avoid
+/// double-registering package-internal R sources as workspace scripts.
 fn collect_scripts(root: &Path, package_dirs: &[PathBuf]) -> Vec<FileEntry> {
     let mut scripts = Vec::new();
-    for entry in WalkBuilder::new(root).build().flatten() {
+    for entry in workspace_walker(root).flatten() {
         let path = entry.path();
         if !is_r_file(path) {
             continue;
@@ -179,4 +227,22 @@ fn collect_scripts(root: &Path, package_dirs: &[PathBuf]) -> Vec<FileEntry> {
         scripts.push(FileEntry { url, contents });
     }
     scripts
+}
+
+/// Build a directory walker for workspace discovery.
+///
+/// Uses the `ignore` crate's default `WalkBuilder`, which honours `.gitignore`
+/// / `.ignore` and skips hidden directories. Matches the ty / Astral / ruff
+/// convention. The concrete payoff for R is `renv/library/` exclusion. Renv
+/// snapshots each installed package with its own `DESCRIPTION` and `R/`, so
+/// walking into them would surface vendored packages and vendored R files as
+/// workspace content.
+///
+/// rust-analyzer takes the opposite approach: walk everything, hardcoded
+/// exclusions for `.git` and `target`. We may want to revisit if the implicit
+/// `.gitignore` filtering surprises users, in which case the natural next step
+/// is an opt-out config (similar to ty's `respect-ignore-files`) and / or a
+/// hardcoded exclusion list.
+fn workspace_walker(root: &Path) -> ignore::Walk {
+    WalkBuilder::new(root).build()
 }

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -20,7 +20,7 @@ use crate::inputs::FileEntry;
 /// plus the R files under `R/`, plus any package-internal R files in
 /// `tests/`, `inst/`, etc. (populated only by the workspace scanner).
 #[derive(Debug)]
-pub(crate) struct PackageDescriptor {
+pub(crate) struct PackageEntry {
     /// URL of the `DESCRIPTION` file. This is the identity key for the
     /// `Package` entity: the same path produces the same entity across
     /// rescans, even when the package's version or files change. So a
@@ -45,7 +45,7 @@ pub(crate) struct PackageDescriptor {
 /// Read a candidate package directory. Returns `None` if `DESCRIPTION`
 /// is missing or malformed. Populates `files` (R/*.R) only; `scripts`
 /// is filled by [`scan_workspace`] for workspace packages.
-pub(crate) fn read_package(dir: &Path) -> Option<PackageDescriptor> {
+pub(crate) fn read_package(dir: &Path) -> Option<PackageEntry> {
     let description_path = dir.join("DESCRIPTION");
     let description_text = fs::read_to_string(&description_path).ok()?;
     let description = Description::parse(&description_text).log_err()?;
@@ -59,7 +59,7 @@ pub(crate) fn read_package(dir: &Path) -> Option<PackageDescriptor> {
     let files = scan_r_files(&dir.join("R"));
     let collation = description.collate();
 
-    Some(PackageDescriptor {
+    Some(PackageEntry {
         description_url,
         name: description.name,
         version: Some(description.version),
@@ -143,11 +143,11 @@ pub(crate) fn read_description_name(dir: &Path) -> Option<String> {
 /// If two `DESCRIPTION` files in the workspace declare the same `Package:`
 /// name, the one whose directory sorts first wins and the rest are dropped with
 /// a warn log. See [`dedup_packages_by_name`] for the rationale.
-pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageDescriptor>, Vec<FileEntry>) {
+pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageEntry>, Vec<FileEntry>) {
     let mut description_dirs = collect_description_dirs(root);
     description_dirs.sort();
 
-    let pairs: Vec<(PathBuf, PackageDescriptor)> = description_dirs
+    let pairs: Vec<(PathBuf, PackageEntry)> = description_dirs
         .iter()
         .filter_map(|dir| {
             read_package(dir).map(|mut pkg| {
@@ -164,7 +164,7 @@ pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageDescriptor>, Vec<FileEn
 }
 
 /// Walk a package directory, returning every `.R` file inside it that's
-/// not in `pkg_dir/R/`. R/ files are owned by [`PackageDescriptor::files`];
+/// not in `pkg_dir/R/`. R/ files are owned by [`PackageEntry::files`];
 /// everything else (tests/, inst/, vignettes/, data-raw/) lands here.
 fn scan_package_scripts(pkg_dir: &Path) -> Vec<FileEntry> {
     let mut scripts = Vec::new();
@@ -196,9 +196,9 @@ fn scan_package_scripts(pkg_dir: &Path) -> Vec<FileEntry> {
 /// entity with the loser's files clobbering the winner's and the duplicate
 /// appearing twice in `root.packages`. First-wins gives a stable, predictable
 /// outcome at the cost of ignoring one of the two.
-fn dedup_packages_by_name(pairs: Vec<(PathBuf, PackageDescriptor)>) -> Vec<PackageDescriptor> {
+fn dedup_packages_by_name(pairs: Vec<(PathBuf, PackageEntry)>) -> Vec<PackageEntry> {
     let mut winners: HashMap<String, PathBuf> = HashMap::new();
-    let mut packages: Vec<PackageDescriptor> = Vec::with_capacity(pairs.len());
+    let mut packages: Vec<PackageEntry> = Vec::with_capacity(pairs.len());
 
     for (dir, pkg) in pairs {
         if let Some(existing) = winners.get(&pkg.name) {

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -44,7 +44,7 @@ pub(crate) struct PackageEntry {
 
 /// Read a candidate package directory. Returns `None` if `DESCRIPTION`
 /// is missing or malformed. Populates `files` (R/*.R) only; `scripts`
-/// is filled by [`scan_workspace`] for workspace packages.
+/// is filled by [`scan_workspace_packages`] for workspace packages.
 pub(crate) fn read_package(package_dir: &Path) -> Option<PackageEntry> {
     let description_path = package_dir.join("DESCRIPTION");
     let description_text = fs::read_to_string(&description_path).ok()?;
@@ -129,21 +129,18 @@ pub(crate) fn read_description_name(package_dir: &Path) -> Option<String> {
     Description::parse(&text).log_err().map(|d| d.name)
 }
 
-/// Walk a workspace root, returning every discovered package and every
-/// top-level R script that isn't inside a package directory.
+/// Walk a workspace root for its packages: every directory that contains a
+/// `DESCRIPTION`, at any depth.
 ///
 /// For each package:
 /// - `pkg.files` is `{pkg_dir}/R/*.R` (the loadable namespace).
 /// - `pkg.scripts` is every other `.R` file under `pkg_dir/` (tests/,
 ///   inst/, vignettes/, data-raw/, etc.).
 ///
-/// Everything else with an `.R` extension becomes a top-level script on
-/// the workspace root.
-///
 /// If two `DESCRIPTION` files in the workspace declare the same `Package:`
 /// name, the one whose directory sorts first wins and the rest are dropped with
 /// a warn log. See [`dedup_packages_by_name`] for the rationale.
-pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageEntry>, Vec<FileEntry>) {
+pub(crate) fn scan_workspace_packages(root: &Path) -> Vec<PackageEntry> {
     let mut description_dirs = collect_description_dirs(root);
     description_dirs.sort();
 
@@ -157,10 +154,23 @@ pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageEntry>, Vec<FileEntry>)
         })
         .collect();
 
-    let packages = dedup_packages_by_name(pairs);
-    let scripts = collect_scripts(root, &description_dirs);
+    dedup_packages_by_name(pairs)
+}
 
-    (packages, scripts)
+/// Walk a workspace root for its top-level scripts: every `.R` file that isn't
+/// inside a package directory.
+///
+/// Package-internal files belong to their package (`R/*.R` as `files`, the rest
+/// as `scripts`), so we skip any `.R` file under a directory that has a
+/// `DESCRIPTION`. We re-derive those directories here rather than taking them
+/// from [`scan_workspace_packages`]: that keeps the two scans independent, and
+/// it excludes the losing side of a same-name package duplicate too. That loser
+/// is dropped by `scan_workspace_packages`, but its files are still package
+/// internals, not loose scripts. The walk is filename-only, so it's cheap next
+/// to reading every script's contents.
+pub(crate) fn scan_workspace_scripts(root: &Path) -> Vec<FileEntry> {
+    let package_dirs = collect_description_dirs(root);
+    collect_scripts(root, &package_dirs)
 }
 
 /// Walk a package directory, returning every `.R` file inside it that's

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use aether_url::UrlId;
+use ignore::WalkBuilder;
 use oak_package_metadata::description::Description;
 use oak_package_metadata::namespace::Namespace;
 use stdext::result::ResultExt;
@@ -108,4 +109,74 @@ fn scan_r_files(r_dir: &Path) -> Vec<FileEntry> {
 
 fn is_r_file(path: &Path) -> bool {
     path.is_file() && oak_core::is_r_file(path)
+}
+
+/// Walk a workspace root, returning every discovered package and every
+/// top-level R script that isn't inside a package directory.
+///
+/// `DESCRIPTION` files are looked up at any depth, honouring `.gitignore`
+/// and `.ignore` and skipping hidden directories. A package's R/ files
+/// are scoped to `{pkg_dir}/R/*.R`. R files that fall inside any
+/// discovered package directory but outside its `R/` (e.g. tests/,
+/// vignettes/, inst/) are excluded from `scripts`. Everything else with
+/// an `.R` extension becomes a top-level script on the workspace root.
+pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageDescriptor>, Vec<FileEntry>) {
+    let description_dirs = collect_description_dirs(root);
+
+    let packages: Vec<PackageDescriptor> = description_dirs
+        .iter()
+        .filter_map(|dir| read_package(dir))
+        .collect();
+
+    let scripts = collect_scripts(root, &description_dirs);
+
+    (packages, scripts)
+}
+
+/// Walk `root` and return every directory that contains a `DESCRIPTION`
+/// file. Honours `.gitignore` / `.ignore` / hidden-file conventions via
+/// the `ignore` crate's standard filters.
+fn collect_description_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    for entry in WalkBuilder::new(root).build().flatten() {
+        let Some(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        if entry.file_name() != "DESCRIPTION" {
+            continue;
+        }
+        if let Some(parent) = entry.path().parent() {
+            dirs.push(parent.to_path_buf());
+        }
+    }
+    dirs
+}
+
+/// Collect `*.R` files anywhere under `root` that aren't inside any
+/// package directory. Files inside `pkg_dir/R/` are owned by that
+/// package; files elsewhere in `pkg_dir` (tests/, inst/, etc.) are
+/// skipped entirely to avoid double-registering package-internal R
+/// sources as workspace scripts.
+fn collect_scripts(root: &Path, package_dirs: &[PathBuf]) -> Vec<FileEntry> {
+    let mut scripts = Vec::new();
+    for entry in WalkBuilder::new(root).build().flatten() {
+        let path = entry.path();
+        if !is_r_file(path) {
+            continue;
+        }
+        if package_dirs.iter().any(|pkg| path.starts_with(pkg)) {
+            continue;
+        }
+        let Ok(contents) = fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(url) = UrlId::from_file_path(path) else {
+            continue;
+        };
+        scripts.push(FileEntry { url, contents });
+    }
+    scripts
 }

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -45,18 +45,18 @@ pub(crate) struct PackageEntry {
 /// Read a candidate package directory. Returns `None` if `DESCRIPTION`
 /// is missing or malformed. Populates `files` (R/*.R) only; `scripts`
 /// is filled by [`scan_workspace`] for workspace packages.
-pub(crate) fn read_package(dir: &Path) -> Option<PackageEntry> {
-    let description_path = dir.join("DESCRIPTION");
+pub(crate) fn read_package(package_dir: &Path) -> Option<PackageEntry> {
+    let description_path = package_dir.join("DESCRIPTION");
     let description_text = fs::read_to_string(&description_path).ok()?;
     let description = Description::parse(&description_text).log_err()?;
     let description_url = UrlId::from_file_path(&description_path).ok()?;
 
-    let namespace = fs::read_to_string(dir.join("NAMESPACE"))
+    let namespace = fs::read_to_string(package_dir.join("NAMESPACE"))
         .ok()
         .and_then(|text| Namespace::parse(&text).log_err())
         .unwrap_or_default();
 
-    let files = scan_r_files(&dir.join("R"));
+    let files = scan_r_files(&package_dir.join("R"));
     let collation = description.collate();
 
     Some(PackageEntry {
@@ -121,11 +121,11 @@ pub(crate) fn is_r_file(path: &Path) -> bool {
     path.is_file() && oak_core::is_r_file(path)
 }
 
-/// Read just the package name from `dir/DESCRIPTION`. Cheaper than
+/// Read just the package name from `package_dir/DESCRIPTION`. Cheaper than
 /// [`read_package`] when the caller only needs to look up an existing
 /// `Package` by name.
-pub(crate) fn read_description_name(dir: &Path) -> Option<String> {
-    let text = fs::read_to_string(dir.join("DESCRIPTION")).ok()?;
+pub(crate) fn read_description_name(package_dir: &Path) -> Option<String> {
+    let text = fs::read_to_string(package_dir.join("DESCRIPTION")).ok()?;
     Description::parse(&text).log_err().map(|d| d.name)
 }
 

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -121,6 +121,35 @@ pub(crate) fn is_r_file(path: &Path) -> bool {
     path.is_file() && oak_core::is_r_file(path)
 }
 
+/// Where an R file inside a package directory belongs.
+///
+/// `R/*.R` (direct children of `R/`) are the package's loadable namespace.
+/// Files nested deeper under `R/` are skipped: R loads `R/` as a flat
+/// directory, so `R/sub/foo.R` isn't part of the namespace and nothing else
+/// reads it. Everything else under the package (tests/, inst/, vignettes/,
+/// data-raw/, ...) is a script: analysed but not loaded.
+///
+/// This is the single definition of the rule. The bulk scanner
+/// ([`scan_package_scripts()`]) and the file watcher (`crate::watch::classify()`)
+/// both route through it so the two can't drift on where a file lands.
+#[derive(Debug, PartialEq)]
+pub(crate) enum PackagePlacement {
+    File,
+    Script,
+    Skip,
+}
+
+pub(crate) fn classify_in_package(package_dir: &Path, path: &Path) -> PackagePlacement {
+    let r_dir = package_dir.join("R");
+    if path.parent() == Some(r_dir.as_path()) {
+        PackagePlacement::File
+    } else if path.starts_with(&r_dir) {
+        PackagePlacement::Skip
+    } else {
+        PackagePlacement::Script
+    }
+}
+
 /// Read just the package name from `package_dir/DESCRIPTION`. Cheaper than
 /// [`read_package`] when the caller only needs to look up an existing
 /// `Package` by name.
@@ -178,13 +207,12 @@ pub(crate) fn scan_workspace_scripts(root: &Path) -> Vec<FileEntry> {
 /// everything else (tests/, inst/, vignettes/, data-raw/) lands here.
 fn scan_package_scripts(pkg_dir: &Path) -> Vec<FileEntry> {
     let mut scripts = Vec::new();
-    let r_dir = pkg_dir.join("R");
     for entry in workspace_walker(pkg_dir).flatten() {
         let path = entry.path();
         if !is_r_file(path) {
             continue;
         }
-        if path.starts_with(&r_dir) {
+        if classify_in_package(pkg_dir, path) != PackagePlacement::Script {
             continue;
         }
         let Ok(contents) = fs::read_to_string(path) else {
@@ -289,4 +317,43 @@ fn collect_scripts(root: &Path, package_dirs: &[PathBuf]) -> Vec<FileEntry> {
 /// hardcoded exclusion list.
 fn workspace_walker(root: &Path) -> ignore::Walk {
     WalkBuilder::new(root).build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::classify_in_package;
+    use super::PackagePlacement;
+
+    #[test]
+    fn classify_in_package_rule() {
+        let pkg = Path::new("/ws/pkg");
+
+        // Direct children of `R/` are the loadable namespace.
+        assert_eq!(
+            classify_in_package(pkg, Path::new("/ws/pkg/R/a.R")),
+            PackagePlacement::File
+        );
+
+        // Nested under `R/` is excluded: R loads `R/` flat.
+        assert_eq!(
+            classify_in_package(pkg, Path::new("/ws/pkg/R/sub/b.R")),
+            PackagePlacement::Skip
+        );
+
+        // Everything else under the package is a script.
+        assert_eq!(
+            classify_in_package(pkg, Path::new("/ws/pkg/tests/testthat/test-a.R")),
+            PackagePlacement::Script
+        );
+        assert_eq!(
+            classify_in_package(pkg, Path::new("/ws/pkg/inst/foo.R")),
+            PackagePlacement::Script
+        );
+        assert_eq!(
+            classify_in_package(pkg, Path::new("/ws/pkg/data-raw/prep.R")),
+            PackagePlacement::Script
+        );
+    }
 }

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -42,10 +42,15 @@ pub(crate) struct PackageEntry {
     pub collation: Option<Vec<String>>,
 }
 
-/// Read a candidate package directory. Returns `None` if `DESCRIPTION`
-/// is missing or malformed. Populates `files` (R/*.R) only; `scripts`
-/// is filled by [`scan_workspace_packages`] for workspace packages.
-pub(crate) fn read_package(package_dir: &Path) -> Option<PackageEntry> {
+/// Read a package's `DESCRIPTION` / `NAMESPACE` metadata. Returns `None` if
+/// `DESCRIPTION` is missing or malformed. The returned entry has empty `files`
+/// and `scripts`; callers fill those separately.
+///
+/// The library scanner uses this directly: installed packages have no `.R`
+/// sources under `R/` (it holds the lazy-load db), so their `files` come from
+/// a cache later, not from a directory scan. The workspace scanner wraps this
+/// in [`read_workspace_package`], which discovers sources by walking the tree.
+pub(crate) fn read_package_metadata(package_dir: &Path) -> Option<PackageEntry> {
     let description_path = package_dir.join("DESCRIPTION");
     let description_text = fs::read_to_string(&description_path).ok()?;
     let description = Description::parse(&description_text).log_err()?;
@@ -56,7 +61,6 @@ pub(crate) fn read_package(package_dir: &Path) -> Option<PackageEntry> {
         .and_then(|text| Namespace::parse(&text).log_err())
         .unwrap_or_default();
 
-    let files = scan_r_files(&package_dir.join("R"));
     let collation = description.collate();
 
     Some(PackageEntry {
@@ -64,57 +68,10 @@ pub(crate) fn read_package(package_dir: &Path) -> Option<PackageEntry> {
         name: description.name,
         version: Some(description.version),
         namespace,
-        files,
+        files: Vec::new(),
         scripts: Vec::new(),
         collation,
     })
-}
-
-/// Read every `*.R` / `*.r` file directly under `r_dir`, in alphabetical
-/// order by basename. Subdirectories are skipped (the standard R package
-/// layout is flat). R files that fail to read are logged at warn level
-/// and skipped. Symlinks resolving to non-files (the `is_r_file` check)
-/// are skipped quietly.
-///
-/// Returns empty for installed (library) packages: their `R/` holds the
-/// lazy-load db (`<pkg>`, `<pkg>.rdb`, `<pkg>.rdx`), not `.R` sources. Only
-/// source packages (the workspace scanner's input) have `R/*.R` to read.
-fn scan_r_files(r_dir: &Path) -> Vec<FileEntry> {
-    let mut entries: Vec<(PathBuf, String)> = Vec::new();
-    let Ok(read_dir) = fs::read_dir(r_dir) else {
-        // Normal for packages without an `R/` directory (data-only,
-        // header-only). Don't log.
-        return Vec::new();
-    };
-
-    for entry in read_dir.flatten() {
-        let path = entry.path();
-        if !is_r_file(&path) {
-            continue;
-        }
-        let contents = match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(err) => {
-                log::warn!("Failed to read R file {}: {err}", path.display());
-                continue;
-            },
-        };
-        entries.push((path, contents));
-    }
-
-    entries.sort_by(|a, b| {
-        let a_name = a.0.file_name().map(|n| n.to_ascii_lowercase());
-        let b_name = b.0.file_name().map(|n| n.to_ascii_lowercase());
-        a_name.cmp(&b_name)
-    });
-
-    entries
-        .into_iter()
-        .filter_map(|(path, contents)| {
-            let url = UrlId::from_file_path(&path).ok()?;
-            Some(FileEntry { url, contents })
-        })
-        .collect()
 }
 
 pub(crate) fn is_r_file(path: &Path) -> bool {
@@ -130,7 +87,7 @@ pub(crate) fn is_r_file(path: &Path) -> bool {
 /// data-raw/, ...) is a script: analysed but not loaded.
 ///
 /// This is the single definition of the rule. The bulk scanner
-/// ([`scan_package_scripts()`]) and the file watcher (`crate::watch::classify()`)
+/// ([`read_workspace_package()`]) and the file watcher (`crate::watch::classify()`)
 /// both route through it so the two can't drift on where a file lands.
 #[derive(Debug, PartialEq)]
 pub(crate) enum PackagePlacement {
@@ -151,7 +108,7 @@ pub(crate) fn classify_in_package(package_dir: &Path, path: &Path) -> PackagePla
 }
 
 /// Read just the package name from `package_dir/DESCRIPTION`. Cheaper than
-/// [`read_package`] when the caller only needs to look up an existing
+/// [`read_package_metadata`] when the caller only needs to look up an existing
 /// `Package` by name.
 pub(crate) fn read_description_name(package_dir: &Path) -> Option<String> {
     let text = fs::read_to_string(package_dir.join("DESCRIPTION")).ok()?;
@@ -175,15 +132,73 @@ pub(crate) fn scan_workspace_packages(root: &Path) -> Vec<PackageEntry> {
 
     let pairs: Vec<(PathBuf, PackageEntry)> = description_dirs
         .iter()
-        .filter_map(|dir| {
-            read_package(dir).map(|mut pkg| {
-                pkg.scripts = scan_package_scripts(dir);
-                (dir.clone(), pkg)
-            })
-        })
+        .filter_map(|dir| read_workspace_package(dir).map(|pkg| (dir.clone(), pkg)))
         .collect();
 
     dedup_packages_by_name(pairs)
+}
+
+/// Read a workspace package: metadata plus a single gitignore-aware walk of
+/// `package_dir` that classifies every `.R` file through [`classify_in_package`].
+///
+/// `R/*.R` lands in `files` (sorted by basename, the order R loads a flat `R/`
+/// in), everything else under the package lands in `scripts`, and files nested
+/// below `R/` are dropped. Honouring `.gitignore` here is what keeps `R/` files
+/// and scripts consistent: both come out of the same walk, so a gitignored R
+/// file is excluded either way.
+fn read_workspace_package(package_dir: &Path) -> Option<PackageEntry> {
+    let mut package = read_package_metadata(package_dir)?;
+
+    let mut files: Vec<(PathBuf, FileEntry)> = Vec::new();
+    let mut scripts: Vec<FileEntry> = Vec::new();
+
+    for entry in workspace_walker(package_dir).flatten() {
+        let path = entry.path();
+        if !is_r_file(path) {
+            continue;
+        }
+        let placement = classify_in_package(package_dir, path);
+        if placement == PackagePlacement::Skip {
+            continue;
+        }
+
+        let contents = match fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(err) => {
+                log::warn!("Failed to read R file {}: {err}", path.display());
+                continue;
+            },
+        };
+        let Ok(url) = UrlId::from_file_path(path) else {
+            log::warn!("Skipping R file, can't build a URL: {}", path.display());
+            continue;
+        };
+        let file = FileEntry { url, contents };
+
+        if placement == PackagePlacement::File {
+            files.push((path.to_path_buf(), file));
+        } else {
+            scripts.push(file);
+        }
+    }
+
+    // The basename order is currently needed, not cosmetic. `file_imports()` in
+    // `oak_db` reads `package.files` order as the collation chain, so a file
+    // only sees the files ordered before it. Alphabetical is R's default load
+    // order when `DESCRIPTION` has no `Collate` field.
+    //
+    // TODO(scan): honour the `Collate` field when present, falling back to this
+    // alphabetical order. The `collation` field is already parsed but unused.
+    files.sort_by(|a, b| {
+        let a_name = a.0.file_name().map(|n| n.to_ascii_lowercase());
+        let b_name = b.0.file_name().map(|n| n.to_ascii_lowercase());
+        a_name.cmp(&b_name)
+    });
+
+    package.files = files.into_iter().map(|(_, file)| file).collect();
+    package.scripts = scripts;
+
+    Some(package)
 }
 
 /// Walk a workspace root for its top-level scripts: every `.R` file that isn't
@@ -200,30 +215,6 @@ pub(crate) fn scan_workspace_packages(root: &Path) -> Vec<PackageEntry> {
 pub(crate) fn scan_workspace_scripts(root: &Path) -> Vec<FileEntry> {
     let package_dirs = collect_description_dirs(root);
     collect_scripts(root, &package_dirs)
-}
-
-/// Walk a package directory, returning every `.R` file inside it that's
-/// not in `pkg_dir/R/`. R/ files are owned by [`PackageEntry::files`];
-/// everything else (tests/, inst/, vignettes/, data-raw/) lands here.
-fn scan_package_scripts(pkg_dir: &Path) -> Vec<FileEntry> {
-    let mut scripts = Vec::new();
-    for entry in workspace_walker(pkg_dir).flatten() {
-        let path = entry.path();
-        if !is_r_file(path) {
-            continue;
-        }
-        if classify_in_package(pkg_dir, path) != PackagePlacement::Script {
-            continue;
-        }
-        let Ok(contents) = fs::read_to_string(path) else {
-            continue;
-        };
-        let Ok(url) = UrlId::from_file_path(path) else {
-            continue;
-        };
-        scripts.push(FileEntry { url, contents });
-    }
-    scripts
 }
 
 /// Keep the first occurrence of each `Package:` name, dropping duplicates with

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -17,7 +17,8 @@ use stdext::result::ResultExt;
 use crate::inputs::FileEntry;
 
 /// One package discovered on disk: its `DESCRIPTION`-derived metadata
-/// plus the R files under `R/`.
+/// plus the R files under `R/`, plus any package-internal R files in
+/// `tests/`, `inst/`, etc. (populated only by the workspace scanner).
 #[derive(Debug)]
 pub(crate) struct PackageDescriptor {
     /// URL of the `DESCRIPTION` file. This is the identity key for the
@@ -31,12 +32,19 @@ pub(crate) struct PackageDescriptor {
     pub name: String,
     pub version: Option<String>,
     pub namespace: Namespace,
+    /// `R/*.R` files: the package's loadable namespace.
     pub files: Vec<FileEntry>,
+    /// R files inside the package directory but outside `R/`: tests/,
+    /// inst/, vignettes/, data-raw/. They get LSP analysis but aren't
+    /// loaded with the package. Empty for library packages (the library
+    /// scanner doesn't recurse into pkg_dir for these).
+    pub scripts: Vec<FileEntry>,
     pub collation: Option<Vec<String>>,
 }
 
 /// Read a candidate package directory. Returns `None` if `DESCRIPTION`
-/// is missing or malformed.
+/// is missing or malformed. Populates `files` (R/*.R) only; `scripts`
+/// is filled by [`scan_workspace`] for workspace packages.
 pub(crate) fn read_package(dir: &Path) -> Option<PackageDescriptor> {
     let description_path = dir.join("DESCRIPTION");
     let description_text = fs::read_to_string(&description_path).ok()?;
@@ -57,6 +65,7 @@ pub(crate) fn read_package(dir: &Path) -> Option<PackageDescriptor> {
         version: Some(description.version),
         namespace,
         files,
+        scripts: Vec::new(),
         collation,
     })
 }
@@ -123,35 +132,60 @@ pub(crate) fn read_description_name(dir: &Path) -> Option<String> {
 /// Walk a workspace root, returning every discovered package and every
 /// top-level R script that isn't inside a package directory.
 ///
-/// A package's R/ files are scoped to `{pkg_dir}/R/*.R`. R files that fall
-/// inside any discovered package directory but outside its `R/` (e.g. tests/,
-/// vignettes/, inst/) are excluded from `scripts`. Everything else with an `.R`
-/// extension becomes a top-level script on the workspace root.
+/// For each package:
+/// - `pkg.files` is `{pkg_dir}/R/*.R` (the loadable namespace).
+/// - `pkg.scripts` is every other `.R` file under `pkg_dir/` (tests/,
+///   inst/, vignettes/, data-raw/, etc.).
 ///
-/// TODO(scan): Package-internal R files outside `R/` (tests/, vignettes/,
-/// inst/, data-raw/) are currently dropped on the floor. Plan: add
-/// `Package.scripts: Vec<File>` to oak_db so they get LSP analysis. Placement
-/// invariant becomes "file.package = Some(pkg) -> file in pkg.files OR
-/// pkg.scripts"; `file_by_url` walks both. Later refinement: a `Script::kind`
-/// enum (testthat / vignette / ...) so analyses don't path-match.
+/// Everything else with an `.R` extension becomes a top-level script on
+/// the workspace root.
 ///
 /// If two `DESCRIPTION` files in the workspace declare the same `Package:`
 /// name, the one whose directory sorts first wins and the rest are dropped with
-/// a warn log. See [`dedup_packages_by_name`] for the rationale and the
-/// long-term plan.
+/// a warn log. See [`dedup_packages_by_name`] for the rationale.
 pub(crate) fn scan_workspace(root: &Path) -> (Vec<PackageDescriptor>, Vec<FileEntry>) {
     let mut description_dirs = collect_description_dirs(root);
     description_dirs.sort();
 
     let pairs: Vec<(PathBuf, PackageDescriptor)> = description_dirs
         .iter()
-        .filter_map(|dir| read_package(dir).map(|pkg| (dir.clone(), pkg)))
+        .filter_map(|dir| {
+            read_package(dir).map(|mut pkg| {
+                pkg.scripts = scan_package_scripts(dir);
+                (dir.clone(), pkg)
+            })
+        })
         .collect();
 
     let packages = dedup_packages_by_name(pairs);
     let scripts = collect_scripts(root, &description_dirs);
 
     (packages, scripts)
+}
+
+/// Walk a package directory, returning every `.R` file inside it that's
+/// not in `pkg_dir/R/`. R/ files are owned by [`PackageDescriptor::files`];
+/// everything else (tests/, inst/, vignettes/, data-raw/) lands here.
+fn scan_package_scripts(pkg_dir: &Path) -> Vec<FileEntry> {
+    let mut scripts = Vec::new();
+    let r_dir = pkg_dir.join("R");
+    for entry in workspace_walker(pkg_dir).flatten() {
+        let path = entry.path();
+        if !is_r_file(path) {
+            continue;
+        }
+        if path.starts_with(&r_dir) {
+            continue;
+        }
+        let Ok(contents) = fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(url) = UrlId::from_file_path(path) else {
+            continue;
+        };
+        scripts.push(FileEntry { url, contents });
+    }
+    scripts
 }
 
 /// Keep the first occurrence of each `Package:` name, dropping duplicates with

--- a/crates/oak_scan/src/stale.rs
+++ b/crates/oak_scan/src/stale.rs
@@ -12,7 +12,7 @@
 //!   `OrphanRoot` has no `packages` field, so an evicted package file
 //!   loses its package association: `file.package` clears to `None` and
 //!   analysis treats it as a standalone script for as long as the
-//!   workspace is removed. If the workspace comes back, `upsert_file`
+//!   workspace is removed. If the workspace comes back, `upsert_root_file`
 //!   finds the same `File` via `OrphanRoot` and re-promotes it into
 //!   `pkg.files`, restoring the package context.
 //!

--- a/crates/oak_scan/src/stale.rs
+++ b/crates/oak_scan/src/stale.rs
@@ -35,6 +35,9 @@ use oak_db::Root;
 use rustc_hash::FxHashMap;
 use salsa::Setter;
 
+use crate::inputs::with_cow_filter;
+use crate::inputs::with_cow_remove;
+
 /// Drop `root` from its live container, rehoming files and packages to
 /// `OrphanRoot` / `StaleRoot` as described in the module doc.
 ///
@@ -77,22 +80,14 @@ pub(crate) fn set_root_stale<DB: Db + DbInputs>(
     if !to_orphan.is_empty() {
         let orphan = db.orphan_root();
         let mut files = orphan.files(db).clone();
-        for file in to_orphan {
-            if !files.contains(&file) {
-                files.push(file);
-            }
-        }
+        files.extend(to_orphan);
         orphan.set_files(db).to(files);
     }
 
     let stale = db.stale_root();
     if !to_stale.is_empty() {
         let mut files = stale.files(db).clone();
-        for file in to_stale {
-            if !files.contains(&file) {
-                files.push(file);
-            }
-        }
+        files.extend(to_stale);
         stale.set_files(db).to(files);
     }
 
@@ -120,22 +115,16 @@ pub(crate) fn set_root_stale<DB: Db + DbInputs>(
 
 pub(crate) fn remove_from_stale_files<DB: Db + DbInputs>(db: &mut DB, file: File) {
     let stale = db.stale_root();
-    if !stale.files(db).contains(&file) {
-        return;
+    if let Some(files) = with_cow_remove(stale.files(db), file) {
+        stale.set_files(db).to(files);
     }
-    let mut files = stale.files(db).clone();
-    files.retain(|f| *f != file);
-    stale.set_files(db).to(files);
 }
 
 pub(crate) fn remove_from_stale_packages<DB: Db + DbInputs>(db: &mut DB, pkg: Package) {
     let stale = db.stale_root();
-    if !stale.packages(db).contains(&pkg) {
-        return;
+    if let Some(packages) = with_cow_filter(stale.packages(db), pkg) {
+        stale.set_packages(db).to(packages);
     }
-    let mut packages = stale.packages(db).clone();
-    packages.retain(|p| *p != pkg);
-    stale.set_packages(db).to(packages);
 }
 
 /// Look up a stale `File` by URL. The scanner's upsert helpers call this to

--- a/crates/oak_scan/src/stale.rs
+++ b/crates/oak_scan/src/stale.rs
@@ -56,6 +56,7 @@ pub(crate) fn set_root_stale<DB: Db + DbInputs>(
     let mut all_files: Vec<File> = root.scripts(db).to_vec();
     for &pkg in &packages {
         all_files.extend(pkg.files(db).iter().copied());
+        all_files.extend(pkg.scripts(db).iter().copied());
     }
 
     // Clear `file.package` first: by the time these files land in their new
@@ -105,13 +106,14 @@ pub(crate) fn set_root_stale<DB: Db + DbInputs>(
         stale.set_packages(db).to(stale_packages);
     }
 
-    // Clear the dropped root's containers and each package's files vec.
-    // The packages themselves now live in `stale_root.packages`; keeping
+    // Clear the dropped root's containers and each package's files / scripts
+    // vec. The packages themselves now live in `stale_root.packages`. Keeping
     // their `files` populated would leave stale references that
     // `package_by_url` can resurrect with inconsistent contents.
     root.set_scripts(db).to(Vec::new());
     for &pkg in &packages {
         pkg.set_files(db).to(Vec::new());
+        pkg.set_scripts(db).to(Vec::new());
     }
     root.set_packages(db).to(Vec::new());
 }

--- a/crates/oak_scan/src/tests/stale.rs
+++ b/crates/oak_scan/src/tests/stale.rs
@@ -16,7 +16,7 @@ use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
 use url::Url;
 
-use crate::inputs::DbExt;
+use crate::inputs::DbScan;
 use crate::inputs::RootExt;
 
 fn file_url(s: &str) -> UrlId {

--- a/crates/oak_scan/src/tests/stale.rs
+++ b/crates/oak_scan/src/tests/stale.rs
@@ -68,6 +68,7 @@ fn test_set_stale_clears_package_on_editor_owned_package_file() {
         None,
         Namespace::default(),
         vec![],
+        Vec::new(),
         None,
     );
     let file = File::new(&db, file_url("/proj/R/a.R"), "x".to_string(), Some(pkg));
@@ -81,6 +82,75 @@ fn test_set_stale_clears_package_on_editor_owned_package_file() {
 
     assert!(db.orphan_root().files(&db).contains(&file));
     assert_eq!(file.package(&db), None);
+    assert!(db.stale_root().packages(&db).contains(&pkg));
+}
+
+#[test]
+fn test_set_stale_routes_pkg_scripts_to_stale() {
+    // A non-editor-owned file in `pkg.scripts` (e.g. tests/test-foo.R)
+    // should go to stale on root eviction, alongside the package itself.
+    let mut db = OakDatabase::new();
+    let root = Root::new(&db, file_url("/proj"), RootKind::Workspace, vec![], vec![]);
+    let pkg = Package::new(
+        &db,
+        file_url("/proj/DESCRIPTION"),
+        "p".to_string(),
+        None,
+        Namespace::default(),
+        vec![],
+        Vec::new(),
+        None,
+    );
+    let test_file = File::new(
+        &db,
+        file_url("/proj/tests/test-foo.R"),
+        "t\n".to_string(),
+        Some(pkg),
+    );
+    pkg.set_scripts(&mut db).to(vec![test_file]);
+    root.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    root.set_stale(&mut db, None);
+
+    assert!(db.stale_root().files(&db).contains(&test_file));
+    assert!(!db.orphan_root().files(&db).contains(&test_file));
+    assert!(db.stale_root().packages(&db).contains(&pkg));
+}
+
+#[test]
+fn test_set_stale_routes_editor_owned_pkg_scripts_to_orphan() {
+    // An open `pkg/tests/test-foo.R` buffer should survive root eviction
+    // in orphan, with its package backpointer cleared so analysis treats
+    // it as a standalone script while the workspace is gone.
+    let mut db = OakDatabase::new();
+    let root = Root::new(&db, file_url("/proj"), RootKind::Workspace, vec![], vec![]);
+    let pkg = Package::new(
+        &db,
+        file_url("/proj/DESCRIPTION"),
+        "p".to_string(),
+        None,
+        Namespace::default(),
+        vec![],
+        Vec::new(),
+        None,
+    );
+    let test_file = File::new(
+        &db,
+        file_url("/proj/tests/test-foo.R"),
+        "t\n".to_string(),
+        Some(pkg),
+    );
+    pkg.set_scripts(&mut db).to(vec![test_file]);
+    root.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let mut owned = HashSet::new();
+    owned.insert(file_url("/proj/tests/test-foo.R"));
+    root.set_stale(&mut db, Some(&owned));
+
+    assert!(db.orphan_root().files(&db).contains(&test_file));
+    assert_eq!(test_file.package(&db), None);
     assert!(db.stale_root().packages(&db).contains(&pkg));
 }
 

--- a/crates/oak_scan/src/tests/stale.rs
+++ b/crates/oak_scan/src/tests/stale.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 
 use aether_url::UrlId;
+use oak_db::Db;
 use oak_db::DbInputs;
 use oak_db::File;
 use oak_db::OakDatabase;
@@ -15,6 +16,7 @@ use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
 use url::Url;
 
+use crate::inputs::DbExt;
 use crate::inputs::RootExt;
 
 fn file_url(s: &str) -> UrlId {
@@ -80,4 +82,59 @@ fn test_set_stale_clears_package_on_editor_owned_package_file() {
     assert!(db.orphan_root().files(&db).contains(&file));
     assert_eq!(file.package(&db), None);
     assert!(db.stale_root().packages(&db).contains(&pkg));
+}
+
+#[test]
+fn test_close_editor_moves_orphan_file_to_stale() {
+    // An untitled / out-of-workspace buffer lives in orphan. On close,
+    // it should move to stale so the entity survives for a possible
+    // re-open instead of leaking as a zombie in orphan.
+    let mut db = OakDatabase::new();
+    let url = file_url("/scratch/foo.R");
+    let file = db.upsert_editor(url.clone(), "hello\n".to_string());
+    assert!(db.orphan_root().files(&db).contains(&file));
+
+    db.close_editor(&url);
+
+    assert!(!db.orphan_root().files(&db).contains(&file));
+    assert!(db.stale_root().files(&db).contains(&file));
+}
+
+#[test]
+fn test_upsert_editor_resurrects_from_stale() {
+    // Closing then reopening the same URL reuses the same `File` entity.
+    use salsa::plumbing::AsId;
+
+    let mut db = OakDatabase::new();
+    let url = file_url("/scratch/foo.R");
+    let id_before = db.upsert_editor(url.clone(), "v1\n".to_string()).as_id();
+    db.close_editor(&url);
+
+    let id_after = db.upsert_editor(url.clone(), "v2\n".to_string()).as_id();
+    assert_eq!(id_before, id_after);
+
+    // The file is back in orphan, content from the second open.
+    let file = db.file_by_url(&url).unwrap();
+    assert!(db.orphan_root().files(&db).contains(&file));
+    assert!(!db.stale_root().files(&db).contains(&file));
+    assert_eq!(file.contents(&db), "v2\n");
+}
+
+#[test]
+fn test_close_editor_is_noop_for_file_in_live_root() {
+    // The editor's release doesn't disturb the scanner's classification.
+    // A file inside a live root's `packages` / `scripts` stays put.
+    let mut db = OakDatabase::new();
+    let root = Root::new(&db, file_url("/proj"), RootKind::Workspace, vec![], vec![]);
+    let url = file_url("/proj/foo.R");
+    let file = File::new(&db, url.clone(), "x".to_string(), None);
+    root.set_scripts(&mut db).to(vec![file]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    db.close_editor(&url);
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.scripts(&db).contains(&file));
+    assert!(!db.orphan_root().files(&db).contains(&file));
+    assert!(!db.stale_root().files(&db).contains(&file));
 }

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -33,8 +33,11 @@ use oak_db::Package;
 use oak_db::Root;
 use salsa::Setter;
 
+use crate::inputs::remove_from_orphan;
 use crate::inputs::remove_from_pkg_files;
 use crate::inputs::upsert_root_file;
+use crate::inputs::with_appended;
+use crate::inputs::with_removed;
 use crate::inputs::FileEntry;
 use crate::packages::classify_in_package;
 use crate::packages::is_r_file;
@@ -156,23 +159,17 @@ pub(crate) fn add_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId, conte
 fn append_to_container<DB: Db + DbInputs>(db: &mut DB, file: File, placement: Placement) {
     match placement {
         Placement::Script(root) => {
-            let mut scripts = root.scripts(db).clone();
-            if !scripts.contains(&file) {
-                scripts.push(file);
+            if let Some(scripts) = with_appended(root.scripts(db), file) {
                 root.set_scripts(db).to(scripts);
             }
         },
         Placement::PackageFile(pkg) => {
-            let mut files = pkg.files(db).clone();
-            if !files.contains(&file) {
-                files.push(file);
+            if let Some(files) = with_appended(pkg.files(db), file) {
                 pkg.set_files(db).to(files);
             }
         },
         Placement::PackageScript(pkg) => {
-            let mut scripts = pkg.scripts(db).clone();
-            if !scripts.contains(&file) {
-                scripts.push(file);
+            if let Some(scripts) = with_appended(pkg.scripts(db), file) {
                 pkg.set_scripts(db).to(scripts);
             }
         },
@@ -195,20 +192,13 @@ pub(crate) fn remove_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId) {
     }
 
     for &root in &db.workspace_roots().roots(db).clone() {
-        let mut scripts = root.scripts(db).clone();
-        if scripts.contains(&file) {
-            scripts.retain(|f| *f != file);
+        if let Some(scripts) = with_removed(root.scripts(db), file) {
             root.set_scripts(db).to(scripts);
             return;
         }
     }
 
-    let orphan = db.orphan_root();
-    let mut files = orphan.files(db).clone();
-    if files.contains(&file) {
-        files.retain(|f| *f != file);
-        orphan.set_files(db).to(files);
-    }
+    remove_from_orphan(db, file);
 }
 
 #[derive(Copy, Clone)]

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -75,11 +75,11 @@ pub(crate) fn apply_watcher_events<DB: Db + DbInputs>(
             continue;
         };
 
-        if path.file_name().is_some_and(|n| n == "DESCRIPTION") {
+        if path.file_name().is_some_and(|name| name == "DESCRIPTION") {
             if let Some(root) = roots
                 .iter()
-                .find(|(p, _)| path.starts_with(p))
-                .map(|(_, r)| *r)
+                .find(|(root_path, _)| path.starts_with(root_path))
+                .map(|(_, root)| *root)
             {
                 stale_roots.insert(root);
             }
@@ -109,8 +109,8 @@ fn workspace_root_paths<DB: Db + DbInputs>(db: &DB) -> Vec<(PathBuf, Root)> {
     db.workspace_roots()
         .roots(db)
         .iter()
-        .filter_map(|r| match r.path(db).to_file_path() {
-            Ok(p) => Some((p, *r)),
+        .filter_map(|root| match root.path(db).to_file_path() {
+            Ok(path) => Some((path, *root)),
             Err(err) => {
                 log::warn!("Skipping workspace root: {err}");
                 None
@@ -244,8 +244,8 @@ fn classify<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Placement> {
     let pkg_dir = path
         .ancestors()
         .skip(1)
-        .take_while(|p| p.starts_with(&root_path))
-        .find(|p| p.join("DESCRIPTION").is_file());
+        .take_while(|path| path.starts_with(&root_path))
+        .find(|path| path.join("DESCRIPTION").is_file());
 
     let Some(pkg_dir) = pkg_dir else {
         return Some(Placement::Script(root));
@@ -255,7 +255,7 @@ fn classify<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Placement> {
     let pkg = root
         .packages(db)
         .iter()
-        .find(|p| p.name(db) == &pkg_name)
+        .find(|pkg| pkg.name(db) == &pkg_name)
         .copied()?;
 
     let r_dir = pkg_dir.join("R");
@@ -275,8 +275,8 @@ fn workspace_root_containing<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<
     db.workspace_roots()
         .roots(db)
         .iter()
-        .find(|r| match r.path(db).to_file_path() {
-            Ok(p) => path.starts_with(&p),
+        .find(|root| match root.path(db).to_file_path() {
+            Ok(root_path) => path.starts_with(&root_path),
             Err(_) => false,
         })
         .copied()

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -112,7 +112,7 @@ fn workspace_root_paths<DB: Db + DbInputs>(db: &DB) -> Vec<(PathBuf, Root)> {
         .filter_map(|root| match root.path(db).to_file_path() {
             Ok(path) => Some((path, *root)),
             Err(err) => {
-                log::warn!("Skipping workspace root: {err}");
+                log::warn!("Can't get file path of workspace root, skipping: {err:?}");
                 None
             },
         })

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -36,8 +36,8 @@ use salsa::Setter;
 use crate::inputs::remove_from_orphan;
 use crate::inputs::remove_from_pkg_files;
 use crate::inputs::upsert_root_file;
-use crate::inputs::with_appended;
-use crate::inputs::with_removed;
+use crate::inputs::with_cow_filter;
+use crate::inputs::with_cow_push;
 use crate::inputs::FileEntry;
 use crate::packages::classify_in_package;
 use crate::packages::is_r_file;
@@ -159,17 +159,17 @@ pub(crate) fn add_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId, conte
 fn append_to_container<DB: Db + DbInputs>(db: &mut DB, file: File, placement: Placement) {
     match placement {
         Placement::Script(root) => {
-            if let Some(scripts) = with_appended(root.scripts(db), file) {
+            if let Some(scripts) = with_cow_push(root.scripts(db), file) {
                 root.set_scripts(db).to(scripts);
             }
         },
         Placement::PackageFile(pkg) => {
-            if let Some(files) = with_appended(pkg.files(db), file) {
+            if let Some(files) = with_cow_push(pkg.files(db), file) {
                 pkg.set_files(db).to(files);
             }
         },
         Placement::PackageScript(pkg) => {
-            if let Some(scripts) = with_appended(pkg.scripts(db), file) {
+            if let Some(scripts) = with_cow_push(pkg.scripts(db), file) {
                 pkg.set_scripts(db).to(scripts);
             }
         },
@@ -192,7 +192,7 @@ pub(crate) fn remove_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId) {
     }
 
     for &root in &db.workspace_roots().roots(db).clone() {
-        if let Some(scripts) = with_removed(root.scripts(db), file) {
+        if let Some(scripts) = with_cow_filter(root.scripts(db), file) {
             root.set_scripts(db).to(scripts);
             return;
         }

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -1,0 +1,274 @@
+//! Surgical updates from file-watcher events.
+//!
+//! The workspace scanner ([`crate::workspace`]) is the bulk path: it
+//! walks an entire root and rebuilds packages and scripts. The helpers
+//! here handle one file event at a time, so a burst of file watcher
+//! notifications doesn't trigger a full rescan per event.
+//!
+//! [`apply_watcher_events`] is the entry point used by drivers (the LSP,
+//! tests, eventually anything else that gets a stream of file events).
+//! Drivers translate their native event type into [`FileEvent`] and
+//! call in, and `apply_watcher_events` does the routing:
+//!
+//! - DESCRIPTION events fall back to
+//!   [`crate::workspace::rescan_workspace_root`] on the containing
+//!   workspace root, deduped within the batch. A `DESCRIPTION` add or
+//!   removal can promote or demote a whole directory, which is too
+//!   tangled for a one-file update.
+//!
+//! - R file events route through [`add_watched_file`] (Created / Changed) or
+//!   [`remove_watched_file`] (Deleted). The `skip` set lets the driver hold
+//!   back URLs whose contents it owns (the LSP uses this for files
+//!   the editor has open).
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+
+use aether_url::UrlId;
+use oak_db::Db;
+use oak_db::DbInputs;
+use oak_db::File;
+use oak_db::Package;
+use oak_db::Root;
+use salsa::Setter;
+
+use crate::inputs::upsert_root_file;
+use crate::inputs::FileEntry;
+use crate::packages::is_r_file;
+use crate::packages::read_description_name;
+
+/// Driver-neutral file event. Drivers (the LSP, tests, ...) translate
+/// their native event type into this shape.
+#[derive(Clone, Debug)]
+pub struct FileEvent {
+    pub kind: FileEventKind,
+    pub url: UrlId,
+}
+
+/// Mirrors the three states an OS file watcher reports.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum FileEventKind {
+    Created,
+    Changed,
+    Deleted,
+}
+
+/// Apply a batch of file events to the oak input tree.
+///
+/// DESCRIPTION events are deduped to one rescan per containing root.
+/// R-file events route through [`add_watched_file`] / [`remove_watched_file`]. URLs
+/// in `skip` are not touched even if their event is for an R file;
+/// callers use this to defer to an in-memory source of truth (e.g.
+/// the LSP's editor buffers).
+pub(crate) fn apply_watcher_events<DB: Db + DbInputs>(
+    db: &mut DB,
+    events: Vec<FileEvent>,
+    skip: &HashSet<UrlId>,
+) {
+    let roots = workspace_root_paths(db);
+    let mut stale_roots: HashSet<Root> = HashSet::new();
+
+    for event in events {
+        let Ok(path) = event.url.to_file_path() else {
+            continue;
+        };
+
+        if path.file_name().is_some_and(|n| n == "DESCRIPTION") {
+            if let Some(root) = roots
+                .iter()
+                .find(|(p, _)| path.starts_with(p))
+                .map(|(_, r)| *r)
+            {
+                stale_roots.insert(root);
+            }
+            continue;
+        }
+
+        if skip.contains(&event.url) {
+            continue;
+        }
+
+        match event.kind {
+            FileEventKind::Created | FileEventKind::Changed => match std::fs::read_to_string(&path)
+            {
+                Ok(contents) => add_watched_file(db, event.url, contents),
+                Err(err) => log::warn!("Skipped watched file {}: {err:?}", path.display()),
+            },
+            FileEventKind::Deleted => remove_watched_file(db, event.url),
+        }
+    }
+
+    for root in stale_roots {
+        crate::workspace::rescan_workspace_root(db, root);
+    }
+}
+
+fn workspace_root_paths<DB: Db + DbInputs>(db: &DB) -> Vec<(PathBuf, Root)> {
+    db.workspace_roots()
+        .roots(db)
+        .iter()
+        .filter_map(|r| match r.path(db).to_file_path() {
+            Ok(p) => Some((p, *r)),
+            Err(err) => {
+                log::warn!("Skipping workspace root: {err}");
+                None
+            },
+        })
+        .collect()
+}
+
+/// React to a Created or Changed event on an R file. Idempotent: if a `File`
+/// already exists at this URL, its contents are updated and its placement is
+/// left alone. If not, the URL is classified against the current workspace
+/// roots and the new file lands in the right container (package files, root
+/// scripts, or skipped if it falls outside every workspace).
+///
+/// R files inside a package's non-`R/` subdirectories (tests/, inst/,
+/// vignettes/, ...) are skipped, matching the workspace scanner.
+pub(crate) fn add_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId, contents: String) {
+    if let Some(existing) = db.file_by_url(&url) {
+        existing.set_contents(db).to(contents);
+        return;
+    }
+
+    let Ok(path) = url.to_file_path() else {
+        log::warn!("Skipping add_watched_file: URL is not a file path");
+        return;
+    };
+
+    let Some(placement) = classify(db, &path) else {
+        // Either the URL falls outside every workspace, or it lives
+        // inside a package subdir we don't track (tests/, inst/, ...).
+        return;
+    };
+
+    let entry = FileEntry { url, contents };
+    let file = upsert_root_file(db, placement.package_backpointer(), entry);
+    append_to_container(db, file, placement);
+}
+
+/// Append `file` to whichever container `placement` points at, if it
+/// isn't already listed. The watcher's single-file equivalent of the
+/// scanner's bulk `pkg.set_files()` / `root.set_scripts()` atomic replace.
+fn append_to_container<DB: Db + DbInputs>(db: &mut DB, file: File, placement: Placement) {
+    match placement {
+        Placement::Script(root) => {
+            let mut scripts = root.scripts(db).clone();
+            if !scripts.contains(&file) {
+                scripts.push(file);
+                root.set_scripts(db).to(scripts);
+            }
+        },
+        Placement::PackageFile(pkg) => {
+            let mut files = pkg.files(db).clone();
+            if !files.contains(&file) {
+                files.push(file);
+                pkg.set_files(db).to(files);
+            }
+        },
+    }
+}
+
+/// React to a Deleted event. Unlinks the file from whichever container
+/// holds it so [`oak_db::Db::file_by_url`] stops returning it. The
+/// `File` entity itself stays in the salsa graph (salsa doesn't
+/// support deleting inputs), but with no container references nothing
+/// will reach it.
+pub(crate) fn remove_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId) {
+    let Some(file) = db.file_by_url(&url) else {
+        return;
+    };
+
+    if let Some(pkg) = file.package(db) {
+        let mut files = pkg.files(db).clone();
+        if files.contains(&file) {
+            files.retain(|f| *f != file);
+            pkg.set_files(db).to(files);
+        }
+        return;
+    }
+
+    for &root in &db.workspace_roots().roots(db).clone() {
+        let mut scripts = root.scripts(db).clone();
+        if scripts.contains(&file) {
+            scripts.retain(|f| *f != file);
+            root.set_scripts(db).to(scripts);
+            return;
+        }
+    }
+
+    let orphan = db.orphan_root();
+    let mut files = orphan.files(db).clone();
+    if files.contains(&file) {
+        files.retain(|f| *f != file);
+        orphan.set_files(db).to(files);
+    }
+}
+
+#[derive(Copy, Clone)]
+enum Placement {
+    Script(Root),
+    PackageFile(Package),
+}
+
+impl Placement {
+    fn package_backpointer(self) -> Option<Package> {
+        match self {
+            Placement::Script(_) => None,
+            Placement::PackageFile(pkg) => Some(pkg),
+        }
+    }
+}
+
+/// Classify a file path against the current workspace tree.
+///
+/// Returns the placement (script container vs package container), or
+/// `None` if the file falls outside every workspace or sits in a
+/// package subdir we don't track.
+fn classify<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Placement> {
+    if !is_r_file(path) {
+        return None;
+    }
+
+    let root = workspace_root_containing(db, path)?;
+    let root_path = root.path(db).to_file_path().ok()?;
+
+    // Find the nearest ancestor (within `root_path`) that contains a
+    // `DESCRIPTION`. None means no package above the file, so it's a
+    // top-level workspace script.
+    let pkg_dir = path
+        .ancestors()
+        .skip(1)
+        .take_while(|p| p.starts_with(&root_path))
+        .find(|p| p.join("DESCRIPTION").is_file());
+
+    let Some(pkg_dir) = pkg_dir else {
+        return Some(Placement::Script(root));
+    };
+
+    // Inside a package: only files directly under `<pkg>/R/` count as
+    // package source. Everything else (tests/, inst/, ...) is skipped.
+    if path.parent() != Some(&pkg_dir.join("R")) {
+        return None;
+    }
+
+    let pkg_name = read_description_name(pkg_dir)?;
+    let pkg = root
+        .packages(db)
+        .iter()
+        .find(|p| p.name(db) == &pkg_name)
+        .copied()?;
+    Some(Placement::PackageFile(pkg))
+}
+
+fn workspace_root_containing<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Root> {
+    db.workspace_roots()
+        .roots(db)
+        .iter()
+        .find(|r| match r.path(db).to_file_path() {
+            Ok(p) => path.starts_with(&p),
+            Err(_) => false,
+        })
+        .copied()
+}

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -33,6 +33,7 @@ use oak_db::Package;
 use oak_db::Root;
 use salsa::Setter;
 
+use crate::inputs::remove_from_pkg_files;
 use crate::inputs::upsert_root_file;
 use crate::inputs::FileEntry;
 use crate::packages::is_r_file;
@@ -121,11 +122,10 @@ fn workspace_root_paths<DB: Db + DbInputs>(db: &DB) -> Vec<(PathBuf, Root)> {
 /// React to a Created or Changed event on an R file. Idempotent: if a `File`
 /// already exists at this URL, its contents are updated and its placement is
 /// left alone. If not, the URL is classified against the current workspace
-/// roots and the new file lands in the right container (package files, root
-/// scripts, or skipped if it falls outside every workspace).
-///
-/// R files inside a package's non-`R/` subdirectories (tests/, inst/,
-/// vignettes/, ...) are skipped, matching the workspace scanner.
+/// roots and the new file lands in the right container: `pkg.files` for
+/// `<pkg>/R/*.R`, `pkg.scripts` for other R files under a package
+/// (tests/, inst/, vignettes/, ...), `root.scripts` for R files outside
+/// every package. Mirrors the placement the bulk scanner would pick.
 pub(crate) fn add_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId, contents: String) {
     if let Some(existing) = db.file_by_url(&url) {
         existing.set_contents(db).to(contents);
@@ -167,6 +167,13 @@ fn append_to_container<DB: Db + DbInputs>(db: &mut DB, file: File, placement: Pl
                 pkg.set_files(db).to(files);
             }
         },
+        Placement::PackageScript(pkg) => {
+            let mut scripts = pkg.scripts(db).clone();
+            if !scripts.contains(&file) {
+                scripts.push(file);
+                pkg.set_scripts(db).to(scripts);
+            }
+        },
     }
 }
 
@@ -181,11 +188,7 @@ pub(crate) fn remove_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId) {
     };
 
     if let Some(pkg) = file.package(db) {
-        let mut files = pkg.files(db).clone();
-        if files.contains(&file) {
-            files.retain(|f| *f != file);
-            pkg.set_files(db).to(files);
-        }
+        remove_from_pkg_files(db, pkg, file);
         return;
     }
 
@@ -210,22 +213,23 @@ pub(crate) fn remove_watched_file<DB: Db + DbInputs>(db: &mut DB, url: UrlId) {
 enum Placement {
     Script(Root),
     PackageFile(Package),
+    PackageScript(Package),
 }
 
 impl Placement {
     fn package_backpointer(self) -> Option<Package> {
         match self {
             Placement::Script(_) => None,
-            Placement::PackageFile(pkg) => Some(pkg),
+            Placement::PackageFile(pkg) | Placement::PackageScript(pkg) => Some(pkg),
         }
     }
 }
 
 /// Classify a file path against the current workspace tree.
 ///
-/// Returns the placement (script container vs package container), or
-/// `None` if the file falls outside every workspace or sits in a
-/// package subdir we don't track.
+/// Returns the placement, or `None` if the file falls outside every
+/// workspace or sits in a package subdir we don't track (e.g.
+/// `<pkg>/R/subdir/` nested below the flat namespace).
 fn classify<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Placement> {
     if !is_r_file(path) {
         return None;
@@ -247,19 +251,24 @@ fn classify<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Placement> {
         return Some(Placement::Script(root));
     };
 
-    // Inside a package: only files directly under `<pkg>/R/` count as
-    // package source. Everything else (tests/, inst/, ...) is skipped.
-    if path.parent() != Some(&pkg_dir.join("R")) {
-        return None;
-    }
-
     let pkg_name = read_description_name(pkg_dir)?;
     let pkg = root
         .packages(db)
         .iter()
         .find(|p| p.name(db) == &pkg_name)
         .copied()?;
-    Some(Placement::PackageFile(pkg))
+
+    let r_dir = pkg_dir.join("R");
+    if path.parent() == Some(&r_dir) {
+        return Some(Placement::PackageFile(pkg));
+    }
+    if path.starts_with(&r_dir) {
+        // Nested below `<pkg>/R/`. The bulk scanner's `scan_r_files`
+        // reads only direct children of `R/`, and `scan_package_scripts`
+        // excludes anything under `R/`. The watcher matches that.
+        return None;
+    }
+    Some(Placement::PackageScript(pkg))
 }
 
 fn workspace_root_containing<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Root> {

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -17,7 +17,7 @@
 //!   tangled for a one-file update.
 //!
 //! - R file events route through [`add_watched_file`] (Created / Changed) or
-//!   [`remove_watched_file`] (Deleted). The `skip` set lets the driver hold
+//!   [`remove_watched_file`] (Deleted). The `editor_owned` set lets the driver hold
 //!   back URLs whose contents it owns (the LSP uses this for files
 //!   the editor has open).
 
@@ -59,13 +59,13 @@ pub enum FileEventKind {
 ///
 /// DESCRIPTION events are deduped to one rescan per containing root.
 /// R-file events route through [`add_watched_file`] / [`remove_watched_file`]. URLs
-/// in `skip` are not touched even if their event is for an R file;
+/// in `editor_owned` are not touched even if their event is for an R file;
 /// callers use this to defer to an in-memory source of truth (e.g.
 /// the LSP's editor buffers).
 pub(crate) fn apply_watcher_events<DB: Db + DbInputs>(
     db: &mut DB,
     events: Vec<FileEvent>,
-    skip: &HashSet<UrlId>,
+    editor_owned: &HashSet<UrlId>,
 ) {
     let roots = workspace_root_paths(db);
     let mut stale_roots: HashSet<Root> = HashSet::new();
@@ -86,7 +86,7 @@ pub(crate) fn apply_watcher_events<DB: Db + DbInputs>(
             continue;
         }
 
-        if skip.contains(&event.url) {
+        if editor_owned.contains(&event.url) {
             continue;
         }
 

--- a/crates/oak_scan/src/watch.rs
+++ b/crates/oak_scan/src/watch.rs
@@ -36,8 +36,10 @@ use salsa::Setter;
 use crate::inputs::remove_from_pkg_files;
 use crate::inputs::upsert_root_file;
 use crate::inputs::FileEntry;
+use crate::packages::classify_in_package;
 use crate::packages::is_r_file;
 use crate::packages::read_description_name;
+use crate::packages::PackagePlacement;
 
 /// Driver-neutral file event. Drivers (the LSP, tests, ...) translate
 /// their native event type into this shape.
@@ -258,17 +260,11 @@ fn classify<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Placement> {
         .find(|pkg| pkg.name(db) == &pkg_name)
         .copied()?;
 
-    let r_dir = pkg_dir.join("R");
-    if path.parent() == Some(&r_dir) {
-        return Some(Placement::PackageFile(pkg));
+    match classify_in_package(pkg_dir, path) {
+        PackagePlacement::File => Some(Placement::PackageFile(pkg)),
+        PackagePlacement::Script => Some(Placement::PackageScript(pkg)),
+        PackagePlacement::Skip => None,
     }
-    if path.starts_with(&r_dir) {
-        // Nested below `<pkg>/R/`. The bulk scanner's `scan_r_files`
-        // reads only direct children of `R/`, and `scan_package_scripts`
-        // excludes anything under `R/`. The watcher matches that.
-        return None;
-    }
-    Some(Placement::PackageScript(pkg))
 }
 
 fn workspace_root_containing<DB: Db + DbInputs>(db: &DB, path: &Path) -> Option<Root> {

--- a/crates/oak_scan/src/workspace.rs
+++ b/crates/oak_scan/src/workspace.rs
@@ -1,13 +1,15 @@
-//! Workspace scanner. Drives `WorkspaceRoots` from the editor's open
-//! folders.
+//! Workspace scanner. Drives `WorkspaceRoots` from the editor's open folders.
 //!
-//! For each workspace path, walks the directory tree (honouring `.gitignore`),
-//! discovers packages via `DESCRIPTION` files at any depth, and registers them
-//! under a `Workspace` root. R files outside any package directory land in
-//! `root.scripts`. Existing `Root`, `Package`, and `File` entities are reused
-//! where possible (see [`crate::inputs`]).
+//! [`set_workspace_paths`] is declarative: it reconciles the live set of
+//! workspace roots to exactly the paths it's given. Unchanged paths are left
+//! alone (the watcher handles in-folder changes via
+//! [`rescan_workspace_root`]). Removed paths are evicted; their files route
+//! to `OrphanRoot` if editor-owned, otherwise to `StaleRoot` for entity reuse
+//! on re-add. New paths are scanned: `DESCRIPTION` files at any depth
+//! (honouring `.gitignore`), plus top-level R scripts.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -22,39 +24,58 @@ use salsa::Setter;
 use crate::inputs::RootExt;
 use crate::packages::scan_workspace;
 
-/// Scan each workspace path and register the result under
-/// `WorkspaceRoots`. Called through
-/// [`crate::DbExt::scan_workspace_paths`].
-pub(crate) fn scan_workspace_paths<DB: Db + DbInputs>(db: &mut DB, paths: &[PathBuf]) {
-    let existing: HashMap<UrlId, Root> = db
+/// Reconcile `WorkspaceRoots` to exactly `paths`. Called through
+/// [`crate::DbExt::set_workspace_paths`].
+pub(crate) fn set_workspace_paths<DB: Db + DbInputs>(
+    db: &mut DB,
+    paths: &[PathBuf],
+    editor_owned: &HashSet<UrlId>,
+) {
+    let new: Vec<(PathBuf, UrlId)> = paths
+        .iter()
+        .filter_map(|p| {
+            let url = UrlId::from_file_path(p).ok()?;
+            Some((p.clone(), url))
+        })
+        .collect();
+    let new_urls: HashSet<UrlId> = new.iter().map(|(_, u)| u.clone()).collect();
+
+    let old: HashMap<UrlId, Root> = db
         .workspace_roots()
         .roots(db)
         .iter()
         .map(|r| (r.path(db).clone(), *r))
         .collect();
 
-    let mut roots = Vec::with_capacity(paths.len());
-    for path in paths {
-        match scan_workspace_path(db, path, &existing) {
-            Some(root) => roots.push(root),
-            None => log::warn!("Skipped workspace path: {}", path.display()),
+    // Evict roots not in the new set. Editor-owned files survive in
+    // `OrphanRoot` so their buffers stay analysable. Everything else goes
+    // to `StaleRoot` for entity reuse on re-add.
+    for (old_url, &old_root) in &old {
+        if !new_urls.contains(old_url) {
+            old_root.set_stale(db, Some(editor_owned));
         }
     }
-    db.workspace_roots().set_roots(db).to(roots);
+
+    // Build the new roots list: reuse the existing `Root` for unchanged paths
+    // (no rescan, the watcher is the path for in-folder changes), scan the
+    // rest.
+    let mut new_roots = Vec::with_capacity(new.len());
+    for (path, url) in new {
+        let root = match old.get(&url) {
+            Some(&r) => r,
+            None => scan_new_workspace_path(db, &path, url),
+        };
+        new_roots.push(root);
+    }
+    db.workspace_roots().set_roots(db).to(new_roots);
 }
 
-fn scan_workspace_path<DB: Db + DbInputs>(
-    db: &mut DB,
-    path: &Path,
-    existing: &HashMap<UrlId, Root>,
-) -> Option<Root> {
-    let url = UrlId::from_file_path(path).ok()?;
-    let root = match existing.get(&url) {
-        Some(&r) => r,
-        None => Root::new(db, url, RootKind::Workspace, Vec::new(), Vec::new()),
-    };
+/// Initial scan of a path that wasn't previously a workspace root. Walks the
+/// directory tree, calls `set_package` per discovered package, sets scripts.
+fn scan_new_workspace_path<DB: Db + DbInputs>(db: &mut DB, path: &Path, url: UrlId) -> Root {
+    let root = Root::new(db, url, RootKind::Workspace, Vec::new(), Vec::new());
     rescan_into(db, root, path);
-    Some(root)
+    root
 }
 
 /// Re-run the workspace scan against an existing root. Used as the

--- a/crates/oak_scan/src/workspace.rs
+++ b/crates/oak_scan/src/workspace.rs
@@ -22,7 +22,8 @@ use oak_db::RootKind;
 use salsa::Setter;
 
 use crate::inputs::RootExt;
-use crate::packages::scan_workspace;
+use crate::packages::scan_workspace_packages;
+use crate::packages::scan_workspace_scripts;
 
 /// Reconcile `WorkspaceRoots` to exactly `paths`. Called through
 /// [`crate::DbScan::set_workspace_paths`].
@@ -90,7 +91,8 @@ pub(crate) fn rescan_workspace_root<DB: Db + DbInputs>(db: &mut DB, root: Root) 
 }
 
 fn rescan_into<DB: Db + DbInputs>(db: &mut DB, root: Root, path: &Path) {
-    let (packages, scripts) = scan_workspace(path);
+    let packages = scan_workspace_packages(path);
+    let scripts = scan_workspace_scripts(path);
 
     let package_entities: Vec<Package> = packages
         .into_iter()

--- a/crates/oak_scan/src/workspace.rs
+++ b/crates/oak_scan/src/workspace.rs
@@ -25,7 +25,7 @@ use crate::inputs::RootExt;
 use crate::packages::scan_workspace;
 
 /// Reconcile `WorkspaceRoots` to exactly `paths`. Called through
-/// [`crate::DbExt::set_workspace_paths`].
+/// [`crate::DbScan::set_workspace_paths`].
 pub(crate) fn set_workspace_paths<DB: Db + DbInputs>(
     db: &mut DB,
     paths: &[PathBuf],

--- a/crates/oak_scan/src/workspace.rs
+++ b/crates/oak_scan/src/workspace.rs
@@ -1,0 +1,79 @@
+//! Workspace scanner. Drives `WorkspaceRoots` from the editor's open
+//! folders.
+//!
+//! For each workspace path, walks the directory tree (honouring
+//! `.gitignore`), discovers packages via `DESCRIPTION` files at any
+//! depth, and registers them under a `Workspace` root. R files outside
+//! any package directory land in `root.scripts`. Existing `Root`,
+//! `Package`, and `File` entities are reused where possible (see
+//! [`crate::inputs`]).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use aether_url::UrlId;
+use oak_db::Db;
+use oak_db::DbInputs;
+use oak_db::Package;
+use oak_db::Root;
+use oak_db::RootKind;
+use salsa::Setter;
+
+use crate::inputs::RootExt;
+use crate::packages::scan_workspace;
+
+/// Scan each workspace path and register the result under
+/// `WorkspaceRoots`. Called through
+/// [`crate::DbExt::scan_workspace_paths`].
+pub(crate) fn scan_workspace_paths<DB: Db + DbInputs>(db: &mut DB, paths: &[PathBuf]) {
+    let existing: HashMap<UrlId, Root> = db
+        .workspace_roots()
+        .roots(db)
+        .iter()
+        .map(|r| (r.path(db).clone(), *r))
+        .collect();
+
+    let mut roots = Vec::with_capacity(paths.len());
+    for path in paths {
+        match scan_workspace_path(db, path, &existing) {
+            Some(root) => roots.push(root),
+            None => log::warn!("Skipped workspace path: {}", path.display()),
+        }
+    }
+    db.workspace_roots().set_roots(db).to(roots);
+}
+
+fn scan_workspace_path<DB: Db + DbInputs>(
+    db: &mut DB,
+    path: &Path,
+    existing: &HashMap<UrlId, Root>,
+) -> Option<Root> {
+    let url = UrlId::from_file_path(path).ok()?;
+    let root = match existing.get(&url) {
+        Some(&r) => r,
+        None => Root::new(db, url, RootKind::Workspace, Vec::new(), Vec::new()),
+    };
+
+    let (packages, scripts) = scan_workspace(path);
+
+    let package_entities: Vec<Package> = packages
+        .into_iter()
+        .map(|pkg| {
+            root.set_package(
+                db,
+                pkg.description_url,
+                pkg.name,
+                pkg.version,
+                pkg.namespace,
+                pkg.files,
+                pkg.collation,
+            )
+        })
+        .collect();
+
+    root.set_packages(db).to(package_entities);
+    root.set_workspace_scripts(db, scripts);
+
+    Some(root)
+}

--- a/crates/oak_scan/src/workspace.rs
+++ b/crates/oak_scan/src/workspace.rs
@@ -102,6 +102,7 @@ fn rescan_into<DB: Db + DbInputs>(db: &mut DB, root: Root, path: &Path) {
                 pkg.version,
                 pkg.namespace,
                 pkg.files,
+                pkg.scripts,
                 pkg.collation,
             )
         })

--- a/crates/oak_scan/src/workspace.rs
+++ b/crates/oak_scan/src/workspace.rs
@@ -1,12 +1,11 @@
 //! Workspace scanner. Drives `WorkspaceRoots` from the editor's open
 //! folders.
 //!
-//! For each workspace path, walks the directory tree (honouring
-//! `.gitignore`), discovers packages via `DESCRIPTION` files at any
-//! depth, and registers them under a `Workspace` root. R files outside
-//! any package directory land in `root.scripts`. Existing `Root`,
-//! `Package`, and `File` entities are reused where possible (see
-//! [`crate::inputs`]).
+//! For each workspace path, walks the directory tree (honouring `.gitignore`),
+//! discovers packages via `DESCRIPTION` files at any depth, and registers them
+//! under a `Workspace` root. R files outside any package directory land in
+//! `root.scripts`. Existing `Root`, `Package`, and `File` entities are reused
+//! where possible (see [`crate::inputs`]).
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -54,7 +53,22 @@ fn scan_workspace_path<DB: Db + DbInputs>(
         Some(&r) => r,
         None => Root::new(db, url, RootKind::Workspace, Vec::new(), Vec::new()),
     };
+    rescan_into(db, root, path);
+    Some(root)
+}
 
+/// Re-run the workspace scan against an existing root. Used as the
+/// fallback for events (DESCRIPTION add / remove / edit) that can
+/// change the set of packages under the root.
+pub(crate) fn rescan_workspace_root<DB: Db + DbInputs>(db: &mut DB, root: Root) {
+    let Ok(path) = root.path(db).to_file_path() else {
+        log::warn!("Skipped rescan: root URL is not a file path");
+        return;
+    };
+    rescan_into(db, root, &path);
+}
+
+fn rescan_into<DB: Db + DbInputs>(db: &mut DB, root: Root, path: &Path) {
     let (packages, scripts) = scan_workspace(path);
 
     let package_entities: Vec<Package> = packages
@@ -74,6 +88,4 @@ fn scan_workspace_path<DB: Db + DbInputs>(
 
     root.set_packages(db).to(package_entities);
     root.set_workspace_scripts(db, scripts);
-
-    Some(root)
 }

--- a/crates/oak_scan/tests/integration/library.rs
+++ b/crates/oak_scan/tests/integration/library.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -378,7 +379,9 @@ fn test_upsert_re_promotes_editor_owned_file_from_orphan() {
     // Editor opens the file before any scan -> orphan.
     let r_url = file_url("/lib/pkg/R/a.R");
     let file = File::new(&db, r_url.clone(), "editor content".to_string(), None);
-    db.orphan_root().set_files(&mut db).to(vec![file]);
+    db.orphan_root()
+        .set_files(&mut db)
+        .to(HashSet::from([file]));
     assert_eq!(file.package(&db), None);
 
     // Now a library scan picks up the same URL as part of a package.

--- a/crates/oak_scan/tests/integration/library.rs
+++ b/crates/oak_scan/tests/integration/library.rs
@@ -60,28 +60,6 @@ fn test_scan_library_discovers_package() {
     assert_eq!(packages.len(), 1);
     assert_eq!(packages[0].name(&db), "dplyr");
     assert_eq!(packages[0].version(&db), &Some("1.0.0".to_string()),);
-
-    let files = packages[0].files(&db).clone();
-    assert_eq!(files.len(), 2);
-    // Alphabetical by basename: mutate.R, select.R.
-    assert!(files[0].url(&db).as_url().path().ends_with("mutate.R"));
-    assert!(files[1].url(&db).as_url().path().ends_with("select.R"));
-}
-
-#[test]
-fn test_scan_library_files_are_findable_by_url() {
-    let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
-    let mut db = OakDatabase::new();
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-
-    let r_path = tmp.path().join("pkg").join("R").join("a.R");
-    let url = UrlId::from_file_path(&r_path).unwrap();
-    let file = db
-        .file_by_url(&url)
-        .expect("scanned file should be findable");
-    assert_eq!(file.contents(&db), "x <- 1\n");
 }
 
 #[test]
@@ -155,23 +133,6 @@ fn test_rescan_preserves_package_identity_by_description_name() {
 }
 
 #[test]
-fn test_rescan_preserves_file_identity_by_url() {
-    use salsa::plumbing::AsId;
-
-    let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
-    let mut db = OakDatabase::new();
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-    let file_id_1 = db.library_roots().roots(&db)[0].packages(&db)[0].files(&db)[0].as_id();
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-    let file_id_2 = db.library_roots().roots(&db)[0].packages(&db)[0].files(&db)[0].as_id();
-
-    assert_eq!(file_id_1, file_id_2);
-}
-
-#[test]
 fn test_rescan_renamed_package_dir_keeps_package_identity() {
     // Identity is `(root, DESCRIPTION name)`, not the directory path.
     // Renaming the package directory but keeping the same DESCRIPTION
@@ -238,35 +199,6 @@ fn test_set_library_paths_removed_path_evicts_root() {
 }
 
 #[test]
-fn test_set_library_paths_re_add_preserves_file_identity() {
-    // The motivating case for `StaleRoot`. Adding, removing, then re-adding
-    // a library path returns the same `File` entity for files at the same
-    // URL, so downstream salsa caches stay warm and don't bloat on every
-    // workspace folder toggle.
-    use salsa::plumbing::AsId;
-
-    let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
-    let mut db = OakDatabase::new();
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-    let file_id_before = db.library_roots().roots(&db)[0].packages(&db)[0].files(&db)[0].as_id();
-
-    db.set_library_paths(&[]);
-    // After removal, the file is not reachable through analysis.
-    let r_path = tmp.path().join("pkg").join("R").join("a.R");
-    let url = UrlId::from_file_path(&r_path).unwrap();
-    assert!(db.file_by_url(&url).is_none());
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-    let file_id_after = db.library_roots().roots(&db)[0].packages(&db)[0].files(&db)[0].as_id();
-
-    assert_eq!(file_id_before, file_id_after);
-    // And it's findable again.
-    assert!(db.file_by_url(&url).is_some());
-}
-
-#[test]
 fn test_set_library_paths_re_add_preserves_package_identity() {
     use salsa::plumbing::AsId;
 
@@ -290,26 +222,19 @@ fn test_set_library_paths_re_add_preserves_package_identity() {
 
 #[test]
 fn test_set_library_paths_stale_invisible_to_analysis() {
-    // Stale files/packages must not show up in `file_by_url` /
-    // `package_by_name`. They're entity-reuse storage, not part of the
-    // analysis universe.
+    // A stale package must not show up in `package_by_name`. Stale is
+    // entity-reuse storage, not part of the analysis universe.
     let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("dplyr"), "dplyr", &[("a.R", "x <- 1\n")]);
+    write_package(&tmp.path().join("dplyr"), "dplyr", &[]);
     let mut db = OakDatabase::new();
 
     db.set_library_paths(&[tmp.path().to_path_buf()]);
-    let r_path = tmp.path().join("dplyr").join("R").join("a.R");
-    let url = UrlId::from_file_path(&r_path).unwrap();
-    assert!(db.file_by_url(&url).is_some());
     assert!(db.package_by_name("dplyr").is_some());
 
     db.set_library_paths(&[]);
 
-    // Both lookups miss; the entities are in stale, not in the live universe.
-    assert!(db.file_by_url(&url).is_none());
+    // The lookup misses; the package is in stale, not the live universe.
     assert!(db.package_by_name("dplyr").is_none());
-    // But the stale buckets do hold them.
-    assert_eq!(db.stale_root().files(&db).len(), 1);
     assert_eq!(db.stale_root().packages(&db).len(), 1);
 }
 
@@ -319,7 +244,7 @@ fn test_set_library_paths_stale_no_duplicates_across_cycles() {
     // re-add the entity comes back out of stale, so by the time we
     // remove it again there's only one copy to push back in.
     let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    write_package(&tmp.path().join("pkg"), "pkg", &[]);
     let mut db = OakDatabase::new();
 
     for _ in 0..3 {
@@ -327,30 +252,7 @@ fn test_set_library_paths_stale_no_duplicates_across_cycles() {
         db.set_library_paths(&[]);
     }
 
-    let stale = db.stale_root();
-    assert_eq!(stale.files(&db).len(), 1);
-    assert_eq!(stale.packages(&db).len(), 1);
-}
-
-#[test]
-fn test_set_library_paths_resurrected_file_picks_up_disk_contents() {
-    // Eviction doesn't snapshot disk contents. When a file is
-    // resurrected from stale, it should reflect the current disk state,
-    // not whatever it had when evicted.
-    let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "v1\n")]);
-    let mut db = OakDatabase::new();
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-    db.set_library_paths(&[]);
-
-    let r_path = tmp.path().join("pkg").join("R").join("a.R");
-    fs::write(&r_path, "v2\n").unwrap();
-
-    db.set_library_paths(&[tmp.path().to_path_buf()]);
-    let url = UrlId::from_file_path(&r_path).unwrap();
-    let file = db.file_by_url(&url).unwrap();
-    assert_eq!(file.contents(&db), "v2\n");
+    assert_eq!(db.stale_root().packages(&db).len(), 1);
 }
 
 // --- nested-root resolution (longest-path-wins) ---

--- a/crates/oak_scan/tests/integration/library.rs
+++ b/crates/oak_scan/tests/integration/library.rs
@@ -400,6 +400,7 @@ fn test_set_package_longer_root_wins_after_shorter_claims_first() {
         None,
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     register_package(&mut db, short, p1);
@@ -411,6 +412,7 @@ fn test_set_package_longer_root_wins_after_shorter_claims_first() {
         "pkg".to_string(),
         None,
         Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );
@@ -435,6 +437,7 @@ fn test_set_package_shorter_root_does_not_steal_from_longer() {
         None,
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     register_package(&mut db, long, p1);
@@ -446,6 +449,7 @@ fn test_set_package_shorter_root_does_not_steal_from_longer() {
         "pkg".to_string(),
         None,
         Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );
@@ -487,6 +491,7 @@ fn test_upsert_re_promotes_editor_owned_file_from_orphan() {
             url: r_url.clone(),
             contents: "disk content".to_string(),
         }],
+        Vec::new(),
         None,
     );
 
@@ -520,6 +525,7 @@ fn test_set_package_stale_resurrection_changes_owning_root() {
         None,
         Namespace::default(),
         Vec::new(),
+        Vec::new(),
         None,
     );
     register_package(&mut db, old, p1);
@@ -537,6 +543,7 @@ fn test_set_package_stale_resurrection_changes_owning_root() {
         "pkg".to_string(),
         None,
         Namespace::default(),
+        Vec::new(),
         Vec::new(),
         None,
     );

--- a/crates/oak_scan/tests/watch.rs
+++ b/crates/oak_scan/tests/watch.rs
@@ -6,7 +6,7 @@ use aether_url::UrlId;
 use oak_db::Db;
 use oak_db::DbInputs;
 use oak_db::OakDatabase;
-use oak_scan::DbExt;
+use oak_scan::DbScan;
 use oak_scan::FileEvent;
 use oak_scan::FileEventKind;
 

--- a/crates/oak_scan/tests/watch.rs
+++ b/crates/oak_scan/tests/watch.rs
@@ -381,6 +381,30 @@ fn test_apply_watcher_events_description_outside_any_workspace_is_noop() {
 }
 
 #[test]
+fn test_apply_watcher_events_ignores_non_r_files() {
+    // The LSP registration filters to `*.{R,r}` and `DESCRIPTION`, so the
+    // dispatcher shouldn't see other paths in practice. Defensive check that
+    // `add_watched_file`'s classifier drops them silently rather than
+    // landing them in the orphan bucket or some root container.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("notes.txt");
+    fs::write(&path, "not R\n").unwrap();
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.apply_watcher_events(
+        vec![file_event(&path, FileEventKind::Created)],
+        &HashSet::new(),
+    );
+
+    assert!(db.file_by_url(&url).is_none());
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.scripts(&db).is_empty());
+    assert!(db.orphan_root().files(&db).is_empty());
+}
+
+#[test]
 fn test_apply_watcher_events_tolerates_non_package_description() {
     // The dispatcher triggers a rescan on any file named `DESCRIPTION`
     // without inspecting its contents. If the file isn't actually an R

--- a/crates/oak_scan/tests/watch.rs
+++ b/crates/oak_scan/tests/watch.rs
@@ -1,0 +1,409 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use aether_url::UrlId;
+use oak_db::Db;
+use oak_db::DbInputs;
+use oak_db::OakDatabase;
+use oak_scan::DbExt;
+use oak_scan::FileEvent;
+use oak_scan::FileEventKind;
+
+fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
+    fs::create_dir_all(dir.join("R")).unwrap();
+    fs::write(
+        dir.join("DESCRIPTION"),
+        format!("Package: {name}\nVersion: 0.0.0\n"),
+    )
+    .unwrap();
+    for (basename, contents) in r_files {
+        fs::write(dir.join("R").join(basename), contents).unwrap();
+    }
+}
+
+#[test]
+fn test_add_watched_file_new_top_level_script() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("new.R");
+    fs::write(&path, "x <- 1\n").unwrap();
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.add_watched_file(url.clone(), "x <- 1\n".to_string());
+
+    let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
+    assert_eq!(scripts.len(), 1);
+    assert!(scripts[0].url(&db).as_url().path().ends_with("new.R"));
+}
+
+#[test]
+fn test_add_watched_file_into_existing_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("pkg/R/b.R");
+    fs::write(&path, "y <- 2\n").unwrap();
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.add_watched_file(url.clone(), "y <- 2\n".to_string());
+
+    let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].files(&db).len(), 2);
+
+    let file = db.file_by_url(&url).expect("findable");
+    assert_eq!(file.package(&db), Some(packages[0]));
+}
+
+#[test]
+fn test_add_watched_file_skips_package_internal_subdir() {
+    // Files inside `<pkg>/tests/` and similar non-`R/` subdirs are not
+    // workspace scripts and not package files. The watcher should
+    // ignore them, matching the bulk scanner.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("pkg/tests/test-foo.R");
+    fs::write(&path, "test code\n").unwrap();
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.add_watched_file(url.clone(), "test code\n".to_string());
+
+    let root = db.workspace_roots().roots(&db)[0];
+    let scripts = root.scripts(&db).clone();
+    let packages = root.packages(&db).clone();
+    assert!(scripts.is_empty());
+    assert_eq!(packages[0].files(&db).len(), 1);
+    assert!(db.file_by_url(&url).is_none());
+}
+
+#[test]
+fn test_add_watched_file_outside_workspace_is_skipped() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[workspace.path().to_path_buf()]);
+
+    let path = outside.path().join("stray.R");
+    fs::write(&path, "z <- 3\n").unwrap();
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.add_watched_file(url.clone(), "z <- 3\n".to_string());
+
+    assert!(db.file_by_url(&url).is_none());
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.scripts(&db).is_empty());
+}
+
+#[test]
+fn test_add_watched_file_updates_existing_content_preserves_placement() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "v1\n")]);
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("pkg/R/a.R");
+    let url = UrlId::from_file_path(&path).unwrap();
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    let file_before = pkg.files(&db)[0];
+
+    db.add_watched_file(url.clone(), "v2\n".to_string());
+
+    let file_after = db.file_by_url(&url).unwrap();
+    assert_eq!(file_before, file_after);
+    assert_eq!(file_after.contents(&db), "v2\n");
+    assert_eq!(file_after.package(&db), Some(pkg));
+    assert_eq!(pkg.files(&db).len(), 1);
+}
+
+#[test]
+fn test_remove_watched_file_from_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[
+        ("a.R", "x <- 1\n"),
+        ("b.R", "y <- 2\n"),
+    ]);
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("pkg/R/a.R");
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.remove_watched_file(url.clone());
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(pkg.files(&db).len(), 1);
+    assert!(db.file_by_url(&url).is_none());
+}
+
+#[test]
+fn test_remove_watched_file_from_workspace_scripts() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
+    fs::write(tmp.path().join("b.R"), "y <- 2\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("a.R");
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.remove_watched_file(url.clone());
+
+    let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
+    assert_eq!(scripts.len(), 1);
+    assert!(db.file_by_url(&url).is_none());
+}
+
+#[test]
+fn test_remove_watched_file_unknown_url_is_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let url = UrlId::from_file_path(tmp.path().join("ghost.R")).unwrap();
+    db.remove_watched_file(url);
+}
+
+#[test]
+fn test_rescan_workspace_root_picks_up_new_description() {
+    // A `DESCRIPTION` appears after the initial scan: a former script
+    // directory is now a package. Surgical add_watched_file can't handle this,
+    // so the LSP layer falls back to a root rescan.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
+    fs::write(tmp.path().join("pkg/R/a.R"), "x <- 1\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    // No DESCRIPTION yet, so the R file came in as a script.
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.packages(&db).is_empty());
+    assert_eq!(root.scripts(&db).len(), 1);
+
+    fs::write(
+        tmp.path().join("pkg/DESCRIPTION"),
+        "Package: pkg\nVersion: 0.0.0\n",
+    )
+    .unwrap();
+    db.rescan_workspace_root(root);
+
+    assert_eq!(root.packages(&db).len(), 1);
+    assert_eq!(root.packages(&db)[0].files(&db).len(), 1);
+    assert!(root.scripts(&db).is_empty());
+}
+
+#[test]
+fn test_rescan_workspace_root_demotes_removed_description() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert_eq!(root.packages(&db).len(), 1);
+
+    fs::remove_file(tmp.path().join("pkg/DESCRIPTION")).unwrap();
+    db.rescan_workspace_root(root);
+
+    assert!(root.packages(&db).is_empty());
+    // The R file under pkg/R/ is no longer in a recognised package, so
+    // it surfaces as a workspace script.
+    assert_eq!(root.scripts(&db).len(), 1);
+}
+
+fn file_event(path: &Path, kind: FileEventKind) -> FileEvent {
+    FileEvent {
+        url: UrlId::from_file_path(path).unwrap(),
+        kind,
+    }
+}
+
+#[test]
+fn test_apply_watcher_events_routes_description_to_rescan() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
+    fs::write(tmp.path().join("pkg/R/a.R"), "x <- 1\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    fs::write(
+        tmp.path().join("pkg/DESCRIPTION"),
+        "Package: pkg\nVersion: 0.0.0\n",
+    )
+    .unwrap();
+    db.apply_watcher_events(
+        vec![file_event(
+            &tmp.path().join("pkg/DESCRIPTION"),
+            FileEventKind::Created,
+        )],
+        &HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert_eq!(root.packages(&db).len(), 1);
+}
+
+#[test]
+fn test_apply_watcher_events_dedupes_descriptions_per_root() {
+    // Two DESCRIPTION events under the same root: rescan_workspace_root
+    // should fire once. We can't observe the call count directly, but
+    // we can check the final state is correct.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg1"), "pkg1", &[]);
+    write_package(&tmp.path().join("pkg2"), "pkg2", &[]);
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    db.apply_watcher_events(
+        vec![
+            file_event(&tmp.path().join("pkg1/DESCRIPTION"), FileEventKind::Changed),
+            file_event(&tmp.path().join("pkg2/DESCRIPTION"), FileEventKind::Changed),
+        ],
+        &HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert_eq!(root.packages(&db).len(), 2);
+}
+
+#[test]
+fn test_apply_watcher_events_routes_r_file_to_add() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("new.R");
+    fs::write(&path, "x <- 1\n").unwrap();
+    db.apply_watcher_events(
+        vec![file_event(&path, FileEventKind::Created)],
+        &HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert_eq!(root.scripts(&db).len(), 1);
+}
+
+#[test]
+fn test_apply_watcher_events_routes_r_file_to_remove() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let path = tmp.path().join("a.R");
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.apply_watcher_events(
+        vec![file_event(&path, FileEventKind::Deleted)],
+        &HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.scripts(&db).is_empty());
+    assert!(db.file_by_url(&url).is_none());
+}
+
+#[test]
+fn test_apply_watcher_events_skip_set_blocks_r_file_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("a.R");
+    fs::write(&path, "disk_v1\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    // Driver "owns" this URL (the editor has it open).
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.set_editor_contents(url.clone(), "editor_v2\n".to_string());
+
+    let mut skip = HashSet::new();
+    skip.insert(url.clone());
+
+    fs::write(&path, "disk_v3\n").unwrap();
+    db.apply_watcher_events(vec![file_event(&path, FileEventKind::Changed)], &skip);
+
+    let file = db.file_by_url(&url).unwrap();
+    assert_eq!(file.contents(&db), "editor_v2\n");
+}
+
+#[test]
+fn test_apply_watcher_events_skip_set_does_not_block_description() {
+    // DESCRIPTION classification is disk-authoritative, so the skip
+    // set (an editor-owned URL set) should not hold back a
+    // DESCRIPTION rescan even if the DESCRIPTION URL is in `skip`.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    fs::write(
+        tmp.path().join("pkg/DESCRIPTION"),
+        "Package: pkg\nVersion: 0.0.0\n",
+    )
+    .unwrap();
+
+    let desc_path = tmp.path().join("pkg/DESCRIPTION");
+    let desc_url = UrlId::from_file_path(&desc_path).unwrap();
+    let mut skip = HashSet::new();
+    skip.insert(desc_url);
+
+    db.apply_watcher_events(vec![file_event(&desc_path, FileEventKind::Created)], &skip);
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert_eq!(root.packages(&db).len(), 1);
+}
+
+#[test]
+fn test_apply_watcher_events_description_outside_any_workspace_is_noop() {
+    // A DESCRIPTION event for a path outside every workspace root has
+    // nowhere to land. The handler should ignore it rather than
+    // rescanning some arbitrary root.
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    fs::write(
+        outside.path().join("DESCRIPTION"),
+        "Package: stray\nVersion: 0.0.0\n",
+    )
+    .unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[workspace.path().to_path_buf()]);
+
+    db.apply_watcher_events(
+        vec![file_event(
+            &outside.path().join("DESCRIPTION"),
+            FileEventKind::Created,
+        )],
+        &HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.packages(&db).is_empty());
+}
+
+#[test]
+fn test_apply_watcher_events_tolerates_non_package_description() {
+    // The dispatcher triggers a rescan on any file named `DESCRIPTION`
+    // without inspecting its contents. If the file isn't actually an R
+    // package DESCRIPTION, the rescan tolerates that and leaves the
+    // workspace unclassified rather than panicking or erroring.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    fs::create_dir_all(tmp.path().join("not-a-pkg")).unwrap();
+    fs::write(
+        tmp.path().join("not-a-pkg/DESCRIPTION"),
+        "Title: Some other project\nVersion: 1.0\n",
+    )
+    .unwrap();
+    db.apply_watcher_events(
+        vec![file_event(
+            &tmp.path().join("not-a-pkg/DESCRIPTION"),
+            FileEventKind::Created,
+        )],
+        &HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.packages(&db).is_empty());
+}

--- a/crates/oak_scan/tests/watch.rs
+++ b/crates/oak_scan/tests/watch.rs
@@ -26,7 +26,10 @@ fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
 fn test_add_watched_file_new_top_level_script() {
     let tmp = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("new.R");
     fs::write(&path, "x <- 1\n").unwrap();
@@ -43,7 +46,10 @@ fn test_add_watched_file_into_existing_package() {
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("pkg/R/b.R");
     fs::write(&path, "y <- 2\n").unwrap();
@@ -67,7 +73,10 @@ fn test_add_watched_file_skips_package_internal_subdir() {
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("pkg/tests/test-foo.R");
     fs::write(&path, "test code\n").unwrap();
@@ -87,7 +96,10 @@ fn test_add_watched_file_outside_workspace_is_skipped() {
     let workspace = tempfile::tempdir().unwrap();
     let outside = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[workspace.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[workspace.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = outside.path().join("stray.R");
     fs::write(&path, "z <- 3\n").unwrap();
@@ -104,7 +116,10 @@ fn test_add_watched_file_updates_existing_content_preserves_placement() {
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "v1\n")]);
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("pkg/R/a.R");
     let url = UrlId::from_file_path(&path).unwrap();
@@ -128,7 +143,10 @@ fn test_remove_watched_file_from_package() {
         ("b.R", "y <- 2\n"),
     ]);
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("pkg/R/a.R");
     let url = UrlId::from_file_path(&path).unwrap();
@@ -145,7 +163,10 @@ fn test_remove_watched_file_from_workspace_scripts() {
     fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
     fs::write(tmp.path().join("b.R"), "y <- 2\n").unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("a.R");
     let url = UrlId::from_file_path(&path).unwrap();
@@ -160,7 +181,10 @@ fn test_remove_watched_file_from_workspace_scripts() {
 fn test_remove_watched_file_unknown_url_is_noop() {
     let tmp = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let url = UrlId::from_file_path(tmp.path().join("ghost.R")).unwrap();
     db.remove_watched_file(url);
@@ -175,7 +199,10 @@ fn test_rescan_workspace_root_picks_up_new_description() {
     fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
     fs::write(tmp.path().join("pkg/R/a.R"), "x <- 1\n").unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     // No DESCRIPTION yet, so the R file came in as a script.
     let root = db.workspace_roots().roots(&db)[0];
@@ -199,7 +226,10 @@ fn test_rescan_workspace_root_demotes_removed_description() {
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let root = db.workspace_roots().roots(&db)[0];
     assert_eq!(root.packages(&db).len(), 1);
@@ -226,7 +256,10 @@ fn test_apply_watcher_events_routes_description_to_rescan() {
     fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
     fs::write(tmp.path().join("pkg/R/a.R"), "x <- 1\n").unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     fs::write(
         tmp.path().join("pkg/DESCRIPTION"),
@@ -254,7 +287,10 @@ fn test_apply_watcher_events_dedupes_descriptions_per_root() {
     write_package(&tmp.path().join("pkg1"), "pkg1", &[]);
     write_package(&tmp.path().join("pkg2"), "pkg2", &[]);
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     db.apply_watcher_events(
         vec![
@@ -272,7 +308,10 @@ fn test_apply_watcher_events_dedupes_descriptions_per_root() {
 fn test_apply_watcher_events_routes_r_file_to_add() {
     let tmp = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("new.R");
     fs::write(&path, "x <- 1\n").unwrap();
@@ -290,7 +329,10 @@ fn test_apply_watcher_events_routes_r_file_to_remove() {
     let tmp = tempfile::tempdir().unwrap();
     fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("a.R");
     let url = UrlId::from_file_path(&path).unwrap();
@@ -310,7 +352,10 @@ fn test_apply_watcher_events_skip_set_blocks_r_file_event() {
     let path = tmp.path().join("a.R");
     fs::write(&path, "disk_v1\n").unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     // Driver "owns" this URL (the editor has it open).
     let url = UrlId::from_file_path(&path).unwrap();
@@ -334,7 +379,10 @@ fn test_apply_watcher_events_skip_set_does_not_block_description() {
     let tmp = tempfile::tempdir().unwrap();
     fs::create_dir_all(tmp.path().join("pkg/R")).unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     fs::write(
         tmp.path().join("pkg/DESCRIPTION"),
@@ -366,7 +414,10 @@ fn test_apply_watcher_events_description_outside_any_workspace_is_noop() {
     )
     .unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[workspace.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[workspace.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     db.apply_watcher_events(
         vec![file_event(
@@ -388,7 +439,10 @@ fn test_apply_watcher_events_ignores_non_r_files() {
     // landing them in the orphan bucket or some root container.
     let tmp = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let path = tmp.path().join("notes.txt");
     fs::write(&path, "not R\n").unwrap();
@@ -412,7 +466,10 @@ fn test_apply_watcher_events_tolerates_non_package_description() {
     // workspace unclassified rather than panicking or erroring.
     let tmp = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     fs::create_dir_all(tmp.path().join("not-a-pkg")).unwrap();
     fs::write(

--- a/crates/oak_scan/tests/watch.rs
+++ b/crates/oak_scan/tests/watch.rs
@@ -359,7 +359,7 @@ fn test_apply_watcher_events_skip_set_blocks_r_file_event() {
 
     // Driver "owns" this URL (the editor has it open).
     let url = UrlId::from_file_path(&path).unwrap();
-    db.set_editor_contents(url.clone(), "editor_v2\n".to_string());
+    db.upsert_editor(url.clone(), "editor_v2\n".to_string());
 
     let mut skip = HashSet::new();
     skip.insert(url.clone());

--- a/crates/oak_scan/tests/watch.rs
+++ b/crates/oak_scan/tests/watch.rs
@@ -65,10 +65,10 @@ fn test_add_watched_file_into_existing_package() {
 }
 
 #[test]
-fn test_add_watched_file_skips_package_internal_subdir() {
-    // Files inside `<pkg>/tests/` and similar non-`R/` subdirs are not
-    // workspace scripts and not package files. The watcher should
-    // ignore them, matching the bulk scanner.
+fn test_add_watched_file_routes_package_subdir_to_pkg_scripts() {
+    // R files inside `<pkg>/tests/` and similar non-`R/` subdirs go to
+    // `pkg.scripts`, matching the bulk scanner. They're not workspace
+    // scripts and not part of `pkg.files`.
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
@@ -84,10 +84,89 @@ fn test_add_watched_file_skips_package_internal_subdir() {
     db.add_watched_file(url.clone(), "test code\n".to_string());
 
     let root = db.workspace_roots().roots(&db)[0];
-    let scripts = root.scripts(&db).clone();
-    let packages = root.packages(&db).clone();
-    assert!(scripts.is_empty());
-    assert_eq!(packages[0].files(&db).len(), 1);
+    let pkg = root.packages(&db)[0];
+    assert!(root.scripts(&db).is_empty());
+    assert_eq!(pkg.files(&db).len(), 1);
+    assert_eq!(pkg.scripts(&db).len(), 1);
+    let file = db.file_by_url(&url).expect("findable via pkg.scripts");
+    assert_eq!(file.package(&db), Some(pkg));
+    assert_eq!(file.contents(&db), "test code\n");
+}
+
+#[test]
+fn test_add_watched_file_skips_nested_r_subdir() {
+    // `<pkg>/R/` is flat in standard R packages. The bulk scanner ignores
+    // anything deeper than `<pkg>/R/*.R`, so the watcher does too instead
+    // of placing it in `pkg.scripts` where the next rescan would drop it.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/R/nested")).unwrap();
+    let mut db = OakDatabase::new();
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let path = tmp.path().join("pkg/R/nested/deep.R");
+    fs::write(&path, "z <- 3\n").unwrap();
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.add_watched_file(url.clone(), "z <- 3\n".to_string());
+
+    let root = db.workspace_roots().roots(&db)[0];
+    let pkg = root.packages(&db)[0];
+    assert_eq!(pkg.files(&db).len(), 1);
+    assert!(pkg.scripts(&db).is_empty());
+    assert!(db.file_by_url(&url).is_none());
+}
+
+#[test]
+fn test_add_watched_file_updates_pkg_scripts_content_preserves_placement() {
+    // Edit of an existing `pkg.scripts` file: contents change, the file
+    // stays in `pkg.scripts` (no duplicate, no move to `pkg.files`).
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    fs::write(tmp.path().join("pkg/tests/test-foo.R"), "v1\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let path = tmp.path().join("pkg/tests/test-foo.R");
+    let url = UrlId::from_file_path(&path).unwrap();
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    let file_before = pkg.scripts(&db)[0];
+
+    db.add_watched_file(url.clone(), "v2\n".to_string());
+
+    let file_after = db.file_by_url(&url).unwrap();
+    assert_eq!(file_before, file_after);
+    assert_eq!(file_after.contents(&db), "v2\n");
+    assert_eq!(file_after.package(&db), Some(pkg));
+    assert_eq!(pkg.scripts(&db).len(), 1);
+    assert_eq!(pkg.files(&db).len(), 1);
+}
+
+#[test]
+fn test_remove_watched_file_from_pkg_scripts() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    fs::write(tmp.path().join("pkg/tests/test-foo.R"), "t\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let path = tmp.path().join("pkg/tests/test-foo.R");
+    let url = UrlId::from_file_path(&path).unwrap();
+    db.remove_watched_file(url.clone());
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert!(pkg.scripts(&db).is_empty());
+    assert_eq!(pkg.files(&db).len(), 1);
     assert!(db.file_by_url(&url).is_none());
 }
 
@@ -219,6 +298,55 @@ fn test_rescan_workspace_root_picks_up_new_description() {
     assert_eq!(root.packages(&db).len(), 1);
     assert_eq!(root.packages(&db)[0].files(&db).len(), 1);
     assert!(root.scripts(&db).is_empty());
+}
+
+#[test]
+fn test_rescan_workspace_root_drops_removed_pkg_scripts() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    fs::write(tmp.path().join("pkg/tests/test-foo.R"), "t\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    let pkg = root.packages(&db)[0];
+    assert_eq!(pkg.scripts(&db).len(), 1);
+
+    fs::remove_file(tmp.path().join("pkg/tests/test-foo.R")).unwrap();
+    db.rescan_workspace_root(root);
+
+    assert!(pkg.scripts(&db).is_empty());
+    assert_eq!(pkg.files(&db).len(), 1);
+}
+
+#[test]
+fn test_rescan_workspace_root_preserves_pkg_scripts_identity() {
+    // A rescan with no on-disk changes should reuse the same `File`
+    // entity for a file already in `pkg.scripts`. Identity matters for
+    // downstream salsa caches keyed on `File`.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    fs::write(tmp.path().join("pkg/tests/test-foo.R"), "t\n").unwrap();
+    let mut db = OakDatabase::new();
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let root = db.workspace_roots().roots(&db)[0];
+    let pkg = root.packages(&db)[0];
+    let file_before = pkg.scripts(&db)[0];
+
+    db.rescan_workspace_root(root);
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(pkg.scripts(&db).len(), 1);
+    assert_eq!(pkg.scripts(&db)[0], file_before);
 }
 
 #[test]

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -5,9 +5,25 @@ use std::path::PathBuf;
 use aether_url::UrlId;
 use oak_db::Db;
 use oak_db::DbInputs;
+use oak_db::File;
 use oak_db::OakDatabase;
 use oak_db::RootKind;
 use oak_scan::DbScan;
+
+fn basenames(db: &OakDatabase, files: &[File]) -> Vec<String> {
+    files
+        .iter()
+        .map(|f| {
+            f.url(db)
+                .as_url()
+                .path()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_string()
+        })
+        .collect()
+}
 
 fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
     fs::create_dir_all(dir.join("R")).unwrap();
@@ -225,6 +241,31 @@ fn test_scan_workspace_honors_gitignore() {
         })
         .collect();
     assert_eq!(basenames, vec!["visible.R"]);
+}
+
+#[test]
+fn test_scan_workspace_honors_gitignore_for_package_files_and_scripts() {
+    // Gitignored files under a package are excluded from both `pkg.files`
+    // (`<pkg>/R/`) and `pkg.scripts` (`<pkg>/tests/`, etc.). Both come out of
+    // one gitignore-aware walk, so they can't diverge.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+    fs::write(tmp.path().join(".gitignore"), "generated.R\nignored.R\n").unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::write(tmp.path().join("pkg/R/generated.R"), "auto <- 1\n").unwrap();
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    fs::write(tmp.path().join("pkg/tests/keep.R"), "test code\n").unwrap();
+    fs::write(tmp.path().join("pkg/tests/ignored.R"), "skip me\n").unwrap();
+    let mut db = OakDatabase::new();
+
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(basenames(&db, pkg.files(&db)), vec!["a.R"]);
+    assert_eq!(basenames(&db, pkg.scripts(&db)), vec!["keep.R"]);
 }
 
 #[test]
@@ -487,8 +528,9 @@ fn test_set_workspace_paths_non_editor_owned_file_goes_to_stale() {
 #[test]
 fn test_set_workspace_paths_unchanged_path_preserves_root_and_package_identity() {
     // Repeated calls with the same paths don't churn entities: the existing
-    // `Root` is reused (no fs walk), and any `Package` salsa caches stay
-    // warm. The watcher is the path for in-folder updates.
+    // `Root` is reused (no fs walk), and the `Package` and `File` entities keep
+    // their ids so salsa caches stay warm. The watcher is the path for
+    // in-folder updates.
     use std::collections::HashSet;
 
     use salsa::plumbing::AsId;
@@ -500,11 +542,81 @@ fn test_set_workspace_paths_unchanged_path_preserves_root_and_package_identity()
     db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
     let root_id_before = db.workspace_roots().roots(&db)[0].as_id();
     let pkg_id_before = db.workspace_roots().roots(&db)[0].packages(&db)[0].as_id();
+    let file_id_before = db.workspace_roots().roots(&db)[0].packages(&db)[0].files(&db)[0].as_id();
 
     db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
     let root_id_after = db.workspace_roots().roots(&db)[0].as_id();
     let pkg_id_after = db.workspace_roots().roots(&db)[0].packages(&db)[0].as_id();
+    let file_id_after = db.workspace_roots().roots(&db)[0].packages(&db)[0].files(&db)[0].as_id();
 
     assert_eq!(root_id_before, root_id_after);
     assert_eq!(pkg_id_before, pkg_id_after);
+    assert_eq!(file_id_before, file_id_after);
+}
+
+#[test]
+fn test_scan_workspace_package_files_sorted_by_basename() {
+    // `pkg.files` is ordered alphabetically by basename, the order R loads a
+    // flat `R/` in.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[
+        ("select.R", "select <- function(x) x\n"),
+        ("mutate.R", "mutate <- function(x) x\n"),
+    ]);
+    let mut db = OakDatabase::new();
+
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    let files = pkg.files(&db).clone();
+    assert_eq!(files.len(), 2);
+    assert!(files[0].url(&db).as_url().path().ends_with("mutate.R"));
+    assert!(files[1].url(&db).as_url().path().ends_with("select.R"));
+}
+
+#[test]
+fn test_set_workspace_paths_resurrected_file_picks_up_disk_contents() {
+    // Eviction to stale doesn't snapshot disk contents. When the folder is
+    // re-added, the resurrected file reflects current disk, not whatever it
+    // held when evicted.
+    use std::collections::HashSet;
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "v1\n")]);
+    let mut db = OakDatabase::new();
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    db.set_workspace_paths(&[], &HashSet::new());
+
+    let r_path = tmp.path().join("pkg/R/a.R");
+    fs::write(&r_path, "v2\n").unwrap();
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    let url = UrlId::from_file_path(&r_path).unwrap();
+    let file = db.file_by_url(&url).unwrap();
+    assert_eq!(file.contents(&db), "v2\n");
+}
+
+#[test]
+fn test_set_workspace_paths_stale_no_duplicates_across_cycles() {
+    // Repeated add/remove must not duplicate entities in stale: on re-add the
+    // entity comes back out of stale, so by the time we remove it again
+    // there's only one copy to push back in.
+    use std::collections::HashSet;
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+
+    for _ in 0..3 {
+        db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+        db.set_workspace_paths(&[], &HashSet::new());
+    }
+
+    let stale = db.stale_root();
+    assert_eq!(stale.files(&db).len(), 1);
+    assert_eq!(stale.packages(&db).len(), 1);
 }

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -301,3 +301,37 @@ fn test_scan_workspace_drops_duplicate_package_names() {
         .path()
         .ends_with("aaa-clone/R/a.R"));
 }
+
+#[test]
+fn test_scan_workspace_excludes_renv_library() {
+    // `renv/library/` snapshots vendored R packages, each with its own
+    // DESCRIPTION and R/. The workspace scanner walks through
+    // `ignore::WalkBuilder` so these don't surface as workspace packages
+    // alongside the user's own code. The mechanism is `.gitignore`; the
+    // scenario worth pinning is the renv-shaped layout.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("mypkg"), "mypkg", &[("a.R", "x <- 1\n")]);
+    write_package(
+        &tmp.path().join("renv/library/R-4.3/dplyr"),
+        "dplyr",
+        &[("dplyr.R", "vendored <- 1\n")],
+    );
+    write_package(
+        &tmp.path().join("renv/library/R-4.3/tibble"),
+        "tibble",
+        &[("tibble.R", "vendored <- 1\n")],
+    );
+    fs::write(tmp.path().join(".gitignore"), "renv/library/\n").unwrap();
+    // The `ignore` crate's `.gitignore` filter activates only when a
+    // `.git` marker is present in the walk (see the comment on
+    // `test_scan_workspace_honors_gitignore`). Real renv projects always
+    // have one.
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name(&db), "mypkg");
+}

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -194,7 +194,7 @@ fn test_scan_workspace_preserves_orphan_content_on_promotion() {
 
     // Editor event before any scan.
     let url = UrlId::from_file_path(&r_path).unwrap();
-    db.set_editor_contents(url.clone(), "edited_version <- 2\n".to_string());
+    db.upsert_editor(url.clone(), "edited_version <- 2\n".to_string());
 
     db.set_workspace_paths(
         &[tmp.path().to_path_buf()],
@@ -220,7 +220,7 @@ fn test_scan_workspace_preserves_package_file_content_on_promotion() {
     let mut db = OakDatabase::new();
 
     let url = UrlId::from_file_path(&r_path).unwrap();
-    db.set_editor_contents(url.clone(), "edited <- 2\n".to_string());
+    db.upsert_editor(url.clone(), "edited <- 2\n".to_string());
 
     db.set_workspace_paths(
         &[tmp.path().to_path_buf()],
@@ -392,7 +392,7 @@ fn test_set_workspace_paths_preserves_editor_owned_file_across_churn() {
 
     // Editor opens the file; subsequent `set_workspace_paths` calls
     // treat it as editor-owned.
-    db.set_editor_contents(url.clone(), "edited <- 2\n".to_string());
+    db.upsert_editor(url.clone(), "edited <- 2\n".to_string());
     let editor_owned: HashSet<UrlId> = [url.clone()].into_iter().collect();
 
     // Workspace folder removed. File routes to orphan, package goes to stale.
@@ -444,8 +444,9 @@ fn test_set_workspace_paths_unchanged_path_preserves_root_and_package_identity()
     // Repeated calls with the same paths don't churn entities: the existing
     // `Root` is reused (no fs walk), and any `Package` salsa caches stay
     // warm. The watcher is the path for in-folder updates.
-    use salsa::plumbing::AsId;
     use std::collections::HashSet;
+
+    use salsa::plumbing::AsId;
 
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -26,7 +26,10 @@ fn test_scan_empty_workspace_registers_empty_root() {
     let tmp = tempfile::tempdir().unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let roots = db.workspace_roots().roots(&db).clone();
     assert_eq!(roots.len(), 1);
@@ -42,7 +45,10 @@ fn test_scan_workspace_discovers_package_at_root() {
     write_package(tmp.path(), "myproj", &[("a.R", "x <- 1\n")]);
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
     assert_eq!(packages.len(), 1);
@@ -56,7 +62,10 @@ fn test_scan_workspace_discovers_multiple_nested_packages() {
     write_package(&tmp.path().join("pkg2"), "pkg2", &[("b.R", "y <- 2\n")]);
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
     assert_eq!(packages.len(), 2);
@@ -72,7 +81,10 @@ fn test_scan_workspace_collects_top_level_scripts() {
     fs::write(tmp.path().join("helpers.R"), "y <- 2\n").unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
     assert_eq!(scripts.len(), 2);
@@ -99,7 +111,10 @@ fn test_scan_workspace_excludes_package_r_files_from_scripts() {
     fs::write(tmp.path().join("outside.R"), "x <- 1\n").unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let root = db.workspace_roots().roots(&db)[0];
     let scripts = root.scripts(&db).clone();
@@ -121,7 +136,10 @@ fn test_scan_workspace_excludes_files_in_package_subdirs() {
     fs::write(tmp.path().join("pkg/tests/test-foo.R"), "test code\n").unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
     assert!(scripts.is_empty());
@@ -143,7 +161,10 @@ fn test_scan_workspace_honors_gitignore() {
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
     let basenames: Vec<String> = scripts
@@ -175,7 +196,10 @@ fn test_scan_workspace_preserves_orphan_content_on_promotion() {
     let url = UrlId::from_file_path(&r_path).unwrap();
     db.set_editor_contents(url.clone(), "edited_version <- 2\n".to_string());
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let file = db
         .file_by_url(&url)
@@ -198,7 +222,10 @@ fn test_scan_workspace_preserves_package_file_content_on_promotion() {
     let url = UrlId::from_file_path(&r_path).unwrap();
     db.set_editor_contents(url.clone(), "edited <- 2\n".to_string());
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let file = db.file_by_url(&url).expect("package file findable");
     assert_eq!(file.contents(&db), "edited <- 2\n");
@@ -213,7 +240,7 @@ fn test_scan_multiple_workspace_paths_preserve_order() {
     let mut db = OakDatabase::new();
 
     let paths: Vec<PathBuf> = vec![tmp1.path().to_path_buf(), tmp2.path().to_path_buf()];
-    db.scan_workspace_paths(&paths);
+    db.set_workspace_paths(&paths, &std::collections::HashSet::new());
 
     let roots = db.workspace_roots().roots(&db).clone();
     assert_eq!(roots.len(), 2);
@@ -236,7 +263,10 @@ fn test_scan_workspace_tolerates_non_package_description() {
     .unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let root = db.workspace_roots().roots(&db)[0];
     assert!(root.packages(&db).is_empty());
@@ -257,7 +287,10 @@ fn test_scan_workspace_dedup_keys_on_description_name_not_folder_name() {
     )]);
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
     assert_eq!(packages.len(), 2);
@@ -285,7 +318,10 @@ fn test_scan_workspace_drops_duplicate_package_names() {
     )]);
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let root = db.workspace_roots().roots(&db)[0];
     let packages = root.packages(&db).clone();
@@ -311,16 +347,13 @@ fn test_scan_workspace_excludes_renv_library() {
     // scenario worth pinning is the renv-shaped layout.
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("mypkg"), "mypkg", &[("a.R", "x <- 1\n")]);
-    write_package(
-        &tmp.path().join("renv/library/R-4.3/dplyr"),
-        "dplyr",
-        &[("dplyr.R", "vendored <- 1\n")],
-    );
-    write_package(
-        &tmp.path().join("renv/library/R-4.3/tibble"),
-        "tibble",
-        &[("tibble.R", "vendored <- 1\n")],
-    );
+    write_package(&tmp.path().join("renv/library/R-4.3/dplyr"), "dplyr", &[(
+        "dplyr.R",
+        "vendored <- 1\n",
+    )]);
+    write_package(&tmp.path().join("renv/library/R-4.3/tibble"), "tibble", &[
+        ("tibble.R", "vendored <- 1\n"),
+    ]);
     fs::write(tmp.path().join(".gitignore"), "renv/library/\n").unwrap();
     // The `ignore` crate's `.gitignore` filter activates only when a
     // `.git` marker is present in the walk (see the comment on
@@ -329,9 +362,103 @@ fn test_scan_workspace_excludes_renv_library() {
     fs::create_dir_all(tmp.path().join(".git")).unwrap();
     let mut db = OakDatabase::new();
 
-    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
 
     let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
     assert_eq!(packages.len(), 1);
     assert_eq!(packages[0].name(&db), "mypkg");
+}
+
+#[test]
+fn test_set_workspace_paths_preserves_editor_owned_file_across_churn() {
+    // The motivating case for routing editor-owned files to `OrphanRoot`
+    // (rather than `StaleRoot`) on eviction: a buffer the user has open
+    // stays analysable while its workspace folder is removed, and snaps
+    // back into `pkg.files` with the same `File` entity when the folder
+    // is re-added.
+    use std::collections::HashSet;
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    let url = UrlId::from_file_path(tmp.path().join("pkg/R/a.R")).unwrap();
+    let file = db.file_by_url(&url).unwrap();
+    assert!(file.package(&db).is_some());
+
+    // Editor opens the file; subsequent `set_workspace_paths` calls
+    // treat it as editor-owned.
+    db.set_editor_contents(url.clone(), "edited <- 2\n".to_string());
+    let editor_owned: HashSet<UrlId> = [url.clone()].into_iter().collect();
+
+    // Workspace folder removed. File routes to orphan, package goes to stale.
+    db.set_workspace_paths(&[], &editor_owned);
+    let after_remove = db.file_by_url(&url).unwrap();
+    assert_eq!(file, after_remove);
+    assert_eq!(after_remove.package(&db), None);
+    assert!(db.orphan_root().files(&db).contains(&after_remove));
+    assert_eq!(after_remove.contents(&db), "edited <- 2\n");
+
+    // Workspace folder re-added. File snaps back into pkg.files, same
+    // entity, editor content preserved (the scan's disk snapshot
+    // doesn't overwrite).
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &editor_owned);
+    let after_readd = db.file_by_url(&url).unwrap();
+    assert_eq!(file, after_readd);
+    assert!(after_readd.package(&db).is_some());
+    assert_eq!(after_readd.contents(&db), "edited <- 2\n");
+    // Orphan reference cleaned up by `upsert_root_file`.
+    assert!(!db.orphan_root().files(&db).contains(&after_readd));
+}
+
+#[test]
+fn test_set_workspace_paths_non_editor_owned_file_goes_to_stale() {
+    // The other half of the routing: with no editor-owned set, all files
+    // route to stale and disappear from analysis until the folder is
+    // re-added.
+    use std::collections::HashSet;
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    let url = UrlId::from_file_path(tmp.path().join("pkg/R/a.R")).unwrap();
+    let file = db.file_by_url(&url).unwrap();
+
+    db.set_workspace_paths(&[], &HashSet::new());
+    assert!(db.file_by_url(&url).is_none());
+    assert!(db.stale_root().files(&db).contains(&file));
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    let resurrected = db.file_by_url(&url).unwrap();
+    assert_eq!(file, resurrected);
+}
+
+#[test]
+fn test_set_workspace_paths_unchanged_path_preserves_root_and_package_identity() {
+    // Repeated calls with the same paths don't churn entities: the existing
+    // `Root` is reused (no fs walk), and any `Package` salsa caches stay
+    // warm. The watcher is the path for in-folder updates.
+    use salsa::plumbing::AsId;
+    use std::collections::HashSet;
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    let root_id_before = db.workspace_roots().roots(&db)[0].as_id();
+    let pkg_id_before = db.workspace_roots().roots(&db)[0].packages(&db)[0].as_id();
+
+    db.set_workspace_paths(&[tmp.path().to_path_buf()], &HashSet::new());
+    let root_id_after = db.workspace_roots().roots(&db)[0].as_id();
+    let pkg_id_after = db.workspace_roots().roots(&db)[0].packages(&db)[0].as_id();
+
+    assert_eq!(root_id_before, root_id_after);
+    assert_eq!(pkg_id_before, pkg_id_after);
 }

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -163,7 +163,7 @@ fn test_scan_workspace_honors_gitignore() {
 
 #[test]
 fn test_scan_workspace_preserves_orphan_content_on_promotion() {
-    // VFS opens a URL before any scan -> orphan File with user-edited
+    // Editor opens a URL before any scan -> orphan File with user-edited
     // contents. Later scan classifies it as a workspace script: the new
     // File entity inherits the orphan's contents, not the disk snapshot.
     let tmp = tempfile::tempdir().unwrap();
@@ -171,9 +171,9 @@ fn test_scan_workspace_preserves_orphan_content_on_promotion() {
     fs::write(&r_path, "disk_version <- 1\n").unwrap();
     let mut db = OakDatabase::new();
 
-    // VFS event before any scan.
+    // Editor event before any scan.
     let url = UrlId::from_file_path(&r_path).unwrap();
-    db.set_file_contents(url.clone(), "edited_version <- 2\n".to_string());
+    db.set_editor_contents(url.clone(), "edited_version <- 2\n".to_string());
 
     db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
 
@@ -182,6 +182,9 @@ fn test_scan_workspace_preserves_orphan_content_on_promotion() {
         .expect("script should be findable after scan");
     // The scanner inherited the orphan's edits rather than re-reading disk.
     assert_eq!(file.contents(&db), "edited_version <- 2\n");
+    // The orphan reference is dropped when the file is promoted into a
+    // workspace container.
+    assert!(!db.orphan_root().files(&db).contains(&file));
 }
 
 #[test]
@@ -193,7 +196,7 @@ fn test_scan_workspace_preserves_package_file_content_on_promotion() {
     let mut db = OakDatabase::new();
 
     let url = UrlId::from_file_path(&r_path).unwrap();
-    db.set_file_contents(url.clone(), "edited <- 2\n".to_string());
+    db.set_editor_contents(url.clone(), "edited <- 2\n".to_string());
 
     db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
 
@@ -216,4 +219,85 @@ fn test_scan_multiple_workspace_paths_preserve_order() {
     assert_eq!(roots.len(), 2);
     assert_eq!(roots[0].packages(&db)[0].name(&db), "first");
     assert_eq!(roots[1].packages(&db)[0].name(&db), "second");
+}
+
+#[test]
+fn test_scan_workspace_tolerates_non_package_description() {
+    // A file literally named `DESCRIPTION` that isn't a valid R package
+    // DESCRIPTION (here: missing the required `Package:` field). The
+    // scanner reads it, parsing fails, and the directory is silently
+    // not classified as a package.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("not-a-pkg")).unwrap();
+    fs::write(
+        tmp.path().join("not-a-pkg/DESCRIPTION"),
+        "Title: Some other project\nVersion: 1.0\n",
+    )
+    .unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.packages(&db).is_empty());
+}
+
+#[test]
+fn test_scan_workspace_dedup_keys_on_description_name_not_folder_name() {
+    // Two directories share the same basename `pkg` but their
+    // DESCRIPTIONs declare different `Package:` values. Both should be
+    // discovered as distinct packages: dedup looks at the DESCRIPTION
+    // field, not the directory name (matching R's own loading model).
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("work").join("pkg"), "foo", &[(
+        "a.R", "x <- 1\n",
+    )]);
+    write_package(&tmp.path().join("fork").join("pkg"), "bar", &[(
+        "b.R", "y <- 2\n",
+    )]);
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
+    assert_eq!(packages.len(), 2);
+    let mut names: Vec<&str> = packages.iter().map(|p| p.name(&db).as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["bar", "foo"]);
+}
+
+#[test]
+fn test_scan_workspace_drops_duplicate_package_names() {
+    // Two DESCRIPTION files in the same workspace declare the same
+    // `Package:` name. The first one (by sorted directory order) wins,
+    // the rest are dropped. Without this dedup, both would collapse
+    // onto the same `Package` entity and clobber each other's files.
+    let tmp = tempfile::tempdir().unwrap();
+    // `aaa-clone` sorts before `bbb-original`, so `aaa-clone` is the
+    // first occurrence and should win regardless of fs walk order.
+    write_package(&tmp.path().join("aaa-clone"), "pkg", &[(
+        "a.R",
+        "from_aaa\n",
+    )]);
+    write_package(&tmp.path().join("bbb-original"), "pkg", &[(
+        "b.R",
+        "from_bbb\n",
+    )]);
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let root = db.workspace_roots().roots(&db)[0];
+    let packages = root.packages(&db).clone();
+    assert_eq!(packages.len(), 1);
+    let pkg = packages[0];
+    assert_eq!(pkg.name(&db), "pkg");
+
+    let files = pkg.files(&db).clone();
+    assert_eq!(files.len(), 1);
+    assert!(files[0]
+        .url(&db)
+        .as_url()
+        .path()
+        .ends_with("aaa-clone/R/a.R"));
 }

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -7,7 +7,7 @@ use oak_db::Db;
 use oak_db::DbInputs;
 use oak_db::OakDatabase;
 use oak_db::RootKind;
-use oak_scan::DbExt;
+use oak_scan::DbScan;
 
 fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
     fs::create_dir_all(dir.join("R")).unwrap();

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -127,13 +127,16 @@ fn test_scan_workspace_excludes_package_r_files_from_scripts() {
 }
 
 #[test]
-fn test_scan_workspace_excludes_files_in_package_subdirs() {
-    // R files in tests/, inst/, etc. are package-internal and shouldn't
-    // surface as workspace scripts.
+fn test_scan_workspace_routes_package_subdir_r_files_to_pkg_scripts() {
+    // R files in tests/, inst/, etc. are package-internal: they don't load
+    // with the package but should still be indexed. They land in
+    // `pkg.scripts` (not `root.scripts`, not `pkg.files`).
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
     fs::write(tmp.path().join("pkg/tests/test-foo.R"), "test code\n").unwrap();
+    fs::create_dir_all(tmp.path().join("pkg/inst")).unwrap();
+    fs::write(tmp.path().join("pkg/inst/helper.R"), "y <- 2\n").unwrap();
     let mut db = OakDatabase::new();
 
     db.set_workspace_paths(
@@ -141,8 +144,50 @@ fn test_scan_workspace_excludes_files_in_package_subdirs() {
         &std::collections::HashSet::new(),
     );
 
-    let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
-    assert!(scripts.is_empty());
+    let root = db.workspace_roots().roots(&db)[0];
+    assert!(root.scripts(&db).is_empty());
+    let pkg = root.packages(&db)[0];
+    // R/*.R goes to pkg.files; tests/ and inst/ go to pkg.scripts.
+    assert_eq!(pkg.files(&db).len(), 1);
+    let mut script_basenames: Vec<String> = pkg
+        .scripts(&db)
+        .iter()
+        .map(|f| {
+            f.url(&db)
+                .as_url()
+                .path()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    script_basenames.sort();
+    assert_eq!(script_basenames, vec!["helper.R", "test-foo.R"]);
+}
+
+#[test]
+fn test_scan_workspace_pkg_scripts_findable_via_file_by_url() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests/testthat")).unwrap();
+    fs::write(
+        tmp.path().join("pkg/tests/testthat/test-x.R"),
+        "expect_true(TRUE)\n",
+    )
+    .unwrap();
+    let mut db = OakDatabase::new();
+    db.set_workspace_paths(
+        &[tmp.path().to_path_buf()],
+        &std::collections::HashSet::new(),
+    );
+
+    let url = UrlId::from_file_path(tmp.path().join("pkg/tests/testthat/test-x.R")).unwrap();
+    let file = db.file_by_url(&url).expect("script must be findable");
+    assert_eq!(file.contents(&db), "expect_true(TRUE)\n");
+    // Package backpointer is set to the containing package.
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(file.package(&db), Some(pkg));
 }
 
 #[test]

--- a/crates/oak_scan/tests/workspace.rs
+++ b/crates/oak_scan/tests/workspace.rs
@@ -1,0 +1,219 @@
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use aether_url::UrlId;
+use oak_db::Db;
+use oak_db::DbInputs;
+use oak_db::OakDatabase;
+use oak_db::RootKind;
+use oak_scan::DbExt;
+
+fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
+    fs::create_dir_all(dir.join("R")).unwrap();
+    fs::write(
+        dir.join("DESCRIPTION"),
+        format!("Package: {name}\nVersion: 0.0.0\n"),
+    )
+    .unwrap();
+    for (basename, contents) in r_files {
+        fs::write(dir.join("R").join(basename), contents).unwrap();
+    }
+}
+
+#[test]
+fn test_scan_empty_workspace_registers_empty_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let roots = db.workspace_roots().roots(&db).clone();
+    assert_eq!(roots.len(), 1);
+    let root = roots[0];
+    assert_eq!(root.kind(&db), RootKind::Workspace);
+    assert!(root.packages(&db).is_empty());
+    assert!(root.scripts(&db).is_empty());
+}
+
+#[test]
+fn test_scan_workspace_discovers_package_at_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(tmp.path(), "myproj", &[("a.R", "x <- 1\n")]);
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name(&db), "myproj");
+}
+
+#[test]
+fn test_scan_workspace_discovers_multiple_nested_packages() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg1"), "pkg1", &[("a.R", "x <- 1\n")]);
+    write_package(&tmp.path().join("pkg2"), "pkg2", &[("b.R", "y <- 2\n")]);
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let packages = db.workspace_roots().roots(&db)[0].packages(&db).clone();
+    assert_eq!(packages.len(), 2);
+    let mut names: Vec<&str> = packages.iter().map(|p| p.name(&db).as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["pkg1", "pkg2"]);
+}
+
+#[test]
+fn test_scan_workspace_collects_top_level_scripts() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("analysis.R"), "x <- 1\n").unwrap();
+    fs::write(tmp.path().join("helpers.R"), "y <- 2\n").unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
+    assert_eq!(scripts.len(), 2);
+    let mut basenames: Vec<String> = scripts
+        .iter()
+        .map(|f| {
+            f.url(&db)
+                .as_url()
+                .path()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    basenames.sort();
+    assert_eq!(basenames, vec!["analysis.R", "helpers.R"]);
+}
+
+#[test]
+fn test_scan_workspace_excludes_package_r_files_from_scripts() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("inside.R", "z <- 3\n")]);
+    fs::write(tmp.path().join("outside.R"), "x <- 1\n").unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let root = db.workspace_roots().roots(&db)[0];
+    let scripts = root.scripts(&db).clone();
+    let packages = root.packages(&db).clone();
+
+    assert_eq!(scripts.len(), 1);
+    assert!(scripts[0].url(&db).as_url().path().ends_with("outside.R"));
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].files(&db).len(), 1);
+}
+
+#[test]
+fn test_scan_workspace_excludes_files_in_package_subdirs() {
+    // R files in tests/, inst/, etc. are package-internal and shouldn't
+    // surface as workspace scripts.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
+    fs::create_dir_all(tmp.path().join("pkg/tests")).unwrap();
+    fs::write(tmp.path().join("pkg/tests/test-foo.R"), "test code\n").unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
+    assert!(scripts.is_empty());
+}
+
+#[test]
+fn test_scan_workspace_honors_gitignore() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Set up as a git-ignored project.
+    fs::write(tmp.path().join(".gitignore"), "ignored.R\nbuild/\n").unwrap();
+    fs::write(tmp.path().join("ignored.R"), "secret <- 1\n").unwrap();
+    fs::write(tmp.path().join("visible.R"), "shown <- 1\n").unwrap();
+    fs::create_dir_all(tmp.path().join("build")).unwrap();
+    fs::write(tmp.path().join("build/inbuild.R"), "z <- 3\n").unwrap();
+    // The `ignore` crate requires a real `.git` directory (or other
+    // marker) to apply `.gitignore`. Without one, `.gitignore` files
+    // along the walk path are still respected, but only as `.gitignore`
+    // not `.git`-anchored.
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+    let mut db = OakDatabase::new();
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let scripts = db.workspace_roots().roots(&db)[0].scripts(&db).clone();
+    let basenames: Vec<String> = scripts
+        .iter()
+        .map(|f| {
+            f.url(&db)
+                .as_url()
+                .path()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(basenames, vec!["visible.R"]);
+}
+
+#[test]
+fn test_scan_workspace_preserves_orphan_content_on_promotion() {
+    // VFS opens a URL before any scan -> orphan File with user-edited
+    // contents. Later scan classifies it as a workspace script: the new
+    // File entity inherits the orphan's contents, not the disk snapshot.
+    let tmp = tempfile::tempdir().unwrap();
+    let r_path = tmp.path().join("draft.R");
+    fs::write(&r_path, "disk_version <- 1\n").unwrap();
+    let mut db = OakDatabase::new();
+
+    // VFS event before any scan.
+    let url = UrlId::from_file_path(&r_path).unwrap();
+    db.set_file_contents(url.clone(), "edited_version <- 2\n".to_string());
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let file = db
+        .file_by_url(&url)
+        .expect("script should be findable after scan");
+    // The scanner inherited the orphan's edits rather than re-reading disk.
+    assert_eq!(file.contents(&db), "edited_version <- 2\n");
+}
+
+#[test]
+fn test_scan_workspace_preserves_package_file_content_on_promotion() {
+    // Same content-preservation across the orphan -> package transition.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "disk <- 1\n")]);
+    let r_path = tmp.path().join("pkg/R/a.R");
+    let mut db = OakDatabase::new();
+
+    let url = UrlId::from_file_path(&r_path).unwrap();
+    db.set_file_contents(url.clone(), "edited <- 2\n".to_string());
+
+    db.scan_workspace_paths(&[tmp.path().to_path_buf()]);
+
+    let file = db.file_by_url(&url).expect("package file findable");
+    assert_eq!(file.contents(&db), "edited <- 2\n");
+}
+
+#[test]
+fn test_scan_multiple_workspace_paths_preserve_order() {
+    let tmp1 = tempfile::tempdir().unwrap();
+    let tmp2 = tempfile::tempdir().unwrap();
+    write_package(&tmp1.path().join("first"), "first", &[]);
+    write_package(&tmp2.path().join("second"), "second", &[]);
+    let mut db = OakDatabase::new();
+
+    let paths: Vec<PathBuf> = vec![tmp1.path().to_path_buf(), tmp2.path().to_path_buf()];
+    db.scan_workspace_paths(&paths);
+
+    let roots = db.workspace_roots().roots(&db).clone();
+    assert_eq!(roots.len(), 2);
+    assert_eq!(roots[0].packages(&db)[0].name(&db), "first");
+    assert_eq!(roots[1].packages(&db)[0].name(&db), "second");
+}


### PR DESCRIPTION
Branched from #1243
Progress towards #1212

This PR adds workspace scanning to `oak_scan` and wires it into the LSP. The scanner walks a workspace folder, finds packages (any `DESCRIPTION` file in the tree with a `Package` field, honoring `.gitignore`) and top-level R scripts, and registers them under a `Root` in `oak_db`.

The LSP feeds three event types into the scanner:

- `initialize` and `didChangeWorkspaceFolders` update workspace roots in the DB.
- `didChangeWatchedFiles` applies surgical updates for single R files. When a change to a `DESCRIPTION` file is detected, this triggers a full rescan of the containing root (package files might be demoted to scripts).

Editor-owned URLs (files the editor has open) get special handling because we ignore disk state for those. The editor contents are the source of truth. When a workspace is removed, these files survive and get placed in `OrphanRoot`. This way analysis keeps working when a user closes a workspace folder while a buffer from it is still open.

Files that leave a live workspace (folder removed, file deleted, buffer closed) route to `StaleRoot`. We keep them there for as long as they remain deleted, and we bring them back if they are added again. This allows reusing the `File` inputs without creating new ones. Salsa inputs are never garbage collected so reusing them (based on their URL key) avoids unbounded memory growth when e.g. switching git branches, which can delete and bring back many files at a time.

Workspace scans run synchronously in the main loop of the LSP in this PR. Since these operations are too heavy to be run synchronously, and would stall requests from user interactions, the next PR moves
them off the main loop.
