### PR TITLE
Resolve symbols from attached and imported packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,6 +2634,7 @@ dependencies = [
  "oak_scan",
  "oak_semantic",
  "salsa",
+ "stdext",
  "url",
 ]
 

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -193,9 +193,9 @@ fn package_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer
     // and including self here would create a cycle in `resolve` for unbound
     // names.
     //
-    // TODO(scan): once `oak_scan` orders `Package.files` by the DESCRIPTION
-    // `Collate` field, this iteration becomes collation-ordered directly.
-    // Today `Package.files` is whatever order the scanner produces.
+    // `package.files(db)` is collation-ordered (see `Package::files`), so
+    // reversing it gives R's LIFO precedence: a name defined late in the
+    // collation shadows the same name defined earlier.
     layers.extend(
         package
             .files(db)

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -13,6 +13,7 @@ use crate::ExportEntry;
 use crate::File;
 use crate::ImportLayer;
 use crate::Name;
+use crate::PackageVisibility;
 
 #[salsa::tracked]
 impl<'db> File {
@@ -29,12 +30,11 @@ impl<'db> File {
     ///    `source()`-forwarded entries. `ExportEntry::Import` is chased
     ///    through `exports(target)` until it lands on a `Local`. Cycles in
     ///    `source()` resolve to empty exports via `exports`'s `cycle_fn`.
-    /// 2. **`imports()` walk**: each `ImportLayer::File` sibling is checked
-    ///    via its own exports chain only (not its full `resolve`). Sibling
-    ///    package files would otherwise cycle through each other's
-    ///    `imports`, and R's namespace semantics don't transitively include
-    ///    siblings' imports anyway. Package-level layers (`From`,
-    ///    `Package`) are deferred to PR 4.
+    /// 2. **`imports()` walk**: each layer is checked in priority order.
+    ///    `File` siblings are checked via their exports chain only (not their
+    ///    full `resolve`), to avoid the cycle that recursing would create.
+    ///    `Package` and `From` layers call [`Package::resolve`] with
+    ///    `Exported` visibility.
     ///
     /// The returned `Definition` is keyed by `(file, scope, name)`, so
     /// downstream queries that only depend on identity stay cached across
@@ -62,16 +62,36 @@ impl<'db> File {
         // and the installed-package search path appear in this file's own
         // `imports()` directly, as `From` / `Package` layers, so finding
         // them does not require walking through siblings.
-        //
-        // TODO(sources): consume `From` and `Package` layers here. Today
-        // resolve only walks `ImportLayer::File`.
-        // Requires materializing installed-package files as `oak_db::File`
-        // entities first.
         for layer in self.imports(db) {
-            if let ImportLayer::File(target) = layer {
-                if let Some(def) = target.resolve_export(db, name) {
-                    return Some(def);
-                }
+            match layer {
+                ImportLayer::File(target) => {
+                    if let Some(def) = target.resolve_export(db, name) {
+                        return Some(def);
+                    }
+                },
+                ImportLayer::Package(pkg) => {
+                    if let Some(def) = pkg
+                        .resolve(db, name, PackageVisibility::Exported)
+                        .into_iter()
+                        .next()
+                    {
+                        return Some(def);
+                    }
+                },
+                ImportLayer::From(map) => {
+                    let name_str = name.text(db).as_str();
+                    if let Some(pkg_name) = map.get(name_str) {
+                        if let Some(pkg) = db.package_by_name(pkg_name) {
+                            if let Some(def) = pkg
+                                .resolve(db, name, PackageVisibility::Exported)
+                                .into_iter()
+                                .next()
+                            {
+                                return Some(def);
+                            }
+                        }
+                    }
+                },
             }
         }
 
@@ -129,12 +149,31 @@ impl<'db> File {
 
         // Top level: collation predecessors / other visible files (exports-only
         // chase, same as `resolve`'s imports walk). Avoids the sibling cycle and
-        // matches R's namespace semantics. TODO: Package-level layers.
+        // matches R's namespace semantics.
         for layer in self.imports_at(db, offset) {
-            if let ImportLayer::File(target) = layer {
-                if let Some(def) = target.resolve_export(db, name) {
-                    return vec![def];
-                }
+            match layer {
+                ImportLayer::File(target) => {
+                    if let Some(def) = target.resolve_export(db, name) {
+                        return vec![def];
+                    }
+                },
+                ImportLayer::Package(pkg) => {
+                    let defs = pkg.resolve(db, name, PackageVisibility::Exported);
+                    if !defs.is_empty() {
+                        return defs;
+                    }
+                },
+                ImportLayer::From(map) => {
+                    let name_str = name.text(db).as_str();
+                    if let Some(pkg_name) = map.get(name_str) {
+                        if let Some(pkg) = db.package_by_name(pkg_name) {
+                            let defs = pkg.resolve(db, name, PackageVisibility::Exported);
+                            if !defs.is_empty() {
+                                return defs;
+                            }
+                        }
+                    }
+                },
             }
         }
 
@@ -164,7 +203,11 @@ impl<'db> File {
     /// `Import` entries through target exports until a `Local` is found. Cycles
     /// resolve to `None` via `exports`'s `cycle_fn`.
     #[salsa::tracked]
-    fn resolve_export(self, db: &'db dyn Db, name: Name<'db>) -> Option<Definition<'db>> {
+    pub(crate) fn resolve_export(
+        self,
+        db: &'db dyn Db,
+        name: Name<'db>,
+    ) -> Option<Definition<'db>> {
         let mut current_file = self;
         let mut current_name: Rc<str> = Rc::from(name.text(db).as_str());
 

--- a/crates/oak_db/src/inputs.rs
+++ b/crates/oak_db/src/inputs.rs
@@ -206,7 +206,14 @@ pub struct Package {
     pub version: Option<String>,
     #[returns(ref)]
     pub namespace: Namespace,
-    /// R source files belonging to this package (the `R/*.R` files).
+    /// R source files belonging to this package (the `R/*.R` files), in
+    /// R's load order. When DESCRIPTION's `Collate:` directive is
+    /// present, this is exactly the files it lists, in that order;
+    /// files in `R/` not listed are excluded (matching R's loader,
+    /// Writing R Extensions §1.1.1). When `Collate:` is absent, files
+    /// are in case-insensitive alphabetical order. TODO(diagnostics):
+    /// Lint files missing from collation.
+    ///
     /// Per-package granularity: adding or removing a file in one
     /// package doesn't invalidate tracked queries reading another
     /// package's files.

--- a/crates/oak_db/src/lib.rs
+++ b/crates/oak_db/src/lib.rs
@@ -8,6 +8,7 @@ mod identifier;
 mod imports;
 mod inputs;
 mod name;
+mod package_resolve;
 mod parse;
 mod storage;
 
@@ -34,4 +35,5 @@ pub use inputs::RootKind;
 pub use inputs::StaleRoot;
 pub use inputs::WorkspaceRoots;
 pub use name::Name;
+pub use package_resolve::PackageVisibility;
 pub use storage::OakDatabase;

--- a/crates/oak_db/src/package_resolve.rs
+++ b/crates/oak_db/src/package_resolve.rs
@@ -1,0 +1,74 @@
+use crate::Db;
+use crate::Definition;
+use crate::Name;
+use crate::Package;
+
+/// Visibility filter for [`Package::resolve`].
+///
+/// Mirrors R's `::` vs `:::` distinction. `Exported` requires `name` to
+/// appear in the package's NAMESPACE `export()` directives. `Internal`
+/// returns any top-level binding the package's files define, exported
+/// or not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PackageVisibility {
+    Exported,
+    Internal,
+}
+
+#[salsa::tracked]
+impl<'db> Package {
+    /// Resolve `name` against this package's top-level bindings.
+    ///
+    /// - `Exported` (R's `pkg::name`) gates on the package's NAMESPACE `export()`
+    ///   directives: an internal binding is invisible even if it exists.
+    /// - `Internal` (R's `pkg:::name`) returns any top-level binding regardless
+    ///   of NAMESPACE.
+    ///
+    /// Iterates [`Package::files`] and aggregates each file's
+    /// [`File::resolve_export`] for `name`.
+    ///
+    /// Returns a `Vec` because a package's namespace can carry more than one
+    /// binding per name. A common pattern is a top-level stub overridden from
+    /// an `.onLoad` hook via `<<-`:
+    ///
+    /// ```r
+    /// # R/foo.R
+    /// foo <- function() stop("not loaded yet")
+    ///
+    /// # R/zzz.R
+    /// .onLoad <- function(libname, pkgname) {
+    ///   foo <<- function() "real implementation"
+    /// }
+    /// ```
+    ///
+    /// Both bindings live in the package namespace; both come back as
+    /// candidates. Conditional fan-out within a single file (e.g.
+    /// `if cond x <- 1 else x <- 2`) surfaces here the same way.
+    ///
+    /// Returns an empty Vec when the name isn't bound anywhere in the package,
+    /// or when `Exported` is requested for a name absent from
+    /// `namespace.exports`.
+    #[salsa::tracked]
+    pub fn resolve(
+        self,
+        db: &'db dyn Db,
+        name: Name<'db>,
+        visibility: PackageVisibility,
+    ) -> Vec<Definition<'db>> {
+        if visibility == PackageVisibility::Exported &&
+            !self
+                .namespace(db)
+                .exports
+                .contains_str(name.text(db).as_str())
+        {
+            return Vec::new();
+        }
+
+        let mut results = Vec::new();
+        for &file in self.files(db) {
+            results.extend(file.resolve_export(db, name));
+        }
+
+        results
+    }
+}

--- a/crates/oak_db/src/package_resolve.rs
+++ b/crates/oak_db/src/package_resolve.rs
@@ -69,6 +69,24 @@ impl<'db> Package {
             results.extend(file.resolve_export(db, name));
         }
 
+        // Re-exports. A name brought in by `importFrom()` and surfaced again by
+        // `export()` has no binding in this package's own files, so the loop
+        // above returns empty. Follow the import to the source package and
+        // resolve the name among its exports instead.
+        if results.is_empty() {
+            let name_str = name.text(db).as_str();
+            if let Some(import) = self
+                .namespace(db)
+                .imports
+                .iter()
+                .find(|import| import.name == name_str)
+            {
+                if let Some(source) = db.package_by_name(&import.package) {
+                    results = source.resolve(db, name, PackageVisibility::Exported);
+                }
+            }
+        }
+
         results
     }
 }

--- a/crates/oak_db/src/tests.rs
+++ b/crates/oak_db/src/tests.rs
@@ -8,5 +8,6 @@ mod file_resolve_at;
 mod file_root;
 mod identifier;
 mod inputs;
+mod package_resolve;
 mod resolver;
 mod test_db;

--- a/crates/oak_db/src/tests/file_resolve_at.rs
+++ b/crates/oak_db/src/tests/file_resolve_at.rs
@@ -1,6 +1,7 @@
 use biome_rowan::TextSize;
 use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
+use stdext::SortedVec;
 
 use crate::tests::test_db::file_path;
 use crate::tests::test_db::workspace_root;
@@ -10,6 +11,7 @@ use crate::Definition;
 use crate::File;
 use crate::Package;
 use crate::Root;
+use crate::RootKind;
 
 fn make_file(db: &mut TestDb, path: &str, contents: &str) -> File {
     File::new(db, file_path(path), contents.to_string(), None)
@@ -338,21 +340,36 @@ fn install_library_package(
     exports: &[&str],
     files: &[(&str, &str)],
 ) -> (Root, Package) {
-    use oak_package_metadata::namespace::Namespace;
-    use stdext::SortedVec;
+    install_package(db, RootKind::Library, name, exports, files)
+}
 
-    use crate::tests::test_db::library_root;
-
-    let root = library_root(db, &format!("library/{name}"));
+fn install_package(
+    db: &mut TestDb,
+    kind: RootKind,
+    name: &str,
+    exports: &[&str],
+    files: &[(&str, &str)],
+) -> (Root, Package) {
+    let (prefix, version) = match kind {
+        RootKind::Library => ("library", Some("1.0.0".to_string())),
+        RootKind::Workspace => ("workspace", None),
+    };
+    let root = Root::new(
+        db,
+        file_url(&format!("{prefix}/{name}")),
+        kind,
+        vec![],
+        vec![],
+    );
     let namespace = Namespace {
         exports: SortedVec::from_vec(exports.iter().map(|s| s.to_string()).collect()),
         ..Default::default()
     };
     let pkg = Package::new(
         db,
-        file_url(&format!("library/{name}/DESCRIPTION")),
+        file_url(&format!("{prefix}/{name}/DESCRIPTION")),
         name.to_string(),
-        Some("1.0.0".to_string()),
+        version,
         namespace,
         Vec::new(),
         Vec::new(),
@@ -364,7 +381,10 @@ fn install_library_package(
         .collect();
     pkg.set_files(db).to(pkg_files);
     root.set_packages(db).to(vec![pkg]);
-    db.library_roots().set_roots(db).to(vec![root]);
+    match kind {
+        RootKind::Library => db.library_roots().set_roots(db).to(vec![root]),
+        RootKind::Workspace => db.workspace_roots().set_roots(db).to(vec![root]),
+    };
     (root, pkg)
 }
 
@@ -386,6 +406,31 @@ fn test_library_call_makes_pkg_export_resolve() {
     let source = script.contents(&db).clone();
 
     // Cursor on `foo` (the use after `library(mypkg)`).
+    let offset = TextSize::from(source.rfind("foo").unwrap() as u32);
+    let def = resolve_one(&db, script, offset);
+
+    assert_eq!(def.file(&db), pkg_file);
+    assert_eq!(def.name(&db).text(&db).as_str(), "foo");
+}
+
+#[test]
+fn test_library_call_makes_workspace_pkg_export_resolve() {
+    // Same as `test_library_call_makes_pkg_export_resolve` but `mypkg` lives
+    // in the workspace rather than an installed library. `package_by_name`
+    // walks both workspace and library roots, so the resolution path is the
+    // same for both.
+    let mut db = TestDb::new();
+    let (_root, pkg) = install_package(&mut db, RootKind::Workspace, "mypkg", &["foo"], &[(
+        "workspace/mypkg/R/a.R",
+        "foo <- function() 42\n",
+    )]);
+    let pkg_file = pkg.files(&db)[0];
+
+    // Script is a floating file (no root registration needed for `imports()`
+    // to find workspace packages via `package_by_name`).
+    let source = "library(mypkg)\nfoo\n";
+    let script = make_file(&mut db, "ws/script.R", source);
+
     let offset = TextSize::from(source.rfind("foo").unwrap() as u32);
     let def = resolve_one(&db, script, offset);
 

--- a/crates/oak_db/src/tests/file_resolve_at.rs
+++ b/crates/oak_db/src/tests/file_resolve_at.rs
@@ -321,20 +321,172 @@ fn test_top_level_conditional_reports_both_arm_defs() {
     assert!(starts.contains(&source.find("foo <- 2").unwrap()));
 }
 
-// Package-layer resolution, pending. `resolve` / `resolve_at` walk only
-// `ImportLayer::File`; the `From` / `Package` layers (`library()`, NAMESPACE
-// `importFrom`, the base search path) are deferred, see the TODOs in
-// `file_resolve.rs`. These scenarios came from the old goto-def `LegacyDb`
-// suite, which only asserted them as unsupported (resolved to `None`). When
-// package layers land, add them here on `resolve_at`:
+// Package-layer resolution, remaining items. These need either installed-package
+// files as `oak_db::File` entities (for navigable locations) or a broader test
+// infrastructure:
 //
-// - `library(pkg)` in a script makes a `pkg` export resolve at a later use.
 // - `importFrom(dplyr, mutate)` in a package's NAMESPACE makes `mutate` resolve.
 // - a package file resolves base symbols (e.g. `cat`).
 // - a standalone script resolves base / default-attached symbols.
 // - a script's search path is identical at top level and in a function body.
 // - `library()` attached inside a sourced file is visible to a function body
 //   that runs after the `source()`.
-//
-// Resolving package symbols also needs a navigable location for installed
-// package files, which aren't `oak_db::File` entities yet.
+
+fn install_library_package(
+    db: &mut TestDb,
+    name: &str,
+    exports: &[&str],
+    files: &[(&str, &str)],
+) -> (Root, Package) {
+    use oak_package_metadata::namespace::Namespace;
+    use stdext::SortedVec;
+
+    use crate::tests::test_db::library_root;
+
+    let root = library_root(db, &format!("library/{name}"));
+    let namespace = Namespace {
+        exports: SortedVec::from_vec(exports.iter().map(|s| s.to_string()).collect()),
+        ..Default::default()
+    };
+    let pkg = Package::new(
+        db,
+        file_url(&format!("library/{name}/DESCRIPTION")),
+        name.to_string(),
+        Some("1.0.0".to_string()),
+        namespace,
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let pkg_files: Vec<File> = files
+        .iter()
+        .map(|(path, contents)| File::new(db, file_url(path), contents.to_string(), Some(pkg)))
+        .collect();
+    pkg.set_files(db).to(pkg_files);
+    root.set_packages(db).to(vec![pkg]);
+    db.library_roots().set_roots(db).to(vec![root]);
+    (root, pkg)
+}
+
+#[test]
+fn test_library_call_makes_pkg_export_resolve() {
+    // `library(mypkg)` in a script attaches `mypkg` as a `Package` layer.
+    // A later bare use of an exported name should resolve to the binding
+    // in `mypkg`'s file.
+    let mut db = TestDb::new();
+    let (_root, pkg) = install_library_package(&mut db, "mypkg", &["foo"], &[(
+        "library/mypkg/R/a.R",
+        "foo <- function() 42\n",
+    )]);
+    let pkg_file = pkg.files(&db)[0];
+
+    let (_ws_root, files) =
+        setup_workspace_scripts(&mut db, "ws", &[("ws/script.R", "library(mypkg)\nfoo\n")]);
+    let script = files[0];
+    let source = script.contents(&db).clone();
+
+    // Cursor on `foo` (the use after `library(mypkg)`).
+    let offset = TextSize::from(source.rfind("foo").unwrap() as u32);
+    let def = resolve_one(&db, script, offset);
+
+    assert_eq!(def.file(&db), pkg_file);
+    assert_eq!(def.name(&db).text(&db).as_str(), "foo");
+}
+
+#[test]
+fn test_namespace_import_pkg_makes_export_resolve_in_package_file() {
+    // A package file whose NAMESPACE has `import(extpkg)` can resolve
+    // a bare use of `bar` to `extpkg`'s file via the `Package` layer that
+    // `package_imports` injects.
+    let mut db = TestDb::new();
+    let (_lib_root, ext_pkg) = install_library_package(&mut db, "extpkg", &["bar"], &[(
+        "library/extpkg/R/b.R",
+        "bar <- function() 99\n",
+    )]);
+    let ext_file = ext_pkg.files(&db)[0];
+
+    // Workspace package that `import(extpkg)` in its NAMESPACE.
+    let ws_root = workspace_root(&db, "workspace/mypkg");
+    let ns = {
+        use oak_package_metadata::namespace::Namespace;
+        Namespace {
+            package_imports: vec!["extpkg".to_string()],
+            ..Default::default()
+        }
+    };
+    let ws_pkg = Package::new(
+        &db,
+        file_url("workspace/mypkg/DESCRIPTION"),
+        "mypkg".to_string(),
+        None,
+        ns,
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let source = "bar\n";
+    let ws_file = File::new(
+        &db,
+        file_url("workspace/mypkg/R/a.R"),
+        source.to_string(),
+        Some(ws_pkg),
+    );
+    ws_pkg.set_files(&mut db).to(vec![ws_file]);
+    ws_root.set_packages(&mut db).to(vec![ws_pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![ws_root]);
+
+    let offset = TextSize::from(0);
+    let def = resolve_one(&db, ws_file, offset);
+
+    assert_eq!(def.file(&db), ext_file);
+    assert_eq!(def.name(&db).text(&db).as_str(), "bar");
+}
+
+#[test]
+fn test_namespace_importfrom_makes_export_resolve_in_package_file() {
+    // A package file whose NAMESPACE has `importFrom(extpkg, baz)` resolves a
+    // bare use of `baz` to `extpkg`'s file via the `From` layer that
+    // `package_imports` injects (symbol -> source-package map).
+    use oak_package_metadata::namespace::Import;
+    use oak_package_metadata::namespace::Namespace;
+
+    let mut db = TestDb::new();
+    let (_lib_root, ext_pkg) = install_library_package(&mut db, "extpkg", &["baz"], &[(
+        "library/extpkg/R/b.R",
+        "baz <- function() 99\n",
+    )]);
+    let ext_file = ext_pkg.files(&db)[0];
+
+    let ws_root = workspace_root(&db, "workspace/mypkg");
+    let ns = Namespace {
+        imports: vec![Import {
+            name: "baz".to_string(),
+            package: "extpkg".to_string(),
+        }],
+        ..Default::default()
+    };
+    let ws_pkg = Package::new(
+        &db,
+        file_url("workspace/mypkg/DESCRIPTION"),
+        "mypkg".to_string(),
+        None,
+        ns,
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let ws_file = File::new(
+        &db,
+        file_url("workspace/mypkg/R/a.R"),
+        "baz\n".to_string(),
+        Some(ws_pkg),
+    );
+    ws_pkg.set_files(&mut db).to(vec![ws_file]);
+    ws_root.set_packages(&mut db).to(vec![ws_pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![ws_root]);
+
+    let def = resolve_one(&db, ws_file, TextSize::from(0));
+
+    assert_eq!(def.file(&db), ext_file);
+    assert_eq!(def.name(&db).text(&db).as_str(), "baz");
+}

--- a/crates/oak_db/src/tests/file_resolve_at.rs
+++ b/crates/oak_db/src/tests/file_resolve_at.rs
@@ -356,7 +356,7 @@ fn install_package(
     };
     let root = Root::new(
         db,
-        file_url(&format!("{prefix}/{name}")),
+        file_path(&format!("{prefix}/{name}")),
         kind,
         vec![],
         vec![],
@@ -367,7 +367,7 @@ fn install_package(
     };
     let pkg = Package::new(
         db,
-        file_url(&format!("{prefix}/{name}/DESCRIPTION")),
+        file_path(&format!("{prefix}/{name}/DESCRIPTION")),
         name.to_string(),
         version,
         namespace,
@@ -377,7 +377,7 @@ fn install_package(
     );
     let pkg_files: Vec<File> = files
         .iter()
-        .map(|(path, contents)| File::new(db, file_url(path), contents.to_string(), Some(pkg)))
+        .map(|(path, contents)| File::new(db, file_path(path), contents.to_string(), Some(pkg)))
         .collect();
     pkg.set_files(db).to(pkg_files);
     root.set_packages(db).to(vec![pkg]);
@@ -461,7 +461,7 @@ fn test_namespace_import_pkg_makes_export_resolve_in_package_file() {
     };
     let ws_pkg = Package::new(
         &db,
-        file_url("workspace/mypkg/DESCRIPTION"),
+        file_path("workspace/mypkg/DESCRIPTION"),
         "mypkg".to_string(),
         None,
         ns,
@@ -472,7 +472,7 @@ fn test_namespace_import_pkg_makes_export_resolve_in_package_file() {
     let source = "bar\n";
     let ws_file = File::new(
         &db,
-        file_url("workspace/mypkg/R/a.R"),
+        file_path("workspace/mypkg/R/a.R"),
         source.to_string(),
         Some(ws_pkg),
     );
@@ -512,7 +512,7 @@ fn test_namespace_importfrom_makes_export_resolve_in_package_file() {
     };
     let ws_pkg = Package::new(
         &db,
-        file_url("workspace/mypkg/DESCRIPTION"),
+        file_path("workspace/mypkg/DESCRIPTION"),
         "mypkg".to_string(),
         None,
         ns,
@@ -522,7 +522,7 @@ fn test_namespace_importfrom_makes_export_resolve_in_package_file() {
     );
     let ws_file = File::new(
         &db,
-        file_url("workspace/mypkg/R/a.R"),
+        file_path("workspace/mypkg/R/a.R"),
         "baz\n".to_string(),
         Some(ws_pkg),
     );

--- a/crates/oak_db/src/tests/package_resolve.rs
+++ b/crates/oak_db/src/tests/package_resolve.rs
@@ -1,0 +1,199 @@
+use oak_package_metadata::namespace::Namespace;
+use salsa::Setter;
+use stdext::SortedVec;
+
+use crate::tests::test_db::file_url;
+use crate::tests::test_db::workspace_root;
+use crate::tests::test_db::TestDb;
+use crate::DbInputs;
+use crate::File;
+use crate::Name;
+use crate::Package;
+use crate::PackageVisibility;
+
+/// Build a `pkg`-named workspace package with files at the given paths and
+/// contents. NAMESPACE exports are taken from `exports`. Returns the package
+/// and the files in input order.
+fn setup_package(
+    db: &mut TestDb,
+    pkg_name: &str,
+    exports: &[&str],
+    files: &[(&str, &str)],
+) -> (Package, Vec<File>) {
+    let root = workspace_root(db, &format!("workspace/{pkg_name}"));
+    let namespace = Namespace {
+        exports: SortedVec::from_vec(exports.iter().map(|s| s.to_string()).collect()),
+        ..Default::default()
+    };
+    let pkg = Package::new(
+        db,
+        file_url(&format!("workspace/{pkg_name}/DESCRIPTION")),
+        pkg_name.to_string(),
+        None,
+        namespace,
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+
+    let file_entities: Vec<File> = files
+        .iter()
+        .map(|(path, contents)| File::new(db, file_url(path), contents.to_string(), Some(pkg)))
+        .collect();
+    pkg.set_files(db).to(file_entities.clone());
+    root.set_packages(db).to(vec![pkg]);
+    db.workspace_roots().set_roots(db).to(vec![root]);
+
+    (pkg, file_entities)
+}
+
+fn name<'db>(db: &'db TestDb, text: &str) -> Name<'db> {
+    Name::new(db, text)
+}
+
+#[test]
+fn test_exported_visible_via_exported_lookup() {
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "pkg", &["foo"], &[(
+        "workspace/pkg/R/a.R",
+        "foo <- function() 1\n",
+    )]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].file(&db), files[0]);
+    assert_eq!(defs[0].name(&db).text(&db).as_str(), "foo");
+}
+
+#[test]
+fn test_exported_lookup_filters_unexported_name() {
+    // `foo` is bound in the package but not in NAMESPACE.exports. The
+    // `Exported` lookup must not surface it.
+    let mut db = TestDb::new();
+    let (pkg, _files) = setup_package(&mut db, "pkg", &[], &[(
+        "workspace/pkg/R/a.R",
+        "foo <- function() 1\n",
+    )]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert!(defs.is_empty());
+}
+
+#[test]
+fn test_internal_lookup_finds_unexported_name() {
+    // `pkg:::foo` sees the binding even though it's not in NAMESPACE.exports.
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "pkg", &[], &[(
+        "workspace/pkg/R/a.R",
+        "foo <- function() 1\n",
+    )]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Internal);
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].file(&db), files[0]);
+}
+
+#[test]
+fn test_internal_lookup_also_finds_exported_name() {
+    // `:::` is a superset: exported names are also reachable via Internal.
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "pkg", &["foo"], &[(
+        "workspace/pkg/R/a.R",
+        "foo <- function() 1\n",
+    )]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Internal);
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].file(&db), files[0]);
+}
+
+#[test]
+fn test_unknown_name_returns_empty() {
+    let mut db = TestDb::new();
+    let (pkg, _files) = setup_package(&mut db, "pkg", &["foo"], &[(
+        "workspace/pkg/R/a.R",
+        "foo <- function() 1\n",
+    )]);
+
+    assert!(pkg
+        .resolve(&db, name(&db, "nope"), PackageVisibility::Exported)
+        .is_empty());
+    assert!(pkg
+        .resolve(&db, name(&db, "nope"), PackageVisibility::Internal)
+        .is_empty());
+}
+
+#[test]
+fn test_resolves_binding_in_correct_file_for_multi_file_package() {
+    // `foo` is in `a.R`, `bar` is in `b.R`. Each `pkg::name` lookup
+    // lands on the right file.
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "pkg", &["foo", "bar"], &[
+        ("workspace/pkg/R/a.R", "foo <- function() 1\n"),
+        ("workspace/pkg/R/b.R", "bar <- function() 2\n"),
+    ]);
+
+    let foo_defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert_eq!(foo_defs.len(), 1);
+    assert_eq!(foo_defs[0].file(&db), files[0]);
+
+    let bar_defs = pkg.resolve(&db, name(&db, "bar"), PackageVisibility::Exported);
+    assert_eq!(bar_defs.len(), 1);
+    assert_eq!(bar_defs[0].file(&db), files[1]);
+}
+
+#[test]
+fn test_conditional_binding_single_under_last_wins_exports() {
+    // Top-level `if (cond) foo <- 1 else foo <- 2` in principle produces two
+    // candidate Definitions for `foo`. Full fan-out requires multi-target
+    // exports (PR 3, deferred). Under the current single-target model,
+    // `file_exports` keeps the last-wins definition, so `Package::resolve`
+    // returns exactly one. The stub+onload case across two files still works.
+    let mut db = TestDb::new();
+    let (pkg, _files) = setup_package(&mut db, "pkg", &["foo"], &[(
+        "workspace/pkg/R/a.R",
+        "if (cond) foo <- 1 else foo <- 2\n",
+    )]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert_eq!(defs.len(), 1);
+}
+
+#[test]
+fn test_stub_and_onload_override_both_returned() {
+    // The R-package idiom: a top-level stub plus a runtime override
+    // installed from `.onLoad` via `<<-`. Both bindings live in the
+    // package namespace, so `Package::resolve` returns both.
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "pkg", &["foo"], &[
+        ("workspace/pkg/R/foo.R", "foo <- function() stop('stub')\n"),
+        (
+            "workspace/pkg/R/zzz.R",
+            ".onLoad <- function(libname, pkgname) {\n  foo <<- function() 'real'\n}\n",
+        ),
+    ]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert_eq!(defs.len(), 2);
+    let target_files: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
+    assert!(target_files.contains(&files[0]));
+    assert!(target_files.contains(&files[1]));
+}
+
+#[test]
+fn test_same_name_defined_in_multiple_files_returns_each() {
+    // Two files in the package both define `foo`. `Package::resolve`
+    // surfaces both candidates. (R's runtime would have one wins via
+    // collation order, but goto-def should offer all candidates.)
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "pkg", &["foo"], &[
+        ("workspace/pkg/R/a.R", "foo <- function() 1\n"),
+        ("workspace/pkg/R/b.R", "foo <- function() 2\n"),
+    ]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert_eq!(defs.len(), 2);
+    let target_files: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
+    assert!(target_files.contains(&files[0]));
+    assert!(target_files.contains(&files[1]));
+}

--- a/crates/oak_db/src/tests/package_resolve.rs
+++ b/crates/oak_db/src/tests/package_resolve.rs
@@ -1,3 +1,4 @@
+use oak_package_metadata::namespace::Import;
 use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
 use stdext::SortedVec;
@@ -178,6 +179,72 @@ fn test_stub_and_onload_override_both_returned() {
     let target_files: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
     assert!(target_files.contains(&files[0]));
     assert!(target_files.contains(&files[1]));
+}
+
+#[test]
+fn test_reexport_via_import_from_resolves_to_source() {
+    // dplyr re-exports tibble's `tibble`: NAMESPACE carries `export(tibble)`
+    // plus `importFrom(tibble, tibble)`, and the only R source is a bare
+    // `tibble::tibble` expression (not an assignment). The binding lives in
+    // tibble, so `dplyr::tibble` must follow the import and resolve there.
+    let mut db = TestDb::new();
+    let root = workspace_root(&db, "workspace");
+
+    let tibble_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["tibble".to_string()]),
+        ..Default::default()
+    };
+    let tibble = Package::new(
+        &db,
+        file_path("workspace/tibble/DESCRIPTION"),
+        "tibble".to_string(),
+        None,
+        tibble_ns,
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let tibble_file = File::new(
+        &db,
+        file_path("workspace/tibble/R/tibble.R"),
+        "tibble <- function() 1\n".to_string(),
+        Some(tibble),
+    );
+    tibble.set_files(&mut db).to(vec![tibble_file]);
+
+    let dplyr_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["tibble".to_string()]),
+        imports: vec![Import {
+            name: "tibble".to_string(),
+            package: "tibble".to_string(),
+        }],
+        ..Default::default()
+    };
+    let dplyr = Package::new(
+        &db,
+        file_path("workspace/dplyr/DESCRIPTION"),
+        "dplyr".to_string(),
+        None,
+        dplyr_ns,
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let dplyr_file = File::new(
+        &db,
+        file_path("workspace/dplyr/R/reexport.R"),
+        "tibble::tibble\n".to_string(),
+        Some(dplyr),
+    );
+    dplyr.set_files(&mut db).to(vec![dplyr_file]);
+
+    root.set_packages(&mut db).to(vec![tibble, dplyr]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let defs = dplyr.resolve(&db, name(&db, "tibble"), PackageVisibility::Exported);
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].file(&db), tibble_file);
+    assert_eq!(defs[0].name(&db).text(&db).as_str(), "tibble");
 }
 
 #[test]

--- a/crates/oak_db/src/tests/package_resolve.rs
+++ b/crates/oak_db/src/tests/package_resolve.rs
@@ -2,7 +2,7 @@ use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
 use stdext::SortedVec;
 
-use crate::tests::test_db::file_url;
+use crate::tests::test_db::file_path;
 use crate::tests::test_db::workspace_root;
 use crate::tests::test_db::TestDb;
 use crate::DbInputs;
@@ -27,7 +27,7 @@ fn setup_package(
     };
     let pkg = Package::new(
         db,
-        file_url(&format!("workspace/{pkg_name}/DESCRIPTION")),
+        file_path(&format!("workspace/{pkg_name}/DESCRIPTION")),
         pkg_name.to_string(),
         None,
         namespace,
@@ -38,7 +38,7 @@ fn setup_package(
 
     let file_entities: Vec<File> = files
         .iter()
-        .map(|(path, contents)| File::new(db, file_url(path), contents.to_string(), Some(pkg)))
+        .map(|(path, contents)| File::new(db, file_path(path), contents.to_string(), Some(pkg)))
         .collect();
     pkg.set_files(db).to(file_entities.clone());
     root.set_packages(db).to(vec![pkg]);

--- a/crates/oak_ide/Cargo.toml
+++ b/crates/oak_ide/Cargo.toml
@@ -29,3 +29,4 @@ oak_package_metadata.workspace = true
 oak_scan.workspace = true
 oak_semantic = { workspace = true, features = ["testing"] }
 salsa.workspace = true
+stdext.workspace = true

--- a/crates/oak_ide/src/find_references.rs
+++ b/crates/oak_ide/src/find_references.rs
@@ -9,6 +9,7 @@ use oak_db::Identifier;
 use oak_db::MemberKind;
 use oak_db::Name;
 use oak_db::PackageVisibility;
+use oak_db::RootKind;
 use oak_semantic::ScopeId;
 
 use crate::FileRange;
@@ -27,11 +28,11 @@ pub fn find_references(
     offset: TextSize,
     include_declaration: bool,
 ) -> Vec<FileRange> {
-    let Some(ident) = Identifier::classify(db, file, offset) else {
+    let Some(identifier) = Identifier::classify(db, file, offset) else {
         return Vec::new();
     };
 
-    match ident {
+    let mut refs = match identifier {
         Identifier::Variable { .. } => {
             find_variable_references(db, file, offset, include_declaration)
         },
@@ -41,7 +42,24 @@ pub fn find_references(
         Identifier::NamespaceAccess {
             namespace, name, ..
         } => find_namespace_references(db, file, namespace, name, include_declaration),
-    }
+    };
+
+    // Installed-package sources are read-only, so references there are noise we
+    // drop. The one exception is the package the cursor sits in: when the user
+    // has navigated into a library, they want references within that same
+    // package. Workspace hits are on the other hand always kept.
+    let cursor_package = file.package(db);
+    refs.retain(|reference| {
+        !is_library_file(db, reference.file) || reference.file.package(db) == cursor_package
+    });
+
+    refs
+}
+
+/// Whether `file` belongs to an installed (library) package root.
+fn is_library_file(db: &dyn Db, file: File) -> bool {
+    file.root(db)
+        .is_some_and(|root| root.kind(db) == RootKind::Library)
 }
 
 fn find_variable_references(

--- a/crates/oak_ide/src/find_references.rs
+++ b/crates/oak_ide/src/find_references.rs
@@ -8,16 +8,19 @@ use oak_db::File;
 use oak_db::Identifier;
 use oak_db::MemberKind;
 use oak_db::Name;
+use oak_db::PackageVisibility;
 use oak_semantic::ScopeId;
 
 use crate::FileRange;
 
 /// Find all references to the symbol at `offset` in `file`.
 ///
-/// Uses `resolve_at()` to confirm each candidate: a textual mention of the
-/// same name is only included when it resolves to the same definition set.
-/// Member-name cursors (`$`/`@` RHS) and namespace-access cursors (`pkg::sym`
-/// RHS) fall back to a structural cross-file scan.
+/// Uses `resolve_at()` to confirm each candidate: a textual mention of the same
+/// name is only included when it resolves to the same definition set. A
+/// `pkg::sym` cursor on a package we know about resolves `sym` to its
+/// definition and runs the same confirmation path. Member-name cursors (`$`/`@`
+/// RHS) and `pkg::sym` cursors on an unknown package fall back to a structural
+/// cross-file scan.
 pub fn find_references(
     db: &dyn Db,
     file: File,
@@ -37,19 +40,7 @@ pub fn find_references(
         },
         Identifier::NamespaceAccess {
             namespace, name, ..
-        } => {
-            // TODO(namespace-refs): also union the bare-name references, the
-            // inverse of the bridge in `find_variable_references`. When
-            // `namespace` is a workspace package, resolve `name` to its
-            // definition and run the variable path. Installed-package symbols
-            // wait on package resolution (see `find_namespace_references`).
-            find_namespace_references(
-                db,
-                file,
-                namespace.text(db).as_str(),
-                name.text(db).as_str(),
-            )
-        },
+        } => find_namespace_references(db, file, namespace, name, include_declaration),
     }
 }
 
@@ -62,6 +53,17 @@ fn find_variable_references(
     let Some((name, _, target_defs)) = file.resolve_variable_at(db, offset) else {
         return Vec::new();
     };
+    collect_definition_references(db, file, name, target_defs, include_declaration)
+}
+
+/// Find every reference that resolves to the same binding as `target_defs`.
+fn collect_definition_references<'db>(
+    db: &'db dyn Db,
+    file: File,
+    name: Name<'db>,
+    target_defs: Vec<Definition<'db>>,
+    include_declaration: bool,
+) -> Vec<FileRange> {
     if target_defs.is_empty() {
         return Vec::new();
     }
@@ -125,10 +127,9 @@ fn find_variable_references(
 /// confirmation that it's the right symbol, so unlike the bare-name path this
 /// needs no re-resolution.
 ///
-/// TODO(namespace-refs): the reverse (cursor on `pkg::name` also finding bare
-/// `name`) is unimplemented in the `NamespaceAccess` arm of `find_references`.
-/// Installed-package symbols bridge in neither direction until package
-/// resolution lands (see `find_namespace_references`).
+/// The reverse direction (cursor on `pkg::name` also finding bare `name`) runs
+/// through [`find_namespace_references`], which resolves `name` in `pkg` and
+/// hands the definitions to `collect_definition_references`.
 fn collect_package_qualified_uses<'db>(
     db: &'db dyn Db,
     target_defs: &[Definition<'db>],
@@ -165,16 +166,37 @@ fn find_member_references(db: &dyn Db, file: File, name: &str, kind: MemberKind)
     results
 }
 
-fn find_namespace_references(
-    db: &dyn Db,
+/// References for a `pkg::name` cursor.
+///
+/// When we know `pkg` (a workspace or installed package in the db), resolve
+/// `name` against it and run the path shared with bare variables. We resolve
+/// with `Internal` visibility because `::` and `:::` name the same binding for
+/// a references search, so we want the definition whether or not it is
+/// exported.
+///
+/// When `pkg` is unknown (e.g. an installed package not loaded into the db),
+/// there is no definition to compare against, so fall back to a structural scan
+/// that matches `pkg::name` sites by text.
+fn find_namespace_references<'db>(
+    db: &'db dyn Db,
     primary: File,
-    namespace: &str,
-    name: &str,
+    namespace: Name<'db>,
+    name: Name<'db>,
+    include_declaration: bool,
 ) -> Vec<FileRange> {
+    if let Some(package) = db.package_by_name(namespace.text(db).as_str()) {
+        let defs = package.resolve(db, name, PackageVisibility::Internal);
+        if !defs.is_empty() {
+            return collect_definition_references(db, primary, name, defs, include_declaration);
+        }
+    }
+
     let mut results = Vec::new();
 
-    for file in all_matching_files(db, name) {
-        for range in file.namespace_uses_of(db, namespace, name) {
+    let namespace = namespace.text(db);
+    let name = name.text(db);
+    for file in all_matching_files(db, name.as_str()) {
+        for range in file.namespace_uses_of(db, namespace.as_str(), name.as_str()) {
             results.push(FileRange { file, range });
         }
     }

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -406,8 +406,7 @@ fn test_cursor_in_installed_package_excludes_other_packages() {
     let mut db = OakDatabase::new();
     let mypkg_file =
         install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 1\n");
-    let _otherpkg_file =
-        install_library_package(&mut db, "otherpkg", &[], "b.R", "mypkg::foo()\n");
+    let _otherpkg_file = install_library_package(&mut db, "otherpkg", &[], "b.R", "mypkg::foo()\n");
     let script = upsert(&mut db, "script.R", "mypkg::foo()\n");
 
     // Cursor on the def `foo` at offset 0 inside `mypkg`.

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -350,5 +350,8 @@ fn test_cross_package_references_via_library() {
     // Excluding the declaration drops the package definition `pkg_file`,
     // leaving only the script use.
     let refs = find_references(&db, script, offset(use_start), false);
-    assert_eq!(pairs(&refs), vec![(script, range(use_start, use_start + 3))]);
+    assert_eq!(pairs(&refs), vec![(
+        script,
+        range(use_start, use_start + 3)
+    )]);
 }

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -9,53 +9,17 @@
 //! then by source offset), so tests assert the full result vector rather than
 //! membership.
 
-use aether_path::FilePath;
-use biome_rowan::TextRange;
 use biome_rowan::TextSize;
-use oak_db::DbInputs;
-use oak_db::File;
 use oak_db::OakDatabase;
-use oak_db::Package;
-use oak_db::Root;
-use oak_db::RootKind;
 use oak_ide::find_references;
-use oak_ide::FileRange;
-use oak_package_metadata::namespace::Namespace;
-use oak_scan::DbScan;
-use salsa::Setter;
-use url::Url;
 
-fn file_url(name: &str) -> Url {
-    // `Url::to_file_path` on Windows requires a drive-letter prefix, so
-    // synthesize one for tests. Linux is happy with rootless paths.
-    if cfg!(windows) {
-        Url::parse(&format!("file:///C:/project/R/{name}")).unwrap()
-    } else {
-        Url::parse(&format!("file:///project/R/{name}")).unwrap()
-    }
-}
-
-fn upsert(db: &mut OakDatabase, name: &str, contents: &str) -> File {
-    db.upsert_editor(FilePath::from_url(&file_url(name)), contents.to_string())
-}
-
-fn offset(n: u32) -> TextSize {
-    TextSize::from(n)
-}
-
-fn range(start: u32, end: u32) -> TextRange {
-    TextRange::new(TextSize::from(start), TextSize::from(end))
-}
-
-/// Project results down to in-file ranges, for single-file tests.
-fn ranges(refs: &[FileRange]) -> Vec<TextRange> {
-    refs.iter().map(|r| r.range).collect()
-}
-
-/// Project results down to (file, range) pairs, for cross-file tests.
-fn pairs(refs: &[FileRange]) -> Vec<(File, TextRange)> {
-    refs.iter().map(|r| (r.file, r.range)).collect()
-}
+use crate::support::install_library_package;
+use crate::support::install_workspace_package;
+use crate::support::offset;
+use crate::support::pairs;
+use crate::support::range;
+use crate::support::ranges;
+use crate::support::upsert;
 
 // --- Local resolution ---
 
@@ -349,8 +313,8 @@ fn test_package_symbol_bridges_to_namespace_access() {
     // same binding. `script.R`'s bare `foo` doesn't resolve to `pkg` (no
     // attach), so it isn't included.
     let mut db = OakDatabase::new();
-    let pkg_files = build_workspace_package(&mut db, &[("foo.R", "foo <- function() 1\n")]);
-    let foo_file = pkg_files[0];
+    let foo_file =
+        install_workspace_package(&mut db, "pkg", &["foo"], "foo.R", "foo <- function() 1\n");
     let script = upsert(&mut db, "script.R", "pkg::foo()\nfoo\n");
 
     // Cursor on the def `foo` at offset 0.
@@ -364,38 +328,22 @@ fn test_package_symbol_bridges_to_namespace_access() {
     ]);
 }
 
-// --- helpers for root / package wiring ---
+#[test]
+fn test_cross_package_references_via_library() {
+    // A script attaches `mypkg` and uses its exported `foo`. The use resolves
+    // through the package layer to the binding in the package file, so
+    // find-references reports both the script use and (with include_declaration)
+    // the package definition. Newly live now that package-layer resolution
+    // feeds `resolve_at`.
+    let mut db = OakDatabase::new();
+    let pkg_file =
+        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
 
-/// Build a workspace package holding `files` (name, contents), each with the
-/// package back-pointer set, and register it under a workspace root. Returns
-/// the created `File`s in order.
-fn build_workspace_package(db: &mut OakDatabase, files: &[(&str, &str)]) -> Vec<File> {
-    let pkg = empty_package(db, "file:///project/pkg/DESCRIPTION");
-    let created: Vec<File> = files
-        .iter()
-        .map(|(name, contents)| {
-            let url =
-                FilePath::from_url(&Url::parse(&format!("file:///project/pkg/R/{name}")).unwrap());
-            File::new(db, url, contents.to_string(), Some(pkg))
-        })
-        .collect();
-    pkg.set_files(db).to(created.clone());
-
-    let root_url = FilePath::from_url(&Url::parse("file:///project/pkg/").unwrap());
-    let root = Root::new(db, root_url, RootKind::Workspace, vec![], vec![pkg]);
-    db.workspace_roots().set_roots(db).to(vec![root]);
-    created
-}
-
-fn empty_package(db: &OakDatabase, description_url: &str) -> Package {
-    Package::new(
-        db,
-        FilePath::from_url(&Url::parse(description_url).unwrap()),
-        "pkg".to_string(),
-        None,
-        Namespace::default(),
-        vec![],
-        vec![],
-        None,
-    )
+    let use_start = "library(mypkg)\n".len() as u32;
+    let refs = find_references(&db, script, offset(use_start), true);
+    assert_eq!(pairs(&refs), vec![
+        (script, range(use_start, use_start + 3)),
+        (pkg_file, range(0, 3)),
+    ]);
 }

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -195,14 +195,12 @@ fn test_unbound_use_returns_empty() {
 
 #[test]
 fn test_namespace_rhs_returns_namespace_scan() {
-    // Cursor on `mutate` RHS of `::` uses the structural namespace scan: it
-    // matches `dplyr::mutate` across files but not `tidyr::mutate` (different
-    // namespace) nor a bare `mutate()` call (installed packages aren't in the
-    // resolution graph, so there's no shared definition to compare against).
-    //
-    // TODO(namespace-refs): once `resolve` consumes the `Package` / `From`
-    // import layers, a bare `mutate` will resolve to dplyr's `mutate` and
-    // belong here.
+    // Cursor on `mutate` RHS of `::` with no `dplyr` package in the db falls
+    // back to the structural namespace scan: it matches `dplyr::mutate` across
+    // files but not `tidyr::mutate` (different namespace) nor a bare `mutate()`
+    // call (no package to resolve through, so there's no shared definition to
+    // compare against). The resolve-and-bridge path is exercised by
+    // `test_namespace_access_bridges_to_bare_name`.
     let mut db = OakDatabase::new();
     let file = upsert(&mut db, "a.R", "dplyr::mutate\n");
     let file2 = upsert(&mut db, "b.R", "dplyr::mutate\ntidyr::mutate\nmutate()\n");
@@ -325,6 +323,29 @@ fn test_package_symbol_bridges_to_namespace_access() {
     assert_eq!(pairs(&refs), vec![
         (foo_file, range(0, 3)),
         (script, range(5, 8)),
+    ]);
+}
+
+#[test]
+fn test_namespace_access_bridges_to_bare_name() {
+    // The inverse of `test_package_symbol_bridges_to_namespace_access`: a cursor
+    // on `mypkg::foo` resolves `foo` in `mypkg` and runs the variable path, so
+    // it surfaces the bare `foo` use that attaches `mypkg` too. `script.R` does
+    // `library(mypkg)`, so its bare `foo` resolves to the same binding.
+    let mut db = OakDatabase::new();
+    let pkg_file =
+        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nmypkg::foo()\nfoo\n");
+
+    // Cursor on the `foo` in `mypkg::foo` (offset 22).
+    let refs = find_references(&db, script, offset(22), true);
+
+    // script.R (primary) first: the `mypkg::foo` qualified site (22..25) then the
+    // bare `foo` use (28..31). Then `mypkg`'s def in a.R (0..3).
+    assert_eq!(pairs(&refs), vec![
+        (script, range(22, 25)),
+        (script, range(28, 31)),
+        (pkg_file, range(0, 3)),
     ]);
 }
 

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -331,10 +331,11 @@ fn test_namespace_access_bridges_to_bare_name() {
     // The inverse of `test_package_symbol_bridges_to_namespace_access`: a cursor
     // on `mypkg::foo` resolves `foo` in `mypkg` and runs the variable path, so
     // it surfaces the bare `foo` use that attaches `mypkg` too. `script.R` does
-    // `library(mypkg)`, so its bare `foo` resolves to the same binding.
+    // `library(mypkg)`, so its bare `foo` resolves to the same binding. `mypkg`
+    // is a workspace package, so its editable def is included.
     let mut db = OakDatabase::new();
     let pkg_file =
-        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+        install_workspace_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
     let script = upsert(&mut db, "script.R", "library(mypkg)\nmypkg::foo()\nfoo\n");
 
     // Cursor on the `foo` in `mypkg::foo` (offset 22).
@@ -350,26 +351,95 @@ fn test_namespace_access_bridges_to_bare_name() {
 }
 
 #[test]
+fn test_namespace_access_excludes_installed_package_def() {
+    // Same shape as the workspace bridge, but `mypkg` is an *installed* package.
+    // Its source is read-only, so the def in a.R is dropped. Only the workspace
+    // sites in script.R survive: the `mypkg::foo` qualified site and the bare
+    // `foo` use that resolves through the attach.
+    let mut db = OakDatabase::new();
+    let _pkg_file =
+        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nmypkg::foo()\nfoo\n");
+
+    let refs = find_references(&db, script, offset(22), true);
+    assert_eq!(pairs(&refs), vec![
+        (script, range(22, 25)),
+        (script, range(28, 31)),
+    ]);
+}
+
+#[test]
+fn test_cursor_in_installed_package_finds_references() {
+    // The cursor is in installed-package source itself: the user has navigated
+    // into `mypkg` and runs find-references on its `foo`. Here library hits are
+    // wanted, so the exclusion is lifted. We get the def and the sibling use
+    // inside `mypkg`, plus the bare `foo` in the workspace script that attaches
+    // it.
+    let mut db = OakDatabase::new();
+    let pkg_file = install_library_package(
+        &mut db,
+        "mypkg",
+        &["foo"],
+        "a.R",
+        "foo <- function() 1\nfoo()\n",
+    );
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
+
+    // Cursor on the def `foo` at offset 0 inside the package file.
+    let refs = find_references(&db, pkg_file, offset(0), true);
+
+    // a.R (primary, the library file) first: def (0..3) then the sibling use
+    // `foo()` (20..23). Then the workspace use in script.R (15..18).
+    assert_eq!(pairs(&refs), vec![
+        (pkg_file, range(0, 3)),
+        (pkg_file, range(20, 23)),
+        (script, range(15, 18)),
+    ]);
+}
+
+#[test]
+fn test_cursor_in_installed_package_excludes_other_packages() {
+    // Cursor in `mypkg` source again, but now a *second* installed package,
+    // `otherpkg`, also calls `mypkg::foo`. References within `mypkg` and in the
+    // workspace are kept, but the hit inside `otherpkg` is dropped: it's
+    // read-only source the user didn't navigate into.
+    let mut db = OakDatabase::new();
+    let mypkg_file =
+        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 1\n");
+    let _otherpkg_file =
+        install_library_package(&mut db, "otherpkg", &[], "b.R", "mypkg::foo()\n");
+    let script = upsert(&mut db, "script.R", "mypkg::foo()\n");
+
+    // Cursor on the def `foo` at offset 0 inside `mypkg`.
+    let refs = find_references(&db, mypkg_file, offset(0), true);
+
+    // `mypkg`'s def (primary) and the workspace `mypkg::foo` site. `otherpkg`'s
+    // `mypkg::foo` is excluded.
+    assert_eq!(pairs(&refs), vec![
+        (mypkg_file, range(0, 3)),
+        (script, range(7, 10)),
+    ]);
+}
+
+#[test]
 fn test_cross_package_references_via_library() {
     // A script attaches `mypkg` and uses its exported `foo`. The use resolves
-    // through the package layer to the binding in the package file, so
-    // find-references reports both the script use and (with include_declaration)
-    // the package definition. Newly live now that package-layer resolution
-    // feeds `resolve_at`.
+    // through the package layer to the binding in the package file, confirming
+    // the cross-package resolution feeds `resolve_at`. The def lives in an
+    // installed package, so it is excluded from the results: only the script
+    // use is reported, with or without `include_declaration`.
     let mut db = OakDatabase::new();
-    let pkg_file =
+    let _pkg_file =
         install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
     let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
 
     let use_start = "library(mypkg)\n".len() as u32;
     let refs = find_references(&db, script, offset(use_start), true);
-    assert_eq!(pairs(&refs), vec![
-        (script, range(use_start, use_start + 3)),
-        (pkg_file, range(0, 3)),
-    ]);
+    assert_eq!(pairs(&refs), vec![(
+        script,
+        range(use_start, use_start + 3)
+    )]);
 
-    // Excluding the declaration drops the package definition `pkg_file`,
-    // leaving only the script use.
     let refs = find_references(&db, script, offset(use_start), false);
     assert_eq!(pairs(&refs), vec![(
         script,

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -346,4 +346,9 @@ fn test_cross_package_references_via_library() {
         (script, range(use_start, use_start + 3)),
         (pkg_file, range(0, 3)),
     ]);
+
+    // Excluding the declaration drops the package definition `pkg_file`,
+    // leaving only the script use.
+    let refs = find_references(&db, script, offset(use_start), false);
+    assert_eq!(pairs(&refs), vec![(script, range(use_start, use_start + 3))]);
 }

--- a/crates/oak_ide/tests/integration/goto_definition.rs
+++ b/crates/oak_ide/tests/integration/goto_definition.rs
@@ -6,32 +6,13 @@
 //! by `oak_db`'s `file_resolve_at` / `file_resolve` tests, and the use-def
 //! logic by `oak_semantic`; we don't re-test it here.
 
-use aether_path::FilePath;
-use biome_rowan::TextRange;
 use biome_rowan::TextSize;
-use oak_db::File;
 use oak_db::OakDatabase;
 use oak_ide::goto_definition;
-use oak_scan::DbScan;
-use url::Url;
 
-fn file_url(name: &str) -> Url {
-    // `Url::to_file_path` on Windows requires a drive-letter prefix, so
-    // synthesize one for tests. Linux is happy with rootless paths.
-    if cfg!(windows) {
-        Url::parse(&format!("file:///C:/project/R/{name}")).unwrap()
-    } else {
-        Url::parse(&format!("file:///project/R/{name}")).unwrap()
-    }
-}
-
-fn upsert(db: &mut OakDatabase, name: &str, contents: &str) -> File {
-    db.upsert_editor(FilePath::from_url(&file_url(name)), contents.to_string())
-}
-
-fn range(start: u32, end: u32) -> TextRange {
-    TextRange::new(TextSize::from(start), TextSize::from(end))
-}
+use crate::support::install_library_package;
+use crate::support::range;
+use crate::support::upsert;
 
 #[test]
 fn test_local_definition_navigates_to_binding() {
@@ -79,4 +60,28 @@ fn test_navigates_across_source_directive() {
     assert_eq!(target.file, helpers);
     assert_eq!(target.name, "helper");
     assert_eq!(target.full_range, range(0, 6));
+}
+
+#[test]
+fn test_navigates_to_package_export_via_library_call() {
+    // The package-layer wiring (`resolve_at` -> `Package::resolve`) must survive
+    // the handler's projection to a `NavigationTarget`. db-layer tests assert
+    // `def.file`/`def.name`; this pins down that a package-resolved binding
+    // actually yields a jump (i.e. its `name_range` is `Some`).
+    let mut db = OakDatabase::new();
+    let pkg_file =
+        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+
+    // A script attaches `mypkg`, then uses the exported `foo`.
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
+    let offset = TextSize::from("library(mypkg)\n".len() as u32);
+
+    let targets = goto_definition(&db, script, offset);
+    assert_eq!(targets.len(), 1);
+    let target = &targets[0];
+
+    // Jumps into the package file, at the `foo` binding's coordinates.
+    assert_eq!(target.file, pkg_file);
+    assert_eq!(target.name, "foo");
+    assert_eq!(target.full_range, range(0, 3));
 }

--- a/crates/oak_ide/tests/integration/main.rs
+++ b/crates/oak_ide/tests/integration/main.rs
@@ -1,3 +1,5 @@
+mod support;
+
 mod find_references;
 mod goto_definition;
 mod rename;

--- a/crates/oak_ide/tests/integration/rename.rs
+++ b/crates/oak_ide/tests/integration/rename.rs
@@ -63,7 +63,10 @@ fn test_prepare_rename_library_package_symbol_errors() {
     let lib_file = build_library_package_file(&mut db, "foo <- function() {}\n");
 
     let err = prepare_rename(&db, lib_file, offset(0)).unwrap_err();
-    assert!(err.to_string().contains("installed package"));
+    assert_eq!(
+        err.to_string(),
+        "Can't rename: symbol is defined in an installed package."
+    );
 }
 
 // --- rename: basic ---
@@ -183,7 +186,10 @@ fn test_rename_refuses_library_package_symbol() {
 
     // Cursor on the def `foo` at offset 0.
     let err = rename(&db, lib_file, offset(0)).unwrap_err();
-    assert!(err.to_string().contains("installed package"));
+    assert_eq!(
+        err.to_string(),
+        "Can't rename: symbol is defined in an installed package."
+    );
 }
 
 #[test]
@@ -199,7 +205,10 @@ fn test_rename_refuses_package_export_used_via_library() {
 
     let use_start = "library(mypkg)\n".len() as u32;
     let err = rename(&db, script, offset(use_start)).unwrap_err();
-    assert!(err.to_string().contains("installed package"));
+    assert_eq!(
+        err.to_string(),
+        "Can't rename: symbol is defined in an installed package."
+    );
 }
 
 #[test]

--- a/crates/oak_ide/tests/integration/rename.rs
+++ b/crates/oak_ide/tests/integration/rename.rs
@@ -14,6 +14,7 @@ use salsa::Setter;
 use url::Url;
 
 use crate::support::install_library_package;
+use crate::support::install_workspace_package;
 use crate::support::offset;
 use crate::support::pairs;
 use crate::support::range;
@@ -199,6 +200,24 @@ fn test_rename_refuses_package_export_used_via_library() {
     let use_start = "library(mypkg)\n".len() as u32;
     let err = rename(&db, script, offset(use_start)).unwrap_err();
     assert!(err.to_string().contains("installed package"));
+}
+
+#[test]
+fn test_rename_succeeds_for_workspace_package_export_via_library() {
+    // `library(mypkg)` where `mypkg` is a *workspace* package. Unlike an
+    // installed package, workspace files are editable, so rename must succeed
+    // and rewrite both the script use and the definition in the package file.
+    let mut db = OakDatabase::new();
+    let pkg_file =
+        install_workspace_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
+
+    let use_start = "library(mypkg)\n".len() as u32;
+    let result = rename(&db, script, offset(use_start), "bar").unwrap();
+    assert_eq!(pairs(&result.ranges), vec![
+        (script, range(use_start, use_start + 3)),
+        (pkg_file, range(0, 3)),
+    ]);
 }
 
 // --- helpers for root / package wiring ---

--- a/crates/oak_ide/tests/integration/rename.rs
+++ b/crates/oak_ide/tests/integration/rename.rs
@@ -222,8 +222,8 @@ fn test_rename_succeeds_for_workspace_package_export_via_library() {
     let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
 
     let use_start = "library(mypkg)\n".len() as u32;
-    let result = rename(&db, script, offset(use_start), "bar").unwrap();
-    assert_eq!(pairs(&result.ranges), vec![
+    let result = rename(&db, script, offset(use_start)).unwrap();
+    assert_eq!(pairs(&result), vec![
         (script, range(use_start, use_start + 3)),
         (pkg_file, range(0, 3)),
     ]);

--- a/crates/oak_ide/tests/integration/rename.rs
+++ b/crates/oak_ide/tests/integration/rename.rs
@@ -1,8 +1,6 @@
 //! Rename at the ide layer.
 
 use aether_path::FilePath;
-use biome_rowan::TextRange;
-use biome_rowan::TextSize;
 use oak_db::DbInputs;
 use oak_db::File;
 use oak_db::OakDatabase;
@@ -11,41 +9,16 @@ use oak_db::Root;
 use oak_db::RootKind;
 use oak_ide::prepare_rename;
 use oak_ide::rename;
-use oak_ide::FileRange;
 use oak_package_metadata::namespace::Namespace;
-use oak_scan::DbScan;
 use salsa::Setter;
 use url::Url;
 
-fn file_url(name: &str) -> Url {
-    // `Url::to_file_path` on Windows requires a drive-letter prefix, so
-    // synthesize one for tests. Linux is happy with rootless paths.
-    if cfg!(windows) {
-        Url::parse(&format!("file:///C:/project/R/{name}")).unwrap()
-    } else {
-        Url::parse(&format!("file:///project/R/{name}")).unwrap()
-    }
-}
-
-fn upsert(db: &mut OakDatabase, name: &str, contents: &str) -> File {
-    db.upsert_editor(FilePath::from_url(&file_url(name)), contents.to_string())
-}
-
-fn offset(n: u32) -> TextSize {
-    TextSize::from(n)
-}
-
-fn range(start: u32, end: u32) -> TextRange {
-    TextRange::new(TextSize::from(start), TextSize::from(end))
-}
-
-fn ranges(targets: &[FileRange]) -> Vec<TextRange> {
-    targets.iter().map(|r| r.range).collect()
-}
-
-fn pairs(targets: &[FileRange]) -> Vec<(File, TextRange)> {
-    targets.iter().map(|r| (r.file, r.range)).collect()
-}
+use crate::support::install_library_package;
+use crate::support::offset;
+use crate::support::pairs;
+use crate::support::range;
+use crate::support::ranges;
+use crate::support::upsert;
 
 // --- prepare_rename ---
 
@@ -209,6 +182,22 @@ fn test_rename_refuses_library_package_symbol() {
 
     // Cursor on the def `foo` at offset 0.
     let err = rename(&db, lib_file, offset(0)).unwrap_err();
+    assert!(err.to_string().contains("installed package"));
+}
+
+#[test]
+fn test_rename_refuses_package_export_used_via_library() {
+    // `library(mypkg)` then a use of its exported `foo`. The use now resolves
+    // through the package layer to the installed-package binding, so rename
+    // refuses with the installed-package guard. Before package-layer resolution
+    // this use was unbound and errored with "no binding" instead.
+    let mut db = OakDatabase::new();
+    let _pkg_file =
+        install_library_package(&mut db, "mypkg", &["foo"], "a.R", "foo <- function() 42\n");
+    let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
+
+    let use_start = "library(mypkg)\n".len() as u32;
+    let err = rename(&db, script, offset(use_start)).unwrap_err();
     assert!(err.to_string().contains("installed package"));
 }
 

--- a/crates/oak_ide/tests/integration/support.rs
+++ b/crates/oak_ide/tests/integration/support.rs
@@ -119,8 +119,7 @@ fn install_pkg(
     let file = File::new(
         db,
         FilePath::from_url(&file_url),
-        oak_db::FileRevision::zero(),
-        Some(contents.to_string()),
+        contents.to_string(),
         Some(pkg),
     );
     pkg.set_files(db).to(vec![file]);

--- a/crates/oak_ide/tests/integration/support.rs
+++ b/crates/oak_ide/tests/integration/support.rs
@@ -127,8 +127,16 @@ fn install_pkg(
         pkg,
     ]);
     match kind {
-        RootKind::Library => db.library_roots().set_roots(db).to(vec![root]),
-        RootKind::Workspace => db.workspace_roots().set_roots(db).to(vec![root]),
+        // Append rather than replace, so a test can install several library
+        // packages into the database.
+        RootKind::Library => {
+            let mut roots = db.library_roots().roots(db).clone();
+            roots.push(root);
+            db.library_roots().set_roots(db).to(roots);
+        },
+        RootKind::Workspace => {
+            db.workspace_roots().set_roots(db).to(vec![root]);
+        },
     };
     file
 }

--- a/crates/oak_package_metadata/src/description.rs
+++ b/crates/oak_package_metadata/src/description.rs
@@ -84,10 +84,16 @@ impl Description {
     }
 
     /// Parse the `Collate` field, if present, returning the whitespace-separated
-    /// file names in the order specified.
+    /// file names in the order specified. R's DCF format quotes each filename
+    /// (`Collate: 'foo.R' 'bar.R'`) so surrounding quotes are stripped.
     pub fn collate(&self) -> Option<Vec<String>> {
         let collate = self.fields.get("Collate")?;
-        Some(collate.split_whitespace().map(|s| s.to_string()).collect())
+        Some(
+            collate
+                .split_whitespace()
+                .map(|s| s.trim_matches(['\'', '"']).to_string())
+                .collect(),
+        )
     }
 }
 
@@ -176,6 +182,34 @@ Priority: recommended"#;
 Version: 1.0.0"#;
         let parsed = Description::parse(desc).unwrap();
         assert!(parsed.priority.is_none());
+    }
+
+    #[test]
+    fn parses_collate_strips_surrounding_quotes() {
+        // Real R DESCRIPTION files quote each filename in the `Collate` field.
+        let desc = r#"Package: mypackage
+Version: 1.0.0
+Collate:
+    'utils.R'
+    'core.R'
+    'zzz.R'"#;
+        let parsed = Description::parse(desc).unwrap();
+        assert_eq!(
+            parsed.collate(),
+            Some(vec![
+                "utils.R".to_string(),
+                "core.R".to_string(),
+                "zzz.R".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_collate_returns_none_when_field_absent() {
+        let desc = r#"Package: mypackage
+Version: 1.0.0"#;
+        let parsed = Description::parse(desc).unwrap();
+        assert_eq!(parsed.collate(), None);
     }
 
     #[test]

--- a/crates/oak_scan/src/packages.rs
+++ b/crates/oak_scan/src/packages.rs
@@ -185,23 +185,86 @@ fn read_workspace_package(package_dir: &Path) -> Option<PackageEntry> {
         }
     }
 
-    // The basename order is currently needed, not cosmetic. `file_imports()` in
-    // `oak_db` reads `package.files` order as the collation chain, so a file
-    // only sees the files ordered before it. Alphabetical is R's default load
-    // order when `DESCRIPTION` has no `Collate` field.
-    //
-    // TODO(scan): honour the `Collate` field when present, falling back to this
-    // alphabetical order. The `collation` field is already parsed but unused.
-    files.sort_by(|a, b| {
-        let a_name = a.0.file_name().map(|n| n.to_ascii_lowercase());
-        let b_name = b.0.file_name().map(|n| n.to_ascii_lowercase());
-        a_name.cmp(&b_name)
-    });
+    // `file_imports()` in `oak_db` reads `package.files` order as the collation
+    // chain, so a file only sees the files ordered before it. `Collate:` is R's
+    // explicit load order; without it R loads `R/` in case-insensitive
+    // alphabetical order. R/ files left out of a `Collate:` directive aren't
+    // loaded into the namespace, so they move to `scripts` rather than `files`.
+    let (loadable, leftover) = match package.collation.as_deref() {
+        Some(order) => order_by_collation(files, order),
+        None => order_alphabetically(files),
+    };
+    scripts.extend(leftover);
 
-    package.files = files.into_iter().map(|(_, file)| file).collect();
+    package.files = loadable;
     package.scripts = scripts;
 
     Some(package)
+}
+
+/// Split the package's `R/*.R` files into `(loadable, leftover)` using the
+/// `Collate:` directive: `loadable` is the listed files in that order, and
+/// `leftover` is the R/ files not listed. Logs mismatches in either direction:
+/// `Collate:` entries with no file on disk, and R/ files absent from `Collate:`
+/// (which become standalone scripts, see [`read_workspace_package`]).
+///
+/// TODO(diagnostics): surface these as LSP diagnostics on `DESCRIPTION`
+/// instead of just log lines.
+fn order_by_collation(
+    files: Vec<(PathBuf, FileEntry)>,
+    order: &[String],
+) -> (Vec<FileEntry>, Vec<FileEntry>) {
+    let mut by_name: HashMap<String, (PathBuf, FileEntry)> = HashMap::with_capacity(files.len());
+    for (path, file) in files {
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            log::warn!("Skipping R file with non-UTF8 basename: {}", path.display());
+            continue;
+        };
+        by_name.insert(name.to_string(), (path, file));
+    }
+
+    let mut loadable = Vec::with_capacity(order.len());
+    for name in order {
+        match by_name.remove(name) {
+            Some((_, file)) => loadable.push(file),
+            None => {
+                log::warn!("`Collate:` lists `{name}` but no matching file is present under `R/`")
+            },
+        }
+    }
+
+    // Anything left in `by_name` is on disk but not in `Collate:`. R won't load
+    // it into the namespace, so it can't go in `files`; keep it as a standalone
+    // script instead of dropping it. Sorted for a deterministic order.
+    let mut leftover: Vec<(PathBuf, FileEntry)> = by_name.into_values().collect();
+    leftover.sort_by_key(|(path, _)| basename_key(path));
+    for (path, _) in &leftover {
+        log::warn!(
+            "R file `{}` is not listed in `Collate:`; treating it as a standalone \
+             script (R will not load it into the namespace)",
+            path.display(),
+        );
+    }
+
+    (
+        loadable,
+        leftover.into_iter().map(|(_, file)| file).collect(),
+    )
+}
+
+/// All files are loadable, in case-insensitive alphabetical order by basename.
+/// No leftover: without `Collate:`, R loads every R/ file.
+fn order_alphabetically(mut files: Vec<(PathBuf, FileEntry)>) -> (Vec<FileEntry>, Vec<FileEntry>) {
+    files.sort_by_key(|(path, _)| basename_key(path));
+    (
+        files.into_iter().map(|(_, file)| file).collect(),
+        Vec::new(),
+    )
+}
+
+/// Case-insensitive sort key from a path's basename.
+fn basename_key(path: &Path) -> Option<std::ffi::OsString> {
+    path.file_name().map(|name| name.to_ascii_lowercase())
 }
 
 /// Walk a workspace root for its top-level scripts: every `.R` file that isn't

--- a/crates/oak_scan/src/tests/workspace.rs
+++ b/crates/oak_scan/src/tests/workspace.rs
@@ -8,6 +8,7 @@ use oak_db::Db;
 use oak_db::DbInputs;
 use oak_db::File;
 use oak_db::OakDatabase;
+use oak_db::Package;
 use oak_db::RootKind;
 
 use crate::scheduler::drain_scheduler;
@@ -47,6 +48,43 @@ fn write_package(dir: &Path, name: &str, r_files: &[(&str, &str)]) {
     for (basename, contents) in r_files {
         fs::write(dir.join("R").join(basename), contents).unwrap();
     }
+}
+
+/// Write a package with an optional `Collate:` directive. The directive
+/// references the given file basenames in quote form (`'foo.R'`) to
+/// match real R DESCRIPTION files.
+fn write_package_with_collate(
+    dir: &Path,
+    name: &str,
+    r_files: &[(&str, &str)],
+    collate: Option<&[&str]>,
+) {
+    fs::create_dir_all(dir.join("R")).unwrap();
+    let mut description = format!("Package: {name}\nVersion: 1.0.0\n");
+    if let Some(order) = collate {
+        description.push_str("Collate:");
+        for basename in order {
+            description.push_str(&format!(" '{basename}'"));
+        }
+        description.push('\n');
+    }
+    fs::write(dir.join("DESCRIPTION"), description).unwrap();
+    for (basename, contents) in r_files {
+        fs::write(dir.join("R").join(basename), contents).unwrap();
+    }
+}
+
+/// Basenames of the package's files in the order `pkg.files` stores them.
+fn file_basenames(db: &OakDatabase, pkg: Package) -> Vec<String> {
+    basenames(db, pkg.files(db))
+}
+
+/// Basenames of the package's scripts, sorted (order isn't meaningful for
+/// scripts, which are standalone).
+fn script_basenames(db: &OakDatabase, pkg: Package) -> Vec<String> {
+    let mut names = basenames(db, pkg.scripts(db));
+    names.sort();
+    names
 }
 
 #[test]
@@ -591,4 +629,93 @@ fn test_set_workspace_paths_stale_no_duplicates_across_cycles() {
     let stale = db.stale_root();
     assert_eq!(stale.files(&db).len(), 1);
     assert_eq!(stale.packages(&db).len(), 1);
+}
+
+#[test]
+fn test_scan_orders_files_alphabetically_without_collate() {
+    // Default behavior: case-insensitive alphabetical filename order.
+    // Matches R's load order for packages without an explicit `Collate:`.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package(&tmp.path().join("pkg"), "pkg", &[
+        ("zzz.R", "z <- 1\n"),
+        ("aaa.R", "a <- 1\n"),
+        ("mmm.R", "m <- 1\n"),
+    ]);
+    let mut db = OakDatabase::new();
+
+    set_workspace_paths(&mut db, &[tmp.path().to_path_buf()], &HashSet::new());
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(file_basenames(&db, pkg), vec!["aaa.R", "mmm.R", "zzz.R"]);
+}
+
+#[test]
+fn test_scan_orders_files_by_collate_directive() {
+    // `Collate: 'zzz.R' 'aaa.R' 'mmm.R'` overrides alphabetical order.
+    // `pkg.files` reflects the collation, so downstream consumers
+    // (sibling-chain resolution, namespace lookup) see R's actual load
+    // order.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package_with_collate(
+        &tmp.path().join("pkg"),
+        "pkg",
+        &[
+            ("aaa.R", "a <- 1\n"),
+            ("mmm.R", "m <- 1\n"),
+            ("zzz.R", "z <- 1\n"),
+        ],
+        Some(&["zzz.R", "aaa.R", "mmm.R"]),
+    );
+    let mut db = OakDatabase::new();
+
+    set_workspace_paths(&mut db, &[tmp.path().to_path_buf()], &HashSet::new());
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(file_basenames(&db, pkg), vec!["zzz.R", "aaa.R", "mmm.R"]);
+}
+
+#[test]
+fn test_scan_collate_routes_unlisted_files_to_scripts() {
+    // R's loader processes exactly the files in `Collate:`; files in `R/` not
+    // listed are not loaded into the namespace (Writing R Extensions §1.1.1).
+    // The scanner keeps `pkg.files` to the listed file, but the unlisted
+    // `aaa.R` / `bbb.R` go to `pkg.scripts` (standalone analysis, out of the
+    // namespace) rather than being dropped.
+    let tmp = tempfile::tempdir().unwrap();
+    write_package_with_collate(
+        &tmp.path().join("pkg"),
+        "pkg",
+        &[
+            ("aaa.R", "a <- 1\n"),
+            ("bbb.R", "b <- 1\n"),
+            ("zzz.R", "z <- 1\n"),
+        ],
+        Some(&["zzz.R"]),
+    );
+    let mut db = OakDatabase::new();
+
+    set_workspace_paths(&mut db, &[tmp.path().to_path_buf()], &HashSet::new());
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(file_basenames(&db, pkg), vec!["zzz.R"]);
+    assert_eq!(script_basenames(&db, pkg), vec!["aaa.R", "bbb.R"]);
+}
+
+#[test]
+fn test_scan_collate_drops_listed_files_missing_from_disk() {
+    // `Collate:` references a file that doesn't exist in `R/`. The
+    // scanner skips it silently (no entry, no panic).
+    let tmp = tempfile::tempdir().unwrap();
+    write_package_with_collate(
+        &tmp.path().join("pkg"),
+        "pkg",
+        &[("aaa.R", "a <- 1\n")],
+        Some(&["aaa.R", "missing.R"]),
+    );
+    let mut db = OakDatabase::new();
+
+    set_workspace_paths(&mut db, &[tmp.path().to_path_buf()], &HashSet::new());
+
+    let pkg = db.workspace_roots().roots(&db)[0].packages(&db)[0];
+    assert_eq!(file_basenames(&db, pkg), vec!["aaa.R"]);
 }


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1257
Progress towards https://github.com/posit-dev/ark/issues/1212

-  `File::resolve()` and `resolve_at()` now handle the `Package` (NAMESPACE `import()`) and `From` (`importFrom()`) import layers (previously only `File` layers were walked; the rest were dropped).

- `Package::resolve()` answers "is this name exported by this package?" by walking the package's files and collecting their exports. It provides a lazy / post-load view of package exports. For instance it returns two definitions when a top-level stub is overwritten in the `.onLoad()` hook via `<<-`.

- `Package::files` are now stored in collation order, which simplifies downstream calls that need to respect R's load order.

`File::imports()` and `Package::resolve()` are both used in `File::resolve()` / `File::resolve_at()`, which themselves support goto-def, find-refs, and rename.

With these changes, when a workspace contains both scripts and a package, you can now use goto-def, find-refs, and rename with symbols imported via `library()`.

goto-def will also work with installed packages when oak_sources is wired up again.