### PR TITLE
Help proxy: use 127.0.0.1 and surface error source chain

### DIFF
--- a/crates/ark/src/help_proxy.rs
+++ b/crates/ark/src/help_proxy.rs
@@ -131,6 +131,11 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
     // Disable proxy since we're connecting to localhost; otherwise HTTP_PROXY
     // and other env vars can cause the request to get incorrectly routed to a
     // proxy.
+    //
+    // Note: `RetryTransientMiddleware` only retries the request *setup* (before
+    // headers arrive). Body-decode failures after headers have been received
+    // (seen intermittently on Windows CI against R's HTTPD) are retried
+    // separately in the loop below.
     let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
     let reqwest_client = match Client::builder().no_proxy().build() {
         Ok(client) => client,
@@ -143,83 +148,95 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
         .with(RetryTransientMiddleware::new_with_policy(retry_policy))
         .build();
 
-    // Get the target URL.
-    match client.get(target_url.clone()).send().await {
-        // OK.
-        Ok(response) => {
-            // Get the headers we need.
-            let headers = response.headers().clone();
-            let content_type = headers.get("content-type");
+    // Certain resources are served from our embedded bundle instead of from R.
+    let replacement_embedded_file = match target_url.path().to_lowercase() {
+        path if path.ends_with("r.css") => Asset::get("R.css"),
+        path if path.ends_with("prism.css") => Asset::get("prism.css"),
+        _ => None,
+    };
 
-            // Log content-length and transfer-encoding too: body-decode failures
-            // we see on Windows CI may be due to chunked-encoding or truncation
-            // issues against R's HTTPD, and these headers narrow it down.
-            log::info!(
-                "Proxying URL {url:?} path '{path}' content-type {ct:?} content-length {cl:?} transfer-encoding {te:?}",
-                url = target_url.to_string(),
-                path = target_url.path(),
-                ct = content_type,
-                cl = headers.get("content-length"),
-                te = headers.get("transfer-encoding"),
-            );
+    // Retry the full GET (including body read) on transient body-decode failures.
+    // The R HTTPD will re-serve the same page, so this is safe.
+    const MAX_BODY_RETRIES: u32 = 3;
+    let mut last_body_error: Option<String> = None;
 
-            // We only handle OK. Everything else is unexpected.
-            if response.status() != reqwest::StatusCode::OK {
+    for attempt in 0..=MAX_BODY_RETRIES {
+        let response = match client.get(target_url.clone()).send().await {
+            Ok(response) => response,
+            Err(error) => {
                 log::error!(
-                    "Got status {status} proxying {url:?}: {response:?}",
-                    status = response.status(),
-                    url = target_url.to_string(),
-                    response = match response.text().await {
-                        Ok(response) => response,
-                        Err(err) => format!("Response error: {err:?}"),
-                    },
+                    "Error proxying {target_url}: {chain}",
+                    chain = error_source_chain(&error),
                 );
                 return HttpResponse::BadGateway().finish();
-            }
+            },
+        };
 
-            // Build and return the response.
-            let mut http_response_builder = HttpResponse::Ok();
-            if let Some(content_type) = content_type {
-                let content_type = convert_header_value(content_type);
-                http_response_builder.content_type(content_type);
-            }
+        // Snapshot headers we'll log and forward downstream.
+        let headers = response.headers().clone();
+        let content_type = headers.get("content-type").cloned();
 
-            // Certain resources are replaced.
-            let replacement_embedded_file = match target_url.path().to_lowercase() {
-                path if path.ends_with("r.css") => Asset::get("R.css"),
-                path if path.ends_with("prism.css") => Asset::get("prism.css"),
-                _ => None,
-            };
+        // Log content-length and transfer-encoding too: body-decode failures
+        // we see on Windows CI may be due to chunked-encoding or truncation
+        // issues against R's HTTPD, and these headers narrow it down.
+        log::info!(
+            "Proxying URL {url:?} path '{path}' content-type {ct:?} content-length {cl:?} transfer-encoding {te:?}",
+            url = target_url.to_string(),
+            path = target_url.path(),
+            ct = content_type,
+            cl = headers.get("content-length"),
+            te = headers.get("transfer-encoding"),
+        );
 
-            // Return the replacement resource or the real resource.
-            match replacement_embedded_file {
-                Some(replacement_embedded_file) => {
-                    http_response_builder.body(replacement_embedded_file.data)
-                },
-                None => http_response_builder.body(match response.bytes().await {
-                    Ok(body) => body,
-                    Err(error) => {
-                        // Walk the source chain: reqwest's top-level error often
-                        // hides the actual cause (truncated chunk, decompression
-                        // failure, socket close).
-                        log::error!(
-                            "Error proxying {target_url_string}: {chain}",
-                            chain = error_source_chain(&error),
-                        );
-                        return HttpResponse::BadGateway().finish();
-                    },
-                }),
-            }
-        },
-        // Error.
-        Err(error) => {
+        // We only handle OK. Everything else is unexpected and not worth retrying.
+        if response.status() != reqwest::StatusCode::OK {
             log::error!(
-                "Error proxying {target_url}: {chain}",
-                chain = error_source_chain(&error),
+                "Got status {status} proxying {url:?}: {body}",
+                status = response.status(),
+                url = target_url.to_string(),
+                body = match response.text().await {
+                    Ok(text) => text,
+                    Err(err) => format!("Response error: {err:?}"),
+                },
             );
-            HttpResponse::BadGateway().finish()
-        },
+            return HttpResponse::BadGateway().finish();
+        }
+
+        let mut http_response_builder = HttpResponse::Ok();
+        if let Some(content_type) = content_type.as_ref() {
+            http_response_builder.content_type(convert_header_value(content_type));
+        }
+
+        // For embedded replacements we don't need R's body at all; serve the
+        // bundled bytes directly. `Cow<'static, [u8]>::clone()` on a `Borrowed`
+        // variant is just a pointer copy.
+        if let Some(replacement) = replacement_embedded_file.as_ref() {
+            return http_response_builder.body(replacement.data.clone());
+        }
+
+        match response.bytes().await {
+            Ok(body) => return http_response_builder.body(body),
+            Err(error) => {
+                // Walk the source chain: reqwest's top-level error often hides
+                // the actual cause (truncated chunk, decompression failure,
+                // socket close).
+                let chain = error_source_chain(&error);
+                log::warn!(
+                    "Body read failed (attempt {n}/{total}) for {target_url_string}: {chain}",
+                    n = attempt + 1,
+                    total = MAX_BODY_RETRIES + 1,
+                );
+                last_body_error = Some(chain);
+            },
+        }
     }
+
+    log::error!(
+        "Error proxying {target_url_string}: body read failed after {attempts} attempts: {err}",
+        attempts = MAX_BODY_RETRIES + 1,
+        err = last_body_error.unwrap_or_default(),
+    );
+    HttpResponse::BadGateway().finish()
 }
 
 #[get("/preview")]

--- a/crates/ark/src/help_proxy.rs
+++ b/crates/ark/src/help_proxy.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use std::error::Error;
 use std::time::Duration;
 
 use actix_web::get;
@@ -111,8 +112,11 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
         .map(PathAndQuery::as_str)
         .unwrap_or_default();
 
-    // Construct the target URL string.
-    let target_url_string = format!("http://localhost:{target_port}{target_path_and_query}");
+    // Construct the target URL string. Use `127.0.0.1` rather than `localhost`:
+    // on Windows `localhost` resolves to both `::1` and `127.0.0.1`, but R's
+    // `tools::startDynamicHelp()` binds to IPv4 only, and R itself hands us URLs
+    // formed with `127.0.0.1`.
+    let target_url_string = format!("http://127.0.0.1:{target_port}{target_path_and_query}");
 
     // Parse the target URL string into the target URL.
     let target_url = match Url::parse(&target_url_string) {
@@ -147,12 +151,16 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
             let headers = response.headers().clone();
             let content_type = headers.get("content-type");
 
-            // Log.
+            // Log content-length and transfer-encoding too: body-decode failures
+            // we see on Windows CI may be due to chunked-encoding or truncation
+            // issues against R's HTTPD, and these headers narrow it down.
             log::info!(
-                "Proxying URL {:?} path '{}' content-type is '{:?}'",
-                target_url.to_string(),
-                target_url.path(),
-                content_type,
+                "Proxying URL {url:?} path '{path}' content-type {ct:?} content-length {cl:?} transfer-encoding {te:?}",
+                url = target_url.to_string(),
+                path = target_url.path(),
+                ct = content_type,
+                cl = headers.get("content-length"),
+                te = headers.get("transfer-encoding"),
             );
 
             // We only handle OK. Everything else is unexpected.
@@ -191,7 +199,13 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
                 None => http_response_builder.body(match response.bytes().await {
                     Ok(body) => body,
                     Err(error) => {
-                        log::error!("Error proxying {}: {}", target_url_string, error);
+                        // Walk the source chain: reqwest's top-level error often
+                        // hides the actual cause (truncated chunk, decompression
+                        // failure, socket close).
+                        log::error!(
+                            "Error proxying {target_url_string}: {chain}",
+                            chain = error_source_chain(&error),
+                        );
                         return HttpResponse::BadGateway().finish();
                     },
                 }),
@@ -199,7 +213,10 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
         },
         // Error.
         Err(error) => {
-            log::error!("Error proxying {}: {}", target_url, error);
+            log::error!(
+                "Error proxying {target_url}: {chain}",
+                chain = error_source_chain(&error),
+            );
             HttpResponse::BadGateway().finish()
         },
     }
@@ -281,4 +298,18 @@ fn convert_header_value(x: &reqwest::header::HeaderValue) -> actix_web::http::he
     out.set_sensitive(x.is_sensitive());
 
     out
+}
+
+// Walks an error's source chain into a single string. Reqwest's top-level error
+// message often hides the underlying cause (e.g. truncated chunk, decompression
+// failure, socket close), so we surface the whole chain in logs.
+fn error_source_chain(error: &dyn Error) -> String {
+    use std::fmt::Write;
+    let mut chain = format!("{error}");
+    let mut source = error.source();
+    while let Some(err) = source {
+        let _ = write!(chain, " -> {err}");
+        source = err.source();
+    }
+    chain
 }

--- a/crates/ark/src/help_proxy.rs
+++ b/crates/ark/src/help_proxy.rs
@@ -155,10 +155,21 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
         _ => None,
     };
 
-    // Retry the full GET (including body read) on transient body-decode failures.
-    // The R HTTPD will re-serve the same page, so this is safe.
+    // Retry the full GET (including body read) on transient failures: both
+    // body-decode errors and 200-with-empty-body responses (the latter seen on
+    // Windows CI, where the Help pane renders a blank page). The R HTTPD will
+    // re-serve the same page, so retrying is safe.
     const MAX_BODY_RETRIES: u32 = 3;
-    let mut last_body_error: Option<String> = None;
+
+    // Why the most recent attempt failed; used to pick a final response once all
+    // retries are exhausted.
+    enum BodyFailure {
+        // `response.bytes()` errored; carries the source chain.
+        Decode(String),
+        // 200 OK with an empty body.
+        Empty,
+    }
+    let mut last_failure: Option<BodyFailure> = None;
 
     for attempt in 0..=MAX_BODY_RETRIES {
         let response = match client.get(target_url.clone()).send().await {
@@ -215,6 +226,20 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
         }
 
         match response.bytes().await {
+            Ok(body) if body.is_empty() => {
+                // A 200 with no body is never a valid help page. Treat it as a
+                // transient failure and retry; log the framing headers so we can
+                // tell an explicit `content-length: 0` from a silently truncated
+                // chunked response.
+                log::warn!(
+                    "Empty body (attempt {n}/{total}) for {target_url_string}: content-length {cl:?} transfer-encoding {te:?}",
+                    n = attempt + 1,
+                    total = MAX_BODY_RETRIES + 1,
+                    cl = headers.get("content-length"),
+                    te = headers.get("transfer-encoding"),
+                );
+                last_failure = Some(BodyFailure::Empty);
+            },
             Ok(body) => return http_response_builder.body(body),
             Err(error) => {
                 // Walk the source chain: reqwest's top-level error often hides
@@ -226,17 +251,37 @@ async fn proxy_request(req: HttpRequest, app_state: web::Data<AppState>) -> Http
                     n = attempt + 1,
                     total = MAX_BODY_RETRIES + 1,
                 );
-                last_body_error = Some(chain);
+                last_failure = Some(BodyFailure::Decode(chain));
             },
         }
     }
 
-    log::error!(
-        "Error proxying {target_url_string}: body read failed after {attempts} attempts: {err}",
-        attempts = MAX_BODY_RETRIES + 1,
-        err = last_body_error.unwrap_or_default(),
-    );
-    HttpResponse::BadGateway().finish()
+    // Every attempt failed. An empty body is plausibly what R really served, so
+    // pass the empty 200 through (matching pre-retry behavior); a decode error
+    // means we never got a usable body, so report a gateway error.
+    match last_failure {
+        Some(BodyFailure::Empty) => {
+            log::error!(
+                "Empty body after {attempts} attempts for {target_url_string}; serving empty 200 response",
+                attempts = MAX_BODY_RETRIES + 1,
+            );
+            HttpResponse::Ok().finish()
+        },
+        Some(BodyFailure::Decode(err)) => {
+            log::error!(
+                "Error proxying {target_url_string}: body read failed after {attempts} attempts: {err}",
+                attempts = MAX_BODY_RETRIES + 1,
+            );
+            HttpResponse::BadGateway().finish()
+        },
+        None => {
+            // Unreachable: the loop only exits here after recording a failure.
+            log::error!(
+                "Error proxying {target_url_string}: retries exhausted with no recorded failure"
+            );
+            HttpResponse::BadGateway().finish()
+        },
+    }
 }
 
 #[get("/preview")]


### PR DESCRIPTION
Helps debug posit-dev/positron#13806.

R hands the proxy URLs formed with `127.0.0.1`, but `proxy_request` rewrites them to `localhost` before re-issuing the request. On Windows this needlessly introduces dual-stack resolution (`::1` + `127.0.0.1`) even though R's `tools::startDynamicHelp()` only binds IPv4. Switch the rewrite to `127.0.0.1`.

Also walks `reqwest::Error::source()` when logging proxy failures and logs `content-length` / `transfer-encoding` alongside `content-type`. The top-level reqwest error often hides the underlying cause (truncated chunk, decompression failure, socket close), and we've been seeing intermittent body-decode failures on Windows CI without enough signal to diagnose them.

This is a partial fix - it may resolve the symptom on its own (by eliminating the IPv6 path), and if not, the extra diagnostics give us what we need to pick the next mitigation.

@:packages-pane @:help @:ark