### PR TITLE
Return package URL from .ps.rpc.pkg_list

### DIFF
--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -54,9 +54,7 @@
                 attached = attached,
                 description = description
             )
-            if (nzchar(url)) {
-                entry$url <- url
-            }
+            entry$url <- if (!is.na(url)) url
             entry
         },
         id,

--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -38,11 +38,7 @@
     # whitespace; the first is conventionally the package's canonical website.
     # Surface it as the single best URL (Positron validates the scheme before
     # opening). Drop everything from the first separator on; "" when absent.
-    url <- sub(
-        "[[:space:],].*$",
-        "",
-        trimws(ifelse(is.na(ip[, "URL"]), "", ip[, "URL"]))
-    )
+    url <- sub("[[:space:],].*$", "", trimws(ip[, "URL"]))
     # Build each package as a list so `url` can be omitted entirely when a
     # package advertises none -- a vectorized `Map(list, url = url)` forces the
     # key onto every package (serializing "" rather than leaving it absent).

--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -16,7 +16,7 @@
 # active project, so the same call works for pak/base/renv callers.
 #' @export
 .ps.rpc.pkg_list <- function(method = c("pak", "base", "renv")) {
-    ip <- utils::installed.packages(fields = "Description")
+    ip <- utils::installed.packages(fields = c("Description", "URL"))
     name <- ip[, "Package"]
     version <- ip[, "Version"]
     id <- paste0(name, "-", version)
@@ -34,18 +34,41 @@
         ifelse(is.na(ip[, "Description"]), "", ip[, "Description"]),
         perl = TRUE
     ))
-    # `Map(list, id = ...)` would name the output list by `id`'s values
-    # (mapply USE.NAMES semantics for a character first arg), and a named
-    # list serializes to a JSON object instead of the array the frontend
-    # expects. Strip the names with unname().
+    # DESCRIPTION's URL field can list several URLs separated by commas and/or
+    # whitespace; the first is conventionally the package's canonical website.
+    # Surface it as the single best URL (Positron validates the scheme before
+    # opening). Drop everything from the first separator on; "" when absent.
+    url <- sub(
+        "[[:space:],].*$",
+        "",
+        trimws(ifelse(is.na(ip[, "URL"]), "", ip[, "URL"]))
+    )
+    # Build each package as a list so `url` can be omitted entirely when a
+    # package advertises none -- a vectorized `Map(list, url = url)` forces the
+    # key onto every package (serializing "" rather than leaving it absent).
+    # `Map`'s first argument (`id`, a character vector) would name the result,
+    # so `unname()` keeps it a JSON array rather than an object keyed by id.
     unname(Map(
-        list,
-        id = id,
-        name = name,
-        displayName = name,
-        version = version,
-        attached = attached,
-        description = description
+        function(id, name, version, attached, description, url) {
+            entry <- list(
+                id = id,
+                name = name,
+                displayName = name,
+                version = version,
+                attached = attached,
+                description = description
+            )
+            if (nzchar(url)) {
+                entry$url <- url
+            }
+            entry
+        },
+        id,
+        name,
+        version,
+        attached,
+        description,
+        url
     ))
 }
 


### PR DESCRIPTION
`.ps.rpc.pkg_list` now returns a `url` field for each installed package,
taken from the first entry of its DESCRIPTION `URL` field (conventionally
the package's canonical website). The field is omitted when a package
advertises no URL.

This feeds the new external-link button in Positron's Packages pane, which
validates the scheme before opening. Multiple / labeled links (repository,
issues, etc.) are left for a future change.

See posit-dev/positron#13890
