### PR TITLE
Update action-gh-release to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             GITHUB_TOKEN: ${{ github.token }}
         steps:
             - name: Create release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               id: create_release
               with:
                   draft: false
@@ -147,7 +147,7 @@ jobs:
                   name: ark-${{ matrix.flavor }}-linux-arm64-archive
 
             - name: Upload macOS release artifact (universal)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -155,7 +155,7 @@ jobs:
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-darwin-universal.zip
 
             - name: Upload macOS release artifact (arm64)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -163,7 +163,7 @@ jobs:
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-darwin-arm64.zip
 
             - name: Upload macOS release artifact (x64)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -171,7 +171,7 @@ jobs:
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-darwin-x64.zip
 
             - name: Upload Windows release artifact (x64)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -179,7 +179,7 @@ jobs:
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-windows-x64.zip
 
             - name: Upload Windows release artifact (arm64)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -187,7 +187,7 @@ jobs:
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-windows-arm64.zip
 
             - name: Upload Linux release artifacts (x64)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -195,7 +195,7 @@ jobs:
                   files: ark-${{ needs.get_version.outputs.ARK_VERSION }}${{ env.DEBUG_FLAG }}-linux-x64.zip
 
             - name: Upload Linux release artifacts (arm64)
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:


### PR DESCRIPTION
Fixes #1247

Maintenance to support node.js v24

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: 1password/load-secrets-action@v3, aws-actions/configure-aws-credentials@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 
We will need to update to continue using the runner. There's also setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` but that won't work on September 16, 2026.

This was addressed in Positron with https://github.com/posit-dev/positron-builds/pull/1018