### PR TITLE
Map LSP documents by normalised `FilePath`

### DIFF
--- a/crates/ark/src/lsp/document.rs
+++ b/crates/ark/src/lsp/document.rs
@@ -11,13 +11,26 @@ use aether_lsp_utils::proto::PositionEncoding;
 use anyhow::anyhow;
 use oak_semantic::semantic_index::SemanticIndex;
 use tower_lsp::lsp_types;
+use tower_lsp::lsp_types::Url;
 use tree_sitter::Parser;
 use tree_sitter::Tree;
 
 use crate::lsp::config::DocumentConfig;
 
+/// Placeholder URL used by `Document::new`. Production paths replace
+/// this with the editor's verbatim URL via `WorldState::insert_document`.
+/// Tests that don't go through `WorldState` leave the placeholder.
+const PLACEHOLDER_URL: &str = "ark://internal/document-url-unset";
+
 #[derive(Clone)]
 pub struct Document {
+    /// The editor's URL for this document, byte-for-byte as received in
+    /// `did_open`. Used for wire output (diagnostics, etc.) so the
+    /// frontend always sees the URI it sent us, never a normalised
+    /// round-trip. `WorldState::insert_document` populates this; the
+    /// default constructor uses a placeholder.
+    pub url: Url,
+
     /// The document's textual contents.
     pub contents: String,
 
@@ -76,6 +89,7 @@ impl Document {
         let line_index = biome_line_index::LineIndex::new(&contents);
 
         Self {
+            url: Url::parse(PLACEHOLDER_URL).expect("placeholder URL parses"),
             contents,
             version,
             ast,

--- a/crates/ark/src/lsp/find_references.rs
+++ b/crates/ark/src/lsp/find_references.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use aether_lsp_utils::proto::from_proto;
 use aether_lsp_utils::proto::to_proto;
+use aether_path::FilePath;
 use anyhow::anyhow;
 use stdext::result::ResultExt;
 use stdext::unwrap;
@@ -35,7 +36,7 @@ pub(crate) fn find_references(
     let position = params.text_document_position.position;
     let include_declaration = params.context.include_declaration;
 
-    let document = state.get_document(&uri)?;
+    let document = state.get_document(&FilePath::from_url(&uri))?;
 
     let mut locations: Vec<Location> = Vec::new();
 

--- a/crates/ark/src/lsp/goto_definition.rs
+++ b/crates/ark/src/lsp/goto_definition.rs
@@ -164,7 +164,7 @@ mod parked_salsa_tests {
 
     fn make_state(uri: &lsp_types::Url, doc: &Document) -> WorldState {
         let mut state = WorldState::default();
-        state.documents.insert(uri.clone(), doc.clone());
+        state.insert_document(uri.clone(), doc.clone());
         state
     }
 
@@ -229,8 +229,8 @@ mod parked_salsa_tests {
         let pkg = Package::from_parts(pkg_root, desc, ns);
 
         let mut state = WorldState::default();
-        state.documents.insert(uri_aaa.clone(), doc_aaa.clone());
-        state.documents.insert(uri_ccc.clone(), doc_ccc.clone());
+        state.insert_document(uri_aaa.clone(), doc_aaa.clone());
+        state.insert_document(uri_ccc.clone(), doc_ccc.clone());
         state.root = Some(SourceRoot::Package(pkg));
 
         // ccc.R sees bbb.R's definition (later in collation)
@@ -283,9 +283,9 @@ mod parked_salsa_tests {
         let pkg = Package::from_parts(pkg_root, desc, ns);
 
         let mut state = WorldState::default();
-        state.documents.insert(uri_aaa.clone(), doc_aaa.clone());
-        state.documents.insert(uri_bbb.clone(), doc_bbb);
-        state.documents.insert(uri_ccc.clone(), doc_ccc.clone());
+        state.insert_document(uri_aaa.clone(), doc_aaa.clone());
+        state.insert_document(uri_bbb.clone(), doc_bbb);
+        state.insert_document(uri_ccc.clone(), doc_ccc.clone());
         state.root = Some(SourceRoot::Package(pkg));
 
         // aaa.R is now last in collation, so it can see bbb.R's definition
@@ -332,7 +332,7 @@ mod parked_salsa_tests {
         let pkg = Package::from_parts(pkg_root, desc, ns);
 
         let mut state = WorldState::default();
-        state.documents.insert(uri_aaa.clone(), doc_aaa.clone());
+        state.insert_document(uri_aaa.clone(), doc_aaa.clone());
         state.root = Some(SourceRoot::Package(pkg));
 
         // Cursor on `helper` inside the function body (line 0, col 16)
@@ -464,7 +464,7 @@ mod parked_salsa_tests {
         // `is.null` is NOT in the INDEX
         let doc_null = Document::new("is.null(1)\n", None);
         let uri_null = lsp_types::Url::from_file_path(pkg_root.join("R/bar.R")).unwrap();
-        state.documents.insert(uri_null.clone(), doc_null.clone());
+        state.insert_document(uri_null.clone(), doc_null.clone());
 
         let params = make_params(uri_null, 0, 0);
         let result = goto_definition(&doc_null, params, &state).unwrap();
@@ -523,9 +523,7 @@ mod parked_salsa_tests {
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
         state.workspace.folders = vec![lsp_types::Url::from_directory_path(dir.path()).unwrap()];
 
         let params = make_params(script_uri, 1, 0);
@@ -551,10 +549,8 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(script_dir.join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state.documents.insert(helpers_uri.clone(), helpers_doc);
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(helpers_uri.clone(), helpers_doc);
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         // Cursor on `helper` (line 1, col 0)
         let params = make_params(script_uri, 1, 0);
@@ -594,7 +590,7 @@ mod parked_salsa_tests {
 
         let mut state = make_state(&script_uri, &script_doc);
         state.library = library;
-        state.documents.insert(helpers_uri.clone(), helpers_doc);
+        state.insert_document(helpers_uri.clone(), helpers_doc);
 
         // `mutate` (line 1) resolves via dplyr, attached by helpers.R's library() call.
         // Package symbol, no NavigationTarget.
@@ -634,9 +630,7 @@ mod parked_salsa_tests {
             lsp_types::Url::from_file_path(script_dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
         // helpers.R is intentionally NOT inserted into state.documents
 
         let params = make_params(script_uri, 1, 0);
@@ -755,9 +749,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         // Should resolve without hanging. Both symbols are reachable
         // because a.R is visited first (gets its exports + b.R's exports),
@@ -801,9 +793,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
@@ -848,9 +838,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         // `foo` on line 2 should resolve to the LOCAL definition on line 1,
         // not to the sourced one from helpers.R.
@@ -897,9 +885,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
         let a_uri = lsp_types::Url::from_file_path(dir.path().join("a.R")).unwrap();
@@ -947,9 +933,7 @@ mod parked_salsa_tests {
         let script_doc = Document::new("source(\"script.R\")\nmy_var <- 1\nmy_var\n", None);
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         // `my_var` (line 2) should resolve to its own definition on line 1,
         // not to a Sourced duplicate.
@@ -993,9 +977,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         let (index, file_scope) = state.file_analysis(&script_uri, &script_doc);
 
@@ -1033,9 +1015,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         let b_uri = lsp_types::Url::from_file_path(dir.path().join("b.R")).unwrap();
 
@@ -1063,9 +1043,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
@@ -1103,9 +1081,7 @@ mod parked_salsa_tests {
         let script_uri = lsp_types::Url::from_file_path(dir.path().join("script.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
@@ -1138,9 +1114,7 @@ mod parked_salsa_tests {
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         // `helper` on line 2 should resolve to helpers.R (source() shadows local)
         let params = make_params(script_uri, 2, 0);
@@ -1177,9 +1151,7 @@ mod parked_salsa_tests {
         let helpers_uri = lsp_types::Url::from_file_path(dir.path().join("helpers.R")).unwrap();
 
         let mut state = WorldState::default();
-        state
-            .documents
-            .insert(script_uri.clone(), script_doc.clone());
+        state.insert_document(script_uri.clone(), script_doc.clone());
 
         // `fn` on line 1 should resolve to the SECOND def in helpers.R (line 1)
         let params = make_params(script_uri, 1, 0);

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use aether_path::FilePath;
 use anyhow::anyhow;
 use serde_json::Value;
 use stdext::result::ResultExt;
@@ -184,7 +185,7 @@ pub(crate) fn handle_folding_range(
     state: &WorldState,
 ) -> LspResult<Option<Vec<FoldingRange>>> {
     let uri = &params.text_document.uri;
-    let document = state.get_document(uri)?;
+    let document = state.get_document(&FilePath::from_url(uri))?;
     match folding_range(document) {
         Ok(foldings) => Ok(Some(foldings)),
         Err(err) => {
@@ -210,7 +211,7 @@ pub(crate) fn handle_completion(
 ) -> LspResult<Option<CompletionResponse>> {
     // Get reference to document.
     let uri = params.text_document_position.text_document.uri;
-    let document = state.get_document(&uri)?;
+    let document = state.get_document(&FilePath::from_url(&uri))?;
 
     let position = params.text_document_position.position;
     let point = document.tree_sitter_point_from_lsp_position(position)?;
@@ -243,7 +244,7 @@ pub(crate) fn handle_completion_resolve(mut item: CompletionItem) -> LspResult<C
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn handle_hover(params: HoverParams, state: &WorldState) -> LspResult<Option<Hover>> {
     let uri = params.text_document_position_params.text_document.uri;
-    let document = state.get_document(&uri)?;
+    let document = state.get_document(&FilePath::from_url(&uri))?;
 
     let position = params.text_document_position_params.position;
     let point = document.tree_sitter_point_from_lsp_position(position)?;
@@ -278,7 +279,7 @@ pub(crate) fn handle_signature_help(
     state: &WorldState,
 ) -> LspResult<Option<SignatureHelp>> {
     let uri = params.text_document_position_params.text_document.uri;
-    let document = state.get_document(&uri)?;
+    let document = state.get_document(&FilePath::from_url(&uri))?;
 
     let position = params.text_document_position_params.position;
     let point = document.tree_sitter_point_from_lsp_position(position)?;
@@ -308,7 +309,7 @@ pub(crate) fn handle_goto_definition(
     state: &WorldState,
 ) -> LspResult<Option<GotoDefinitionResponse>> {
     let uri = &params.text_document_position_params.text_document.uri;
-    let document = state.get_document(uri)?;
+    let document = state.get_document(&FilePath::from_url(uri))?;
 
     Ok(goto_definition(document, params).log_err().flatten())
 }
@@ -318,7 +319,7 @@ pub(crate) fn handle_selection_range(
     params: SelectionRangeParams,
     state: &WorldState,
 ) -> LspResult<Option<Vec<SelectionRange>>> {
-    let document = state.get_document(&params.text_document.uri)?;
+    let document = state.get_document(&FilePath::from_url(&params.text_document.uri))?;
 
     // Get tree-sitter points to return selection ranges for
     let points = params
@@ -382,7 +383,7 @@ pub(crate) fn handle_statement_range(
     params: StatementRangeParams,
     state: &WorldState,
 ) -> LspResult<Option<StatementRangeResponse>> {
-    let document = state.get_document(&params.text_document.uri)?;
+    let document = state.get_document(&FilePath::from_url(&params.text_document.uri))?;
     let point = document.tree_sitter_point_from_lsp_position(params.position)?;
     statement_range(document, point)
 }
@@ -392,7 +393,7 @@ pub(crate) fn handle_help_topic(
     params: HelpTopicParams,
     state: &WorldState,
 ) -> LspResult<Option<HelpTopicResponse>> {
-    let document = state.get_document(&params.text_document.uri)?;
+    let document = state.get_document(&FilePath::from_url(&params.text_document.uri))?;
     let point = document.tree_sitter_point_from_lsp_position(params.position)?;
     help_topic(point, document)
 }
@@ -403,7 +404,7 @@ pub(crate) fn handle_indent(
     state: &WorldState,
 ) -> LspResult<Option<Vec<TextEdit>>> {
     let ctxt = params.text_document_position;
-    let doc = state.get_document(&ctxt.text_document.uri)?;
+    let doc = state.get_document(&FilePath::from_url(&ctxt.text_document.uri))?;
     let point = doc.tree_sitter_point_from_lsp_position(ctxt.position)?;
 
     indent_edit(doc, point.row)
@@ -416,7 +417,7 @@ pub(crate) fn handle_code_action(
     state: &WorldState,
 ) -> LspResult<Option<CodeActionResponse>> {
     let uri = params.text_document.uri;
-    let doc = state.get_document(&uri)?;
+    let doc = state.get_document(&FilePath::from_url(&uri))?;
     let range = doc.tree_sitter_range_from_lsp_range(params.range)?;
 
     let code_actions = code_actions(&uri, doc, range, &lsp_state.capabilities);

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -1077,7 +1077,7 @@ pub(crate) fn index_update(uris: Vec<Url>, state: WorldState) {
             continue;
         }
 
-        let document = match state.get_document(&uri) {
+        let document = match state.get_document(&FilePath::from_url(&uri)) {
             Ok(doc) => doc.clone(),
             Err(err) => {
                 tracing::warn!("Can't get document '{uri}' for indexing: {err:?}");

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -455,12 +455,7 @@ impl GlobalState {
                 // time: a buffer may have opened or closed since the scan
                 // kicked off. The buffer-drain inside `apply_scan_completed` uses
                 // this set as its watcher-event `skip` argument.
-                let editor_owned: HashSet<FilePath> = self.world
-                    .documents
-                    .keys()
-                    .map(FilePath::from_url)
-                    .collect();
-
+                let editor_owned: HashSet<FilePath> = self.world.documents.keys().cloned().collect();
                 let followups = self.lsp_state.oak_scheduler.apply_scan_completed(
                     &mut self.world.db,
                     scan,
@@ -1000,7 +995,7 @@ async fn process_diagnostics_batch(batch: Vec<RefreshDiagnosticsTask>) {
         futures.push(task::spawn_blocking(move || {
             let _span = tracing::info_span!("diagnostics_refresh", uri = %uri).entered();
 
-            if let Some(document) = state.documents.get(&uri) {
+            if let Some(document) = state.documents.get(&FilePath::from_url(&uri)) {
                 // Special case testthat-specific behaviour. This is a simple
                 // stopgap approach that has some false positives (e.g. when we
                 // work on testthat itself the flag will always be true), but
@@ -1136,8 +1131,8 @@ pub(crate) fn diagnostics_refresh_all(state: WorldState) {
         n = state.documents.len()
     );
 
-    for (uri, _document) in state.documents.iter() {
-        if !ExtUrl::should_diagnose(uri) {
+    for document in state.documents.values() {
+        if !ExtUrl::should_diagnose(&document.url) {
             continue;
         }
 
@@ -1147,7 +1142,7 @@ pub(crate) fn diagnostics_refresh_all(state: WorldState) {
         // non-oak state).
         INDEXER_QUEUE
             .send(IndexerQueueTask::Diagnostics(RefreshDiagnosticsTask {
-                uri: uri.clone(),
+                uri: document.url.clone(),
                 state: state.legacy_snapshot(),
             }))
             .unwrap_or_else(|err| lsp::log_error!("Failed to queue diagnostics refresh: {err}"));

--- a/crates/ark/src/lsp/rename.rs
+++ b/crates/ark/src/lsp/rename.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use aether_lsp_utils::proto::from_proto;
 use aether_lsp_utils::proto::to_proto;
+use aether_path::FilePath;
 use tower_lsp::lsp_types;
 use tower_lsp::lsp_types::PrepareRenameResponse;
 use tower_lsp::lsp_types::RenameParams;
@@ -17,7 +18,7 @@ pub(crate) fn prepare_rename(
 ) -> anyhow::Result<Option<PrepareRenameResponse>> {
     let uri = params.text_document.uri;
     let position = params.position;
-    let document = state.get_document(&uri)?;
+    let document = state.get_document(&FilePath::from_url(&uri))?;
 
     let offset = from_proto::offset_from_position(
         position,
@@ -46,7 +47,7 @@ pub(crate) fn rename(
     let uri = params.text_document_position.text_document.uri;
     let position = params.text_document_position.position;
     let new_name = params.new_name;
-    let document = state.get_document(&uri)?;
+    let document = state.get_document(&FilePath::from_url(&uri))?;
 
     let offset = from_proto::offset_from_position(
         position,

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use aether_path::FilePath;
 use anyhow::anyhow;
 use oak_db::OakDatabase;
 use oak_semantic::library::Library;
@@ -18,8 +19,10 @@ pub(crate) struct WorldState {
     /// Salsa input tree for Oak queries.
     pub(crate) db: OakDatabase,
 
-    /// Watched documents
-    pub(crate) documents: HashMap<Url, Document>,
+    /// Watched documents, keyed on the normalised [`FilePath`] form.
+    /// The verbatim editor URL is preserved on each [`Document::url`]
+    /// for wire output.
+    pub(crate) documents: HashMap<FilePath, Document>,
 
     /// Watched folders
     pub(crate) workspace: Workspace,
@@ -79,7 +82,8 @@ impl WorldState {
     }
 
     pub(crate) fn get_document(&self, uri: &Url) -> anyhow::Result<&Document> {
-        if let Some(doc) = self.documents.get(uri) {
+        let key = FilePath::from_url(uri);
+        if let Some(doc) = self.documents.get(&key) {
             Ok(doc)
         } else {
             Err(anyhow!("Can't find document for URI {uri}"))
@@ -87,7 +91,8 @@ impl WorldState {
     }
 
     pub(crate) fn get_document_mut(&mut self, uri: &Url) -> anyhow::Result<&mut Document> {
-        if let Some(doc) = self.documents.get_mut(uri) {
+        let key = FilePath::from_url(uri);
+        if let Some(doc) = self.documents.get_mut(&key) {
             Ok(doc)
         } else {
             Err(anyhow!("Can't find document for URI {uri}"))
@@ -114,6 +119,15 @@ impl WorldState {
             db: OakDatabase::new(),
             ..self.clone()
         }
+    }
+
+    /// Insert a document, keying on the normalised [`FilePath`] and
+    /// stashing the verbatim editor URL on [`Document::url`] for wire
+    /// output.
+    pub(crate) fn insert_document(&mut self, uri: Url, mut doc: Document) {
+        let key = FilePath::from_url(&uri);
+        doc.url = uri;
+        self.documents.insert(key, doc);
     }
 }
 
@@ -151,8 +165,11 @@ where
 }
 
 pub(crate) fn workspace_uris(state: &WorldState) -> Vec<Url> {
-    let uris: Vec<Url> = state.documents.iter().map(|elt| elt.0.clone()).collect();
-    uris
+    state
+        .documents
+        .values()
+        .map(|doc| doc.url.clone())
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -81,21 +81,19 @@ impl WorldState {
         }
     }
 
-    pub(crate) fn get_document(&self, uri: &Url) -> anyhow::Result<&Document> {
-        let key = FilePath::from_url(uri);
-        if let Some(doc) = self.documents.get(&key) {
+    pub(crate) fn get_document(&self, path: &FilePath) -> anyhow::Result<&Document> {
+        if let Some(doc) = self.documents.get(path) {
             Ok(doc)
         } else {
-            Err(anyhow!("Can't find document for URI {uri}"))
+            Err(anyhow!("Can't find document for path {path}"))
         }
     }
 
-    pub(crate) fn get_document_mut(&mut self, uri: &Url) -> anyhow::Result<&mut Document> {
-        let key = FilePath::from_url(uri);
-        if let Some(doc) = self.documents.get_mut(&key) {
+    pub(crate) fn get_document_mut(&mut self, path: &FilePath) -> anyhow::Result<&mut Document> {
+        if let Some(doc) = self.documents.get_mut(path) {
             Ok(doc)
         } else {
-            Err(anyhow!("Can't find document for URI {uri}"))
+            Err(anyhow!("Can't find document for path {path}"))
         }
     }
 
@@ -148,16 +146,16 @@ where
     // If we have a cached copy of the document (because we're monitoring it)
     // then use that; otherwise, try to read the document from the provided
     // path and use that instead.
-    let Ok(uri) = Url::from_file_path(path) else {
+    let Some(key) = FilePath::from_path_buf(path.to_path_buf()) else {
         log::info!(
-            "couldn't construct uri from {}; reading from disk instead",
+            "couldn't construct file path from {}; reading from disk instead",
             path.display()
         );
         return fallback();
     };
 
-    let Ok(document) = state.get_document(&uri) else {
-        log::info!("no document for uri {uri}; reading from disk instead");
+    let Ok(document) = state.get_document(&key) else {
+        log::info!("no document for path {key}; reading from disk instead");
         return fallback();
     };
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -146,7 +146,7 @@ pub(crate) fn initialize(
     // Start first round of indexing. `state.documents` is empty at init since
     // no `didOpen` has fired yet, but build the set through the same shape we
     // use elsewhere so the call site reads consistently.
-    let editor_owned: HashSet<FilePath> = state.documents.keys().map(FilePath::from_url).collect();
+    let editor_owned: HashSet<FilePath> = state.documents.keys().cloned().collect();
     let requests =
         lsp_state
             .oak_scheduler
@@ -272,7 +272,7 @@ pub(crate) fn did_open(
     let document = Document::new_with_parser(contents, &mut parser, Some(version));
 
     lsp_state.parsers.insert(uri.clone(), parser);
-    state.documents.insert(uri.clone(), document.clone());
+    state.insert_document(uri.clone(), document.clone());
 
     let path = FilePath::from_url(&uri);
     state.db.upsert_editor(path, contents.to_string());
@@ -331,7 +331,7 @@ pub(crate) fn did_close(
 
     state
         .documents
-        .remove(&uri)
+        .remove(&FilePath::from_url(&uri))
         .ok_or(anyhow!("Failed to remove document for URI: {uri}"))?;
 
     lsp_state
@@ -407,7 +407,7 @@ pub(crate) fn did_change_watched_files(
 ) -> anyhow::Result<()> {
     // Editor owns the contents of files it has open: Oak should ignore
     // disk-side events for those URLs.
-    let editor_owned: HashSet<FilePath> = state.documents.keys().map(FilePath::from_url).collect();
+    let editor_owned: HashSet<FilePath> = state.documents.keys().cloned().collect();
 
     let events: Vec<FileEvent> = params
         .changes
@@ -460,7 +460,7 @@ pub(crate) fn did_change_workspace_folders(
     // Editor-owned URLs survive eviction in `OrphanRoot` so the user's
     // open buffers keep getting analysed even when their workspace
     // folder goes away.
-    let editor_owned: HashSet<FilePath> = state.documents.keys().map(FilePath::from_url).collect();
+    let editor_owned: HashSet<FilePath> = state.documents.keys().cloned().collect();
 
     let requests =
         lsp_state

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -292,7 +292,7 @@ pub(crate) fn did_change(
     state: &mut WorldState,
 ) -> anyhow::Result<()> {
     let uri = &params.text_document.uri;
-    let document = state.get_document_mut(uri)?;
+    let document = state.get_document_mut(&FilePath::from_url(uri))?;
 
     let parser = lsp_state
         .parsers
@@ -503,7 +503,7 @@ pub(crate) fn did_change_formatting_options(
     opts: &FormattingOptions,
     state: &mut WorldState,
 ) {
-    let Ok(doc) = state.get_document_mut(uri) else {
+    let Ok(doc) = state.get_document_mut(&FilePath::from_url(uri)) else {
         return;
     };
 
@@ -594,8 +594,9 @@ async fn update_config(
         let tail = remaining.split_off(DOCUMENT_SETTINGS.len());
         let head = std::mem::replace(&mut remaining, tail);
 
+        let path = FilePath::from_url(&uri);
         for (mapping, value) in DOCUMENT_SETTINGS.iter().zip(head) {
-            if let Ok(doc) = state.get_document_mut(&uri) {
+            if let Ok(doc) = state.get_document_mut(&path) {
                 (mapping.set)(&mut doc.config, value);
             }
         }

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -9,6 +9,7 @@
 
 use std::result::Result::Ok;
 
+use aether_path::FilePath;
 use stdext::unwrap::IntoResult;
 use tower_lsp::lsp_types::DocumentSymbol;
 use tower_lsp::lsp_types::DocumentSymbolParams;
@@ -159,7 +160,10 @@ pub(crate) fn document_symbols(
     params: &DocumentSymbolParams,
 ) -> anyhow::Result<Vec<DocumentSymbol>> {
     let uri = &params.text_document.uri;
-    let doc = state.documents.get(uri).into_result()?;
+    let doc = state
+        .documents
+        .get(&FilePath::from_url(uri))
+        .into_result()?;
     let ast = &doc.ast;
 
     // Start walking from the root node

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -64,7 +64,7 @@ fn set_workspace_paths(
 }
 
 fn editor_owned_of(state: &WorldState) -> HashSet<FilePath> {
-    state.documents.keys().map(FilePath::from_url).collect()
+    state.documents.keys().cloned().collect()
 }
 
 fn did_change_watched_files(
@@ -268,9 +268,7 @@ fn test_r_file_changed_for_editor_open_file_is_skipped() {
     let mut state = workspace_state(tmp.path());
 
     let url = Url::from_file_path(&path).unwrap();
-    state
-        .documents
-        .insert(url.clone(), Document::new("editor_v2\n", None));
+    state.insert_document(url.clone(), Document::new("editor_v2\n", None));
     // Pretend the editor pushed its content into oak too.
     let file_path = FilePath::from_url(&url);
     state
@@ -357,9 +355,7 @@ fn test_r_file_deleted_for_editor_open_file_is_skipped() {
     let mut state = workspace_state(tmp.path());
 
     let url = Url::from_file_path(&path).unwrap();
-    state
-        .documents
-        .insert(url.clone(), Document::new("editor_v2\n", None));
+    state.insert_document(url.clone(), Document::new("editor_v2\n", None));
     let file_path = FilePath::from_url(&url);
     state
         .db
@@ -577,9 +573,7 @@ fn test_did_change_workspace_folders_preserves_open_buffer_across_churn() {
     let r_path = tmp.path().join("pkg/R/a.R");
     let url = Url::from_file_path(&r_path).unwrap();
     let file_path = FilePath::from_url(&url);
-    state
-        .documents
-        .insert(url.clone(), Document::new("editor <- 2\n", None));
+    state.insert_document(url.clone(), Document::new("editor <- 2\n", None));
     state
         .db
         .upsert_editor(file_path.clone(), "editor <- 2\n".to_string());
@@ -637,9 +631,7 @@ fn test_did_close_releases_orphan_file_to_stale() {
 
     // Simulate `didOpen` via state mutation (matches the rest of the file's
     // pattern).
-    state
-        .documents
-        .insert(url.clone(), Document::new("edited\n", None));
+    state.insert_document(url.clone(), Document::new("edited\n", None));
     lsp_state
         .parsers
         .insert(url.clone(), tree_sitter::Parser::new());

--- a/crates/ark/src/lsp/tests/utils.rs
+++ b/crates/ark/src/lsp/tests/utils.rs
@@ -5,7 +5,7 @@ use crate::lsp::state::WorldState;
 
 pub(super) fn make_state(uri: &lsp_types::Url, doc: &Document) -> WorldState {
     let mut state = WorldState::default();
-    state.documents.insert(uri.clone(), doc.clone());
+    state.insert_document(uri.clone(), doc.clone());
     state
 }
 


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1251
Progress towards https://github.com/posit-dev/ark/issues/1212

See  https://github.com/posit-dev/ark/pull/1250 for more context.

- `WorldState` now keys documents by normalised `FilePath` instead of `Url`. See `state.rs`. Keying by normalised paths will prevent bugs when matching to paths that don't come from the frontend, e.g. `source()` paths in user code.

- The original `Url` sent by the LSP frontend is stored in `Document`. This is used in communications with the frontend so that we send back exact byte-for-byte Urls, preventing any file matching bugs that could be caused by our internal normalisation of file paths.

Unlike the DAP which has to deal with paths normalised by R, we never resolve symlinks on the LSP side. All matching is done on `FilePath` based on pure lexical normalisation of paths.