### PR TITLE
Add import layers for testthat files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "anyhow",
  "camino",
  "log",
+ "percent-encoding",
  "stdext",
  "tempfile",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ oak_sources = { path = "crates/oak_sources" }
 once_cell = "1.21.4"
 parking_lot = "0.12.5"
 paste = "1.0.15"
+percent-encoding = "2.3.2"
 quote = "1.0.45"
 rand = "0.10"
 regex = "1.12.3"

--- a/crates/aether_path/Cargo.toml
+++ b/crates/aether_path/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 anyhow.workspace = true
 camino.workspace = true
 log.workspace = true
+percent-encoding.workspace = true
 stdext.workspace = true
 url.workspace = true
 

--- a/crates/aether_path/src/file_path.rs
+++ b/crates/aether_path/src/file_path.rs
@@ -118,8 +118,11 @@ impl FilePath {
                     .as_url()
                     .path_segments()?
                     .next_back()
+                    // A trailing slash (`.../foo/`) yields a final empty segment,
+                    // meaning the URL points at a directory. Drop it so we return
+                    // `None` rather than `""`.
                     .filter(|seg| !seg.is_empty())?;
-                Some(percent_decode_str(last).decode_utf8_lossy())
+                percent_decode_str(last).decode_utf8().warn_on_err()
             },
         }
     }

--- a/crates/aether_path/src/file_path.rs
+++ b/crates/aether_path/src/file_path.rs
@@ -12,11 +12,13 @@
 //! is the job of secondary canonical-path indexes at the specific call
 //! sites that need it, never of this type.
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use camino::Utf8Component;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use percent_encoding::percent_decode_str;
 use stdext::result::ResultExt;
 use url::Url;
 
@@ -99,6 +101,26 @@ impl FilePath {
         match self {
             Self::Virtual(u) => Some(u),
             Self::File(_) => None,
+        }
+    }
+
+    /// File name (final path component) of this identity, percent-decoded.
+    ///
+    /// For the `File` arm it's the path basename. For the `Virtual` arm it's
+    /// the last path segment of the URI, dropping any query and fragment.
+    /// `None` for URIs like `untitled:Untitled-1`, which have no path structure
+    /// to take a segment from.
+    pub fn file_name(&self) -> Option<Cow<'_, str>> {
+        match self {
+            Self::File(p) => p.as_path().file_name().map(Cow::Borrowed),
+            Self::Virtual(u) => {
+                let last = u
+                    .as_url()
+                    .path_segments()?
+                    .next_back()
+                    .filter(|seg| !seg.is_empty())?;
+                Some(percent_decode_str(last).decode_utf8_lossy())
+            },
         }
     }
 }

--- a/crates/aether_path/src/file_path/tests.rs
+++ b/crates/aether_path/src/file_path/tests.rs
@@ -24,6 +24,25 @@ fn test_virtual_preserves_bytes() {
 }
 
 #[test]
+fn test_file_name_returns_basename_for_file_arm() {
+    let file = FilePath::from_url(&url("file:///C:/a/b/foo.R"));
+    assert_eq!(file.file_name().as_deref(), Some("foo.R"));
+}
+
+#[test]
+fn test_file_name_returns_last_segment_for_virtual_arm() {
+    // Query and fragment are dropped; the segment is percent-decoded.
+    let ark = FilePath::from_url(&url("ark://namespace/foo%20bar.R?cell=2#frag"));
+    assert_eq!(ark.file_name().as_deref(), Some("foo bar.R"));
+}
+
+#[test]
+fn test_file_name_is_none_for_cannot_be_a_base_uri() {
+    let untitled = FilePath::from_url(&url("untitled:Untitled-1"));
+    assert_eq!(untitled.file_name(), None);
+}
+
+#[test]
 #[cfg(not(windows))]
 fn test_abs_path_normalises_dot_dot() {
     let path = AbsPathBuf::from_utf8_path_buf(Utf8PathBuf::from("/a/./b/../c")).unwrap();

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -66,7 +66,9 @@ impl File {
     #[salsa::tracked(returns(ref))]
     pub fn imports(self, db: &dyn Db) -> Vec<ImportLayer> {
         match self.package(db) {
-            Some(package) if is_testthat_file(self, db) => testthat_imports(self, db, package),
+            Some(package) if is_testthat_file(self, db) => {
+                testthat_imports(self, db, package, None)
+            },
             Some(package) => package_imports(self, db, package),
             None => script_imports(self, db),
         }
@@ -104,10 +106,13 @@ impl File {
 
         // Top-level cursor: sequential narrowing.
         match self.package(db) {
-            // testthat sources every helper/setup file before any test
-            // runs, so there's nothing to narrow by offset. The EOF view
-            // already reflects what a test file sees at any point.
-            Some(_) if is_testthat_file(self, db) => self.imports(db).clone(),
+            // Helpers, setup, the package, and testthat are all sourced or
+            // attached before a test file's body runs, so they stay visible
+            // at any offset. Only the file's own top-level `library()` calls
+            // narrow.
+            Some(package) if is_testthat_file(self, db) => {
+                testthat_imports(self, db, package, Some(offset))
+            },
             Some(package) => narrow_package_top_level(self, db, package),
             None => narrow_script_top_level(self, db, offset),
         }
@@ -115,19 +120,7 @@ impl File {
 }
 
 fn narrow_script_top_level(file: File, db: &dyn Db, offset: TextSize) -> Vec<ImportLayer> {
-    let index = file.semantic_index(db);
-    let file_scope = ScopeId::from(0);
-
-    // Keep file-scope `library()` calls that have run by `offset`, in
-    // LIFO order (latest-attached first).
-    let mut layers: Vec<_> = index
-        .semantic_calls()
-        .iter()
-        .rev()
-        .filter(|call| call.scope() == file_scope && call.offset() < offset)
-        .filter_map(|call| attach_layer(db, call))
-        .collect();
-
+    let mut layers = attach_layers(file, db, Some(offset));
     extend_with_default_search_path(db, &mut layers);
     layers
 }
@@ -164,30 +157,41 @@ fn narrow_package_top_level(file: File, db: &dyn Db, package: Package) -> Vec<Im
     layers
 }
 
+/// The file's `library()` / `require()` attaches as `Package` layers, in LIFO
+/// order (latest-attached first). `before` narrows to a top-level cursor: with
+/// `Some(offset)`, keep only file-scope calls that have run by `offset`; with
+/// `None`, keep every attach (the end-of-file view, used for lazy contexts).
+fn attach_layers(file: File, db: &dyn Db, before: Option<TextSize>) -> Vec<ImportLayer> {
+    let index = file.semantic_index(db);
+    let file_scope = ScopeId::from(0);
+    index
+        .semantic_calls()
+        .iter()
+        .rev()
+        .filter(|call| match before {
+            Some(offset) => call.scope() == file_scope && call.offset() < offset,
+            None => true,
+        })
+        .filter_map(|call| attach_layer(db, call))
+        .collect()
+}
+
 fn attach_layer(db: &dyn Db, call: &SemanticCall) -> Option<ImportLayer> {
     match call.kind() {
         SemanticCallKind::Attach { package: name } => {
             db.package_by_name(name).map(ImportLayer::Package)
         },
         SemanticCallKind::Source { .. } => {
-            // `source()` injects into local scope, not the search path,
-            // so it's not a scope-chain layer.
+            // A `library()` inside the sourced file is forwarded separately by
+            // the semantic index builder as its own `Attach`, scoped to this
+            // `source()`.
             None
         },
     }
 }
 
 fn script_imports(file: File, db: &dyn Db) -> Vec<ImportLayer> {
-    let index = file.semantic_index(db);
-
-    // Reverse: R searches LIFO, so latest-attached comes first.
-    let mut layers: Vec<_> = index
-        .semantic_calls()
-        .iter()
-        .rev()
-        .filter_map(|call| attach_layer(db, call))
-        .collect();
-
+    let mut layers = attach_layers(file, db, None);
     extend_with_default_search_path(db, &mut layers);
     layers
 }
@@ -230,9 +234,20 @@ fn package_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer
 /// 1. helper/setup files (sourced into the test env, shadow everything),
 /// 2. the whole package's `R/` code,
 /// 3. the package's NAMESPACE imports,
-/// 4. `testthat` on the search path,
-/// 5. base.
-fn testthat_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer> {
+/// 4. the file's own top-level `library()` calls,
+/// 5. `testthat` on the search path,
+/// 6. base.
+///
+/// `offset` narrows the components of layer 4. `None` produces the end-of-file
+/// view and keeps every `library()` call. `Some(offset)` keeps only the calls
+/// that have run by `offset`. The other layers are sourced or attached before
+/// the file body runs, so they never narrow.
+fn testthat_imports(
+    file: File,
+    db: &dyn Db,
+    package: Package,
+    offset: Option<TextSize>,
+) -> Vec<ImportLayer> {
     let mut layers = Vec::new();
 
     // testthat sources `helper*.R` / `setup*.R` sorted, so reversing gives
@@ -263,6 +278,11 @@ fn testthat_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLaye
     let namespace = package.namespace(db);
     extend_with_namespace_imports(namespace, &mut layers);
     extend_with_namespace_package_imports(db, namespace, &mut layers);
+
+    // The test file's own top-level `library()` / `require()` calls attach to
+    // the search path, below the package namespace and its imports but above
+    // `testthat` (they run after the runner attached it).
+    layers.extend(attach_layers(file, db, offset));
 
     if let Some(testthat) = db.package_by_name("testthat") {
         layers.push(ImportLayer::Package(testthat));

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -296,7 +296,7 @@ fn testthat_imports(
 /// layout testthat sources and runs files from. This is what separates a
 /// test file from an ordinary package script under e.g. `tests/` or `inst/`.
 fn is_testthat_file(file: File, db: &dyn Db) -> bool {
-    match file.url(db).as_file() {
+    match file.path(db).as_file() {
         Some(path) => in_testthat_dir(path.as_path()),
         None => false,
     }
@@ -321,7 +321,7 @@ fn is_testthat_support_file(file: File, db: &dyn Db) -> bool {
     if !is_testthat_file(file, db) {
         return false;
     }
-    match file.url(db).file_name() {
+    match file.path(db).file_name() {
         Some(name) => name.starts_with("helper") || name.starts_with("setup"),
         None => false,
     }
@@ -333,7 +333,7 @@ fn is_testthat_support_file(file: File, db: &dyn Db) -> bool {
 /// which currently sorts based on locale, but arguably this should be fixed on
 /// the testthat side.
 fn testthat_support_key(file: File, db: &dyn Db) -> Cow<'_, str> {
-    file.url(db).file_name().unwrap_or_default()
+    file.path(db).file_name().unwrap_or_default()
 }
 
 /// Push the `From` layer if the namespace has any `importFrom` entries.

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -158,9 +158,12 @@ fn narrow_package_top_level(file: File, db: &dyn Db, package: Package) -> Vec<Im
 }
 
 /// The file's `library()` / `require()` attaches as `Package` layers, in LIFO
-/// order (latest-attached first). `before` narrows to a top-level cursor: with
-/// `Some(offset)`, keep only file-scope calls that have run by `offset`; with
-/// `None`, keep every attach (the end-of-file view, used for lazy contexts).
+/// order (latest-attached first). `before` selects which calls to include:
+///
+/// - `None`: every attach. The end-of-file view, used for lazy contexts.
+/// - `Some(offset)`: only top-level (file-scope) calls that have run by
+///   `offset`. Calls nested in a block (e.g. inside `test_that({})`) are
+///   dropped, as are calls after the offset.
 fn attach_layers(file: File, db: &dyn Db, before: Option<TextSize>) -> Vec<ImportLayer> {
     let index = file.semantic_index(db);
     let file_scope = ScopeId::from(0);
@@ -239,7 +242,7 @@ fn package_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer
 /// 6. base.
 ///
 /// `offset` narrows the components of layer 4. `None` produces the end-of-file
-/// view and keeps every `library()` call. `Some(offset)` keeps only the calls
+/// view and uses every `library()` call. `Some(offset)` uses only the calls
 /// that have run by `offset`. The other layers are sourced or attached before
 /// the file body runs, so they never narrow.
 fn testthat_imports(

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use biome_rowan::TextSize;
+use camino::Utf8Path;
 use oak_package_metadata::namespace::Namespace;
 use oak_semantic::semantic_index::SemanticCall;
 use oak_semantic::semantic_index::SemanticCallKind;
@@ -64,6 +66,7 @@ impl File {
     #[salsa::tracked(returns(ref))]
     pub fn imports(self, db: &dyn Db) -> Vec<ImportLayer> {
         match self.package(db) {
+            Some(package) if is_testthat_file(self, db) => testthat_imports(self, db, package),
             Some(package) => package_imports(self, db, package),
             None => script_imports(self, db),
         }
@@ -101,6 +104,10 @@ impl File {
 
         // Top-level cursor: sequential narrowing.
         match self.package(db) {
+            // testthat sources every helper/setup file before any test
+            // runs, so there's nothing to narrow by offset. The EOF view
+            // already reflects what a test file sees at any point.
+            Some(_) if is_testthat_file(self, db) => self.imports(db).clone(),
             Some(package) => narrow_package_top_level(self, db, package),
             None => narrow_script_top_level(self, db, offset),
         }
@@ -212,6 +219,101 @@ fn package_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer
 
     extend_with_base(db, &mut layers);
     layers
+}
+
+/// Imports visible to a `tests/testthat/` file, in R's LIFO priority order.
+///
+/// A test file runs with the package loaded and `testthat` attached, after
+/// testthat has sourced the package's `helper*.R` and `setup*.R` files into
+/// the test environment. So the layering, highest priority first, is:
+///
+/// 1. helper/setup files (sourced into the test env, shadow everything),
+/// 2. the whole package's `R/` code,
+/// 3. the package's NAMESPACE imports,
+/// 4. `testthat` on the search path,
+/// 5. base.
+fn testthat_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer> {
+    let mut layers = Vec::new();
+
+    // testthat sources `helper*.R` / `setup*.R` sorted, so reversing gives
+    // LIFO precedence. Self is dropped when the file being
+    // analysed is itself a helper/setup file: its own bindings come from
+    // `exports`, and keeping it would create a cycle in `resolve()` for
+    // unbound names (same reasoning as self-exclusion in `package_imports()`).
+    let mut support: Vec<File> = package
+        .scripts(db)
+        .iter()
+        .copied()
+        .filter(|f| *f != file && is_testthat_support_file(*f, db))
+        .collect();
+    support.sort_by_cached_key(|f| testthat_support_key(*f, db));
+    layers.extend(support.into_iter().rev().map(ImportLayer::File));
+
+    // The whole package is loaded when tests run, so every `R/` file is
+    // visible. Collation order reversed for LIFO, same as `package_imports()`.
+    layers.extend(
+        package
+            .files(db)
+            .iter()
+            .rev()
+            .copied()
+            .map(ImportLayer::File),
+    );
+
+    let namespace = package.namespace(db);
+    extend_with_namespace_imports(namespace, &mut layers);
+    extend_with_namespace_package_imports(db, namespace, &mut layers);
+
+    if let Some(testthat) = db.package_by_name("testthat") {
+        layers.push(ImportLayer::Package(testthat));
+    }
+
+    extend_with_base(db, &mut layers);
+    layers
+}
+
+/// True when `file` sits directly in a `tests/testthat/` directory, the
+/// layout testthat sources and runs files from. This is what separates a
+/// test file from an ordinary package script under e.g. `tests/` or `inst/`.
+fn is_testthat_file(file: File, db: &dyn Db) -> bool {
+    match file.url(db).as_file() {
+        Some(path) => in_testthat_dir(path.as_path()),
+        None => false,
+    }
+}
+
+fn in_testthat_dir(path: &Utf8Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    parent.file_name() == Some("testthat") &&
+        parent.parent().and_then(Utf8Path::file_name) == Some("tests")
+}
+
+/// testthat sources `helper*.R` and `setup*.R` from `tests/testthat/` into the
+/// test environment before running any test file, so their top-level bindings
+/// are visible to every test. testthat matches `^helper.*\.[rR]$` and
+/// `^setup.*\.[rR]$`; only the basename prefix matters here, since
+/// `package.scripts` already holds nothing but `.R` files. Teardown files are
+/// sourced after tests and rarely define names tests reference, so they're left
+/// out.
+fn is_testthat_support_file(file: File, db: &dyn Db) -> bool {
+    if !is_testthat_file(file, db) {
+        return false;
+    }
+    match file.url(db).file_name() {
+        Some(name) => name.starts_with("helper") || name.starts_with("setup"),
+        None => false,
+    }
+}
+
+/// Sort key for support files, matching testthat's `sort(dir(...))` order.
+/// We sort by raw basename (byte order = C locale for ASCII): case-sensitive
+/// like testthat, and platform-stable. This is a bit different to testthat
+/// which currently sorts based on locale, but arguably this should be fixed on
+/// the testthat side.
+fn testthat_support_key(file: File, db: &dyn Db) -> Cow<'_, str> {
+    file.url(db).file_name().unwrap_or_default()
 }
 
 /// Push the `From` layer if the namespace has any `importFrom` entries.

--- a/crates/oak_db/src/tests/file_imports.rs
+++ b/crates/oak_db/src/tests/file_imports.rs
@@ -302,6 +302,55 @@ fn test_package_r_file_does_not_take_testthat_path() {
     ]);
 }
 
+#[test]
+fn test_testthat_file_includes_top_level_library_calls() {
+    let mut db = TestDb::new();
+    let installed = install_packages(&mut db, &["cli", "testthat", "base"]);
+    let cli = installed[0];
+    let testthat = installed[1];
+    let base = installed[2];
+
+    let workspace = workspace_root(&db, "w");
+    let pkg = Package::new(
+        &db,
+        file_url("w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        None,
+        Namespace::default(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let r_file = File::new(
+        &db,
+        file_url("w/pkg/R/a.R"),
+        "f <- 1\n".to_string(),
+        Some(pkg),
+    );
+    let test_foo = File::new(
+        &db,
+        file_url("w/pkg/tests/testthat/test-foo.R"),
+        "library(cli)\ntest_that('x', expect_true(TRUE))\n".to_string(),
+        Some(pkg),
+    );
+    pkg.set_files(&mut db).to(vec![r_file]);
+    pkg.set_scripts(&mut db).to(vec![test_foo]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    let _ = (cli, testthat, base);
+    assert_eq!(shape(&db, test_foo.imports(&db)), vec![
+        // The package's own R/ code.
+        "File(a.R)".to_string(),
+        // The test file's own `library()` call sits below the package but
+        // above testthat (attached more recently than the runner attached
+        // testthat).
+        "Package(cli)".to_string(),
+        "Package(testthat)".to_string(),
+        "Package(base)".to_string(),
+    ]);
+}
+
 /// Render `ImportLayer`s to a stable, assertable shape. `File` layers
 /// collapse to their basename.
 fn shape(db: &TestDb, layers: &[ImportLayer]) -> Vec<String> {

--- a/crates/oak_db/src/tests/file_imports.rs
+++ b/crates/oak_db/src/tests/file_imports.rs
@@ -188,6 +188,142 @@ fn test_package_file_emits_namespace_and_collation_layers() {
 }
 
 #[test]
+fn test_testthat_file_sees_helpers_package_and_testthat() {
+    let mut db = TestDb::new();
+    let installed = install_packages(&mut db, &["testthat", "base"]);
+    let testthat = installed[0];
+    let base = installed[1];
+
+    let workspace = workspace_root(&db, "w");
+    let pkg = Package::new(
+        &db,
+        file_url("w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        None,
+        Namespace::default(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+
+    let r_file = File::new(
+        &db,
+        file_url("w/pkg/R/a.R"),
+        "f <- 1\n".to_string(),
+        Some(pkg),
+    );
+    let helper = File::new(
+        &db,
+        file_url("w/pkg/tests/testthat/helper-b.R"),
+        "h <- 1\n".to_string(),
+        Some(pkg),
+    );
+    let setup = File::new(
+        &db,
+        file_url("w/pkg/tests/testthat/setup-c.R"),
+        "s <- 1\n".to_string(),
+        Some(pkg),
+    );
+    let test_foo = File::new(
+        &db,
+        file_url("w/pkg/tests/testthat/test-foo.R"),
+        "test_that('x', expect_true(TRUE))\n".to_string(),
+        Some(pkg),
+    );
+    // A sibling test file. Each test file runs in its own environment, so
+    // it must not appear in `test_foo`'s imports.
+    let test_bar = File::new(
+        &db,
+        file_url("w/pkg/tests/testthat/test-bar.R"),
+        "test_that('y', expect_true(TRUE))\n".to_string(),
+        Some(pkg),
+    );
+
+    pkg.set_files(&mut db).to(vec![r_file]);
+    pkg.set_scripts(&mut db)
+        .to(vec![helper, setup, test_foo, test_bar]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    let _ = (testthat, base);
+    assert_eq!(shape(&db, test_foo.imports(&db)), vec![
+        // helper/setup files come first (sourced into the test env). LIFO
+        // over byte-order basename sort, so `setup-c` (sourced last)
+        // outranks `helper-b`.
+        "File(setup-c.R)".to_string(),
+        "File(helper-b.R)".to_string(),
+        // Then the package's own R/ code.
+        "File(a.R)".to_string(),
+        // testthat is attached, base is always last.
+        "Package(testthat)".to_string(),
+        "Package(base)".to_string(),
+    ]);
+}
+
+#[test]
+fn test_package_r_file_does_not_take_testthat_path() {
+    let mut db = TestDb::new();
+    let installed = install_packages(&mut db, &["testthat", "base"]);
+    let base = installed[1];
+
+    let workspace = workspace_root(&db, "w");
+    let pkg = Package::new(
+        &db,
+        file_url("w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        None,
+        Namespace::default(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    );
+    let r_file = File::new(
+        &db,
+        file_url("w/pkg/R/a.R"),
+        "f <- 1\n".to_string(),
+        Some(pkg),
+    );
+    let helper = File::new(
+        &db,
+        file_url("w/pkg/tests/testthat/helper-b.R"),
+        "h <- 1\n".to_string(),
+        Some(pkg),
+    );
+    pkg.set_files(&mut db).to(vec![r_file]);
+    pkg.set_scripts(&mut db).to(vec![helper]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    let _ = base;
+    // An `R/` file is not a testthat file: no helper layer, no testthat
+    // layer, just base (no other R/ files, empty namespace).
+    assert_eq!(shape(&db, r_file.imports(&db)), vec![
+        "Package(base)".to_string()
+    ]);
+}
+
+/// Render `ImportLayer`s to a stable, assertable shape. `File` layers
+/// collapse to their basename.
+fn shape(db: &TestDb, layers: &[ImportLayer]) -> Vec<String> {
+    layers
+        .iter()
+        .map(|layer| match layer {
+            ImportLayer::From(map) => {
+                let mut entries: Vec<(String, String)> =
+                    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                entries.sort();
+                format!("From({entries:?})")
+            },
+            ImportLayer::Package(p) => format!("Package({})", p.name(db)),
+            ImportLayer::File(f) => {
+                let url = f.url(db).to_url();
+                format!("File({})", url.path().rsplit('/').next().unwrap_or("?"))
+            },
+        })
+        .collect()
+}
+
+#[test]
 fn test_imports_is_cached_per_file() {
     let mut db = TestDb::new();
     let _ = install_packages(&mut db, &["dplyr"]);

--- a/crates/oak_db/src/tests/file_imports.rs
+++ b/crates/oak_db/src/tests/file_imports.rs
@@ -197,7 +197,7 @@ fn test_testthat_file_sees_helpers_package_and_testthat() {
     let workspace = workspace_root(&db, "w");
     let pkg = Package::new(
         &db,
-        file_url("w/pkg/DESCRIPTION"),
+        file_path("w/pkg/DESCRIPTION"),
         "pkg".to_string(),
         None,
         Namespace::default(),
@@ -208,25 +208,25 @@ fn test_testthat_file_sees_helpers_package_and_testthat() {
 
     let r_file = File::new(
         &db,
-        file_url("w/pkg/R/a.R"),
+        file_path("w/pkg/R/a.R"),
         "f <- 1\n".to_string(),
         Some(pkg),
     );
     let helper = File::new(
         &db,
-        file_url("w/pkg/tests/testthat/helper-b.R"),
+        file_path("w/pkg/tests/testthat/helper-b.R"),
         "h <- 1\n".to_string(),
         Some(pkg),
     );
     let setup = File::new(
         &db,
-        file_url("w/pkg/tests/testthat/setup-c.R"),
+        file_path("w/pkg/tests/testthat/setup-c.R"),
         "s <- 1\n".to_string(),
         Some(pkg),
     );
     let test_foo = File::new(
         &db,
-        file_url("w/pkg/tests/testthat/test-foo.R"),
+        file_path("w/pkg/tests/testthat/test-foo.R"),
         "test_that('x', expect_true(TRUE))\n".to_string(),
         Some(pkg),
     );
@@ -234,7 +234,7 @@ fn test_testthat_file_sees_helpers_package_and_testthat() {
     // it must not appear in `test_foo`'s imports.
     let test_bar = File::new(
         &db,
-        file_url("w/pkg/tests/testthat/test-bar.R"),
+        file_path("w/pkg/tests/testthat/test-bar.R"),
         "test_that('y', expect_true(TRUE))\n".to_string(),
         Some(pkg),
     );
@@ -269,7 +269,7 @@ fn test_package_r_file_does_not_take_testthat_path() {
     let workspace = workspace_root(&db, "w");
     let pkg = Package::new(
         &db,
-        file_url("w/pkg/DESCRIPTION"),
+        file_path("w/pkg/DESCRIPTION"),
         "pkg".to_string(),
         None,
         Namespace::default(),
@@ -279,13 +279,13 @@ fn test_package_r_file_does_not_take_testthat_path() {
     );
     let r_file = File::new(
         &db,
-        file_url("w/pkg/R/a.R"),
+        file_path("w/pkg/R/a.R"),
         "f <- 1\n".to_string(),
         Some(pkg),
     );
     let helper = File::new(
         &db,
-        file_url("w/pkg/tests/testthat/helper-b.R"),
+        file_path("w/pkg/tests/testthat/helper-b.R"),
         "h <- 1\n".to_string(),
         Some(pkg),
     );
@@ -313,7 +313,7 @@ fn test_testthat_file_includes_top_level_library_calls() {
     let workspace = workspace_root(&db, "w");
     let pkg = Package::new(
         &db,
-        file_url("w/pkg/DESCRIPTION"),
+        file_path("w/pkg/DESCRIPTION"),
         "pkg".to_string(),
         None,
         Namespace::default(),
@@ -323,13 +323,13 @@ fn test_testthat_file_includes_top_level_library_calls() {
     );
     let r_file = File::new(
         &db,
-        file_url("w/pkg/R/a.R"),
+        file_path("w/pkg/R/a.R"),
         "f <- 1\n".to_string(),
         Some(pkg),
     );
     let test_foo = File::new(
         &db,
-        file_url("w/pkg/tests/testthat/test-foo.R"),
+        file_path("w/pkg/tests/testthat/test-foo.R"),
         "library(cli)\ntest_that('x', expect_true(TRUE))\n".to_string(),
         Some(pkg),
     );
@@ -365,7 +365,7 @@ fn shape(db: &TestDb, layers: &[ImportLayer]) -> Vec<String> {
             },
             ImportLayer::Package(p) => format!("Package({})", p.name(db)),
             ImportLayer::File(f) => {
-                let url = f.url(db).to_url();
+                let url = f.path(db).to_url();
                 format!("File({})", url.path().rsplit('/').next().unwrap_or("?"))
             },
         })

--- a/crates/oak_db/src/tests/file_imports_at.rs
+++ b/crates/oak_db/src/tests/file_imports_at.rs
@@ -219,6 +219,31 @@ fn test_package_namespace_and_base_layers_always_visible() {
 }
 
 #[test]
+fn test_testthat_top_level_library_narrows_by_offset() {
+    // A test file's own top-level `library()` call narrows like a script's:
+    // invisible before the call, visible after. Helpers, the package, and
+    // testthat (omitted here) stay visible at any offset.
+    let mut db = TestDb::new();
+    let cli = install_packages(&mut db, &["cli", "testthat", "base"])[0];
+    let pkg = install_workspace_package(&mut db, "pkg");
+
+    let source = "library(cli)\ntest_that('x', expect_true(TRUE))\n";
+    let test_file = make_package_file(
+        &mut db,
+        "workspace/pkg/tests/testthat/test-x.R",
+        source,
+        pkg,
+    );
+    pkg.set_scripts(&mut db).to(vec![test_file]);
+
+    let before = test_file.imports_at(&db, TextSize::from(0));
+    assert!(!attached_packages(&before).contains(&cli));
+
+    let after = test_file.imports_at(&db, TextSize::from(source.len() as u32));
+    assert!(attached_packages(&after).contains(&cli));
+}
+
+#[test]
 fn test_library_in_function_scoped_source_is_visible_only_in_that_function() {
     // A `library()` inside a file that's `source()`d from a function body is
     // forwarded by the builder as an `Attach` scoped to that `source()` call,


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1259

Whereas scripts in `tests/` folders are standalone, scripts in `tests/testthat/` are sourced in an environment where:

- Setup and helper files are run.
- The package namespace is injected
- The `testthat` exports are attached

This PR detects testthat files and adjusts the import layers accordingly, so that symbols injected by testthat are visible in these files.