### PR TITLE
Don't canonicalise file keys

### DIFF
--- a/crates/aether_url/src/lib.rs
+++ b/crates/aether_url/src/lib.rs
@@ -10,99 +10,63 @@ use std::fmt;
 use stdext::result::ResultExt;
 use url::Url;
 
-/// Canonicalised file URL identity.
+/// Lexically normalised file URL identity.
 ///
-/// # The multi-source URI reconciliation problem
+/// Internal identity key for files received from any source (LSP, DAP,
+/// scanner, R runtime). Constructed via the same lexical normalisation
+/// at every entry point so that two paths the editor considers "the
+/// same file" produce the same [`UrlId`].
 ///
-/// File URIs for the same file can arrive from independent sources, each
-/// with its own representation:
+/// What we normalise: drive-letter casing on Windows; percent-encoding
+/// of `:` (decoded via `Url -> PathBuf -> Url` round-trip). No I/O:
+/// `std::fs::canonicalize()`, no symlink resolution. The same input URI
+/// produces the same [`UrlId`] whether or not the file exists on disk.
 ///
-/// - **DAP (SetBreakpoints)**: Receives raw file paths from the frontend,
-///   converted to URIs via `UrlId::from_file_path`. These are stored as
-///   HashMap keys for breakpoint lookup.
+/// # Bridging across symlinks
 ///
-/// - **LSP (didChange, etc.)**: Receives URIs directly from the editor
-///   client, which may use non-canonical forms (e.g. percent-encoded
-///   colons on Windows, or symlinked paths on macOS).
+/// R's `normalizePath()` resolves symlinks on its own. A srcref URI
+/// from the R runtime may name `/private/tmp/foo.R` while the editor
+/// sent us `/tmp/foo.R`. The two don't compare equal, so a `HashMap`
+/// keyed on `UrlId` treats them as separate files. Code that needs to
+/// match a srcref URI back to an open document or a breakpoint should
+/// maintain a secondary index of `fs::canonicalize`d paths and fall
+/// back to it on a primary miss.
+/// [`crate::dap::dap_state::BreakpointMap`] in `ark` does this for
+/// breakpoints.
 ///
-/// - **Execute requests**: A frontend may attach a `code_location` URI
-///   that comes straight from the editor's document model, again
-///   potentially non-canonical.
+/// # Important: don't leak normalised URIs back out
 ///
-/// - **R runtime**: When R evaluates `source()` or annotates code, it
-///   passes URIs that went through R's `normalizePath()`, which resolves
-///   symlinks to their canonical target (e.g. `/tmp` resolves to `/private/tmp`
-///   on macOS), producing a path the editor never sent. More generally,
-///   arbitrary R code can create source references that we may end up
-///   consuming for breakpoint or debug purposes, and the paths in those
-///   references may or may not be canonical.
-///
-/// All four sources must agree on file identity. For instance breakpoints set
-/// via DAP are looked up in a HashMap keyed by URI when code is executed or
-/// sourced, and invalidated when documents change via LSP.
-///
-/// # Design decision
-///
-/// We solve this by canonicalizing URIs into [`UrlId`] at every entry
-/// point, rather than interning paths into opaque IDs (as rust-analyzer
-/// does with its VFS `FileId` approach). Interning would be a larger
-/// architectural change and is not warranted here since we only need
-/// canonical keys at a handful of call sites.
-///
-/// Canonicalization uses `std::fs::canonicalize()` to resolve symlinks
-/// (e.g. `/tmp` to `/private/tmp` on macOS), round-trips through the
-/// filesystem path to normalize encoding variants (e.g. `%3A` to `:` on
-/// Windows), and uppercases drive letters on Windows. When the file does
-/// not exist on disk, we fall back to the original URI.
-///
-/// # Important: canonical URIs must not leak
-///
-/// [`UrlId`] is strictly for internal identity. When a URI flows back
-/// to R (e.g. in `#line` directives or injected breakpoint calls) or to
-/// the frontend (e.g. in DAP stack frames), always use the original raw
-/// URI. The frontend (and possibly R code) expects their own URI
-/// representation, and a canonical URI (e.g. `/private/tmp/...` instead of
-/// `/tmp/...`) could be treated as a different file (e.g. open a new editor in
-/// the frontend instead of an existing one).
-///
-/// A canonicalized file URI for use as a stable identity key.
-///
-/// Wraps a [`Url`] that has been canonicalized to resolve symlinks,
-/// normalize encoding variants, and uppercase drive letters on Windows.
-/// Use this type in HashMaps and anywhere file identity matters.
-///
-/// Construct via [`UrlId::from_url`], [`UrlId::from_file_path`], or
-/// [`UrlId::parse`].
-///
-/// On Windows, `std::fs::canonicalize()` returns extended-length paths
-/// prefixed with `\\?\` (e.g. `\\?\C:\Users\...`). Projects like Ruff
-/// use the `dunce` crate to strip this prefix, but we don't need it
-/// because `Url::from_file_path` already handles
-/// `Prefix::VerbatimDisk` and produces a clean `file:///C:/...` URI.
+/// Even though [`UrlId`] no longer fs-canonicalises, it still
+/// uppercases the Windows drive letter and decodes the percent-encoded
+/// colon. When sending URIs back to the editor or to R, prefer the
+/// original bytes the frontend sent. The frontend treats a URI as the
+/// editor's identity for the file; a normalised form may look like a
+/// different file to it (e.g. open a new editor pane).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UrlId(Url);
 
 impl UrlId {
-    /// Canonicalize a [`Url`] into a [`UrlId`].
+    /// Lexically normalise a [`Url`] into a [`UrlId`].
     ///
-    /// Resolves symlinks via `std::fs::canonicalize()` and normalizes
-    /// encoding variants (e.g. `%3A` to `:` on Windows). On Windows, also
-    /// uppercases the drive letter. Falls back to the original URI for
-    /// non-file schemes or when the path can't be resolved.
+    /// Decodes encoding variants (e.g. `%3A` to `:` on Windows) and
+    /// uppercases the Windows drive letter. Does no filesystem I/O.
+    /// Non-`file:` URLs (`ark://`, `untitled:`, ...) pass through
+    /// untouched.
     pub fn from_url(uri: Url) -> Self {
         if uri.scheme() != "file" {
             return Self(uri);
         }
 
-        let Some(path) = uri.to_file_path().warn_on_err() else {
-            return Self(uri);
+        // Round-trip through `PathBuf` so the URI form matches what
+        // `Url::from_file_path` produces (decoded `%3A`, etc.). Skip
+        // on error, we let pathological URIs flow through unchanged.
+        let uri = match uri.to_file_path().warn_on_err() {
+            Some(path) => Url::from_file_path(&path)
+                .map_err(|()| anyhow::anyhow!("Failed to convert path to URI: {path:?}"))
+                .warn_on_err()
+                .unwrap_or(uri),
+            None => uri,
         };
-
-        let path = std::fs::canonicalize(&path).trace_on_err().unwrap_or(path);
-        let uri = Url::from_file_path(&path)
-            .map_err(|()| anyhow::anyhow!("Failed to convert path to URI: {path:?}"))
-            .warn_on_err()
-            .unwrap_or(uri);
 
         #[cfg(windows)]
         let uri = uppercase_windows_drive_in_uri(uri);
@@ -110,17 +74,11 @@ impl UrlId {
         Self(uri)
     }
 
-    /// Wrap a [`Url`] that the caller asserts is already canonical.
-    pub fn from_canonical(uri: Url) -> Self {
-        Self(uri)
-    }
-
-    /// Convert a file path to a canonical [`UrlId`].
+    /// Build a [`UrlId`] from a filesystem path.
     ///
-    /// Canonicalizes the path to resolve symlinks (e.g. `/var/folders` to
-    /// `/private/var/folders` on macOS) so the URI matches what R's
-    /// `normalizePath()` produces. Falls back to the original path if
-    /// canonicalization fails.
+    /// Same lexical normalisation as [`Self::from_url`], no filesystem
+    /// I/O. Errors only if `path` can't be expressed as a URL (e.g.
+    /// not absolute on platforms that require it).
     pub fn from_file_path(path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
         let path = path.as_ref();
         let url = Url::from_file_path(path)
@@ -128,7 +86,7 @@ impl UrlId {
         Ok(Self::from_url(url))
     }
 
-    /// Parse a URI string into a canonical [`UrlId`].
+    /// Parse a URI string into a [`UrlId`].
     pub fn parse(s: &str) -> Result<Self, url::ParseError> {
         let url = Url::parse(s)?;
         Ok(Self::from_url(url))
@@ -223,9 +181,9 @@ mod tests {
 
     #[test]
     #[cfg(not(windows))]
-    fn test_fallback_for_nonexistent_path() {
-        // For paths that don't exist, canonicalization falls back to the
-        // original path so the URI is unchanged.
+    fn test_nonexistent_path_unchanged() {
+        // Construction is lexical-only, so nonexistent paths flow
+        // through unchanged.
         let uri = Url::parse("file:///nonexistent/path/test.R").unwrap();
         let id = UrlId::from_url(uri.clone());
         assert_eq!(*id.as_url(), uri);
@@ -233,18 +191,23 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn test_resolves_tmp_symlink() {
-        // On macOS, `/tmp` is a symlink to `/private/tmp`. `UrlId` should
-        // resolve it so that URIs from different sources match.
+    fn test_does_not_resolve_symlinks() {
+        // On macOS, `/tmp` is a symlink to `/private/tmp`. `UrlId` does
+        // *not* resolve it; same input bytes produce the same output
+        // regardless of the symlink graph on disk. Bridging across
+        // symlinked names is the job of secondary canonical indexes at
+        // specific seams (e.g. the DAP breakpoint store), not of
+        // construction.
         let dir = tempfile::tempdir_in("/tmp").unwrap();
         let file = dir.path().join("test.R");
         std::fs::write(&file, "").unwrap();
 
-        let non_canonical = Url::from_file_path(&file).unwrap();
-        assert!(non_canonical.path().starts_with("/tmp/"));
+        let original = Url::from_file_path(&file).unwrap();
+        assert!(original.path().starts_with("/tmp/"));
 
-        let id = UrlId::from_url(non_canonical);
-        assert!(id.as_url().path().starts_with("/private/tmp/"));
+        let id = UrlId::from_url(original.clone());
+        assert_eq!(*id.as_url(), original);
+        assert!(id.as_url().path().starts_with("/tmp/"));
     }
 
     #[test]

--- a/crates/aether_url/src/lib.rs
+++ b/crates/aether_url/src/lib.rs
@@ -6,6 +6,7 @@
 //
 
 use std::fmt;
+use std::path::Component;
 
 use stdext::result::ResultExt;
 use url::Url;
@@ -17,10 +18,16 @@ use url::Url;
 /// at every entry point so that two paths the editor considers "the
 /// same file" produce the same [`UrlId`].
 ///
-/// What we normalise: drive-letter casing on Windows; percent-encoding
-/// of `:` (decoded via `Url -> PathBuf -> Url` round-trip). No I/O:
-/// `std::fs::canonicalize()`, no symlink resolution. The same input URI
-/// produces the same [`UrlId`] whether or not the file exists on disk.
+/// What we normalise: dot segments (`.` and `..`, collapsed lexically);
+/// drive-letter casing on Windows; percent-encoding of `:` (decoded via
+/// `Url -> PathBuf -> Url` round-trip). No I/O: `std::fs::canonicalize()`,
+/// no symlink resolution. The same input URI produces the same [`UrlId`]
+/// whether or not the file exists on disk.
+///
+/// "Lexical" means we resolve `..` by dropping the previous segment, not
+/// by asking the filesystem. So `/a/b/../c.R` becomes `/a/c.R` even if
+/// `/a/b` is a symlink that points elsewhere. That's the same trade-off
+/// the editor makes, so the two agree.
 ///
 /// # Bridging across symlinks
 ///
@@ -47,10 +54,10 @@ pub struct UrlId(Url);
 impl UrlId {
     /// Lexically normalise a [`Url`] into a [`UrlId`].
     ///
-    /// Decodes encoding variants (e.g. `%3A` to `:` on Windows) and
-    /// uppercases the Windows drive letter. Does no filesystem I/O.
-    /// Non-`file:` URLs (`ark://`, `untitled:`, ...) pass through
-    /// untouched.
+    /// Decodes encoding variants (e.g. `%3A` to `:` on Windows),
+    /// uppercases the Windows drive letter, and collapses `.` and `..`
+    /// segments lexically. Does no filesystem I/O. Non-`file:` URLs
+    /// (`ark://`, `untitled:`, ...) pass through untouched.
     pub fn from_url(uri: Url) -> Self {
         if uri.scheme() != "file" {
             return Self(uri);
@@ -59,11 +66,19 @@ impl UrlId {
         // Round-trip through `PathBuf` so the URI form matches what
         // `Url::from_file_path` produces (decoded `%3A`, etc.). Skip
         // on error, we let pathological URIs flow through unchanged.
+        //
+        // `Url::parse` already collapses dot segments for `file:` URLs,
+        // but `Url::from_file_path` does not, so `from_file_path` entry
+        // points would keep a stray `..`. Normalise the path here so all
+        // three constructors land on the same `UrlId`.
         let uri = match uri.to_file_path().warn_on_err() {
-            Some(path) => Url::from_file_path(&path)
-                .map_err(|()| anyhow::anyhow!("Failed to convert path to URI: {path:?}"))
-                .warn_on_err()
-                .unwrap_or(uri),
+            Some(path) => {
+                let path = lexically_normalize(&path);
+                Url::from_file_path(&path)
+                    .map_err(|()| anyhow::anyhow!("Failed to convert path to URI: {path:?}"))
+                    .warn_on_err()
+                    .unwrap_or(uri)
+            },
             None => uri,
         };
 
@@ -121,6 +136,33 @@ impl fmt::Display for UrlId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+/// Collapse `.` and `..` segments without touching the filesystem.
+///
+/// `Path::components` already drops `.` and redundant separators, so all
+/// we add is popping the previous segment when we hit a `..`. A `..` that
+/// would climb above the root is dropped, matching how the URL parser
+/// clamps `file:` paths. Inputs here are always absolute (a `file:` URL
+/// can't be built from a relative path), so the leading root component is
+/// preserved and a `..` never escapes it.
+fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
+    let mut out = std::path::PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::ParentDir => match out.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                },
+                Some(Component::RootDir | Component::Prefix(_)) => {},
+                _ => out.push(component),
+            },
+            other => out.push(other),
+        }
+    }
+
+    out
 }
 
 /// Uppercase the drive letter in a Windows file URI for consistent hashing.
@@ -214,6 +256,38 @@ mod tests {
     fn test_from_file_path_unix() {
         let id = UrlId::from_file_path("/home/user/test.R").unwrap();
         assert_eq!(id.as_url().as_str(), "file:///home/user/test.R");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_resolves_dot_segments_on_parse() {
+        let id = UrlId::parse("file:///a/b/../c/./d.R").unwrap();
+        assert_eq!(id.as_url().as_str(), "file:///a/c/d.R");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_resolves_dot_segments_from_file_path() {
+        // `Url::from_file_path` keeps `..`, unlike `Url::parse`. The
+        // explicit lexical pass in `from_url` is what makes this entry
+        // point agree with the others.
+        let id = UrlId::from_file_path("/a/b/../c/./d.R").unwrap();
+        assert_eq!(id.as_url().as_str(), "file:///a/c/d.R");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_dot_segments_consistent_across_constructors() {
+        let parsed = UrlId::parse("file:///a/b/../c.R").unwrap();
+        let from_path = UrlId::from_file_path("/a/b/../c.R").unwrap();
+        assert_eq!(parsed, from_path);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_parent_dir_clamped_at_root() {
+        let id = UrlId::from_file_path("/../../a.R").unwrap();
+        assert_eq!(id.as_url().as_str(), "file:///a.R");
     }
 
     // Windows-specific tests

--- a/crates/aether_url/src/lib.rs
+++ b/crates/aether_url/src/lib.rs
@@ -36,12 +36,11 @@ use url::Url;
 ///
 /// # Important: don't leak normalised URIs back out
 ///
-/// Even though [`UrlId`] no longer fs-canonicalises, it still
-/// uppercases the Windows drive letter and decodes the percent-encoded
-/// colon. When sending URIs back to the editor or to R, prefer the
-/// original bytes the frontend sent. The frontend treats a URI as the
-/// editor's identity for the file; a normalised form may look like a
-/// different file to it (e.g. open a new editor pane).
+/// When sending URIs back to the editor or to R, prefer the original
+/// bytes the frontend sent rather than the lexically normalized form.
+/// The frontend treats a URI as the editor's identity for the file; a
+/// normalised form may look like a different file to it (e.g. open a
+/// new editor pane).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UrlId(Url);
 

--- a/crates/ark/src/console/console_annotate.rs
+++ b/crates/ark/src/console/console_annotate.rs
@@ -940,9 +940,10 @@ pub unsafe extern "C-unwind" fn ps_annotate_source(
     // If there are no breakpoints for this file, return NULL to signal no
     // annotation needed. Scope the mutable borrow so we can re-borrow after.
     let annotated = {
-        let Some((_, breakpoints)) = dap_guard.breakpoints.get_mut(&uri_id) else {
+        let Some(entry) = dap_guard.breakpoints.get_mut(&uri_id) else {
             return Ok(harp::r_null());
         };
+        let breakpoints = &mut entry.breakpoints;
         if breakpoints.is_empty() {
             return Ok(harp::r_null());
         }
@@ -960,8 +961,10 @@ pub unsafe extern "C-unwind" fn ps_annotate_source(
     // Remove disabled breakpoints. Their verification state is now stale since
     // they weren't injected during this annotation. If the user re-enables
     // them, they'll be treated as new unverified breakpoints.
-    if let Some((_, breakpoints)) = dap_guard.breakpoints.get_mut(&uri_id) {
-        breakpoints.retain(|bp| !matches!(bp.state, BreakpointState::Disabled));
+    if let Some(entry) = dap_guard.breakpoints.get_mut(&uri_id) {
+        entry
+            .breakpoints
+            .retain(|bp| !matches!(bp.state, BreakpointState::Disabled));
     }
 
     Ok(RObject::from(annotated).sexp)

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -1534,7 +1534,7 @@ impl Console {
                 let breakpoints = uri_id
                     .as_ref()
                     .and_then(|uri_id| dap_guard.breakpoints.get_mut(uri_id))
-                    .map(|(_, v)| v.as_mut_slice());
+                    .map(|entry| entry.breakpoints.as_mut_slice());
 
                 match PendingInputs::read(&code, loc, breakpoints) {
                     Ok(ParseResult::Success(inputs)) => {

--- a/crates/ark/src/dap/dap_jupyter_handler.rs
+++ b/crates/ark/src/dap/dap_jupyter_handler.rs
@@ -186,12 +186,13 @@ impl DapJupyterHandler {
         let breakpoints: Vec<serde_json::Value> = state
             .breakpoints
             .iter()
-            .map(|(uri, (_, bps))| {
-                let source = uri
-                    .as_url()
-                    .to_file_path()
-                    .map_or_else(|_| uri.to_string(), |p| p.to_string_lossy().into_owned());
-                let source_breakpoints: Vec<serde_json::Value> = bps
+            .map(|(_, entry)| {
+                // Echo the verbatim path the frontend sent rather than the
+                // normalized key, so it sees back its own bytes (e.g. its
+                // Windows drive-letter casing).
+                let source = entry.verbatim_path.clone();
+                let source_breakpoints: Vec<serde_json::Value> = entry
+                    .breakpoints
                     .iter()
                     .filter(|bp| !matches!(bp.state, BreakpointState::Disabled))
                     .map(|bp| {

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -36,6 +36,7 @@ use stdext::result::ResultExt;
 use stdext::spawn;
 
 use super::dap_state::Breakpoint;
+use super::dap_state::BreakpointEntry;
 use super::dap_state::BreakpointState;
 use super::dap_state::Dap;
 use super::dap_state::DapBackendEvent;
@@ -293,7 +294,7 @@ impl DapHandler {
         // changed after a reconnection, the breakpoints are no longer valid.
         let doc_hash = blake3::hash(doc_content.as_bytes());
         let doc_changed = match &old_breakpoints {
-            Some((existing_hash, _)) => existing_hash != &doc_hash,
+            Some(entry) => entry.hash != doc_hash,
             None => true,
         };
 
@@ -322,7 +323,7 @@ impl DapHandler {
             log::trace!("DAP: Document unchanged for {uri}, preserving breakpoint states");
 
             // Unwrap Safety: `doc_changed` is false, so `old_breakpoints` is Some
-            let (_, old_breakpoints) = old_breakpoints.unwrap();
+            let old_breakpoints = old_breakpoints.unwrap().breakpoints;
             // Use original_line for lookup since that's what the frontend sends back
             let mut old_by_line: HashMap<u32, Breakpoint> = old_breakpoints
                 .into_iter()
@@ -426,7 +427,11 @@ impl DapHandler {
             })
             .collect();
 
-        state.breakpoints.insert(uri, (doc_hash, new_breakpoints));
+        state.breakpoints.insert(uri, BreakpointEntry {
+            verbatim_path: path.clone(),
+            hash: doc_hash,
+            breakpoints: new_breakpoints,
+        });
 
         drop(state);
 
@@ -1009,6 +1014,14 @@ fn into_dap_frame(frame: &FrameInfo, fallback_sources: &HashMap<String, String>)
     // Retrieve either `path` or `source_reference` depending on the `source` type.
     // In the `Text` case, a `source_reference` should always exist because we loaded
     // the map with all possible text values in `start_debug()`.
+    //
+    // We report R's view of the path (the srcref filename), not the verbatim
+    // path the frontend sent for a breakpoint. A breakpoint's `verbatim_path` can
+    // differ (e.g. a symlinked path that R resolved through `normalizePath()`),
+    // and we could match a frame back to it through `BreakpointMap`'s canonical
+    // index. But that would only reach files that happen to have a breakpoint,
+    // so a frame's path would flip form depending on whether a breakpoint is
+    // set. Using R's path keeps every frame consistent regardless.
     let path = match source {
         FrameSource::File(path) => Some(path),
         FrameSource::Text(source) => fallback_sources.get(&source).cloned().or_else(|| {

--- a/crates/ark/src/dap/dap_state.rs
+++ b/crates/ark/src/dap/dap_state.rs
@@ -221,11 +221,11 @@ impl DapBackendEvent {
     }
 }
 
-/// Breakpoint storage keyed on the verbatim `UrlId` the frontend sent in
-/// `setBreakpoints`. A secondary index maps `fs::canonicalize`d paths
-/// back to the primary key, bridging R-runtime srcref URIs (which go
-/// through `normalizePath()` and therefore arrive symlink-resolved)
-/// against the editor's pre-resolution form.
+/// Breakpoint storage keyed on the lexically normalized `UrlId` the frontend
+/// sent in `setBreakpoints`. A secondary index maps `fs::canonicalize`d paths
+/// back to the primary key, bridging R-runtime srcref URIs (which go through
+/// `normalizePath()` and therefore arrive symlink-resolved) against the
+/// editor's pre-resolution form.
 ///
 /// `fs::canonicalize` runs at insert time and at lookup-fallback time
 /// only. Lookups try the primary first (cheap, no fs touch), then

--- a/crates/ark/src/dap/dap_state.rs
+++ b/crates/ark/src/dap/dap_state.rs
@@ -6,6 +6,7 @@
 //
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -220,6 +221,92 @@ impl DapBackendEvent {
     }
 }
 
+/// Breakpoint storage keyed on the verbatim `UrlId` the frontend sent in
+/// `setBreakpoints`. A secondary index maps `fs::canonicalize`d paths
+/// back to the primary key, bridging R-runtime srcref URIs (which go
+/// through `normalizePath()` and therefore arrive symlink-resolved)
+/// against the editor's pre-resolution form.
+///
+/// `fs::canonicalize` runs at insert time and at lookup-fallback time
+/// only. Lookups try the primary first (cheap, no fs touch), then
+/// canonicalise the incoming URI and consult the secondary. DAP wire
+/// output (`debugInfo` source paths, breakpoint events) round-trips the
+/// primary key unchanged, so the frontend always sees the URI it sent.
+#[derive(Debug, Default)]
+pub struct BreakpointMap {
+    /// Primary index, keyed on the URI the frontend gave us.
+    by_url: HashMap<UrlId, (blake3::Hash, Vec<Breakpoint>)>,
+    /// `fs::canonicalize`d path -> primary key. Populated at insert
+    /// only when the URL is a `file:` and `canonicalize` succeeds (i.e.
+    /// the file exists, which it does at `setBreakpoints` time).
+    by_canonical: HashMap<PathBuf, UrlId>,
+}
+
+impl BreakpointMap {
+    pub fn insert(&mut self, url: UrlId, value: (blake3::Hash, Vec<Breakpoint>)) {
+        if let Some(canonical) = canonical_path(&url) {
+            self.by_canonical.insert(canonical, url.clone());
+        }
+        self.by_url.insert(url, value);
+    }
+
+    pub fn remove(&mut self, url: &UrlId) -> Option<(blake3::Hash, Vec<Breakpoint>)> {
+        let primary = self.resolve_primary(url)?.clone();
+        self.by_canonical.retain(|_, p| p != &primary);
+        self.by_url.remove(&primary)
+    }
+
+    pub fn get(&self, url: &UrlId) -> Option<&(blake3::Hash, Vec<Breakpoint>)> {
+        let primary = self.resolve_primary(url)?;
+        self.by_url.get(primary)
+    }
+
+    pub fn get_mut(&mut self, url: &UrlId) -> Option<&mut (blake3::Hash, Vec<Breakpoint>)> {
+        // Cloning because the mut accessors can't hold a `&self.by_canonical`
+        // borrow across `&mut self.by_url`.
+        let primary = self.resolve_primary(url)?.clone();
+        self.by_url.get_mut(&primary)
+    }
+
+    pub fn contains_key(&self, url: &UrlId) -> bool {
+        self.resolve_primary(url).is_some()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&UrlId, &(blake3::Hash, Vec<Breakpoint>))> {
+        self.by_url.iter()
+    }
+
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&UrlId, &mut (blake3::Hash, Vec<Breakpoint>))> {
+        self.by_url.iter_mut()
+    }
+
+    /// Resolve to the primary key. Tries bare `url` first. On miss,
+    /// canonicalises `url` and consults the secondary index. The
+    /// secondary catches cases like an R srcref `/private/tmp/foo.R`
+    /// (resolved by `normalizePath()`) looking up an editor URI
+    /// `/tmp/foo.R` (not resolved).
+    fn resolve_primary<'a>(&'a self, url: &'a UrlId) -> Option<&'a UrlId> {
+        if self.by_url.contains_key(url) {
+            return Some(url);
+        }
+        let canonical = canonical_path(url)?;
+        self.by_canonical.get(&canonical)
+    }
+}
+
+/// `fs::canonicalize` of the path component of a `file:` URL, if any.
+/// Returns `None` for non-`file:` URLs (`ark://`, `untitled:`, ...) and
+/// when the file isn't on disk.
+fn canonical_path(url: &UrlId) -> Option<PathBuf> {
+    if !url.is_file() {
+        return None;
+    }
+    let path = url.to_file_path().ok()?;
+    std::fs::canonicalize(path).ok()
+}
+
 pub struct Dap {
     /// Whether the REPL is stopped with a browser prompt.
     pub is_debugging: bool,
@@ -241,8 +328,8 @@ pub struct Dap {
     /// Current call stack
     pub stack: Option<Vec<FrameInfo>>,
 
-    /// Known breakpoints keyed by canonical URI, with document hash
-    pub breakpoints: HashMap<UrlId, (blake3::Hash, Vec<Breakpoint>)>,
+    /// Known breakpoints, with document hash.
+    pub breakpoints: BreakpointMap,
 
     /// Filters for enabled condition breakpoints
     pub exception_breakpoint_filters: Vec<String>,
@@ -306,7 +393,7 @@ impl Dap {
             is_connected: false,
             backend_events_tx: None,
             stack: None,
-            breakpoints: HashMap::new(),
+            breakpoints: BreakpointMap::default(),
             exception_breakpoint_filters: Vec::new(),
             fallback_sources: HashMap::new(),
             frame_id_to_variables_reference: HashMap::new(),
@@ -864,7 +951,7 @@ mod tests {
             is_connected: true,
             backend_events_tx: Some(backend_events_tx),
             stack: None,
-            breakpoints: HashMap::new(),
+            breakpoints: BreakpointMap::default(),
             exception_breakpoint_filters: Vec::new(),
             fallback_sources: HashMap::new(),
             frame_id_to_variables_reference: HashMap::new(),
@@ -978,7 +1065,7 @@ mod tests {
             is_connected: false,
             backend_events_tx: None,
             stack: None,
-            breakpoints: HashMap::new(),
+            breakpoints: BreakpointMap::default(),
             exception_breakpoint_filters: Vec::new(),
             fallback_sources: HashMap::new(),
             frame_id_to_variables_reference: HashMap::new(),

--- a/crates/ark/src/dap/dap_state.rs
+++ b/crates/ark/src/dap/dap_state.rs
@@ -221,21 +221,39 @@ impl DapBackendEvent {
     }
 }
 
+/// One file's breakpoints in a [`BreakpointMap`], plus the bookkeeping we need
+/// to talk back to the frontend about them.
+#[derive(Debug, Clone)]
+pub struct BreakpointEntry {
+    /// The verbatim `source.path` string the frontend sent in `setBreakpoints`.
+    /// The editor treats a URI as a file's identity, so handing back a
+    /// normalized form risks getting the frontend confused.
+    ///
+    /// In practice only `debugInfo` reads this. Verbatim paths rarely matter
+    /// for the DAP. Breakpoint responses and events identify breakpoints by
+    /// `id`, not by path, and a stack frame's `source.path` comes from the R
+    /// srcref. `debugInfo` is the one spot that echoes a path keyed on this
+    /// entry, so it returns `verbatim_path` instead of the normalized key.
+    pub verbatim_path: String,
+    /// Hash of the document when the breakpoints were set. A mismatch on
+    /// reconnect means the file changed and the breakpoints are stale.
+    pub hash: blake3::Hash,
+    pub breakpoints: Vec<Breakpoint>,
+}
+
 /// Breakpoint storage keyed on the lexically normalized `UrlId` the frontend
 /// sent in `setBreakpoints`. A secondary index maps `fs::canonicalize`d paths
 /// back to the primary key, bridging R-runtime srcref URIs (which go through
-/// `normalizePath()` and therefore arrive symlink-resolved) against the
-/// editor's pre-resolution form.
+/// `normalizePath()` and so arrive symlink-resolved) against the editor's
+/// pre-resolution form.
 ///
-/// `fs::canonicalize` runs at insert time and at lookup-fallback time
-/// only. Lookups try the primary first (cheap, no fs touch), then
-/// canonicalise the incoming URI and consult the secondary. DAP wire
-/// output (`debugInfo` source paths, breakpoint events) round-trips the
-/// primary key unchanged, so the frontend always sees the URI it sent.
+/// `fs::canonicalize` runs at insert time and at lookup-fallback time only.
+/// Lookups try the primary first (cheap, no fs touch), then canonicalise the
+/// incoming URI and consult the secondary.
 #[derive(Debug, Default)]
 pub struct BreakpointMap {
-    /// Primary index, keyed on the URI the frontend gave us.
-    by_url: HashMap<UrlId, (blake3::Hash, Vec<Breakpoint>)>,
+    /// Primary index, keyed on the normalized URI the frontend gave us.
+    by_url: HashMap<UrlId, BreakpointEntry>,
     /// `fs::canonicalize`d path -> primary key. Populated at insert
     /// only when the URL is a `file:` and `canonicalize` succeeds (i.e.
     /// the file exists, which it does at `setBreakpoints` time).
@@ -243,25 +261,25 @@ pub struct BreakpointMap {
 }
 
 impl BreakpointMap {
-    pub fn insert(&mut self, url: UrlId, value: (blake3::Hash, Vec<Breakpoint>)) {
+    pub fn insert(&mut self, url: UrlId, entry: BreakpointEntry) {
         if let Some(canonical) = canonical_path(&url) {
             self.by_canonical.insert(canonical, url.clone());
         }
-        self.by_url.insert(url, value);
+        self.by_url.insert(url, entry);
     }
 
-    pub fn remove(&mut self, url: &UrlId) -> Option<(blake3::Hash, Vec<Breakpoint>)> {
+    pub fn remove(&mut self, url: &UrlId) -> Option<BreakpointEntry> {
         let primary = self.resolve_primary(url)?.clone();
         self.by_canonical.retain(|_, p| p != &primary);
         self.by_url.remove(&primary)
     }
 
-    pub fn get(&self, url: &UrlId) -> Option<&(blake3::Hash, Vec<Breakpoint>)> {
+    pub fn get(&self, url: &UrlId) -> Option<&BreakpointEntry> {
         let primary = self.resolve_primary(url)?;
         self.by_url.get(primary)
     }
 
-    pub fn get_mut(&mut self, url: &UrlId) -> Option<&mut (blake3::Hash, Vec<Breakpoint>)> {
+    pub fn get_mut(&mut self, url: &UrlId) -> Option<&mut BreakpointEntry> {
         // Cloning because the mut accessors can't hold a `&self.by_canonical`
         // borrow across `&mut self.by_url`.
         let primary = self.resolve_primary(url)?.clone();
@@ -272,13 +290,11 @@ impl BreakpointMap {
         self.resolve_primary(url).is_some()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&UrlId, &(blake3::Hash, Vec<Breakpoint>))> {
+    pub fn iter(&self) -> impl Iterator<Item = (&UrlId, &BreakpointEntry)> {
         self.by_url.iter()
     }
 
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (&UrlId, &mut (blake3::Hash, Vec<Breakpoint>))> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&UrlId, &mut BreakpointEntry)> {
         self.by_url.iter_mut()
     }
 
@@ -694,9 +710,10 @@ impl Dap {
     /// breakpoints that fall within the range [start_line, end_line).
     /// Sends a `BreakpointVerified` event for each newly verified breakpoint.
     pub fn verify_breakpoints(&mut self, uri: &UrlId, start_line: u32, end_line: u32) {
-        let Some((_, bp_list)) = self.breakpoints.get_mut(uri) else {
+        let Some(entry) = self.breakpoints.get_mut(uri) else {
             return;
         };
+        let bp_list = &mut entry.breakpoints;
 
         // Collect events first: `bp_list` borrows from `self.breakpoints`,
         // which prevents calling `&mut self` methods like `send_backend_event()`.
@@ -740,10 +757,14 @@ impl Dap {
     /// if it was previously unverified. Sends a `BreakpointVerified` event.
     pub fn verify_breakpoint(&mut self, uri: &UrlId, id: &str) {
         let event = {
-            let Some((_, bp_list)) = self.breakpoints.get_mut(uri) else {
+            let Some(entry) = self.breakpoints.get_mut(uri) else {
                 return;
             };
-            let Some(bp) = bp_list.iter_mut().find(|bp| bp.id.to_string() == id) else {
+            let Some(bp) = entry
+                .breakpoints
+                .iter_mut()
+                .find(|bp| bp.id.to_string() == id)
+            else {
                 return;
             };
 
@@ -769,9 +790,10 @@ impl Dap {
     pub fn did_change_document(&mut self, uri: &UrlId) {
         log::trace!("DAP: did_change_document for {uri}");
 
-        let Some((_, breakpoints)) = self.breakpoints.remove(uri) else {
+        let Some(entry) = self.breakpoints.remove(uri) else {
             return;
         };
+        let breakpoints = entry.breakpoints;
 
         log::trace!("DAP: Removing {} breakpoints for {uri}", breakpoints.len());
 
@@ -792,7 +814,7 @@ impl Dap {
             .breakpoints
             .get(uri)
             .into_iter()
-            .flat_map(|(_, breakpoints)| breakpoints)
+            .flat_map(|entry| &entry.breakpoints)
             .filter_map(|bp| {
                 let BreakpointState::Invalid(reason) = &bp.state else {
                     return None;
@@ -813,21 +835,23 @@ impl Dap {
 
     /// Remove disabled breakpoints for a given URI.
     pub fn remove_disabled_breakpoints(&mut self, uri: &UrlId) {
-        let Some((_, bps)) = self.breakpoints.get_mut(uri) else {
+        let Some(entry) = self.breakpoints.get_mut(uri) else {
             return;
         };
-        bps.retain(|bp| !matches!(bp.state, BreakpointState::Disabled));
+        entry
+            .breakpoints
+            .retain(|bp| !matches!(bp.state, BreakpointState::Disabled));
     }
 
     pub(crate) fn is_breakpoint_enabled(&self, uri: &UrlId, id: i64) -> bool {
-        let Some((_, breakpoints)) = self.breakpoints.get(uri) else {
+        let Some(entry) = self.breakpoints.get(uri) else {
             return false;
         };
 
         // Unverified breakpoints are enabled. This happens when we hit a
         // breakpoint in an expression that hasn't been evaluated yet (or hasn't
         // finished).
-        breakpoints.iter().any(|bp| {
+        entry.breakpoints.iter().any(|bp| {
             bp.id == id &&
                 matches!(
                     bp.state,
@@ -860,16 +884,16 @@ impl Dap {
     }
 
     pub(crate) fn get_breakpoint(&self, uri: &UrlId, id: i64) -> Option<&Breakpoint> {
-        let (_, breakpoints) = self.breakpoints.get(uri)?;
-        breakpoints.iter().find(|bp| bp.id == id)
+        let entry = self.breakpoints.get(uri)?;
+        entry.breakpoints.iter().find(|bp| bp.id == id)
     }
 
     /// Reset per-execution breakpoint state (hit counts).
     /// Called when `ReadConsole` returns to a top-level (non-browser) prompt,
     /// meaning the execution that may have hit breakpoints is complete.
     pub(crate) fn reset(&mut self) {
-        for (_, (_, breakpoints)) in self.breakpoints.iter_mut() {
-            for bp in breakpoints.iter_mut() {
+        for (_, entry) in self.breakpoints.iter_mut() {
+            for bp in entry.breakpoints.iter_mut() {
                 bp.hit_count = 0;
             }
         }
@@ -877,10 +901,10 @@ impl Dap {
 
     /// Increment the hit count for a breakpoint and return the new count.
     pub(crate) fn increment_hit_count(&mut self, uri: &UrlId, id: i64) -> u64 {
-        let Some((_, breakpoints)) = self.breakpoints.get_mut(uri) else {
+        let Some(entry) = self.breakpoints.get_mut(uri) else {
             return 0;
         };
-        let Some(bp) = breakpoints.iter_mut().find(|bp| bp.id == id) else {
+        let Some(bp) = entry.breakpoints.iter_mut().find(|bp| bp.id == id) else {
             return 0;
         };
         bp.hit_count += 1;
@@ -977,13 +1001,14 @@ mod tests {
         let uri = url_id("file:///test.R");
         let hash = blake3::hash(b"test content");
 
-        dap.breakpoints.insert(
-            uri.clone(),
-            (hash, vec![
+        dap.breakpoints.insert(uri.clone(), BreakpointEntry {
+            verbatim_path: String::from("/test.R"),
+            hash,
+            breakpoints: vec![
                 Breakpoint::new(1, 10, BreakpointState::Verified),
                 Breakpoint::new(2, 20, BreakpointState::Verified),
-            ]),
-        );
+            ],
+        });
 
         dap.did_change_document(&uri);
 
@@ -1026,22 +1051,16 @@ mod tests {
         let hash1 = blake3::hash(b"content 1");
         let hash2 = blake3::hash(b"content 2");
 
-        dap.breakpoints.insert(
-            uri1.clone(),
-            (hash1, vec![Breakpoint::new(
-                1,
-                10,
-                BreakpointState::Verified,
-            )]),
-        );
-        dap.breakpoints.insert(
-            uri2.clone(),
-            (hash2, vec![Breakpoint::new(
-                2,
-                20,
-                BreakpointState::Verified,
-            )]),
-        );
+        dap.breakpoints.insert(uri1.clone(), BreakpointEntry {
+            verbatim_path: String::from("/test1.R"),
+            hash: hash1,
+            breakpoints: vec![Breakpoint::new(1, 10, BreakpointState::Verified)],
+        });
+        dap.breakpoints.insert(uri2.clone(), BreakpointEntry {
+            verbatim_path: String::from("/test2.R"),
+            hash: hash2,
+            breakpoints: vec![Breakpoint::new(2, 20, BreakpointState::Verified)],
+        });
 
         dap.did_change_document(&uri1);
 
@@ -1084,19 +1103,62 @@ mod tests {
         let uri = url_id("file:///test.R");
         let hash = blake3::hash(b"test content");
 
-        dap.breakpoints.insert(
-            uri.clone(),
-            (hash, vec![Breakpoint::new(
-                1,
-                10,
-                BreakpointState::Verified,
-            )]),
-        );
+        dap.breakpoints.insert(uri.clone(), BreakpointEntry {
+            verbatim_path: String::from("/test.R"),
+            hash,
+            breakpoints: vec![Breakpoint::new(1, 10, BreakpointState::Verified)],
+        });
 
         // Should not panic even without `backend_events_tx`
         dap.did_change_document(&uri);
 
         // Breakpoints should still be removed
         assert!(!dap.breakpoints.contains_key(&uri));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_breakpoint_map_keeps_verbatim_source_path() {
+        // The `source.path` the frontend sends can normalize to a different
+        // `UrlId` (here the `..` segment is collapsed). `debugInfo` echoes
+        // `verbatim_path`, so we store the original bytes rather than rebuild
+        // them from the normalized key.
+        let mut map = BreakpointMap::default();
+        let sent = "/home/user/../user/test.R";
+        let uri = UrlId::from_file_path(sent).unwrap();
+
+        map.insert(uri.clone(), BreakpointEntry {
+            verbatim_path: String::from(sent),
+            hash: blake3::hash(b""),
+            breakpoints: vec![],
+        });
+
+        assert_eq!(map.get(&uri).unwrap().verbatim_path, sent);
+
+        // Rebuilding the path from the key would hand the frontend different
+        // bytes, since the key dropped the `..`.
+        assert_ne!(uri.to_file_path().unwrap().to_string_lossy(), sent);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_breakpoint_map_keeps_verbatim_source_path() {
+        // Positron often sends a lowercase Windows drive letter. The `UrlId`
+        // key uppercases it, so we echo the original `verbatim_path` back via
+        // `debugInfo` rather than the normalized key.
+        let mut map = BreakpointMap::default();
+        let sent = "c:\\Users\\test\\file.R";
+        let uri = UrlId::from_file_path(sent).unwrap();
+
+        map.insert(uri.clone(), BreakpointEntry {
+            source_path: String::from(sent),
+            hash: blake3::hash(b""),
+            breakpoints: vec![],
+        });
+
+        assert_eq!(map.get(&uri).unwrap().source_path, sent);
+
+        // The key uppercased the drive letter.
+        assert!(uri.as_url().as_str().contains("/C:/"));
     }
 }

--- a/crates/ark/src/dap/dap_state.rs
+++ b/crates/ark/src/dap/dap_state.rs
@@ -1151,12 +1151,12 @@ mod tests {
         let uri = UrlId::from_file_path(sent).unwrap();
 
         map.insert(uri.clone(), BreakpointEntry {
-            source_path: String::from(sent),
+            verbatim_path: String::from(sent),
             hash: blake3::hash(b""),
             breakpoints: vec![],
         });
 
-        assert_eq!(map.get(&uri).unwrap().source_path, sent);
+        assert_eq!(map.get(&uri).unwrap().verbatim_path, sent);
 
         // The key uppercased the drive letter.
         assert!(uri.as_url().as_str().contains("/C:/"));

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -336,7 +336,6 @@ fn test_r_file_changed_for_unopened_file_updates_contents() {
 }
 
 #[test]
-#[ignore = "blocked by UrlId canonicalization gap for missing paths"]
 fn test_r_file_deleted_for_editor_open_file_is_skipped() {
     // Mirror of `test_r_file_changed_for_editor_open_file_is_skipped`
     // for the Deleted kind. The skip check in `apply_watcher_events`
@@ -344,17 +343,6 @@ fn test_r_file_deleted_for_editor_open_file_is_skipped() {
     // protected from deletion too: the buffer stays visible to the
     // user and queries keep resolving against the editor's
     // last-pushed content.
-    //
-    // The assertion passes today, but only incidentally: the same
-    // canonicalization gap that blocks the DESCRIPTION test below also
-    // breaks the skip lookup here. The event URL canonicalizes to the
-    // raw `/var/...` path (the file is gone, canonicalize fails),
-    // so the skip set (built from open documents while the file
-    // existed, i.e. `/private/var/...`) does not contain it. The event
-    // therefore reaches `remove_watched_file`, which also fails to find
-    // the file by URL and bails out. Net: file survives, but the skip
-    // mechanism is never actually exercised. Marked ignore until the
-    // canonicalization gap is fixed.
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("a.R");
     fs::write(&path, "disk_v1\n").unwrap();
@@ -380,18 +368,10 @@ fn test_r_file_deleted_for_editor_open_file_is_skipped() {
 }
 
 #[test]
-#[ignore = "blocked by UrlId canonicalization gap for missing paths; see dev-notes/notes/oak/2026-05-22-0846-watcher-test-gaps.md"]
 fn test_description_deleted_demotes_package_to_scripts() {
     // Inverse of `test_description_created_triggers_root_rescan`: a
     // DESCRIPTION removed mid-session triggers a root rescan and the
     // former package's R/ files surface as workspace scripts.
-    //
-    // Currently fails because `UrlId::from_url` canonicalizes via
-    // `std::fs::canonicalize`, which fails for paths that no longer
-    // exist and falls back to the raw path. On macOS this means the
-    // Deleted event's URL keeps the `/var/...` prefix while the
-    // workspace root URL uses `/private/var/...`, and the routing in
-    // `apply_watcher_events` misses.
     let tmp = tempfile::tempdir().unwrap();
     write_package(&tmp.path().join("pkg"), "pkg", &[("a.R", "x <- 1\n")]);
     let mut state = workspace_state(tmp.path());

--- a/crates/ark/tests/integration/dap_notebook.rs
+++ b/crates/ark/tests/integration/dap_notebook.rs
@@ -851,3 +851,65 @@ fn test_notebook_debug_info_reports_breakpoints() {
     frontend.recv_debug_reply();
     frontend.recv_iopub_idle();
 }
+
+/// `debugInfo` must hand back the exact `source.path` the frontend sent, not
+/// the normalized `UrlId` we key breakpoints on. Here the path carries a `..`
+/// segment that `UrlId` collapses, so a normalized echo would differ from what
+/// the editor sent and could open a second editor pane on the same file.
+#[test]
+#[cfg(not(windows))]
+fn test_notebook_debug_info_echoes_verbatim_breakpoint_path() {
+    let frontend = DummyArkFrontendNotebook::lock();
+
+    // Dump a cell to get a real file on disk that `setBreakpoints` can read.
+    frontend.send_debug_request(serde_json::json!({
+        "type": "request",
+        "seq": 1,
+        "command": "dumpCell",
+        "arguments": { "code": "x <- 1\ny <- 2" }
+    }));
+    frontend.recv_iopub_busy();
+    let dump_reply = frontend.recv_debug_reply();
+    frontend.recv_iopub_idle();
+    let source_path = dump_reply["body"]["sourcePath"].as_str().unwrap();
+
+    // Build a `..`-variant of that path. It resolves to the same file (the
+    // intermediate dir exists), but `UrlId` collapses the `..`, so the
+    // normalized key no longer matches these bytes.
+    let path = std::path::Path::new(source_path);
+    let dir = path.parent().unwrap();
+    let dir_base = dir.file_name().unwrap().to_string_lossy();
+    let file_name = path.file_name().unwrap().to_string_lossy();
+    let sent_path = format!("{}/../{dir_base}/{file_name}", dir.to_string_lossy());
+    assert_ne!(sent_path, source_path);
+
+    frontend.send_debug_request(serde_json::json!({
+        "type": "request",
+        "seq": 2,
+        "command": "setBreakpoints",
+        "arguments": {
+            "source": { "path": sent_path },
+            "breakpoints": [{ "line": 1 }]
+        }
+    }));
+    frontend.recv_iopub_busy();
+    frontend.recv_debug_reply();
+    frontend.recv_iopub_idle();
+
+    frontend.send_debug_request(serde_json::json!({
+        "type": "request",
+        "seq": 3,
+        "command": "debugInfo",
+        "arguments": {}
+    }));
+    frontend.recv_iopub_busy();
+    let info_reply = frontend.recv_debug_reply();
+    frontend.recv_iopub_idle();
+
+    let bp_groups = info_reply["body"]["breakpoints"].as_array().unwrap();
+    let group = bp_groups
+        .iter()
+        .find(|group| group["source"].as_str() == Some(sent_path.as_str()))
+        .expect("debugInfo did not echo the verbatim breakpoint path");
+    assert_eq!(group["breakpoints"].as_array().unwrap().len(), 1);
+}

--- a/crates/ark/tests/integration/kernel_shutdown.rs
+++ b/crates/ark/tests/integration/kernel_shutdown.rs
@@ -1,6 +1,8 @@
 #[cfg(unix)]
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
+#[cfg(unix)]
 use amalthea::wire::jupyter_message::Status;
+#[cfg(unix)]
 use ark_test::DummyArkFrontend;
 
 /// Install a SIGINT handler for shutdown tests. This overrides the test runner
@@ -55,6 +57,7 @@ fn test_shutdown_request_with_restart() {
     DummyArkFrontend::wait_for_cleanup();
 }
 
+#[cfg(unix)]
 static SHUTDOWN_TESTS_ENABLED: bool = false;
 
 // Can shut down Ark when running a nested debug console

--- a/crates/ark_test/src/dummy_frontend.rs
+++ b/crates/ark_test/src/dummy_frontend.rs
@@ -1431,7 +1431,12 @@ impl DummyArkFrontend {
         // Use forward slashes for R compatibility on Windows (backslashes would be
         // interpreted as escape sequences in R strings)
         let path = file.path().to_string_lossy().replace('\\', "/");
-        let uri_id = UrlId::from_file_path(file.path()).unwrap().to_string();
+        // `uri_id` is what R-side code reports back. R's `path_to_file_uri()`
+        // applies `normalizePath()` which resolves symlinks (e.g. macOS
+        // `/var/...` -> `/private/var/...`), so canonicalize here so tests
+        // can compare against R-reported URIs byte for byte.
+        let canonical = file.path().canonicalize().unwrap();
+        let uri_id = UrlId::from_file_path(&canonical).unwrap().to_string();
         let filename = file
             .path()
             .file_name()
@@ -1822,7 +1827,11 @@ impl SourceFile {
         // Use forward slashes for R compatibility on Windows (backslashes would be
         // interpreted as escape sequences in R strings)
         let path = file.path().to_string_lossy().replace('\\', "/");
-        let url = UrlId::from_file_path(file.path()).unwrap();
+        // `uri_id` is what R reports via `path_to_file_uri()` (which goes
+        // through `normalizePath()`), so canonicalize here so tests can
+        // compare against R-reported URIs byte for byte.
+        let canonical = file.path().canonicalize().unwrap();
+        let url = UrlId::from_file_path(&canonical).unwrap();
         let uri_id = url.to_string();
 
         // Extract file name

--- a/crates/ark_test/src/dummy_frontend.rs
+++ b/crates/ark_test/src/dummy_frontend.rs
@@ -1431,10 +1431,10 @@ impl DummyArkFrontend {
         // Use forward slashes for R compatibility on Windows (backslashes would be
         // interpreted as escape sequences in R strings)
         let path = file.path().to_string_lossy().replace('\\', "/");
-        // `uri_id` is what R-side code reports back. R's `path_to_file_uri()`
-        // applies `normalizePath()` which resolves symlinks (e.g. macOS
-        // `/var/...` -> `/private/var/...`), so canonicalize here so tests
-        // can compare against R-reported URIs byte for byte.
+
+        // R side `path_to_file_uri()` applies `normalizePath()`, which resolves
+        // symlinks (e.g. macOS `/var/...` -> `/private/var/...`). To match that
+        // in tests, we also canonicalize here.
         let canonical = file.path().canonicalize().unwrap();
         let uri_id = UrlId::from_file_path(&canonical).unwrap().to_string();
         let filename = file
@@ -1827,9 +1827,10 @@ impl SourceFile {
         // Use forward slashes for R compatibility on Windows (backslashes would be
         // interpreted as escape sequences in R strings)
         let path = file.path().to_string_lossy().replace('\\', "/");
-        // `uri_id` is what R reports via `path_to_file_uri()` (which goes
-        // through `normalizePath()`), so canonicalize here so tests can
-        // compare against R-reported URIs byte for byte.
+
+        // R side `path_to_file_uri()` applies `normalizePath()`, which resolves
+        // symlinks (e.g. macOS `/var/...` -> `/private/var/...`). To match that
+        // in tests, we also canonicalize here.
         let canonical = file.path().canonicalize().unwrap();
         let url = UrlId::from_file_path(&canonical).unwrap();
         let uri_id = url.to_string();

--- a/crates/oak_db/src/file_exports.rs
+++ b/crates/oak_db/src/file_exports.rs
@@ -68,7 +68,7 @@ impl File {
                     name: target_name,
                     ..
                 } => {
-                    let target_url_id = UrlId::from_canonical(target_url.clone());
+                    let target_url_id = UrlId::from_url(target_url.clone());
                     let Some(target_file) = db.file_by_url(&target_url_id) else {
                         continue;
                     };

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -107,7 +107,7 @@ fn resolve_relative_to(anchor_dir: &Path, path: &str) -> Option<UrlId> {
     let raw: PathBuf = anchor_dir.join(path);
     let target_path = normalise_path(&raw);
     let url = Url::from_file_path(&target_path).ok()?;
-    Some(UrlId::from_canonical(url))
+    Some(UrlId::from_url(url))
 }
 
 /// Resolve `..` and `.` components in `path` lexically, without

--- a/crates/oak_db/src/tests/test_db.rs
+++ b/crates/oak_db/src/tests/test_db.rs
@@ -125,7 +125,7 @@ pub(super) fn file_url(name: &str) -> UrlId {
     } else {
         Url::parse(&format!("file:///{name}")).unwrap()
     };
-    UrlId::from_canonical(url)
+    UrlId::from_url(url)
 }
 
 /// Build a fresh empty `RootKind::Workspace` `Root` at `path`. Each

--- a/crates/oak_scan/src/tests/scheduler.rs
+++ b/crates/oak_scan/src/tests/scheduler.rs
@@ -263,11 +263,7 @@ fn test_set_workspace_paths_inserts_empty_root_immediately() {
     let roots = db.workspace_roots().roots(&db).clone();
     assert_eq!(roots.len(), 1);
     assert!(roots[0].packages(&db).is_empty());
-    // Path matches. Compare via the URL conversion the scheduler uses
-    // internally, so this stays cross-platform: macOS canonicalization
-    // resolves symlinks (`/var` -> `/private/var`), Windows adds a `\\?\`
-    // UNC prefix, and going through `UrlId::from_file_path` on both sides
-    // is the only round-trip that matches.
-    let expected = UrlId::from_file_path(tmp.path()).unwrap();
-    assert_eq!(roots[0].path(&db), &expected);
+    // `UrlId` construction is lexical, so the stored path is the one
+    // we handed in, byte for byte.
+    assert_eq!(roots[0].path(&db).to_file_path().unwrap(), tmp.path());
 }

--- a/crates/oak_scan/src/tests/stale.rs
+++ b/crates/oak_scan/src/tests/stale.rs
@@ -20,7 +20,7 @@ use crate::inputs::DbScan;
 use crate::inputs::RootExt;
 
 fn file_url(s: &str) -> UrlId {
-    UrlId::from_canonical(Url::parse(&format!("file://{s}")).unwrap())
+    UrlId::from_url(Url::parse(&format!("file://{s}")).unwrap())
 }
 
 #[test]

--- a/crates/oak_scan/tests/integration/library.rs
+++ b/crates/oak_scan/tests/integration/library.rs
@@ -267,9 +267,7 @@ fn test_set_library_paths_stale_no_duplicates_across_cycles() {
 // and is the realistic trigger -- depends on.
 
 fn file_url(s: &str) -> UrlId {
-    // Bypass `UrlId::from_file_path`'s canonicalization (these paths
-    // don't exist on disk).
-    UrlId::from_canonical(Url::parse(&format!("file://{s}")).unwrap())
+    UrlId::from_url(Url::parse(&format!("file://{s}")).unwrap())
 }
 
 fn empty_library_root(db: &OakDatabase, path: &str) -> Root {


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1245
Progress towards https://github.com/posit-dev/ark/issues/1212

While I was working on breakpoints I ran into difficulties matching files from different locations: frontend URIs via DAP requests and source references from R whose paths went through `normalizePath()`. The latter does file canonicalisation, which means that in addition to resolving `.` and `..`, it also follows symlinks. The frontend URIs are not canonicalised, which caused CI failures when running tests in projects storedc in temporary folders, with mismatches between `/tmp` and `/private/tmp`. The fix I implemented was to canonicalise everywhere and encode that canonicalisation happened with the `UrlId` file, which we stored as file keys in our maps tracking state (e.g. breakpoints) by file.

The `UrlId` normalisation also dealt with other issues that surfaced over time, such as windows letter drive casing because to fix issues with lowercase on one end and uppercase on the other.

The same sort of issue came up with the LSP: we get URIs from the frontend, but we also encounter `source()` calls that may be relative and we need to resolve them. So I reached for the same `UrlId` approach to make the different file paths agree with each other.

It turns out that doing any sort of normalisation that requires I/O is a red flag. If a file gets deleted on disk, and we get an event about that file, there is literally no way to match it back to what we know. For the LSP that's a real issue because we get file deletion events after the file is deleted.

The other thing to watch out for: Always report back the unormalised URI/path to the frontend, because that's what they use to map files on their end. Any changes might cause the frontend to treat the file as different.

With this PR:

- We no longer canonicalise files that we store as keys. We only do lexical normalisation: resolve `.` and `..`. That matches r-a and ty.
- We still do canonicalisation at comparison time, in a secondary lookup. This way we can still match file paths coming from different sources.
- We keep track of original file URI/paths for communication with the frontend. For now only in the DAP, this will be done for the LSP in another PR.