### PR TITLE
Resolve names to all their candidate definitions

### DIFF
--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -147,9 +147,35 @@ fn test_local_def_shadows_sourced() {
 
 #[test]
 fn test_sourced_file_with_repeated_def_offers_both() {
-    // When the sourced file binds the same name twice, goto-def offers both
-    // candidate definitions, in definition order. The last link is the binding
-    // R picks at runtime. Ranges are in the target file's coordinates.
+    // When the sourced file binds the same name on both arms of a top-level
+    // `if`/`else`, either arm could run, so goto-def offers both candidate
+    // definitions, in definition order. Ranges are in the target file's
+    // coordinates.
+    let script_uri = test_path("script.R");
+    let helpers_uri = test_path("helpers.R");
+    let state = make_state_with(&[
+        (&script_uri, "source(\"helpers.R\")\nfn\n"),
+        (&helpers_uri, "if (cond) fn <- 1 else fn <- 2\n"),
+    ]);
+
+    let params = make_params(script_uri, 1, 0);
+    assert_matches!(
+        goto_definition(params, &state).unwrap(),
+        Some(GotoDefinitionResponse::Link(ref links)) => {
+            assert_eq!(links.len(), 2);
+            assert_eq!(links[0].target_uri, helpers_uri);
+            assert_eq!(links[0].target_range, range((0, 10), (0, 12)));
+            assert_eq!(links[1].target_uri, helpers_uri);
+            assert_eq!(links[1].target_range, range((0, 23), (0, 25)));
+        }
+    );
+}
+
+#[test]
+fn test_sourced_file_with_sequential_redef_offers_runtime_winner() {
+    // When the sourced file binds the same name twice in sequence, the second
+    // overwrites the first, so only the last binding is in effect when
+    // `source()` finishes. goto-def offers just that one.
     let script_uri = test_path("script.R");
     let helpers_uri = test_path("helpers.R");
     let state = make_state_with(&[
@@ -164,11 +190,9 @@ fn test_sourced_file_with_repeated_def_offers_both() {
     assert_matches!(
         goto_definition(params, &state).unwrap(),
         Some(GotoDefinitionResponse::Link(ref links)) => {
-            assert_eq!(links.len(), 2);
+            assert_eq!(links.len(), 1);
             assert_eq!(links[0].target_uri, helpers_uri);
-            assert_eq!(links[0].target_range, range((0, 0), (0, 2)));
-            assert_eq!(links[1].target_uri, helpers_uri);
-            assert_eq!(links[1].target_range, range((1, 0), (1, 2)));
+            assert_eq!(links[0].target_range, range((1, 0), (1, 2)));
         }
     );
 }

--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -146,10 +146,10 @@ fn test_local_def_shadows_sourced() {
 }
 
 #[test]
-fn test_last_def_in_sourced_file_wins() {
-    // When the sourced file binds the same name twice, the use navigates to
-    // the last definition. The link range must point at that second def, in
-    // the target file's coordinates.
+fn test_sourced_file_with_repeated_def_offers_both() {
+    // When the sourced file binds the same name twice, goto-def offers both
+    // candidate definitions, in definition order. The last link is the binding
+    // R picks at runtime. Ranges are in the target file's coordinates.
     let script_uri = test_path("script.R");
     let helpers_uri = test_path("helpers.R");
     let state = make_state_with(&[
@@ -164,8 +164,11 @@ fn test_last_def_in_sourced_file_wins() {
     assert_matches!(
         goto_definition(params, &state).unwrap(),
         Some(GotoDefinitionResponse::Link(ref links)) => {
+            assert_eq!(links.len(), 2);
             assert_eq!(links[0].target_uri, helpers_uri);
-            assert_eq!(links[0].target_range, range((1, 0), (1, 2)));
+            assert_eq!(links[0].target_range, range((0, 0), (0, 2)));
+            assert_eq!(links[1].target_uri, helpers_uri);
+            assert_eq!(links[1].target_range, range((1, 0), (1, 2)));
         }
     );
 }

--- a/crates/oak_db/src/file_exports.rs
+++ b/crates/oak_db/src/file_exports.rs
@@ -15,7 +15,7 @@ use crate::File;
 /// internal edits.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FileExports {
-    entries: HashMap<String, ExportEntry>,
+    entries: HashMap<String, Vec<ExportEntry>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,12 +28,16 @@ pub enum ExportEntry {
 }
 
 impl FileExports {
-    pub fn get(&self, name: &str) -> Option<&ExportEntry> {
-        self.entries.get(name)
+    /// Every entry bound to `name` in this file, deduplicated. A `Local`
+    /// marker appears at most once even when the name has several top-level
+    /// definitions; `File::resolve_export()` fans those back out by re-reading
+    /// the semantic index. `Import` entries are distinct per `(file, name)`.
+    pub fn get(&self, name: &str) -> Option<&[ExportEntry]> {
+        self.entries.get(name).map(Vec::as_slice)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &ExportEntry)> {
-        self.entries.iter().map(|(k, v)| (k.as_str(), v))
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &[ExportEntry])> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), v.as_slice()))
     }
 
     pub fn len(&self) -> usize {
@@ -60,27 +64,42 @@ impl File {
     /// chains by returning empty exports for every cycle participant.
     #[salsa::tracked(returns(ref), cycle_result = exports_cycle_result)]
     pub fn exports(self, db: &dyn Db) -> FileExports {
-        let mut entries: HashMap<String, ExportEntry> = HashMap::new();
-        for (name, (_def_id, def)) in self.semantic_index(db).exports() {
-            let entry = match def.kind() {
-                DefinitionKind::Import {
-                    file: target_url,
-                    name: target_name,
-                    ..
-                } => {
-                    let target_url_id = FilePath::from_url(target_url);
-                    let Some(target_file) = db.file_by_path(&target_url_id) else {
-                        continue;
-                    };
-                    ExportEntry::Import {
-                        file: target_file,
-                        name: target_name.clone(),
-                    }
-                },
-                _ => ExportEntry::Local,
-            };
-            entries.insert(name.to_string(), entry);
+        let mut entries: HashMap<String, Vec<ExportEntry>> = HashMap::new();
+
+        for (name, defs) in self.semantic_index(db).exports() {
+            let list = entries.entry(name.to_string()).or_default();
+            for (_def_id, def) in defs {
+                let entry = match def.kind() {
+                    DefinitionKind::Import {
+                        file: target_url,
+                        name: target_name,
+                        ..
+                    } => {
+                        let target_url_id = FilePath::from_url(target_url);
+                        let Some(target_file) = db.file_by_path(&target_url_id) else {
+                            continue;
+                        };
+                        ExportEntry::Import {
+                            file: target_file,
+                            name: target_name.clone(),
+                        }
+                    },
+                    _ => ExportEntry::Local,
+                };
+                // Dedup, moving each entry to its last position so the final
+                // entry is the binding R picks at runtime (statements run in
+                // order, last write wins). `Local` carries no `def_id` (that
+                // contentlessness is what keeps `exports()` stable across body
+                // edits), so a name's several top-level definitions collapse to
+                // one `Local`, identical `source()` forwards to one `Import`,
+                // and `resolve_export` re-mints from the marker either way.
+                if let Some(pos) = list.iter().position(|e| e == &entry) {
+                    list.remove(pos);
+                }
+                list.push(entry);
+            }
         }
+
         FileExports { entries }
     }
 }

--- a/crates/oak_db/src/file_exports.rs
+++ b/crates/oak_db/src/file_exports.rs
@@ -86,17 +86,13 @@ impl File {
                     },
                     _ => ExportEntry::Local,
                 };
-                // Dedup, moving each entry to its last position so the final
-                // entry is the binding R picks at runtime (statements run in
-                // order, last write wins). `Local` carries no `def_id` (that
-                // contentlessness is what keeps `exports()` stable across body
-                // edits), so a name's several top-level definitions collapse to
-                // one `Local`, identical `source()` forwards to one `Import`,
-                // and `resolve_export` re-mints from the marker either way.
-                if let Some(pos) = list.iter().position(|e| e == &entry) {
-                    list.remove(pos);
+                // A name can have several live defs (e.g. both arms of an
+                // `if`/`else`), and several can collapse to one marker: `Local`
+                // and `Import` carry no `def_id`, so duplicates are byte-equal.
+                // Dedup them, keeping definition order.
+                if !list.contains(&entry) {
+                    list.push(entry);
                 }
-                list.push(entry);
             }
         }
 

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -36,7 +36,12 @@ impl<'db> File {
     ///    `Package` and `From` layers call [`Package::resolve`] with
     ///    `Exported` visibility.
     ///
-    /// The returned `Definition` is keyed by `(file, scope, name)`, so
+    /// Returns every definition the name reaches in the first layer that binds
+    /// it, so a name with two top-level bindings yields both. The own-file
+    /// `exports()` chain shadows imports, matching R: if the file binds the
+    /// name at top level we stop there and never fall through to a package.
+    ///
+    /// Each returned `Definition` is keyed by `(file, scope, name)`, so
     /// downstream queries that only depend on identity stay cached across
     /// edits that shift the binding's source position. Consumers that need
     /// a position or the bound expression read `def.kind(db)` and project
@@ -45,9 +50,10 @@ impl<'db> File {
     /// For the offset-aware, sequential-semantics variant, see
     /// [`File::resolve_at`].
     #[salsa::tracked]
-    pub fn resolve(self, db: &'db dyn Db, name: Name<'db>) -> Option<Definition<'db>> {
-        if let Some(def) = self.resolve_export(db, name) {
-            return Some(def);
+    pub fn resolve(self, db: &'db dyn Db, name: Name<'db>) -> Vec<Definition<'db>> {
+        let exported = self.resolve_export(db, name);
+        if !exported.is_empty() {
+            return exported;
         }
 
         // For each sibling `ImportLayer::File`, check the target's exports
@@ -65,29 +71,24 @@ impl<'db> File {
         for layer in self.imports(db) {
             match layer {
                 ImportLayer::File(target) => {
-                    if let Some(def) = target.resolve_export(db, name) {
-                        return Some(def);
+                    let defs = target.resolve_export(db, name);
+                    if !defs.is_empty() {
+                        return defs;
                     }
                 },
                 ImportLayer::Package(pkg) => {
-                    if let Some(def) = pkg
-                        .resolve(db, name, PackageVisibility::Exported)
-                        .into_iter()
-                        .next()
-                    {
-                        return Some(def);
+                    let defs = pkg.resolve(db, name, PackageVisibility::Exported);
+                    if !defs.is_empty() {
+                        return defs;
                     }
                 },
                 ImportLayer::From(map) => {
                     let name_str = name.text(db).as_str();
                     if let Some(pkg_name) = map.get(name_str) {
                         if let Some(pkg) = db.package_by_name(pkg_name) {
-                            if let Some(def) = pkg
-                                .resolve(db, name, PackageVisibility::Exported)
-                                .into_iter()
-                                .next()
-                            {
-                                return Some(def);
+                            let defs = pkg.resolve(db, name, PackageVisibility::Exported);
+                            if !defs.is_empty() {
+                                return defs;
                             }
                         }
                     }
@@ -95,7 +96,7 @@ impl<'db> File {
             }
         }
 
-        None
+        Vec::new()
     }
 
     /// Resolve the name at `offset` to its definition(s).
@@ -136,7 +137,7 @@ impl<'db> File {
         if !reaching.is_empty() {
             return reaching
                 .into_iter()
-                .filter_map(|(scope, def_id)| self.resolve_definition(db, scope, def_id))
+                .flat_map(|(scope, def_id)| self.resolve_definition(db, scope, def_id))
                 .collect();
         }
 
@@ -144,7 +145,7 @@ impl<'db> File {
         let file_scope = ScopeId::from(0);
         if use_scope != file_scope {
             // Function body: the lazy / end-of-file view the body sees at run time.
-            return self.resolve(db, name).into_iter().collect();
+            return self.resolve(db, name);
         }
 
         // Top level: collation predecessors / other visible files (exports-only
@@ -153,8 +154,9 @@ impl<'db> File {
         for layer in self.imports_at(db, offset) {
             match layer {
                 ImportLayer::File(target) => {
-                    if let Some(def) = target.resolve_export(db, name) {
-                        return vec![def];
+                    let defs = target.resolve_export(db, name);
+                    if !defs.is_empty() {
+                        return defs;
                     }
                 },
                 ImportLayer::Package(pkg) => {
@@ -185,7 +187,7 @@ impl<'db> File {
         db: &'db dyn Db,
         scope_id: ScopeId,
         def_id: DefinitionId,
-    ) -> Option<Definition<'db>> {
+    ) -> Vec<Definition<'db>> {
         let index = self.semantic_index(db);
         if let DefinitionKind::Import {
             file: target_url,
@@ -193,55 +195,64 @@ impl<'db> File {
             ..
         } = index.definitions(scope_id)[def_id].kind()
         {
-            let target = db.file_by_path(&FilePath::from_url(target_url))?;
+            let Some(target) = db.file_by_path(&FilePath::from_url(target_url)) else {
+                return Vec::new();
+            };
             return target.resolve_export(db, Name::new(db, forwarded.as_str()));
         }
-        self.definition(db, scope_id, def_id)
+        self.definition(db, scope_id, def_id).into_iter().collect()
     }
 
-    /// Walk this file's exports chain for `name`, chasing `source()`-forwarded
-    /// `Import` entries through target exports until a `Local` is found. Cycles
-    /// resolve to `None` via `exports`'s `cycle_fn`.
+    /// Walk this file's exports for `name`, chasing `source()`-forwarded
+    /// `Import` entries through target exports until they land on `Local`
+    /// definitions. Returns every definition the name reaches, so a name with
+    /// two top-level bindings, or forwards from two different sourced files,
+    /// yields all of them. Cycles resolve to empty via `exports`'s `cycle_fn`.
     #[salsa::tracked]
-    pub(crate) fn resolve_export(
-        self,
-        db: &'db dyn Db,
-        name: Name<'db>,
-    ) -> Option<Definition<'db>> {
-        let mut current_file = self;
-        let mut current_name: Rc<str> = Rc::from(name.text(db).as_str());
+    pub(crate) fn resolve_export(self, db: &'db dyn Db, name: Name<'db>) -> Vec<Definition<'db>> {
+        let mut results = Vec::new();
 
-        // Defensive: cycle through `Import` is prevented upstream by
-        // `exports()`'s `cycle_result` (which returns empty for one cycle
-        // participant). The `Rc<str>` is cheap to clone (refcount bump).
+        // `visited` keys on `(file, name)` so each binding is minted once even
+        // when several forwards converge on it, and so an `Import` cycle (which
+        // `exports()`'s `cycle_result` already breaks) can't loop here. The
+        // `Rc<str>` is cheap to clone (refcount bump).
         let mut visited: HashSet<(File, Rc<str>)> = HashSet::new();
+        let mut worklist: Vec<(File, Rc<str>)> = vec![(self, Rc::from(name.text(db).as_str()))];
 
-        loop {
+        while let Some((current_file, current_name)) = worklist.pop() {
             if !visited.insert((current_file, current_name.clone())) {
-                log::error!(
-                    "Internal error: Cycle through `Import` forwards while resolving \
-                    `{current_name}` in {url}.",
-                    url = current_file.path(db),
-                );
-                return None;
+                continue;
             }
 
-            match current_file.exports(db).get(current_name.as_ref())? {
-                ExportEntry::Local => {
-                    // Look up the file-scope binding through the semantic index
-                    // to recover its `def_id`, then fetch the interned
-                    // definition. `exports()` returns the last-wins
-                    // definitions, so this is the right binding for the name.
-                    let index = current_file.semantic_index(db);
-                    let def_id = index.exports().get(current_name.as_ref())?.0;
-                    return current_file.definition(db, ScopeId::from(0), def_id);
-                },
+            let Some(entries) = current_file.exports(db).get(current_name.as_ref()) else {
+                continue;
+            };
 
-                ExportEntry::Import { file, name } => {
-                    current_file = *file;
-                    current_name = Rc::from(name.as_str());
-                },
+            for entry in entries {
+                match entry {
+                    ExportEntry::Local => {
+                        // The `Local` marker doesn't carry a `def_id`, so recover
+                        // every file-scope `def_id` for the name from the semantic
+                        // index and mint each through the single site. A name bound
+                        // more than once at top level fans out here.
+                        let index = current_file.semantic_index(db);
+                        for &(def_id, _) in index
+                            .exports()
+                            .get(current_name.as_ref())
+                            .into_iter()
+                            .flatten()
+                        {
+                            results.extend(current_file.definition(db, ScopeId::from(0), def_id));
+                        }
+                    },
+
+                    ExportEntry::Import { file, name } => {
+                        worklist.push((*file, Rc::from(name.as_str())));
+                    },
+                }
             }
         }
+
+        results
     }
 }

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -207,7 +207,16 @@ impl<'db> File {
     /// `Import` entries through target exports until they land on `Local`
     /// definitions. Returns every definition the name reaches, so a name with
     /// two top-level bindings, or forwards from two different sourced files,
-    /// yields all of them. Cycles resolve to empty via `exports`'s `cycle_fn`.
+    /// yields all of them.
+    ///
+    /// Order follows `exports()`: entries are visited in definition order and
+    /// imports are chased in place, so the last element is the binding R picks
+    /// at runtime (statements run in order, last write wins). Several top-level
+    /// locals collapse to one `Local` marker, so they come out grouped at that
+    /// marker's position rather than each at its own offset, but the runtime
+    /// winner is still last.
+    ///
+    /// Cycles resolve to empty via `exports`'s `cycle_fn`.
     #[salsa::tracked]
     pub(crate) fn resolve_export(self, db: &'db dyn Db, name: Name<'db>) -> Vec<Definition<'db>> {
         let mut results = Vec::new();
@@ -217,51 +226,63 @@ impl<'db> File {
         // `exports()`'s `cycle_result` already breaks) can't loop here. The
         // `Rc<str>` is cheap to clone (refcount bump).
         let mut visited: HashSet<(File, Rc<str>)> = HashSet::new();
-        let mut worklist: Vec<(File, Rc<str>)> = vec![(self, Rc::from(name.text(db).as_str()))];
-
-        while let Some((current_file, current_name)) = worklist.pop() {
-            if !visited.insert((current_file, current_name.clone())) {
-                continue;
-            }
-
-            let Some(entries) = current_file.exports(db).get(current_name.as_ref()) else {
-                continue;
-            };
-
-            for entry in entries {
-                match entry {
-                    ExportEntry::Local => {
-                        // The `Local` marker doesn't carry a `def_id`, so recover
-                        // every file-scope `def_id` for the name from the semantic
-                        // index and mint each through the single site. A name bound
-                        // more than once at top level fans out here.
-                        //
-                        // `exports()` also lists the `Import`-kind defs that
-                        // `source()` emits at file scope. Skip them: they're the
-                        // forwards already chased through the `Import` entries
-                        // above, and minting one here would add a bogus target at
-                        // the empty `source()` call span.
-                        let index = current_file.semantic_index(db);
-                        for &(def_id, def) in index
-                            .exports()
-                            .get(current_name.as_ref())
-                            .into_iter()
-                            .flatten()
-                        {
-                            if matches!(def.kind(), DefinitionKind::Import { .. }) {
-                                continue;
-                            }
-                            results.extend(current_file.definition(db, ScopeId::from(0), def_id));
-                        }
-                    },
-
-                    ExportEntry::Import { file, name } => {
-                        worklist.push((*file, Rc::from(name.as_str())));
-                    },
-                }
-            }
-        }
+        self.collect_exports(
+            db,
+            Rc::from(name.text(db).as_str()),
+            &mut visited,
+            &mut results,
+        );
 
         results
+    }
+
+    /// Append every definition `name` reaches in `self`'s exports to `results`,
+    /// in `exports()` order, recursing into `Import` forwards in place. See
+    /// [`File::resolve_export`] for the ordering contract.
+    fn collect_exports(
+        self,
+        db: &'db dyn Db,
+        name: Rc<str>,
+        visited: &mut HashSet<(File, Rc<str>)>,
+        results: &mut Vec<Definition<'db>>,
+    ) {
+        if !visited.insert((self, name.clone())) {
+            return;
+        }
+
+        let Some(entries) = self.exports(db).get(name.as_ref()) else {
+            return;
+        };
+
+        for entry in entries {
+            match entry {
+                ExportEntry::Local => {
+                    // The `Local` marker doesn't carry a `def_id`, so recover
+                    // every file-scope `def_id` for the name from the semantic
+                    // index and mint each through the single site. A name bound
+                    // more than once at top level fans out here.
+                    //
+                    // `exports()` also lists the `Import`-kind defs that
+                    // `source()` emits at file scope. Skip them: they're the
+                    // forwards already chased through the `Import` entries, and
+                    // minting one here would add a bogus target at the empty
+                    // `source()` call span.
+                    let index = self.semantic_index(db);
+                    for &(def_id, def) in index.exports().get(name.as_ref()).into_iter().flatten() {
+                        if matches!(def.kind(), DefinitionKind::Import { .. }) {
+                            continue;
+                        }
+                        results.extend(self.definition(db, ScopeId::from(0), def_id));
+                    }
+                },
+
+                ExportEntry::Import {
+                    file,
+                    name: forwarded,
+                } => {
+                    file.collect_exports(db, Rc::from(forwarded.as_str()), visited, results);
+                },
+            }
+        }
     }
 }

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -258,9 +258,11 @@ impl<'db> File {
             match entry {
                 ExportEntry::Local => {
                     // The `Local` marker doesn't carry a `def_id`, so recover
-                    // every file-scope `def_id` for the name from the semantic
-                    // index and mint each through the single site. A name bound
-                    // more than once at top level fans out here.
+                    // from the semantic index the file-scope `def_id`s still in
+                    // effect once the file has run top to bottom, and mint each
+                    // through the single site. Usually that's one def; a name
+                    // still bound on several paths (both arms of a top-level
+                    // `if`/`else`) fans out to several here.
                     //
                     // `exports()` also lists the `Import`-kind defs that
                     // `source()` emits at file scope. Skip them: they're the

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -235,13 +235,22 @@ impl<'db> File {
                         // every file-scope `def_id` for the name from the semantic
                         // index and mint each through the single site. A name bound
                         // more than once at top level fans out here.
+                        //
+                        // `exports()` also lists the `Import`-kind defs that
+                        // `source()` emits at file scope. Skip them: they're the
+                        // forwards already chased through the `Import` entries
+                        // above, and minting one here would add a bogus target at
+                        // the empty `source()` call span.
                         let index = current_file.semantic_index(db);
-                        for &(def_id, _) in index
+                        for &(def_id, def) in index
                             .exports()
                             .get(current_name.as_ref())
                             .into_iter()
                             .flatten()
                         {
+                            if matches!(def.kind(), DefinitionKind::Import { .. }) {
+                                continue;
+                            }
                             results.extend(current_file.definition(db, ScopeId::from(0), def_id));
                         }
                     },

--- a/crates/oak_db/src/tests/file_exports.rs
+++ b/crates/oak_db/src/tests/file_exports.rs
@@ -23,10 +23,10 @@ fn setup_workspace(db: &mut TestDb, scripts: &[(&str, &str)]) -> Vec<File> {
     files
 }
 
-fn entries(db: &TestDb, file: File) -> HashMap<String, ExportEntry> {
+fn entries(db: &TestDb, file: File) -> HashMap<String, Vec<ExportEntry>> {
     file.exports(db)
         .iter()
-        .map(|(k, v)| (k.to_string(), v.clone()))
+        .map(|(k, v)| (k.to_string(), v.to_vec()))
         .collect()
 }
 
@@ -37,8 +37,8 @@ fn test_local_top_level_definitions_become_local_entries() {
 
     let map = entries(&db, files[0]);
     assert_eq!(map.len(), 2);
-    assert_eq!(map.get("x"), Some(&ExportEntry::Local));
-    assert_eq!(map.get("f"), Some(&ExportEntry::Local));
+    assert_eq!(map.get("x"), Some(&vec![ExportEntry::Local]));
+    assert_eq!(map.get("f"), Some(&vec![ExportEntry::Local]));
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_source_call_to_unresolved_path_drops_forwarding() {
 
     let map = entries(&db, files[0]);
     assert_eq!(map.len(), 1);
-    assert_eq!(map.get("x"), Some(&ExportEntry::Local));
+    assert_eq!(map.get("x"), Some(&vec![ExportEntry::Local]));
 }
 
 #[test]
@@ -76,115 +76,199 @@ fn test_source_call_to_resolved_file_produces_import_entries() {
 
     let map = entries(&db, analysis);
     assert_eq!(map.len(), 2);
-    assert_eq!(map.get("x"), Some(&ExportEntry::Local));
+    assert_eq!(map.get("x"), Some(&vec![ExportEntry::Local]));
     assert_eq!(
         map.get("helper"),
-        Some(&ExportEntry::Import {
+        Some(&vec![ExportEntry::Import {
             file: helpers,
             name: "helper".to_string(),
-        })
+        }])
     );
 }
 
 #[test]
-fn test_local_definition_shadows_sourced_name() {
+fn test_sourced_then_local_keep_both() {
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[
         ("w/helpers.R", "shared <- 1\n"),
         ("w/analysis.R", "source(\"helpers.R\")\nshared <- 2\n"),
     ]);
+    let helpers = files[0];
     let analysis = files[1];
 
+    // Multi-target keeps every candidate in definition order. The sourced
+    // forward comes first, the local `shared <- 2` second. R's runtime takes
+    // the last one (the local), but goto-def offers both.
     let map = entries(&db, analysis);
-    assert_eq!(map.get("shared"), Some(&ExportEntry::Local));
+    assert_eq!(
+        map.get("shared"),
+        Some(&vec![
+            ExportEntry::Import {
+                file: helpers,
+                name: "shared".to_string(),
+            },
+            ExportEntry::Local,
+        ])
+    );
 }
 
 #[test]
-fn test_later_source_overrides_earlier_when_both_export_the_same_name() {
+fn test_two_sources_of_same_name_keep_both_forwards() {
     let mut db = TestDb::new();
 
-    // Both `b` and `c` define `dup`. R evaluates each `source()` in
-    // sequence and the later one's assignment wins.
+    // Both `b` and `c` define `dup`. R evaluates each `source()` in sequence
+    // and the later one's assignment wins at runtime. Multi-target keeps both
+    // forwards, in source order, so the runtime winner (`c`) is last.
     let files = setup_workspace(&mut db, &[
         ("w/b.R", "dup <- 1\n"),
         ("w/c.R", "dup <- 2\n"),
         ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\n"),
     ]);
+    let b = files[0];
     let c = files[1];
     let a = files[2];
 
     let map = entries(&db, a);
     assert_eq!(
         map.get("dup"),
-        Some(&ExportEntry::Import {
-            file: c,
-            name: "dup".to_string(),
-        })
+        Some(&vec![
+            ExportEntry::Import {
+                file: b,
+                name: "dup".to_string(),
+            },
+            ExportEntry::Import {
+                file: c,
+                name: "dup".to_string(),
+            },
+        ])
     );
 }
 
 #[test]
-fn test_local_after_sources_wins() {
+fn test_sources_then_local_keep_all_in_order() {
     let mut db = TestDb::new();
 
-    // sources first, then local. Local is the last assignment so it
-    // ends up bound at end-of-file.
+    // sources first, then local. Local is the last assignment so it ends up
+    // bound at end-of-file. Multi-target keeps both forwards plus the local, in
+    // definition order, so the runtime winner (the local) is last.
     let files = setup_workspace(&mut db, &[
         ("w/b.R", "dup <- 1\n"),
         ("w/c.R", "dup <- 2\n"),
         ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\ndup <- 3\n"),
     ]);
+    let b = files[0];
+    let c = files[1];
     let a = files[2];
 
     let map = entries(&db, a);
-    assert_eq!(map.get("dup"), Some(&ExportEntry::Local));
+    assert_eq!(
+        map.get("dup"),
+        Some(&vec![
+            ExportEntry::Import {
+                file: b,
+                name: "dup".to_string(),
+            },
+            ExportEntry::Import {
+                file: c,
+                name: "dup".to_string(),
+            },
+            ExportEntry::Local,
+        ])
+    );
 }
 
 #[test]
-fn test_later_source_after_local_overrides_it() {
+fn test_source_local_source_keep_all_in_order() {
     let mut db = TestDb::new();
 
-    // Local in the middle is shadowed by the *later* source. Matches
-    // R's runtime: each statement assigns in order; the last write
-    // wins.
+    // Local in the middle, sources either side. Matches R's runtime: each
+    // statement assigns in order; the last write (the `c` source) wins.
+    // Multi-target keeps all three candidates in definition order.
     let files = setup_workspace(&mut db, &[
         ("w/b.R", "dup <- 1\n"),
         ("w/c.R", "dup <- 2\n"),
         ("w/a.R", "source(\"b.R\")\ndup <- 3\nsource(\"c.R\")\n"),
     ]);
+    let b = files[0];
     let c = files[1];
     let a = files[2];
 
     let map = entries(&db, a);
     assert_eq!(
         map.get("dup"),
-        Some(&ExportEntry::Import {
-            file: c,
-            name: "dup".to_string(),
-        })
+        Some(&vec![
+            ExportEntry::Import {
+                file: b,
+                name: "dup".to_string(),
+            },
+            ExportEntry::Local,
+            ExportEntry::Import {
+                file: c,
+                name: "dup".to_string(),
+            },
+        ])
     );
 }
 
 #[test]
-fn test_local_before_sources_is_overridden() {
+fn test_local_then_sources_keep_all_in_order() {
     let mut db = TestDb::new();
 
-    // Local first, sources later. Sources reassign, last source wins.
+    // Local first, sources later. Sources reassign, last source wins at
+    // runtime. Multi-target keeps all three candidates in definition order, so
+    // the runtime winner (`c`) is last.
     let files = setup_workspace(&mut db, &[
         ("w/b.R", "dup <- 1\n"),
         ("w/c.R", "dup <- 2\n"),
         ("w/a.R", "dup <- 3\nsource(\"b.R\")\nsource(\"c.R\")\n"),
     ]);
+    let b = files[0];
     let c = files[1];
     let a = files[2];
 
     let map = entries(&db, a);
     assert_eq!(
         map.get("dup"),
-        Some(&ExportEntry::Import {
-            file: c,
-            name: "dup".to_string(),
-        })
+        Some(&vec![
+            ExportEntry::Local,
+            ExportEntry::Import {
+                file: b,
+                name: "dup".to_string(),
+            },
+            ExportEntry::Import {
+                file: c,
+                name: "dup".to_string(),
+            },
+        ])
+    );
+}
+
+#[test]
+fn test_repeated_local_moves_to_runtime_winning_position() {
+    let mut db = TestDb::new();
+
+    // Local, then a sourced forward of the same name, then a later local. The
+    // two locals collapse to one `Local` marker, and the dedup keeps it at the
+    // *last* local's position. So the entry order is `[Import{b}, Local]` and
+    // the final entry is the binding R picks at runtime (`dup <- 3`), not the
+    // earlier `Import{b}`.
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/a.R", "dup <- 2\nsource(\"b.R\")\ndup <- 3\n"),
+    ]);
+    let b = files[0];
+    let a = files[1];
+
+    let map = entries(&db, a);
+    assert_eq!(
+        map.get("dup"),
+        Some(&vec![
+            ExportEntry::Import {
+                file: b,
+                name: "dup".to_string(),
+            },
+            ExportEntry::Local,
+        ])
     );
 }
 
@@ -224,10 +308,10 @@ fn test_source_chain_forwards_through_two_files() {
     let map = entries(&db, top);
     assert_eq!(
         map.get("deep"),
-        Some(&ExportEntry::Import {
+        Some(&vec![ExportEntry::Import {
             file: mid,
             name: "deep".to_string(),
-        })
+        }])
     );
 }
 

--- a/crates/oak_db/src/tests/file_exports.rs
+++ b/crates/oak_db/src/tests/file_exports.rs
@@ -87,18 +87,147 @@ fn test_source_call_to_resolved_file_produces_import_entries() {
 }
 
 #[test]
-fn test_sourced_then_local_keep_both() {
+fn test_sourced_then_local_resolves_to_local() {
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[
         ("w/helpers.R", "shared <- 1\n"),
         ("w/analysis.R", "source(\"helpers.R\")\nshared <- 2\n"),
     ]);
+    let analysis = files[1];
+
+    // The local `shared <- 2` runs after the `source()`, overwriting the
+    // sourced binding. Only the local is in effect at end of file.
+    let map = entries(&db, analysis);
+    assert_eq!(map.get("shared"), Some(&vec![ExportEntry::Local]));
+}
+
+#[test]
+fn test_two_sources_of_same_name_keeps_last_forward() {
+    let mut db = TestDb::new();
+
+    // Both `b` and `c` define `dup`. R evaluates each `source()` in sequence,
+    // so `c`'s assignment overwrites `b`'s. Only the `c` forward is in effect
+    // at end of file.
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/c.R", "dup <- 2\n"),
+        ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\n"),
+    ]);
+    let c = files[1];
+    let a = files[2];
+
+    let map = entries(&db, a);
+    assert_eq!(
+        map.get("dup"),
+        Some(&vec![ExportEntry::Import {
+            file: c,
+            name: "dup".to_string(),
+        }])
+    );
+}
+
+#[test]
+fn test_sources_then_local_resolves_to_local() {
+    let mut db = TestDb::new();
+
+    // sources first, then local. The local is the last assignment, so it
+    // overwrites both sourced forwards and is the only binding in effect at
+    // end of file.
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/c.R", "dup <- 2\n"),
+        ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\ndup <- 3\n"),
+    ]);
+    let a = files[2];
+
+    let map = entries(&db, a);
+    assert_eq!(map.get("dup"), Some(&vec![ExportEntry::Local]));
+}
+
+#[test]
+fn test_source_local_source_resolves_to_last_source() {
+    let mut db = TestDb::new();
+
+    // Local in the middle, sources either side. Each statement assigns in
+    // order; the last write (the `c` source) overwrites the rest, so only the
+    // `c` forward is in effect at end of file.
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/c.R", "dup <- 2\n"),
+        ("w/a.R", "source(\"b.R\")\ndup <- 3\nsource(\"c.R\")\n"),
+    ]);
+    let c = files[1];
+    let a = files[2];
+
+    let map = entries(&db, a);
+    assert_eq!(
+        map.get("dup"),
+        Some(&vec![ExportEntry::Import {
+            file: c,
+            name: "dup".to_string(),
+        }])
+    );
+}
+
+#[test]
+fn test_local_then_sources_resolves_to_last_source() {
+    let mut db = TestDb::new();
+
+    // Local first, sources later. The sources reassign in order, so the last
+    // source (`c`) overwrites the rest and is the only binding in effect at
+    // end of file.
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/c.R", "dup <- 2\n"),
+        ("w/a.R", "dup <- 3\nsource(\"b.R\")\nsource(\"c.R\")\n"),
+    ]);
+    let c = files[1];
+    let a = files[2];
+
+    let map = entries(&db, a);
+    assert_eq!(
+        map.get("dup"),
+        Some(&vec![ExportEntry::Import {
+            file: c,
+            name: "dup".to_string(),
+        }])
+    );
+}
+
+#[test]
+fn test_repeated_local_with_source_resolves_to_last_local() {
+    let mut db = TestDb::new();
+
+    // Local, then a sourced forward of the same name, then a later local. The
+    // last statement (`dup <- 3`) overwrites the rest, so only the local is in
+    // effect at end of file.
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/a.R", "dup <- 2\nsource(\"b.R\")\ndup <- 3\n"),
+    ]);
+    let a = files[1];
+
+    let map = entries(&db, a);
+    assert_eq!(map.get("dup"), Some(&vec![ExportEntry::Local]));
+}
+
+#[test]
+fn test_if_else_source_and_local_keeps_both_entries() {
+    let mut db = TestDb::new();
+
+    // `source()` on one `if` arm, a local rebind on the other. Either arm could
+    // run, so both the sourced forward and the local are in effect at end of
+    // file. The firewall keeps both entries, in definition order.
+    let files = setup_workspace(&mut db, &[
+        ("w/helpers.R", "shared <- 1\n"),
+        (
+            "w/analysis.R",
+            "if (cond) source(\"helpers.R\") else shared <- 2\n",
+        ),
+    ]);
     let helpers = files[0];
     let analysis = files[1];
 
-    // Multi-target keeps every candidate in definition order. The sourced
-    // forward comes first, the local `shared <- 2` second. R's runtime takes
-    // the last one (the local), but goto-def offers both.
     let map = entries(&db, analysis);
     assert_eq!(
         map.get("shared"),
@@ -106,166 +235,6 @@ fn test_sourced_then_local_keep_both() {
             ExportEntry::Import {
                 file: helpers,
                 name: "shared".to_string(),
-            },
-            ExportEntry::Local,
-        ])
-    );
-}
-
-#[test]
-fn test_two_sources_of_same_name_keep_both_forwards() {
-    let mut db = TestDb::new();
-
-    // Both `b` and `c` define `dup`. R evaluates each `source()` in sequence
-    // and the later one's assignment wins at runtime. Multi-target keeps both
-    // forwards, in source order, so the runtime winner (`c`) is last.
-    let files = setup_workspace(&mut db, &[
-        ("w/b.R", "dup <- 1\n"),
-        ("w/c.R", "dup <- 2\n"),
-        ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\n"),
-    ]);
-    let b = files[0];
-    let c = files[1];
-    let a = files[2];
-
-    let map = entries(&db, a);
-    assert_eq!(
-        map.get("dup"),
-        Some(&vec![
-            ExportEntry::Import {
-                file: b,
-                name: "dup".to_string(),
-            },
-            ExportEntry::Import {
-                file: c,
-                name: "dup".to_string(),
-            },
-        ])
-    );
-}
-
-#[test]
-fn test_sources_then_local_keep_all_in_order() {
-    let mut db = TestDb::new();
-
-    // sources first, then local. Local is the last assignment so it ends up
-    // bound at end-of-file. Multi-target keeps both forwards plus the local, in
-    // definition order, so the runtime winner (the local) is last.
-    let files = setup_workspace(&mut db, &[
-        ("w/b.R", "dup <- 1\n"),
-        ("w/c.R", "dup <- 2\n"),
-        ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\ndup <- 3\n"),
-    ]);
-    let b = files[0];
-    let c = files[1];
-    let a = files[2];
-
-    let map = entries(&db, a);
-    assert_eq!(
-        map.get("dup"),
-        Some(&vec![
-            ExportEntry::Import {
-                file: b,
-                name: "dup".to_string(),
-            },
-            ExportEntry::Import {
-                file: c,
-                name: "dup".to_string(),
-            },
-            ExportEntry::Local,
-        ])
-    );
-}
-
-#[test]
-fn test_source_local_source_keep_all_in_order() {
-    let mut db = TestDb::new();
-
-    // Local in the middle, sources either side. Matches R's runtime: each
-    // statement assigns in order; the last write (the `c` source) wins.
-    // Multi-target keeps all three candidates in definition order.
-    let files = setup_workspace(&mut db, &[
-        ("w/b.R", "dup <- 1\n"),
-        ("w/c.R", "dup <- 2\n"),
-        ("w/a.R", "source(\"b.R\")\ndup <- 3\nsource(\"c.R\")\n"),
-    ]);
-    let b = files[0];
-    let c = files[1];
-    let a = files[2];
-
-    let map = entries(&db, a);
-    assert_eq!(
-        map.get("dup"),
-        Some(&vec![
-            ExportEntry::Import {
-                file: b,
-                name: "dup".to_string(),
-            },
-            ExportEntry::Local,
-            ExportEntry::Import {
-                file: c,
-                name: "dup".to_string(),
-            },
-        ])
-    );
-}
-
-#[test]
-fn test_local_then_sources_keep_all_in_order() {
-    let mut db = TestDb::new();
-
-    // Local first, sources later. Sources reassign, last source wins at
-    // runtime. Multi-target keeps all three candidates in definition order, so
-    // the runtime winner (`c`) is last.
-    let files = setup_workspace(&mut db, &[
-        ("w/b.R", "dup <- 1\n"),
-        ("w/c.R", "dup <- 2\n"),
-        ("w/a.R", "dup <- 3\nsource(\"b.R\")\nsource(\"c.R\")\n"),
-    ]);
-    let b = files[0];
-    let c = files[1];
-    let a = files[2];
-
-    let map = entries(&db, a);
-    assert_eq!(
-        map.get("dup"),
-        Some(&vec![
-            ExportEntry::Local,
-            ExportEntry::Import {
-                file: b,
-                name: "dup".to_string(),
-            },
-            ExportEntry::Import {
-                file: c,
-                name: "dup".to_string(),
-            },
-        ])
-    );
-}
-
-#[test]
-fn test_repeated_local_moves_to_runtime_winning_position() {
-    let mut db = TestDb::new();
-
-    // Local, then a sourced forward of the same name, then a later local. The
-    // two locals collapse to one `Local` marker, and the dedup keeps it at the
-    // *last* local's position. So the entry order is `[Import{b}, Local]` and
-    // the final entry is the binding R picks at runtime (`dup <- 3`), not the
-    // earlier `Import{b}`.
-    let files = setup_workspace(&mut db, &[
-        ("w/b.R", "dup <- 1\n"),
-        ("w/a.R", "dup <- 2\nsource(\"b.R\")\ndup <- 3\n"),
-    ]);
-    let b = files[0];
-    let a = files[1];
-
-    let map = entries(&db, a);
-    assert_eq!(
-        map.get("dup"),
-        Some(&vec![
-            ExportEntry::Import {
-                file: b,
-                name: "dup".to_string(),
             },
             ExportEntry::Local,
         ])

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -4,6 +4,7 @@ use crate::tests::test_db::file_path;
 use crate::tests::test_db::workspace_root;
 use crate::tests::test_db::TestDb;
 use crate::DbInputs;
+use crate::Definition;
 use crate::File;
 use crate::Name;
 
@@ -26,13 +27,22 @@ fn name<'db>(db: &'db TestDb, text: &str) -> Name<'db> {
     Name::new(db, text)
 }
 
+/// Resolve `text` in `file`, asserting it lands on exactly one definition.
+/// Most cases here bind a name once; the multi-target fan-out cases assert on
+/// the full `Vec` directly.
+fn resolve_one<'db>(db: &'db TestDb, file: File, text: &str) -> Definition<'db> {
+    let defs = file.resolve(db, name(db, text));
+    assert_eq!(defs.len(), 1);
+    defs.into_iter().next().unwrap()
+}
+
 #[test]
 fn test_resolve_local_name_lands_on_owning_file() {
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[("w/a.R", "x <- 1\n")]);
     let file = files[0];
 
-    let def = file.resolve(&db, name(&db, "x")).expect("x should resolve");
+    let def = resolve_one(&db, file, "x");
     assert_eq!(def.file(&db), file);
     assert_eq!(def.name(&db).text(&db).as_str(), "x");
     // The name range is just the `x` identifier in `x <- 1`.
@@ -46,7 +56,7 @@ fn test_unresolved_name_returns_none() {
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[("w/a.R", "x <- 1\n")]);
     let file = files[0];
-    assert!(file.resolve(&db, name(&db, "nope")).is_none());
+    assert!(file.resolve(&db, name(&db, "nope")).is_empty());
 }
 
 #[test]
@@ -59,9 +69,7 @@ fn test_resolve_chases_source_forwarding_to_origin_file() {
     let helpers = files[0];
     let analysis = files[1];
 
-    let def = analysis
-        .resolve(&db, name(&db, "helper"))
-        .expect("helper should resolve through source()");
+    let def = resolve_one(&db, analysis, "helper");
 
     assert_eq!(def.file(&db), helpers);
     assert_eq!(def.name(&db).text(&db).as_str(), "helper");
@@ -78,9 +86,7 @@ fn test_resolve_chases_two_step_source_chain() {
     let leaf = files[0];
     let top = files[2];
 
-    let def = top
-        .resolve(&db, name(&db, "deep"))
-        .expect("deep should chase through mid -> leaf");
+    let def = resolve_one(&db, top, "deep");
 
     assert_eq!(def.file(&db), leaf);
     assert_eq!(def.name(&db).text(&db).as_str(), "deep");
@@ -117,8 +123,8 @@ fn test_resolve_in_cyclic_source_returns_none_without_panicking() {
     // names that would otherwise be found in those exports. The
     // point of the test is that resolution terminates cleanly rather
     // than panicking.
-    assert!(a.resolve(&db, name(&db, "a_local")).is_none());
-    assert!(b.resolve(&db, name(&db, "b_local")).is_none());
+    assert!(a.resolve(&db, name(&db, "a_local")).is_empty());
+    assert!(b.resolve(&db, name(&db, "b_local")).is_empty());
 }
 
 /// Extract the source slice at `range` from `source`.
@@ -131,9 +137,7 @@ fn test_name_range_for_left_assignment() {
     let mut db = TestDb::new();
     let source = "x <- 1\n";
     let files = setup_workspace(&mut db, &[("w/a.R", source)]);
-    let def = files[0]
-        .resolve(&db, name(&db, "x"))
-        .expect("x should resolve");
+    let def = resolve_one(&db, files[0], "x");
     let range = def.name_range(&db).expect("Local has name range");
     assert_eq!(slice(source, range), "x");
 }
@@ -143,9 +147,7 @@ fn test_name_range_for_right_assignment() {
     let mut db = TestDb::new();
     let source = "1 -> x\n";
     let files = setup_workspace(&mut db, &[("w/a.R", source)]);
-    let def = files[0]
-        .resolve(&db, name(&db, "x"))
-        .expect("x should resolve");
+    let def = resolve_one(&db, files[0], "x");
     let range = def.name_range(&db).expect("Local has name range");
     assert_eq!(slice(source, range), "x");
 }
@@ -155,9 +157,7 @@ fn test_name_range_for_super_left_assignment() {
     let mut db = TestDb::new();
     let source = "x <<- 1\n";
     let files = setup_workspace(&mut db, &[("w/a.R", source)]);
-    let def = files[0]
-        .resolve(&db, name(&db, "x"))
-        .expect("x should resolve");
+    let def = resolve_one(&db, files[0], "x");
     let range = def.name_range(&db).expect("Local has name range");
     assert_eq!(slice(source, range), "x");
 }
@@ -167,9 +167,7 @@ fn test_name_range_for_super_right_assignment() {
     let mut db = TestDb::new();
     let source = "1 ->> x\n";
     let files = setup_workspace(&mut db, &[("w/a.R", source)]);
-    let def = files[0]
-        .resolve(&db, name(&db, "x"))
-        .expect("x should resolve");
+    let def = resolve_one(&db, files[0], "x");
     let range = def.name_range(&db).expect("Local has name range");
     assert_eq!(slice(source, range), "x");
 }
@@ -182,9 +180,7 @@ fn test_name_range_for_string_as_name() {
     let mut db = TestDb::new();
     let source = "\"x\" <- 1\n";
     let files = setup_workspace(&mut db, &[("w/a.R", source)]);
-    let def = files[0]
-        .resolve(&db, name(&db, "x"))
-        .expect("x should resolve");
+    let def = resolve_one(&db, files[0], "x");
     let range = def.name_range(&db).expect("Local has name range");
     assert_eq!(slice(source, range), "\"x\"");
 }
@@ -250,7 +246,7 @@ fn test_definition_id_stable_across_body_edits() {
     // since the `Definition<'db>` borrow conflicts with `set_contents`'s
     // mutable borrow.
     let (id1, range1) = {
-        let def = file.resolve(&db, name(&db, "x")).expect("x should resolve");
+        let def = resolve_one(&db, file, "x");
         (def.as_id(), def.name_range(&db))
     };
 
@@ -259,9 +255,7 @@ fn test_definition_id_stable_across_body_edits() {
         .to("f <- function() 2\nx <- 1\n".to_string());
 
     let (id2, range2) = {
-        let def = file
-            .resolve(&db, name(&db, "x"))
-            .expect("x should still resolve");
+        let def = resolve_one(&db, file, "x");
         (def.as_id(), def.name_range(&db))
     };
 
@@ -316,16 +310,29 @@ fn test_definitions_mints_distinct_entities_for_same_name_redefinition() {
     // Two file-scope `x` bindings share the `(file, scope, name)` id-fields.
     // The single mint site must create two distinct salsa entities rather than
     // collide or panic; salsa disambiguates same-id-field tracked structs by
-    // creation order. Resolving `x` forces the mint of both (via `definitions`)
-    // and must land on the last definition (offset 7).
+    // creation order. With multi-target exports, resolving `x` returns both
+    // bindings, in definition order.
+    use salsa::plumbing::AsId;
+
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[("w/a.R", "x <- 1\nx <- 2\n")]);
     let file = files[0];
 
-    let def = file.resolve(&db, name(&db, "x")).expect("x should resolve");
-    assert_eq!(def.name(&db).text(&db).as_str(), "x");
-    let range = def.name_range(&db).expect("local binding has a name range");
-    assert_eq!(usize::from(range.start()), 7);
+    let defs = file.resolve(&db, name(&db, "x"));
+    assert_eq!(defs.len(), 2);
+    assert_ne!(defs[0].as_id(), defs[1].as_id());
+
+    let starts: Vec<usize> = defs
+        .iter()
+        .map(|d| {
+            usize::from(
+                d.name_range(&db)
+                    .expect("local binding has a name range")
+                    .start(),
+            )
+        })
+        .collect();
+    assert_eq!(starts, vec![0, 7]);
 }
 
 #[test]
@@ -350,7 +357,7 @@ fn test_position_shift_keeps_id_and_does_not_invalidate_identity_consumers() {
     let file = files[0];
 
     let (id1, range1) = {
-        let def = file.resolve(&db, name(&db, "x")).expect("x resolves");
+        let def = resolve_one(&db, file, "x");
         let _ = name_len(&db, def);
         (def.as_id(), def.name_range(&db))
     };
@@ -361,7 +368,7 @@ fn test_position_shift_keeps_id_and_does_not_invalidate_identity_consumers() {
         .to("# comment\nx <- 1\n".to_string());
 
     let (id2, range2) = {
-        let def = file.resolve(&db, name(&db, "x")).expect("x still resolves");
+        let def = resolve_one(&db, file, "x");
         let _ = name_len(&db, def);
         (def.as_id(), def.name_range(&db))
     };
@@ -389,19 +396,22 @@ fn test_same_name_sibling_insertion_churns_later_definition_id() {
     let files = setup_workspace(&mut db, &[("w/a.R", "x <- 1\nx <- 2\n")]);
     let file = files[0];
 
-    // `resolve` is last-wins, so it returns the final `x` (`x <- 2`), ordinal 1.
+    // `resolve` returns the file-scope `x` bindings in definition order; the
+    // final `x` (`x <- 2`) is the last element, ordinal 1 among same-name siblings.
     let id1 = file
         .resolve(&db, name(&db, "x"))
+        .last()
         .expect("x resolves")
         .as_id();
 
-    // Insert another `x` at the top. The final `x` is still last-wins, but its
+    // Insert another `x` at the top. The final `x` is still last, but its
     // ordinal among same-name siblings shifts from 1 to 2.
     file.set_contents(&mut db)
         .to("x <- 0\nx <- 1\nx <- 2\n".to_string());
 
     let id2 = file
         .resolve(&db, name(&db, "x"))
+        .last()
         .expect("x still resolves")
         .as_id();
 
@@ -443,8 +453,8 @@ fn test_resolve_unbound_name_in_package_does_not_cycle() {
     workspace.set_packages(&mut db).to(vec![pkg]);
     db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
 
-    assert!(a.resolve(&db, name(&db, "nope")).is_none());
-    assert!(b.resolve(&db, name(&db, "nope")).is_none());
+    assert!(a.resolve(&db, name(&db, "nope")).is_empty());
+    assert!(b.resolve(&db, name(&db, "nope")).is_empty());
 }
 
 #[test]
@@ -486,7 +496,7 @@ fn test_resolve_walks_package_files_for_lazy_lookups() {
     // `b` has no top-level `shared`, but `a` (a sibling file in the
     // same package) does. `b.resolve("shared")` should find it via the
     // imports walk.
-    let def = b.resolve(&db, name(&db, "shared")).expect("should resolve");
+    let def = resolve_one(&db, b, "shared");
     assert_eq!(def.file(&db), a);
     assert_eq!(def.name(&db).text(&db).as_str(), "shared");
 }

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -93,6 +93,44 @@ fn test_resolve_chases_two_step_source_chain() {
 }
 
 #[test]
+fn test_resolve_sourced_and_local_same_name_skips_import_marker() {
+    // `analysis.R` both sources `shared` and rebinds it locally, so its file
+    // scope holds an `Import` def (from `source()`) and a `Local` def for the
+    // same name. resolve must return the two real bindings: the sourced def in
+    // `helpers` and the local rebind in `analysis`. It must not also mint the
+    // `Import` def as a candidate, which would point at the empty `source()`
+    // call span (`name_range == None`).
+    let mut db = TestDb::new();
+    let files = setup_workspace(&mut db, &[
+        ("w/helpers.R", "shared <- 1\n"),
+        ("w/analysis.R", "source(\"helpers.R\")\nshared <- 2\n"),
+    ]);
+    let helpers = files[0];
+    let analysis = files[1];
+
+    let defs = analysis.resolve(&db, name(&db, "shared"));
+    assert_eq!(defs.len(), 2);
+
+    // Order out of resolve isn't a contract, so key on the name range to
+    // assert exactly which two bindings came back.
+    let mut hits: Vec<(File, usize)> = defs
+        .iter()
+        .map(|d| {
+            let start = d
+                .name_range(&db)
+                .expect("both real bindings have a name range")
+                .start();
+            (d.file(&db), usize::from(start))
+        })
+        .collect();
+    hits.sort_by_key(|(_, start)| *start);
+
+    // `shared <- 1` at offset 0 in helpers, `shared <- 2` at offset 20 in
+    // analysis (past `source("helpers.R")\n`).
+    assert_eq!(hits, vec![(helpers, 0), (analysis, 20)]);
+}
+
+#[test]
 fn test_resolve_is_cached_across_repeat_calls() {
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[("w/a.R", "x <- 1\n")]);

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -109,11 +109,12 @@ fn test_resolve_sourced_and_local_same_name_skips_import_marker() {
     let analysis = files[1];
 
     let defs = analysis.resolve(&db, name(&db, "shared"));
-    assert_eq!(defs.len(), 2);
 
-    // Order out of resolve isn't a contract, so key on the name range to
-    // assert exactly which two bindings came back.
-    let mut hits: Vec<(File, usize)> = defs
+    // Two real bindings, in `exports()` order: the sourced `shared <- 1` in
+    // helpers (offset 0), then the local `shared <- 2` in analysis (offset 20,
+    // past `source("helpers.R")\n`). The local is R's runtime winner, so it's
+    // last. No third entry for the `Import` marker.
+    let hits: Vec<(File, usize)> = defs
         .iter()
         .map(|d| {
             let start = d
@@ -123,11 +124,48 @@ fn test_resolve_sourced_and_local_same_name_skips_import_marker() {
             (d.file(&db), usize::from(start))
         })
         .collect();
-    hits.sort_by_key(|(_, start)| *start);
-
-    // `shared <- 1` at offset 0 in helpers, `shared <- 2` at offset 20 in
-    // analysis (past `source("helpers.R")\n`).
     assert_eq!(hits, vec![(helpers, 0), (analysis, 20)]);
+}
+
+#[test]
+fn test_resolve_two_sourced_defs_put_runtime_winner_last() {
+    // `a.R` sources `b.R` then `c.R`, both binding `dup`. R runs the sources in
+    // order, so `c`'s binding wins at runtime. resolve returns both forwards in
+    // source order, so the runtime winner (`c`) is the last element.
+    let mut db = TestDb::new();
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/c.R", "dup <- 2\n"),
+        ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\n"),
+    ]);
+    let b = files[0];
+    let c = files[1];
+    let a = files[2];
+
+    let defs = a.resolve(&db, name(&db, "dup"));
+    let hits: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
+    assert_eq!(hits, vec![b, c]);
+}
+
+#[test]
+fn test_resolve_interleaved_source_local_source_puts_runtime_winner_last() {
+    // `source("b.R")`, then a local `dup <- 3`, then `source("c.R")`, all
+    // binding `dup`. The last statement (the `c` source) wins at runtime, so it
+    // must be last. Entries come back in `exports()` order: the `b` forward, the
+    // local, then the `c` forward.
+    let mut db = TestDb::new();
+    let files = setup_workspace(&mut db, &[
+        ("w/b.R", "dup <- 1\n"),
+        ("w/c.R", "dup <- 2\n"),
+        ("w/a.R", "source(\"b.R\")\ndup <- 3\nsource(\"c.R\")\n"),
+    ]);
+    let b = files[0];
+    let c = files[1];
+    let a = files[2];
+
+    let defs = a.resolve(&db, name(&db, "dup"));
+    let hits: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
+    assert_eq!(hits, vec![b, a, c]);
 }
 
 #[test]

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -93,27 +93,31 @@ fn test_resolve_chases_two_step_source_chain() {
 }
 
 #[test]
-fn test_resolve_sourced_and_local_same_name_skips_import_marker() {
-    // `analysis.R` both sources `shared` and rebinds it locally, so its file
-    // scope holds an `Import` def (from `source()`) and a `Local` def for the
-    // same name. resolve must return the two real bindings: the sourced def in
-    // `helpers` and the local rebind in `analysis`. It must not also mint the
-    // `Import` def as a candidate, which would point at the empty `source()`
-    // call span (`name_range == None`).
+fn test_resolve_if_else_source_and_local_skips_import_marker() {
+    // `analysis.R` sources `shared` on one `if` arm and rebinds it locally on
+    // the other, so either arm could run and both are in effect at end of file:
+    // an `Import` def (from `source()`) and a `Local` def for the same name.
+    // resolve must return the two real bindings: the sourced def in `helpers`
+    // and the local rebind in `analysis`. It must not also mint the `Import`
+    // def as a candidate, which would point at the empty `source()` call span
+    // (`name_range == None`).
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[
         ("w/helpers.R", "shared <- 1\n"),
-        ("w/analysis.R", "source(\"helpers.R\")\nshared <- 2\n"),
+        (
+            "w/analysis.R",
+            "if (cond) source(\"helpers.R\") else shared <- 2\n",
+        ),
     ]);
     let helpers = files[0];
     let analysis = files[1];
 
     let defs = analysis.resolve(&db, name(&db, "shared"));
 
-    // Two real bindings, in `exports()` order: the sourced `shared <- 1` in
-    // helpers (offset 0), then the local `shared <- 2` in analysis (offset 20,
-    // past `source("helpers.R")\n`). The local is R's runtime winner, so it's
-    // last. No third entry for the `Import` marker.
+    // Two real bindings: the sourced `shared <- 1` in helpers (offset 0) and
+    // the local `shared <- 2` in analysis (offset 35, past
+    // `if (cond) source("helpers.R") else `). No third entry for the `Import`
+    // marker.
     let hits: Vec<(File, usize)> = defs
         .iter()
         .map(|d| {
@@ -124,48 +128,73 @@ fn test_resolve_sourced_and_local_same_name_skips_import_marker() {
             (d.file(&db), usize::from(start))
         })
         .collect();
-    assert_eq!(hits, vec![(helpers, 0), (analysis, 20)]);
+    assert_eq!(hits, vec![(helpers, 0), (analysis, 35)]);
 }
 
 #[test]
-fn test_resolve_two_sourced_defs_put_runtime_winner_last() {
+fn test_resolve_two_sourced_defs_resolves_to_last() {
     // `a.R` sources `b.R` then `c.R`, both binding `dup`. R runs the sources in
-    // order, so `c`'s binding wins at runtime. resolve returns both forwards in
-    // source order, so the runtime winner (`c`) is the last element.
+    // order, so `c`'s binding overwrites `b`'s. resolve returns only the `c`
+    // forward, the binding in effect at end of file.
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[
         ("w/b.R", "dup <- 1\n"),
         ("w/c.R", "dup <- 2\n"),
         ("w/a.R", "source(\"b.R\")\nsource(\"c.R\")\n"),
     ]);
-    let b = files[0];
     let c = files[1];
     let a = files[2];
 
     let defs = a.resolve(&db, name(&db, "dup"));
     let hits: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
-    assert_eq!(hits, vec![b, c]);
+    assert_eq!(hits, vec![c]);
 }
 
 #[test]
-fn test_resolve_interleaved_source_local_source_puts_runtime_winner_last() {
+fn test_resolve_interleaved_source_local_source_resolves_to_last_source() {
     // `source("b.R")`, then a local `dup <- 3`, then `source("c.R")`, all
-    // binding `dup`. The last statement (the `c` source) wins at runtime, so it
-    // must be last. Entries come back in `exports()` order: the `b` forward, the
-    // local, then the `c` forward.
+    // binding `dup`. The last statement (the `c` source) overwrites the rest,
+    // so resolve returns only the `c` forward.
     let mut db = TestDb::new();
     let files = setup_workspace(&mut db, &[
         ("w/b.R", "dup <- 1\n"),
         ("w/c.R", "dup <- 2\n"),
         ("w/a.R", "source(\"b.R\")\ndup <- 3\nsource(\"c.R\")\n"),
     ]);
-    let b = files[0];
     let c = files[1];
     let a = files[2];
 
     let defs = a.resolve(&db, name(&db, "dup"));
     let hits: Vec<File> = defs.iter().map(|d| d.file(&db)).collect();
-    assert_eq!(hits, vec![b, a, c]);
+    assert_eq!(hits, vec![c]);
+}
+
+#[test]
+fn test_resolve_if_else_in_sourced_file_offers_both() {
+    // `helpers.R` binds `fn` on both arms of a top-level `if`/`else`, so either
+    // arm could run and both are in effect when `source()` finishes. resolve
+    // from the sourcing file offers both, in definition order.
+    let mut db = TestDb::new();
+    let files = setup_workspace(&mut db, &[
+        ("w/helpers.R", "if (cond) fn <- 1 else fn <- 2\n"),
+        ("w/analysis.R", "source(\"helpers.R\")\n"),
+    ]);
+    let helpers = files[0];
+    let analysis = files[1];
+
+    let defs = analysis.resolve(&db, name(&db, "fn"));
+    let hits: Vec<(File, usize)> = defs
+        .iter()
+        .map(|d| {
+            let start = d
+                .name_range(&db)
+                .expect("both arms have a name range")
+                .start();
+            (d.file(&db), usize::from(start))
+        })
+        .collect();
+    // `fn <- 1` at offset 10, `fn <- 2` at offset 23, both in helpers.
+    assert_eq!(hits, vec![(helpers, 10), (helpers, 23)]);
 }
 
 #[test]
@@ -382,16 +411,17 @@ fn test_definition_id_stable_across_def_id_renumber_local_path() {
 }
 
 #[test]
-fn test_definitions_mints_distinct_entities_for_same_name_redefinition() {
-    // Two file-scope `x` bindings share the `(file, scope, name)` id-fields.
-    // The single mint site must create two distinct salsa entities rather than
-    // collide or panic; salsa disambiguates same-id-field tracked structs by
-    // creation order. With multi-target exports, resolving `x` returns both
-    // bindings, in definition order.
+fn test_definitions_mints_distinct_entities_for_same_name() {
+    // Two file-scope `x` bindings on the arms of an `if`/`else` share the
+    // `(file, scope, name)` id-fields. The single mint site must create two
+    // distinct salsa entities rather than collide or panic; salsa
+    // disambiguates same-id-field tracked structs by creation order. Both arms
+    // are in effect at end of file, so resolving `x` returns both, in
+    // definition order.
     use salsa::plumbing::AsId;
 
     let mut db = TestDb::new();
-    let files = setup_workspace(&mut db, &[("w/a.R", "x <- 1\nx <- 2\n")]);
+    let files = setup_workspace(&mut db, &[("w/a.R", "if (cond) x <- 1 else x <- 2\n")]);
     let file = files[0];
 
     let defs = file.resolve(&db, name(&db, "x"));
@@ -408,7 +438,8 @@ fn test_definitions_mints_distinct_entities_for_same_name_redefinition() {
             )
         })
         .collect();
-    assert_eq!(starts, vec![0, 7]);
+    // `x <- 1` at offset 10, `x <- 2` at offset 22.
+    assert_eq!(starts, vec![10, 22]);
 }
 
 #[test]
@@ -575,4 +606,103 @@ fn test_resolve_walks_package_files_for_lazy_lookups() {
     let def = resolve_one(&db, b, "shared");
     assert_eq!(def.file(&db), a);
     assert_eq!(def.name(&db).text(&db).as_str(), "shared");
+}
+
+#[test]
+fn test_resolve_if_else_in_collated_file_offers_both() {
+    // A collation file binds `fn` on both arms of a top-level `if`/`else`, so
+    // either arm could run and both are in the namespace once the package is
+    // loaded. A sibling file's reference resolves to both, in definition order.
+    let mut db = TestDb::new();
+    let workspace = workspace_root(&db, "w/pkg");
+    let pkg = crate::Package::new(
+        &db,
+        file_path("/w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        None,
+        oak_package_metadata::namespace::Namespace::default(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+
+    let a = File::new(
+        &db,
+        file_path("/w/pkg/R/a.R"),
+        "if (cond) fn <- 1 else fn <- 2\n".to_string(),
+        Some(pkg),
+    );
+    let b = File::new(
+        &db,
+        file_path("/w/pkg/R/b.R"),
+        "use_fn <- function() fn\n".to_string(),
+        Some(pkg),
+    );
+    pkg.set_files(&mut db).to(vec![a, b]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    let defs = b.resolve(&db, name(&db, "fn"));
+    let hits: Vec<(File, usize)> = defs
+        .iter()
+        .map(|d| {
+            let start = d
+                .name_range(&db)
+                .expect("both arms have a name range")
+                .start();
+            (d.file(&db), usize::from(start))
+        })
+        .collect();
+    // `fn <- 1` at offset 10, `fn <- 2` at offset 23, both in `a`.
+    assert_eq!(hits, vec![(a, 10), (a, 23)]);
+}
+
+#[test]
+fn test_resolve_collated_sequential_redef_resolves_to_last() {
+    // An earlier collation file rebinds `shared` in sequence; the second
+    // assignment overwrites the first, so the namespace holds only the final
+    // binding once the package is loaded. A sibling file's reference resolves
+    // to that single binding, not the overwritten one.
+    let mut db = TestDb::new();
+    let workspace = workspace_root(&db, "w/pkg");
+    let pkg = crate::Package::new(
+        &db,
+        file_path("/w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        None,
+        oak_package_metadata::namespace::Namespace::default(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+
+    let a = File::new(
+        &db,
+        file_path("/w/pkg/R/a.R"),
+        "shared <- 1\nshared <- 2\n".to_string(),
+        Some(pkg),
+    );
+    let b = File::new(
+        &db,
+        file_path("/w/pkg/R/b.R"),
+        "use_shared <- function() shared\n".to_string(),
+        Some(pkg),
+    );
+    pkg.set_files(&mut db).to(vec![a, b]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    let defs = b.resolve(&db, name(&db, "shared"));
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].file(&db), a);
+    // The surviving binding is `shared <- 2` (offset 12), not `shared <- 1`.
+    assert_eq!(
+        usize::from(
+            defs[0]
+                .name_range(&db)
+                .expect("local binding has a name range")
+                .start()
+        ),
+        12
+    );
 }

--- a/crates/oak_db/src/tests/package_resolve.rs
+++ b/crates/oak_db/src/tests/package_resolve.rs
@@ -144,12 +144,10 @@ fn test_resolves_binding_in_correct_file_for_multi_file_package() {
 }
 
 #[test]
-fn test_conditional_binding_single_under_last_wins_exports() {
-    // Top-level `if (cond) foo <- 1 else foo <- 2` in principle produces two
-    // candidate Definitions for `foo`. Full fan-out requires multi-target
-    // exports (PR 3, deferred). Under the current single-target model,
-    // `file_exports` keeps the last-wins definition, so `Package::resolve`
-    // returns exactly one. The stub+onload case across two files still works.
+fn test_conditional_binding_fans_out() {
+    // Top-level `if (cond) foo <- 1 else foo <- 2` produces two candidate
+    // Definitions for `foo`, one per branch. Multi-target exports surface both,
+    // so `Package::resolve` returns both candidates from the single file.
     let mut db = TestDb::new();
     let (pkg, _files) = setup_package(&mut db, "pkg", &["foo"], &[(
         "workspace/pkg/R/a.R",
@@ -157,7 +155,7 @@ fn test_conditional_binding_single_under_last_wins_exports() {
     )]);
 
     let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
-    assert_eq!(defs.len(), 1);
+    assert_eq!(defs.len(), 2);
 }
 
 #[test]

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -272,6 +272,27 @@ fn test_cross_file_via_source() {
 }
 
 #[test]
+fn test_cross_file_ambiguous_binding_includes_both_defs() {
+    // helpers.R binds `foo` on both arms of a top-level `if`/`else`, so the
+    // name has two candidate definitions. script.R sources it and uses `foo`.
+    // The use resolves to both candidates through the multi-target export
+    // forward, so find-references reports both defs alongside the use.
+    let mut db = OakDatabase::new();
+    let helpers = upsert(&mut db, "helpers.R", "if (cond) foo <- 1 else foo <- 2\n");
+    let script = upsert(&mut db, "script.R", "source(\"helpers.R\")\nfoo\n");
+
+    let use_start = "source(\"helpers.R\")\n".len() as u32;
+    let refs = find_references(&db, script, offset(use_start), true);
+
+    // script.R (primary) first with its use, then helpers.R with both defs.
+    assert_eq!(pairs(&refs), vec![
+        (script, range(use_start, use_start + 3)),
+        (helpers, range(10, 13)),
+        (helpers, range(24, 27)),
+    ]);
+}
+
+#[test]
 fn test_different_binding_not_included() {
     // file2 has its own `foo` binding. Cursor on file1's `foo` must not
     // include file2's `foo` (confirmed distinct by resolve_at).

--- a/crates/oak_ide/tests/integration/goto_definition.rs
+++ b/crates/oak_ide/tests/integration/goto_definition.rs
@@ -85,3 +85,23 @@ fn test_navigates_to_package_export_via_library_call() {
     assert_eq!(target.name, "foo");
     assert_eq!(target.full_range, range(0, 3));
 }
+
+#[test]
+fn test_navigates_to_both_candidates_through_source() {
+    // The sourced file binds `foo` on both arms of a top-level `if`/`else`, so
+    // the name has two candidate definitions. Multi-target exports carry both
+    // through the `source()` forward, and goto-def offers both jumps.
+    let mut db = OakDatabase::new();
+    let helpers = upsert(&mut db, "helpers.R", "if (cond) foo <- 1 else foo <- 2\n");
+    let script = upsert(&mut db, "script.R", "source(\"helpers.R\")\nfoo\n");
+
+    let offset = TextSize::from("source(\"helpers.R\")\n".len() as u32);
+    let mut targets = goto_definition(&db, script, offset);
+    assert_eq!(targets.len(), 2);
+
+    // Both land in the sourced file, in definition order.
+    targets.sort_by_key(|t| t.focus_range.start());
+    assert!(targets.iter().all(|t| t.file == helpers && t.name == "foo"));
+    assert_eq!(targets[0].focus_range, range(10, 13));
+    assert_eq!(targets[1].focus_range, range(24, 27));
+}

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -175,6 +175,27 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     // the first scope where the symbol is already bound. If no binding is
     // found, it assigns in the global (file) scope.
     fn add_super_definition(&mut self, name: &str, kind: DefinitionKind, range: TextRange) {
+        let target_scope = self.resolve_super_target(name);
+
+        // A top-level `<<-` resolves its target to the file scope it already
+        // sits in (no enclosing frame to walk to), so the marker scope and the
+        // binding scope coincide. Record one definition carrying both flags,
+        // rather than pushing duplicate definition entries.
+        if target_scope == self.current_scope {
+            let symbol_id = self.symbol_tables[self.current_scope].intern(
+                name,
+                SymbolFlags::IS_SUPER_BOUND.union(SymbolFlags::IS_BOUND),
+            );
+            let def_id = self.definitions[self.current_scope].push(Definition {
+                symbol: symbol_id,
+                kind,
+                range,
+            });
+            self.use_def_maps[self.current_scope].ensure_symbol(symbol_id);
+            self.use_def_maps[self.current_scope].record_deferred_definition(symbol_id, def_id);
+            return;
+        }
+
         let symbol_id =
             self.symbol_tables[self.current_scope].intern(name, SymbolFlags::IS_SUPER_BOUND);
         self.definitions[self.current_scope].push(Definition {
@@ -182,8 +203,6 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             kind: kind.clone(),
             range,
         });
-
-        let target_scope = self.resolve_super_target(name);
 
         let target_symbol = self.symbol_tables[target_scope].intern(name, SymbolFlags::IS_BOUND);
         let target_def_id = self.definitions[target_scope].push(Definition {

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -175,13 +175,11 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     // the first scope where the symbol is already bound. If no binding is
     // found, it assigns in the global (file) scope.
     fn add_super_definition(&mut self, name: &str, kind: DefinitionKind, range: TextRange) {
-        let target_scope = self.resolve_super_target(name);
-
-        // A top-level `<<-` resolves its target to the file scope it already
-        // sits in (no enclosing frame to walk to), so the marker scope and the
-        // binding scope coincide. Record one definition carrying both flags,
-        // rather than pushing duplicate definition entries.
-        if target_scope == self.current_scope {
+        let Some(parent) = self.scopes[self.current_scope].parent else {
+            // A top-level `<<-` has no enclosing frame to walk to, so it binds
+            // in the file scope it already sits in. The marker scope and the
+            // binding scope coincide, so record one definition carrying both
+            // flags rather than pushing two coinciding entries.
             let symbol_id = self.symbol_tables[self.current_scope].intern(
                 name,
                 SymbolFlags::IS_SUPER_BOUND.union(SymbolFlags::IS_BOUND),
@@ -194,7 +192,9 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             self.use_def_maps[self.current_scope].ensure_symbol(symbol_id);
             self.use_def_maps[self.current_scope].record_deferred_definition(symbol_id, def_id);
             return;
-        }
+        };
+
+        let target_scope = self.resolve_super_target(name, parent);
 
         let symbol_id =
             self.symbol_tables[self.current_scope].intern(name, SymbolFlags::IS_SUPER_BOUND);
@@ -214,15 +214,13 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         self.use_def_maps[target_scope].record_deferred_definition(target_symbol, target_def_id);
     }
 
-    // Walk up from the parent scope looking for a scope where `name` already
-    // has `IS_BOUND`. Returns that scope, or the file scope if no binding is
-    // found (mirroring R's assignment to the global environment).
-    fn resolve_super_target(&self, name: &str) -> ScopeId {
-        let file_scope = ScopeId::from(0);
-        let Some(mut scope) = self.scopes[self.current_scope].parent else {
-            return file_scope;
-        };
-
+    // Walk up from `start` to the first scope where `name` already has
+    // `IS_BOUND`. Returns that scope, or the file scope if no binding is found
+    // (mirroring R's assignment to the global environment). Reaching the file
+    // scope unbound ends the walk there, so its `parent` of `None` is the
+    // natural terminator.
+    fn resolve_super_target(&self, name: &str, start: ScopeId) -> ScopeId {
+        let mut scope = start;
         loop {
             if let Some(id) = self.symbol_tables[scope].id(name) {
                 if self.symbol_tables[scope]
@@ -234,7 +232,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 }
             }
             let Some(parent) = self.scopes[scope].parent else {
-                return file_scope;
+                return scope;
             };
             scope = parent;
         }

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -876,6 +876,11 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             .into_iter()
             .map(|b| Arc::new(b.build()))
             .collect();
+
+        // The file scope's exit flow state is the file's exports. Capture it
+        // before the builders are consumed below.
+        let file_final_bindings = self.use_def_maps[ScopeId::from(0)].final_bindings().clone();
+
         let use_def_maps: IndexVec<ScopeId, _> = self
             .use_def_maps
             .into_iter()
@@ -891,6 +896,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             use_def_maps,
             self.enclosing_snapshots,
             self.semantic_calls,
+            file_final_bindings,
         )
     }
 }

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -80,6 +80,12 @@ pub struct SemanticIndex {
     // Cross-file call sites recorded during indexing, such as `library()`
     // attachments or `source()` injections.
     semantic_calls: Vec<SemanticCall>,
+
+    // The file scope's exit flow state: for each top-level symbol, the
+    // definitions still in effect once the file has run top to bottom. This is
+    // the file's exports (see `exports()`). Only the file scope's exit state is
+    // ever needed, so we keep this one copy rather than per-scope state.
+    final_bindings: IndexVec<SymbolId, Bindings>,
 }
 
 impl SemanticIndex {
@@ -91,6 +97,7 @@ impl SemanticIndex {
         use_def_maps: IndexVec<ScopeId, Arc<UseDefMap>>,
         enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
         semantic_calls: Vec<SemanticCall>,
+        final_bindings: IndexVec<SymbolId, Bindings>,
     ) -> Self {
         Self {
             scopes,
@@ -100,6 +107,7 @@ impl SemanticIndex {
             use_def_maps,
             enclosing_snapshots,
             semantic_calls,
+            final_bindings,
         }
     }
 
@@ -126,17 +134,28 @@ impl SemanticIndex {
     /// Top-level definitions exported by this file (definitions in the file scope).
     /// Includes `Import`-kind forwarding definitions from `source()` calls.
     ///
-    /// A name maps to every file-scope definition that binds it, in definition
-    /// order, so a name bound twice (e.g. `if (cond) x <- 1 else x <- 2`) yields
-    /// both. Callers that want R's last-wins runtime view take the last element.
+    /// For each name, the definitions still in effect once the file has run top
+    /// to bottom, which is what another file sees after `source()`-ing this one.
+    /// A name rebound in sequence keeps only the last def (the earlier one was
+    /// overwritten), so `x <- 1; x <- 2` exports just the second. A name bound
+    /// on both arms of an `if`/`else` (`if (cond) x <- 1 else x <- 2`) keeps
+    /// both, since either could be the one that ran. Definitions come back in
+    /// definition order.
     pub fn exports(&self) -> FxHashMap<&str, Vec<(DefinitionId, &Definition)>> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
+        let defs = &self.definitions[file_scope];
 
         let mut exports: FxHashMap<&str, Vec<(DefinitionId, &Definition)>> = FxHashMap::default();
-        for (id, def) in self.definitions[file_scope].iter() {
-            let name = symbols.symbol(def.symbol()).name();
-            exports.entry(name).or_default().push((id, def));
+        for (symbol_id, bindings) in self.final_bindings.iter() {
+            if bindings.definitions().is_empty() {
+                continue;
+            }
+            let name = symbols.symbol(symbol_id).name();
+            let list = exports.entry(name).or_default();
+            for &def_id in bindings.definitions() {
+                list.push((def_id, &defs[def_id]));
+            }
         }
 
         exports

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -136,16 +136,7 @@ impl SemanticIndex {
         let mut exports: FxHashMap<&str, Vec<(DefinitionId, &Definition)>> = FxHashMap::default();
         for (id, def) in self.definitions[file_scope].iter() {
             let name = symbols.symbol(def.symbol()).name();
-            let list = exports.entry(name).or_default();
-            // A top-level `<<-` records the binding in both the scope where it
-            // appears and the super-assign target scope, which coincide at file
-            // scope, so the same binding lands here twice. Drop the byte-equal
-            // duplicate while still keeping genuinely distinct definitions, like
-            // both arms of a top-level `if`/`else` or two `source()` forwards of
-            // one name (those differ in range or in the forwarded file).
-            if !list.iter().any(|(_, d)| *d == def) {
-                list.push((id, def));
-            }
+            exports.entry(name).or_default().push((id, def));
         }
 
         exports

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -125,15 +125,27 @@ impl SemanticIndex {
 
     /// Top-level definitions exported by this file (definitions in the file scope).
     /// Includes `Import`-kind forwarding definitions from `source()` calls.
-    /// Last definition of each name wins (later assignments shadow earlier ones).
-    pub fn exports(&self) -> FxHashMap<&str, (DefinitionId, &Definition)> {
+    ///
+    /// A name maps to every file-scope definition that binds it, in definition
+    /// order, so a name bound twice (e.g. `if (cond) x <- 1 else x <- 2`) yields
+    /// both. Callers that want R's last-wins runtime view take the last element.
+    pub fn exports(&self) -> FxHashMap<&str, Vec<(DefinitionId, &Definition)>> {
         let file_scope = ScopeId::from(0);
         let symbols = &self.symbol_tables[file_scope];
 
-        let mut exports = FxHashMap::default();
+        let mut exports: FxHashMap<&str, Vec<(DefinitionId, &Definition)>> = FxHashMap::default();
         for (id, def) in self.definitions[file_scope].iter() {
             let name = symbols.symbol(def.symbol()).name();
-            exports.insert(name, (id, def));
+            let list = exports.entry(name).or_default();
+            // A top-level `<<-` records the binding in both the scope where it
+            // appears and the super-assign target scope, which coincide at file
+            // scope, so the same binding lands here twice. Drop the byte-equal
+            // duplicate while still keeping genuinely distinct definitions, like
+            // both arms of a top-level `if`/`else` or two `source()` forwards of
+            // one name (those differ in range or in the forwarded file).
+            if !list.iter().any(|(_, d)| *d == def) {
+                list.push((id, def));
+            }
         }
 
         exports

--- a/crates/oak_semantic/src/use_def_map.rs
+++ b/crates/oak_semantic/src/use_def_map.rs
@@ -479,6 +479,12 @@ impl UseDefMapBuilder {
         }
     }
 
+    /// The scope's exit flow state: for each symbol, the definitions still in
+    /// effect once the last statement has run
+    pub(crate) fn final_bindings(&self) -> &IndexVec<SymbolId, Bindings> {
+        &self.symbol_states
+    }
+
     /// Finalize into an immutable [`UseDefMap`].
     pub(crate) fn finish(mut self, uses: &IndexVec<UseId, Use>) -> UseDefMap {
         self.finish_deferred_defs(uses);

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -1299,9 +1299,9 @@ fn test_file_exports_empty() {
 fn test_file_exports_multiple_defs_same_symbol() {
     let index = index("x <- 1\nx <- 2");
     let exports = index.exports();
-    // Deduplicates: last definition wins
+    // One name, but both definitions are kept (in definition order).
     assert_eq!(exports.len(), 1);
-    assert!(exports.contains_key("x"));
+    assert_eq!(exports.get("x").unwrap().len(), 2);
 }
 
 // --- File directives ---
@@ -1505,15 +1505,24 @@ fn test_source_call_emitted_without_resolver() {
 }
 
 #[test]
-fn test_file_exports_last_def_wins() {
+fn test_file_exports_keeps_all_defs_in_order() {
     // When the same name is defined multiple times at file scope,
-    // file_exports() returns only the last definition.
+    // exports() keeps all of them, in definition order; the last is R's
+    // runtime winner.
     let index = index("foo <- 1\nfoo <- 2\nbar <- 3\n");
     let exports = index.exports();
     assert_eq!(exports.len(), 2);
-    // The range should be the second `foo` (offset 9..12)
-    let (_def_id, def) = exports.get("foo").unwrap();
-    assert_eq!(def.range().start(), biome_rowan::TextSize::from(9));
+
+    let foo = exports.get("foo").unwrap();
+    let starts: Vec<biome_rowan::TextSize> = foo
+        .iter()
+        .map(|(_def_id, def)| def.range().start())
+        .collect();
+    // First `foo` at offset 0, second at offset 9.
+    assert_eq!(starts, vec![
+        biome_rowan::TextSize::from(0),
+        biome_rowan::TextSize::from(9),
+    ]);
 }
 
 // --- source() semantic calls: bail paths ---

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -1292,12 +1292,16 @@ fn test_file_exports_empty() {
 }
 
 #[test]
-fn test_file_exports_multiple_defs_same_symbol() {
+fn test_file_exports_sequential_redef_keeps_last() {
     let index = index("x <- 1\nx <- 2");
     let exports = index.exports();
-    // One name, but both definitions are kept (in definition order).
+    // The second assignment overwrites the first, so only the last def is in
+    // effect at end of file.
     assert_eq!(exports.len(), 1);
-    assert_eq!(exports.get("x").unwrap().len(), 2);
+    let x = exports.get("x").unwrap();
+    assert_eq!(x.len(), 1);
+    // The surviving def is the second `x` (offset 7), not the first (offset 0).
+    assert_eq!(x[0].1.range().start(), biome_rowan::TextSize::from(7));
 }
 
 // --- File directives ---
@@ -1501,11 +1505,10 @@ fn test_source_call_emitted_without_resolver() {
 }
 
 #[test]
-fn test_file_exports_keeps_all_defs_in_order() {
-    // When the same name is defined multiple times at file scope,
-    // exports() keeps all of them, in definition order; the last is R's
-    // runtime winner.
-    let index = index("foo <- 1\nfoo <- 2\nbar <- 3\n");
+fn test_file_exports_if_else_keeps_both_branches() {
+    // Both arms of a top-level `if`/`else` could run, so both bindings are in
+    // effect at end of file. exports() keeps both, in definition order.
+    let index = index("if (cond) foo <- 1 else foo <- 2\nbar <- 3\n");
     let exports = index.exports();
     assert_eq!(exports.len(), 2);
 
@@ -1514,10 +1517,10 @@ fn test_file_exports_keeps_all_defs_in_order() {
         .iter()
         .map(|(_def_id, def)| def.range().start())
         .collect();
-    // First `foo` at offset 0, second at offset 9.
+    // `foo <- 1` at offset 10, `foo <- 2` at offset 24.
     assert_eq!(starts, vec![
-        biome_rowan::TextSize::from(0),
-        biome_rowan::TextSize::from(9),
+        biome_rowan::TextSize::from(10),
+        biome_rowan::TextSize::from(24),
     ]);
 }
 

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -562,8 +562,9 @@ fn test_repeat_loop() {
 
 #[test]
 fn test_super_assignment_at_file_scope() {
-    // At file scope, `<<-` targets the file scope itself (no parent to
-    // walk to), so the symbol gets both IS_SUPER_BOUND and IS_BOUND.
+    // At file scope, `<<-` targets the file scope itself (no parent to walk
+    // to), so the marker scope and the binding scope coincide. The symbol gets
+    // both IS_SUPER_BOUND and IS_BOUND from a single recording.
     let index = index("x <<- 1");
     let file = ScopeId::from(0);
 
@@ -573,15 +574,10 @@ fn test_super_assignment_at_file_scope() {
         SymbolFlags::IS_SUPER_BOUND.union(SymbolFlags::IS_BOUND)
     );
 
-    // Two definitions: one from the current-scope recording, one from the
-    // target-scope recording (same scope in this case).
-    assert_eq!(index.definitions(file).len(), 2);
+    // One definition, not a self-duplicate.
+    assert_eq!(index.definitions(file).len(), 1);
     assert!(matches!(
         index.definitions(file)[DefinitionId::from(0)].kind(),
-        DefinitionKind::SuperAssignment(_)
-    ));
-    assert!(matches!(
-        index.definitions(file)[DefinitionId::from(1)].kind(),
         DefinitionKind::SuperAssignment(_)
     ));
     assert_eq!(index.uses(file).len(), 0);
@@ -598,7 +594,7 @@ fn test_super_assignment_right_at_file_scope() {
         SymbolFlags::IS_SUPER_BOUND.union(SymbolFlags::IS_BOUND)
     );
 
-    assert_eq!(index.definitions(file).len(), 2);
+    assert_eq!(index.definitions(file).len(), 1);
     assert!(matches!(
         index.definitions(file)[DefinitionId::from(0)].kind(),
         DefinitionKind::SuperAssignment(_)

--- a/crates/oak_semantic/tests/integration/use_def_map.rs
+++ b/crates/oak_semantic/tests/integration/use_def_map.rs
@@ -656,6 +656,23 @@ f <- function() { x <<- 1 }  # file: def 0 (x <<- in parent), def 1 (f)
 }
 
 #[test]
+fn test_super_assignment_at_file_scope_reaches_later_use() {
+    // A top-level `<<-` collapses to a single file-scope binding (no enclosing
+    // frame to target). A later use of the name resolves to that one definition.
+    let index = index(
+        "\
+x <<- 1                      # file: def 0 (x, the sole binding)
+x                            # file: use 0 -> {def 0}
+",
+    );
+    let file = ScopeId::from(0);
+    let map = index.use_def_map(file);
+
+    let bindings = map.bindings_at_use(UseId::from(0));
+    assert_eq!(bindings.definitions(), &[DefinitionId::from(0)]);
+}
+
+#[test]
 fn test_super_assignment_merges_with_if() {
     let index = index(
         "\


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1258
Progress towards https://github.com/posit-dev/ark/issues/1212

Symbol resolvers that don't take cursor offsets (`File::resolve()`, `resolve_at()`, etc) now return all potential candidates, rather than the last one. The goto-def, find-refs, and rename handlers now offer all of them.

- Candidates come back in definition order, with R's runtime winner (last assignment wins) as the last element, and that order is preserved across `source()` imports.

- A top-level `<<-` now records a single file-scope definition carrying both `IS_SUPER_BOUND` and `IS_BOUND,` rather than a marker plus a same-scope target. At file scope there's no enclosing frame to walk to, so the two coincide. This avoids a spurious duplicate candidate.