### PR TITLE
Migrate the workspace indexer to `ArkFile` and make it a query

### DIFF
--- a/crates/ark/src/lsp/backend.rs
+++ b/crates/ark/src/lsp/backend.rs
@@ -136,9 +136,6 @@ pub(crate) enum LspNotification {
     DidChangeTextDocument(DidChangeTextDocumentParams),
     DidSaveTextDocument(DidSaveTextDocumentParams),
     DidCloseTextDocument(DidCloseTextDocumentParams),
-    DidCreateFiles(CreateFilesParams),
-    DidDeleteFiles(DeleteFilesParams),
-    DidRenameFiles(RenameFilesParams),
 }
 
 #[derive(Debug)]
@@ -295,18 +292,6 @@ impl LanguageServer for Backend {
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
         self.notify(LspNotification::DidChangeWatchedFiles(params));
-    }
-
-    async fn did_create_files(&self, params: CreateFilesParams) {
-        self.notify(LspNotification::DidCreateFiles(params));
-    }
-
-    async fn did_delete_files(&self, params: DeleteFilesParams) {
-        self.notify(LspNotification::DidDeleteFiles(params));
-    }
-
-    async fn did_rename_files(&self, params: RenameFilesParams) {
-        self.notify(LspNotification::DidRenameFiles(params));
     }
 
     async fn symbol(

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -21,6 +21,7 @@ use crate::lsp::completions::sources::utils::call_node_position_type;
 use crate::lsp::completions::sources::utils::set_sort_text_by_first_appearance;
 use crate::lsp::completions::sources::utils::CallNodePositionType;
 use crate::lsp::completions::sources::CompletionSource;
+use crate::lsp::db::ArkDb;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::indexer;
 use crate::lsp::traits::node::NodeExt;
@@ -93,7 +94,7 @@ fn completions_from_call(
         },
     };
 
-    completions_from_arguments(document_context, callee, object)
+    completions_from_arguments(&context.state.db, document_context, callee, object)
 }
 
 fn get_first_argument(context: &DocumentContext, node: &Node) -> anyhow::Result<Option<RObject>> {
@@ -156,6 +157,7 @@ fn get_first_argument(context: &DocumentContext, node: &Node) -> anyhow::Result<
 }
 
 fn completions_from_arguments(
+    db: &dyn ArkDb,
     context: &DocumentContext,
     callable: &str,
     object: RObject,
@@ -168,7 +170,7 @@ fn completions_from_arguments(
         return Ok(Some(completions));
     }
 
-    if let Some(completions) = completions_from_workspace_arguments(context, callable)? {
+    if let Some(completions) = completions_from_workspace_arguments(db, callable, context)? {
         return Ok(Some(completions));
     }
 
@@ -234,14 +236,15 @@ fn completions_from_session_arguments(
 }
 
 fn completions_from_workspace_arguments(
-    context: &DocumentContext,
+    db: &dyn ArkDb,
     callable: &str,
+    context: &DocumentContext,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_workspace_arguments({callable:?})");
 
     // Try to find the `callable` in the workspace and use its arguments
     // if we can
-    let Some((_path, entry)) = indexer::find(callable) else {
+    let Some(entry) = indexer::find(db, callable) else {
         // Didn't find any workspace object with this name
         return Ok(None);
     };

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -69,7 +69,7 @@ fn completions_from_workspace(
     let token = token.as_str();
 
     // get entries from the index
-    indexer::map(|uri, symbol, entry| {
+    indexer::map(&state.db, |uri, symbol, entry| {
         if !symbol.fuzzy_matches(token) {
             return;
         }
@@ -112,7 +112,7 @@ fn completions_from_workspace(
                 let value = format!(
                     "Defined in `{}` on line {}.",
                     path,
-                    entry.range.start.line + 1
+                    entry.range.start.row + 1
                 );
                 let markup = MarkupContent {
                     kind: MarkupKind::Markdown,

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -171,7 +171,7 @@ pub(crate) fn generate_diagnostics(
     context.document_symbols.push(HashMap::new());
 
     // Add the current workspace symbols.
-    indexer::map(|_uri, _symbol, entry| match &entry.data {
+    indexer::map(db, |_uri, _symbol, entry| match &entry.data {
         indexer::IndexEntryData::Function { name, arguments: _ } => {
             context.workspace_symbols.insert(name.to_string());
         },

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -24,7 +24,6 @@ use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
 use crate::treesitter::NodeTypeExt;
 use crate::treesitter::TsQuery;
-use crate::url::ExtUrl;
 
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub enum IndexEntryData {
@@ -91,8 +90,7 @@ pub(crate) struct FileIndex {
 /// foreign code the user can't edit.
 pub(crate) fn find(db: &dyn ArkDb, symbol: &str) -> Option<IndexEntry> {
     for &file in oak_db::workspace_files(db) {
-        let url = file.path(db).to_url();
-        if !ExtUrl::is_indexable(&url) {
+        if !is_indexable(db, file) {
             continue;
         }
         if let Some(entry) = file_index(db, file).symbols.get(symbol) {
@@ -129,10 +127,10 @@ fn file_index(db: &dyn ArkDb, file: File) -> FileIndex {
 /// Visit every workspace symbol across all indexable files.
 pub(crate) fn map(db: &dyn ArkDb, mut callback: impl FnMut(&Url, &str, &IndexEntry)) {
     for &file in oak_db::workspace_files(db) {
-        let url = file.path(db).to_url();
-        if !ExtUrl::is_indexable(&url) {
+        if !is_indexable(db, file) {
             continue;
         }
+        let url = file.path(db).to_url();
         for (symbol, entry) in file_index(db, file).symbols.iter() {
             callback(&url, symbol, entry);
         }
@@ -145,6 +143,13 @@ pub(crate) fn map(db: &dyn ArkDb, mut callback: impl FnMut(&Url, &str, &IndexEnt
 pub(crate) fn warm(db: &dyn ArkDb) {
     for &file in oak_db::workspace_files(db) {
         file_index(db, file);
+    }
+}
+
+fn is_indexable(db: &dyn ArkDb, file: File) -> bool {
+    match file.path(db) {
+        aether_path::FilePath::File(_) => true,
+        aether_path::FilePath::Virtual(uri) => uri.as_url().scheme() != "ark",
     }
 }
 

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 use crate::lsp;
 use crate::lsp::db::ArkDb;
-use crate::lsp::db::FileExt;
+use crate::lsp::db::FileArkExt;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 
+use aether_lsp_utils::proto::PositionEncoding;
 use regex::Regex;
 use stdext::unwrap;
 use stdext::unwrap::IntoResult;
@@ -18,11 +19,10 @@ use tower_lsp::lsp_types::Range;
 use tree_sitter::Node;
 use tree_sitter::Query;
 use url::Url;
-use walkdir::DirEntry;
-use walkdir::WalkDir;
 
 use crate::lsp;
-use crate::lsp::document::Document;
+use crate::lsp::ark_file::ArkFile;
+use crate::lsp::db::ArkDb;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
@@ -85,36 +85,6 @@ static WORKSPACE_INDEX: LazyLock<WorkspaceIndex> = LazyLock::new(Default::defaul
 pub static RE_COMMENT_SECTION: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(#+)\s*(.*?)\s*[#=-]{4,}\s*$").unwrap());
 
-#[tracing::instrument(level = "info", skip_all)]
-pub fn start(folders: Vec<String>) {
-    let now = std::time::Instant::now();
-    lsp::log_info!("Initial indexing started");
-
-    for folder in folders {
-        let walker = WalkDir::new(folder);
-        for entry in walker.into_iter().filter_entry(filter_entry) {
-            let Ok(entry) = entry else {
-                continue;
-            };
-            if !entry.file_type().is_file() {
-                continue;
-            }
-            let Ok(uri) = Url::from_file_path(entry.path()) else {
-                lsp::log_warn!("Can't convert file path to URI {:?}", entry.path());
-                continue;
-            };
-            if let Err(err) = create(&uri) {
-                lsp::log_error!("Can't index file {:?}: {err:?}", entry.path());
-            }
-        }
-    }
-
-    lsp::log_info!(
-        "Initial indexing finished after {}ms",
-        now.elapsed().as_millis()
-    );
-}
-
 /// Search the workspace files and return the first symbol match
 pub fn find(symbol: &str) -> Option<(FileId, IndexEntry)> {
     let index = WORKSPACE_INDEX.lock().unwrap();
@@ -154,14 +124,35 @@ pub fn map(mut callback: impl FnMut(&Url, &String, &IndexEntry)) {
     }
 }
 
-#[tracing::instrument(level = "trace", skip_all, fields(uri = %uri))]
-pub fn update(document: &Document, uri: &Url) -> anyhow::Result<()> {
+/// Index a single `oak_db` file, replacing any existing entries for its URL.
+#[tracing::instrument(level = "trace", skip_all)]
+pub(crate) fn index_file(
+    db: &dyn ArkDb,
+    file: oak_db::File,
+    encoding: PositionEncoding,
+) -> anyhow::Result<()> {
+    let url = file.url(db).to_url();
+
     // Defensive, callers are expected to filter virtual doc URIs before queuing
-    if !ExtUrl::is_indexable(uri) {
+    if !ExtUrl::is_indexable(&url) {
         return Ok(());
     }
-    delete(uri)?;
-    index_document(document, uri);
+
+    // Build an `ArkFile` directly from the `oak_db::File` rather than go through
+    // `WorldState::ark_file()`, which requires a stored editor `Document`.
+    // Scanned workspace files have no `Document`, so we synthesize a minimal
+    // `ArkFile` that carries only what the extraction reads (tree, contents,
+    // line index).
+    let file = ArkFile {
+        file,
+        version: None,
+        config: Default::default(),
+        url: url.clone(),
+        encoding,
+    };
+
+    delete(&url)?;
+    index_document(db, &file, &url);
     Ok(())
 }
 
@@ -236,64 +227,14 @@ impl Drop for ResetIndexerGuard {
     }
 }
 
-// TODO: Should we consult the project .gitignore for ignored files?
-// TODO: What about front-end ignores?
-// TODO: What about other kinds of ignores (e.g. revdepcheck)?
-pub fn filter_entry(entry: &DirEntry) -> bool {
-    let name = entry.file_name();
-
-    // skip common ignores
-    for ignore in [".git", ".Rproj.user", "node_modules", "revdep"] {
-        if name == ignore {
-            return false;
-        }
-    }
-
-    // skip project 'renv' folder
-    if name == "renv" {
-        let companion = entry.path().join("activate.R");
-        if companion.exists() {
-            return false;
-        }
-    }
-
-    true
-}
-
-// Only called for actual files during workspace walking. Documents managed by
-// the LSP go through `update()` instead.
-pub(crate) fn create(uri: &Url) -> anyhow::Result<()> {
-    if uri.scheme() != "file" {
-        return Ok(());
-    }
-    let Ok(path) = uri.to_file_path() else {
-        return Ok(());
-    };
-
-    let ext = path.extension().unwrap_or_default();
-    if ext != "r" && ext != "R" {
-        return Ok(());
-    }
-
-    // TODO: Handle document encodings here.
-    // TODO: Check if there's an up-to-date buffer to be used.
-    let contents = std::fs::read(path)?;
-    let contents = String::from_utf8(contents)?;
-    let document = Document::new(contents.as_str(), None);
-
-    index_document(&document, uri);
-
-    Ok(())
-}
-
-fn index_document(doc: &Document, uri: &Url) {
-    let ast = &doc.ast;
+fn index_document(db: &dyn ArkDb, file: &ArkFile, uri: &Url) {
+    let ast = file.tree_sitter(db);
     let root = ast.root_node();
     let mut cursor = root.walk();
     let mut entries = Vec::new();
 
     for node in root.children(&mut cursor) {
-        if let Err(err) = index_node(doc, &node, &mut entries) {
+        if let Err(err) = index_node(db, file, &node, &mut entries) {
             lsp::log_error!("Can't index document: {err:?}");
         }
     }
@@ -305,14 +246,20 @@ fn index_document(doc: &Document, uri: &Url) {
     }
 }
 
-fn index_node(doc: &Document, node: &Node, entries: &mut Vec<IndexEntry>) -> anyhow::Result<()> {
-    index_assignment(doc, node, entries)?;
-    index_comment(doc, node, entries)?;
+fn index_node(
+    db: &dyn ArkDb,
+    file: &ArkFile,
+    node: &Node,
+    entries: &mut Vec<IndexEntry>,
+) -> anyhow::Result<()> {
+    index_assignment(db, file, node, entries)?;
+    index_comment(db, file, node, entries)?;
     Ok(())
 }
 
 fn index_assignment(
-    doc: &Document,
+    db: &dyn ArkDb,
+    file: &ArkFile,
     node: &Node,
     entries: &mut Vec<IndexEntry>,
 ) -> anyhow::Result<()> {
@@ -333,14 +280,16 @@ fn index_assignment(
         return Ok(());
     };
 
-    if crate::treesitter::node_is_call(&rhs, "R6Class", &doc.contents) ||
-        crate::treesitter::node_is_namespaced_call(&rhs, "R6", "R6Class", &doc.contents)
+    let contents = file.contents(db);
+
+    if crate::treesitter::node_is_call(&rhs, "R6Class", contents) ||
+        crate::treesitter::node_is_namespaced_call(&rhs, "R6", "R6Class", contents)
     {
-        index_r6_class_methods(doc, &rhs, entries)?;
+        index_r6_class_methods(db, file, &rhs, entries)?;
         // Fallthrough to index the variable to which the R6 class is assigned
     }
 
-    let lhs_text = lhs.node_to_string(&doc.contents)?;
+    let lhs_text = lhs.node_to_string(contents)?;
 
     // The method matching is super hacky but let's wait until the typed API to
     // do better
@@ -360,7 +309,7 @@ fn index_assignment(
             for child in parameters.children(&mut cursor) {
                 let name = unwrap!(child.child_by_field_name("name"), None => continue);
                 if name.is_identifier() {
-                    let name = name.node_to_string(&doc.contents)?;
+                    let name = name.node_to_string(contents)?;
                     arguments.push(name);
                 }
             }
@@ -368,8 +317,8 @@ fn index_assignment(
 
         // Note that unlike document symbols whose ranges cover the whole entity
         // they represent, the range of workspace symbols only cover the identifers
-        let start = doc.lsp_position_from_tree_sitter_point(lhs.start_position())?;
-        let end = doc.lsp_position_from_tree_sitter_point(lhs.end_position())?;
+        let start = file.lsp_position_from_tree_sitter_point(db, lhs.start_position())?;
+        let end = file.lsp_position_from_tree_sitter_point(db, lhs.end_position())?;
 
         entries.push(IndexEntry {
             key: lhs_text.clone(),
@@ -381,8 +330,8 @@ fn index_assignment(
         });
     } else {
         // Otherwise, emit variable
-        let start = doc.lsp_position_from_tree_sitter_point(lhs.start_position())?;
-        let end = doc.lsp_position_from_tree_sitter_point(lhs.end_position())?;
+        let start = file.lsp_position_from_tree_sitter_point(db, lhs.start_position())?;
+        let end = file.lsp_position_from_tree_sitter_point(db, lhs.end_position())?;
         entries.push(IndexEntry {
             key: lhs_text.clone(),
             range: Range { start, end },
@@ -394,7 +343,8 @@ fn index_assignment(
 }
 
 fn index_r6_class_methods(
-    doc: &Document,
+    db: &dyn ArkDb,
+    file: &ArkFile,
     node: &Node,
     entries: &mut Vec<IndexEntry>,
 ) -> anyhow::Result<()> {
@@ -421,10 +371,12 @@ fn index_r6_class_methods(
     });
     let mut ts_query = TsQuery::from_query(&R6_METHODS_QUERY);
 
-    for method_node in ts_query.captures_for(*node, "method_name", doc.contents.as_bytes()) {
-        let name = method_node.node_to_string(&doc.contents)?;
-        let start = doc.lsp_position_from_tree_sitter_point(method_node.start_position())?;
-        let end = doc.lsp_position_from_tree_sitter_point(method_node.end_position())?;
+    let contents = file.contents(db);
+
+    for method_node in ts_query.captures_for(*node, "method_name", contents.as_bytes()) {
+        let name = method_node.node_to_string(contents)?;
+        let start = file.lsp_position_from_tree_sitter_point(db, method_node.start_position())?;
+        let end = file.lsp_position_from_tree_sitter_point(db, method_node.end_position())?;
 
         entries.push(IndexEntry {
             key: name.clone(),
@@ -436,14 +388,19 @@ fn index_r6_class_methods(
     Ok(())
 }
 
-fn index_comment(doc: &Document, node: &Node, entries: &mut Vec<IndexEntry>) -> anyhow::Result<()> {
+fn index_comment(
+    db: &dyn ArkDb,
+    file: &ArkFile,
+    node: &Node,
+    entries: &mut Vec<IndexEntry>,
+) -> anyhow::Result<()> {
     // check for comment
     if !node.is_comment() {
         return Ok(());
     }
 
     // see if it looks like a section
-    let comment = node.node_as_str(&doc.contents)?;
+    let comment = node.node_as_str(file.contents(db))?;
     let matches = match RE_COMMENT_SECTION.captures(comment) {
         Some(m) => m,
         None => return Ok(()),
@@ -460,8 +417,8 @@ fn index_comment(doc: &Document, node: &Node, entries: &mut Vec<IndexEntry>) -> 
         return Ok(());
     }
 
-    let start = doc.lsp_position_from_tree_sitter_point(node.start_position())?;
-    let end = doc.lsp_position_from_tree_sitter_point(node.end_position())?;
+    let start = file.lsp_position_from_tree_sitter_point(db, node.start_position())?;
+    let end = file.lsp_position_from_tree_sitter_point(db, node.end_position())?;
 
     entries.push(IndexEntry {
         key: title.clone(),
@@ -476,21 +433,25 @@ fn index_comment(doc: &Document, node: &Node, entries: &mut Vec<IndexEntry>) -> 
 mod tests {
 
     use assert_matches::assert_matches;
+    use biome_line_index::WideEncoding;
     use insta::assert_debug_snapshot;
     use tower_lsp::lsp_types;
 
     use super::*;
-    use crate::lsp::document::Document;
+    use crate::lsp::ark_file::test_ark_file;
+
+    const ENCODING: PositionEncoding = PositionEncoding::Wide(WideEncoding::Utf16);
 
     macro_rules! test_index {
         ($code:expr) => {
-            let doc = Document::new($code, None);
-            let root = doc.ast.root_node();
+            let (db, file) = test_ark_file($code);
+            let tree = file.tree_sitter(&db);
+            let root = tree.root_node();
             let mut cursor = root.walk();
 
             let mut entries = vec![];
             for node in root.children(&mut cursor) {
-                let _ = index_node(&doc, &node, &mut entries);
+                let _ = index_node(&db, &file, &node, &mut entries);
             }
             assert_debug_snapshot!(entries);
         };
@@ -671,35 +632,29 @@ class <- R6::R6Class(
         );
     }
 
+    fn index_file_for_test(uri: &str, contents: &str) {
+        use aether_path::FilePath;
+
+        let db = oak_db::OakDatabase::new();
+        let url = Url::parse(uri).unwrap();
+        let key = FilePath::from_url(&url);
+        let file = oak_db::File::new(&db, key, contents.to_string(), None);
+        index_file(&db, file, ENCODING).unwrap();
+    }
+
     #[test]
-    fn test_update_skips_ark_virtual_doc() {
+    fn test_index_skips_ark_virtual_doc() {
         let _guard = ResetIndexerGuard;
 
-        let ark_uri = Url::parse("ark://namespace/test.R").unwrap();
-        let doc = Document::new("foo <- 1", None);
-
-        update(&doc, &ark_uri).unwrap();
+        index_file_for_test("ark://namespace/test.R", "foo <- 1");
         assert!(find("foo").is_none());
     }
 
     #[test]
-    fn test_update_indexes_git_uri() {
+    fn test_index_indexes_git_uri() {
         let _guard = ResetIndexerGuard;
 
-        let git_uri = Url::parse("git:///home/user/test.R?ref=HEAD").unwrap();
-        let doc = Document::new("foo <- 1", None);
-
-        update(&doc, &git_uri).unwrap();
+        index_file_for_test("git:///home/user/test.R?ref=HEAD", "foo <- 1");
         assert!(find("foo").is_some());
-    }
-
-    #[test]
-    fn test_create_skips_non_file_uri() {
-        let _guard = ResetIndexerGuard;
-
-        let ark_uri = Url::parse("ark://namespace/test.R").unwrap();
-
-        create(&ark_uri).unwrap();
-        assert!(find("foo").is_none());
     }
 }

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -139,6 +139,15 @@ pub(crate) fn map(db: &dyn ArkDb, mut callback: impl FnMut(&Url, &str, &IndexEnt
     }
 }
 
+/// Call [`file_index()`] for every workspace file. This ensures workspace
+/// symbols are loaded before the user needs to read them (e.g. by looking up a
+/// workspace symbol without any file opened).
+pub(crate) fn warm(db: &dyn ArkDb) {
+    for &file in oak_db::workspace_files(db) {
+        file_index(db, file);
+    }
+}
+
 fn index_insert(index: &mut rustc_hash::FxHashMap<String, IndexEntry>, entry: IndexEntry) {
     // We generally retain only the first occurrence in the index. In the
     // future we'll track every occurrences and their scopes but for now we

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -5,24 +5,20 @@
 //
 //
 
-use std::collections::HashMap;
 use std::result::Result::Ok;
-use std::sync::Arc;
 use std::sync::LazyLock;
-use std::sync::Mutex;
 
-use aether_lsp_utils::proto::PositionEncoding;
+use oak_db::File;
 use regex::Regex;
 use stdext::unwrap;
 use stdext::unwrap::IntoResult;
-use tower_lsp::lsp_types::Range;
 use tree_sitter::Node;
 use tree_sitter::Query;
 use url::Url;
 
 use crate::lsp;
-use crate::lsp::ark_file::ArkFile;
 use crate::lsp::db::ArkDb;
+use crate::lsp::db::FileExt;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::BinaryOperatorType;
 use crate::treesitter::NodeType;
@@ -30,28 +26,7 @@ use crate::treesitter::NodeTypeExt;
 use crate::treesitter::TsQuery;
 use crate::url::ExtUrl;
 
-/// FileId represents a unique identifier for a file in the workspace index
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub struct FileId {
-    /// The URL representing the file
-    uri: Url,
-}
-
-impl FileId {
-    pub fn from_uri(uri: Url) -> Self {
-        Self { uri }
-    }
-
-    pub fn as_str(&self) -> &str {
-        self.uri.as_str()
-    }
-
-    pub fn as_uri(&self) -> &Url {
-        &self.uri
-    }
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub enum IndexEntryData {
     Variable {
         name: String,
@@ -70,103 +45,101 @@ pub enum IndexEntryData {
     },
 }
 
-#[derive(Clone, Debug)]
+/// A position in a file as a tree-sitter point: zero-based row, and column in
+/// bytes within that row. Encoding-free, so the per-file index stays a pure
+/// salsa query. Consumers that need an LSP position convert via the file's
+/// line index and the session encoding (see `symbols.rs`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
+pub struct IndexPoint {
+    pub row: u32,
+    pub column: u32,
+}
+
+impl From<tree_sitter::Point> for IndexPoint {
+    fn from(point: tree_sitter::Point) -> Self {
+        Self {
+            row: point.row as u32,
+            column: point.column as u32,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
+pub struct IndexRange {
+    pub start: IndexPoint,
+    pub end: IndexPoint,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub struct IndexEntry {
     pub key: String,
-    pub range: Range,
+    pub range: IndexRange,
     pub data: IndexEntryData,
 }
 
-type DocumentSymbol = String;
-type DocumentSymbolIndex = HashMap<DocumentSymbol, IndexEntry>;
-type WorkspaceIndex = Arc<Mutex<HashMap<FileId, DocumentSymbolIndex>>>;
-
-static WORKSPACE_INDEX: LazyLock<WorkspaceIndex> = LazyLock::new(Default::default);
 pub static RE_COMMENT_SECTION: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(#+)\s*(.*?)\s*[#=-]{4,}\s*$").unwrap());
 
-/// Search the workspace files and return the first symbol match
-pub fn find(symbol: &str) -> Option<(FileId, IndexEntry)> {
-    let index = WORKSPACE_INDEX.lock().unwrap();
+/// One file's workspace symbols, keyed by symbol name. Built by [`file_index`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, salsa::Update)]
+pub(crate) struct FileIndex {
+    pub(crate) symbols: rustc_hash::FxHashMap<String, IndexEntry>,
+}
 
-    for (file_id, index) in index.iter() {
-        if let Some(entry) = index.get(symbol) {
-            return Some((file_id.clone(), entry.clone()));
+/// Find the first workspace symbol matching `symbol`, scanning files in
+/// `workspace_files` order. `ark://` virtual docs are skipped: they show
+/// foreign code the user can't edit.
+pub(crate) fn find(db: &dyn ArkDb, symbol: &str) -> Option<IndexEntry> {
+    for &file in oak_db::workspace_files(db) {
+        let url = file.path(db).to_url();
+        if !ExtUrl::is_indexable(&url) {
+            continue;
+        }
+        if let Some(entry) = file_index(db, file).symbols.get(symbol) {
+            return Some(entry.clone());
         }
     }
-
     None
 }
 
-/// Search a specific workspace file for a symbol
-pub fn find_in_file(symbol: &str, uri: &Url) -> Option<(FileId, IndexEntry)> {
-    let index = WORKSPACE_INDEX.lock().unwrap();
+/// Extract a file's workspace symbols.
+#[salsa::tracked(returns(ref))]
+fn file_index(db: &dyn ArkDb, file: File) -> FileIndex {
+    let tree = file.tree_sitter(db);
+    let contents = file.contents(db).as_str();
 
-    let file_id = FileId::from_uri(uri.clone());
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let mut entries = Vec::new();
 
-    if let Some(symbol_index) = index.get(&file_id) {
-        if let Some(entry) = symbol_index.get(symbol) {
-            return Some((file_id, entry.clone()));
+    for node in root.children(&mut cursor) {
+        if let Err(err) = index_node(contents, &node, &mut entries) {
+            lsp::log_error!("Can't index document: {err:?}");
         }
     }
 
-    None
+    let mut symbols = rustc_hash::FxHashMap::default();
+    for entry in entries {
+        index_insert(&mut symbols, entry);
+    }
+
+    FileIndex { symbols }
 }
 
-pub fn map(mut callback: impl FnMut(&Url, &String, &IndexEntry)) {
-    let index = WORKSPACE_INDEX.lock().unwrap();
-
-    for (file_id, symbol_index) in index.iter() {
-        let uri = file_id.as_uri();
-        for (symbol, entry) in symbol_index.iter() {
-            callback(uri, symbol, entry);
+/// Visit every workspace symbol across all indexable files.
+pub(crate) fn map(db: &dyn ArkDb, mut callback: impl FnMut(&Url, &str, &IndexEntry)) {
+    for &file in oak_db::workspace_files(db) {
+        let url = file.path(db).to_url();
+        if !ExtUrl::is_indexable(&url) {
+            continue;
+        }
+        for (symbol, entry) in file_index(db, file).symbols.iter() {
+            callback(&url, symbol, entry);
         }
     }
 }
 
-/// Index a single `oak_db` file, replacing any existing entries for its URL.
-#[tracing::instrument(level = "trace", skip_all)]
-pub(crate) fn index_file(
-    db: &dyn ArkDb,
-    file: oak_db::File,
-    encoding: PositionEncoding,
-) -> anyhow::Result<()> {
-    let url = file.path(db).to_url();
-
-    // Defensive, callers are expected to filter virtual doc URIs before queuing
-    if !ExtUrl::is_indexable(&url) {
-        return Ok(());
-    }
-
-    // Build an `ArkFile` directly from the `oak_db::File` rather than go through
-    // `WorldState::ark_file()`, which requires a stored editor `Document`.
-    // Scanned workspace files have no `Document`, so we synthesize a minimal
-    // `ArkFile` that carries only what the extraction reads (tree, contents,
-    // line index).
-    let file = ArkFile {
-        file,
-        version: None,
-        config: Default::default(),
-        url: url.clone(),
-        encoding,
-    };
-
-    delete(&url)?;
-    index_document(db, &file, &url);
-    Ok(())
-}
-
-fn insert(uri: &Url, entry: IndexEntry) -> anyhow::Result<()> {
-    let mut index = WORKSPACE_INDEX.lock().unwrap();
-    let file_id = FileId::from_uri(uri.clone());
-
-    let file_index = index.entry(file_id).or_default();
-    index_insert(file_index, entry);
-
-    Ok(())
-}
-
-fn index_insert(index: &mut HashMap<String, IndexEntry>, entry: IndexEntry) {
+fn index_insert(index: &mut rustc_hash::FxHashMap<String, IndexEntry>, entry: IndexEntry) {
     // We generally retain only the first occurrence in the index. In the
     // future we'll track every occurrences and their scopes but for now we
     // only track the first definition of an object (in a way, its
@@ -182,84 +155,14 @@ fn index_insert(index: &mut HashMap<String, IndexEntry>, entry: IndexEntry) {
     }
 }
 
-#[tracing::instrument(level = "trace")]
-pub(crate) fn delete(uri: &Url) -> anyhow::Result<()> {
-    let file_id = FileId::from_uri(uri.clone());
-    let mut index = WORKSPACE_INDEX.lock().unwrap();
-
-    // Only clears if the key exists
-    index.entry(file_id).and_modify(|index| {
-        index.clear();
-    });
-
-    Ok(())
-}
-
-#[tracing::instrument(level = "trace")]
-pub(crate) fn rename(old_uri: &Url, new_uri: &Url) -> anyhow::Result<()> {
-    let mut index = WORKSPACE_INDEX.lock().unwrap();
-
-    let old_file_id = FileId::from_uri(old_uri.clone());
-    let new_file_id = FileId::from_uri(new_uri.clone());
-
-    if let Some(entries) = index.remove(&old_file_id) {
-        index.insert(new_file_id, entries);
-    }
-
-    Ok(())
-}
-
-#[cfg(test)]
-pub(crate) fn indexer_clear() {
-    let mut index = WORKSPACE_INDEX.lock().unwrap();
-    index.clear();
-}
-
-/// RAII guard that clears `WORKSPACE_INDEX` when dropped.
-/// Useful for ensuring a clean index state in tests.
-#[cfg(test)]
-pub(crate) struct ResetIndexerGuard;
-
-#[cfg(test)]
-impl Drop for ResetIndexerGuard {
-    fn drop(&mut self) {
-        indexer_clear();
-    }
-}
-
-fn index_document(db: &dyn ArkDb, file: &ArkFile, uri: &Url) {
-    let ast = file.tree_sitter(db);
-    let root = ast.root_node();
-    let mut cursor = root.walk();
-    let mut entries = Vec::new();
-
-    for node in root.children(&mut cursor) {
-        if let Err(err) = index_node(db, file, &node, &mut entries) {
-            lsp::log_error!("Can't index document: {err:?}");
-        }
-    }
-
-    for entry in entries {
-        if let Err(err) = insert(uri, entry) {
-            lsp::log_error!("Can't insert index entry: {err:?}");
-        }
-    }
-}
-
-fn index_node(
-    db: &dyn ArkDb,
-    file: &ArkFile,
-    node: &Node,
-    entries: &mut Vec<IndexEntry>,
-) -> anyhow::Result<()> {
-    index_assignment(db, file, node, entries)?;
-    index_comment(db, file, node, entries)?;
+fn index_node(contents: &str, node: &Node, entries: &mut Vec<IndexEntry>) -> anyhow::Result<()> {
+    index_assignment(contents, node, entries)?;
+    index_comment(contents, node, entries)?;
     Ok(())
 }
 
 fn index_assignment(
-    db: &dyn ArkDb,
-    file: &ArkFile,
+    contents: &str,
     node: &Node,
     entries: &mut Vec<IndexEntry>,
 ) -> anyhow::Result<()> {
@@ -280,12 +183,10 @@ fn index_assignment(
         return Ok(());
     };
 
-    let contents = file.contents(db);
-
     if crate::treesitter::node_is_call(&rhs, "R6Class", contents) ||
         crate::treesitter::node_is_namespaced_call(&rhs, "R6", "R6Class", contents)
     {
-        index_r6_class_methods(db, file, &rhs, entries)?;
+        index_r6_class_methods(contents, &rhs, entries)?;
         // Fallthrough to index the variable to which the R6 class is assigned
     }
 
@@ -317,12 +218,12 @@ fn index_assignment(
 
         // Note that unlike document symbols whose ranges cover the whole entity
         // they represent, the range of workspace symbols only cover the identifers
-        let start = file.lsp_position_from_tree_sitter_point(db, lhs.start_position())?;
-        let end = file.lsp_position_from_tree_sitter_point(db, lhs.end_position())?;
-
         entries.push(IndexEntry {
             key: lhs_text.clone(),
-            range: Range { start, end },
+            range: IndexRange {
+                start: lhs.start_position().into(),
+                end: lhs.end_position().into(),
+            },
             data: IndexEntryData::Function {
                 name: lhs_text,
                 arguments,
@@ -330,11 +231,12 @@ fn index_assignment(
         });
     } else {
         // Otherwise, emit variable
-        let start = file.lsp_position_from_tree_sitter_point(db, lhs.start_position())?;
-        let end = file.lsp_position_from_tree_sitter_point(db, lhs.end_position())?;
         entries.push(IndexEntry {
             key: lhs_text.clone(),
-            range: Range { start, end },
+            range: IndexRange {
+                start: lhs.start_position().into(),
+                end: lhs.end_position().into(),
+            },
             data: IndexEntryData::Variable { name: lhs_text },
         });
     }
@@ -343,8 +245,7 @@ fn index_assignment(
 }
 
 fn index_r6_class_methods(
-    db: &dyn ArkDb,
-    file: &ArkFile,
+    contents: &str,
     node: &Node,
     entries: &mut Vec<IndexEntry>,
 ) -> anyhow::Result<()> {
@@ -371,16 +272,15 @@ fn index_r6_class_methods(
     });
     let mut ts_query = TsQuery::from_query(&R6_METHODS_QUERY);
 
-    let contents = file.contents(db);
-
     for method_node in ts_query.captures_for(*node, "method_name", contents.as_bytes()) {
         let name = method_node.node_to_string(contents)?;
-        let start = file.lsp_position_from_tree_sitter_point(db, method_node.start_position())?;
-        let end = file.lsp_position_from_tree_sitter_point(db, method_node.end_position())?;
 
         entries.push(IndexEntry {
             key: name.clone(),
-            range: Range { start, end },
+            range: IndexRange {
+                start: method_node.start_position().into(),
+                end: method_node.end_position().into(),
+            },
             data: IndexEntryData::Method { name },
         });
     }
@@ -388,19 +288,14 @@ fn index_r6_class_methods(
     Ok(())
 }
 
-fn index_comment(
-    db: &dyn ArkDb,
-    file: &ArkFile,
-    node: &Node,
-    entries: &mut Vec<IndexEntry>,
-) -> anyhow::Result<()> {
+fn index_comment(contents: &str, node: &Node, entries: &mut Vec<IndexEntry>) -> anyhow::Result<()> {
     // check for comment
     if !node.is_comment() {
         return Ok(());
     }
 
     // see if it looks like a section
-    let comment = node.node_as_str(file.contents(db))?;
+    let comment = node.node_as_str(contents)?;
     let matches = match RE_COMMENT_SECTION.captures(comment) {
         Some(m) => m,
         None => return Ok(()),
@@ -417,12 +312,12 @@ fn index_comment(
         return Ok(());
     }
 
-    let start = file.lsp_position_from_tree_sitter_point(db, node.start_position())?;
-    let end = file.lsp_position_from_tree_sitter_point(db, node.end_position())?;
-
     entries.push(IndexEntry {
         key: title.clone(),
-        range: Range::new(start, end),
+        range: IndexRange {
+            start: node.start_position().into(),
+            end: node.end_position().into(),
+        },
         data: IndexEntryData::Section { level, title },
     });
 
@@ -433,25 +328,23 @@ fn index_comment(
 mod tests {
 
     use assert_matches::assert_matches;
-    use biome_line_index::WideEncoding;
     use insta::assert_debug_snapshot;
-    use tower_lsp::lsp_types;
+    use oak_scan::DbScan;
 
     use super::*;
     use crate::lsp::ark_file::test_ark_file;
-
-    const ENCODING: PositionEncoding = PositionEncoding::Wide(WideEncoding::Utf16);
 
     macro_rules! test_index {
         ($code:expr) => {
             let (db, file) = test_ark_file($code);
             let tree = file.tree_sitter(&db);
+            let contents = file.contents(&db);
             let root = tree.root_node();
             let mut cursor = root.walk();
 
             let mut entries = vec![];
             for node in root.children(&mut cursor) {
-                let _ = index_node(&db, &file, &node, &mut entries);
+                let _ = index_node(contents, &node, &mut entries);
             }
             assert_debug_snapshot!(entries);
         };
@@ -571,14 +464,14 @@ class <- R6::R6Class(
 
     #[test]
     fn test_index_insert_priority() {
-        let mut index = HashMap::new();
+        let mut index = rustc_hash::FxHashMap::default();
 
         let section_entry = IndexEntry {
             key: "foo".to_string(),
-            range: Range::new(
-                lsp_types::Position::new(0, 0),
-                lsp_types::Position::new(0, 3),
-            ),
+            range: IndexRange {
+                start: IndexPoint { row: 0, column: 0 },
+                end: IndexPoint { row: 0, column: 3 },
+            },
             data: IndexEntryData::Section {
                 level: 1,
                 title: "foo".to_string(),
@@ -587,10 +480,10 @@ class <- R6::R6Class(
 
         let variable_entry = IndexEntry {
             key: "foo".to_string(),
-            range: Range::new(
-                lsp_types::Position::new(1, 0),
-                lsp_types::Position::new(1, 3),
-            ),
+            range: IndexRange {
+                start: IndexPoint { row: 1, column: 0 },
+                end: IndexPoint { row: 1, column: 3 },
+            },
             data: IndexEntryData::Variable {
                 name: "foo".to_string(),
             },
@@ -613,10 +506,10 @@ class <- R6::R6Class(
 
         let function_entry = IndexEntry {
             key: "foo".to_string(),
-            range: Range::new(
-                lsp_types::Position::new(2, 0),
-                lsp_types::Position::new(2, 3),
-            ),
+            range: IndexRange {
+                start: IndexPoint { row: 2, column: 0 },
+                end: IndexPoint { row: 2, column: 3 },
+            },
             data: IndexEntryData::Function {
                 name: "foo".to_string(),
                 arguments: vec!["a".to_string()],
@@ -632,29 +525,21 @@ class <- R6::R6Class(
         );
     }
 
-    fn index_file_for_test(uri: &str, contents: &str) {
-        use aether_path::FilePath;
-
-        let db = oak_db::OakDatabase::new();
-        let url = Url::parse(uri).unwrap();
-        let key = FilePath::from_url(&url);
-        let file = oak_db::File::new(&db, key, contents.to_string(), None);
-        index_file(&db, file, ENCODING).unwrap();
-    }
-
     #[test]
     fn test_index_skips_ark_virtual_doc() {
-        let _guard = ResetIndexerGuard;
-
-        index_file_for_test("ark://namespace/test.R", "foo <- 1");
-        assert!(find("foo").is_none());
+        use aether_path::FilePath;
+        let mut db = oak_db::OakDatabase::new();
+        let url = Url::parse("ark://namespace/test.R").unwrap();
+        db.upsert_editor(FilePath::from_url(&url), "foo <- 1".to_string());
+        assert!(find(&db, "foo").is_none());
     }
 
     #[test]
     fn test_index_indexes_git_uri() {
-        let _guard = ResetIndexerGuard;
-
-        index_file_for_test("git:///home/user/test.R?ref=HEAD", "foo <- 1");
-        assert!(find("foo").is_some());
+        use aether_path::FilePath;
+        let mut db = oak_db::OakDatabase::new();
+        let url = Url::parse("git:///home/user/test.R?ref=HEAD").unwrap();
+        db.upsert_editor(FilePath::from_url(&url), "foo <- 1".to_string());
+        assert!(find(&db, "foo").is_some());
     }
 }

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -8,10 +8,15 @@
 use std::result::Result::Ok;
 use std::sync::LazyLock;
 
+use aether_lsp_utils::proto::to_proto;
+use aether_lsp_utils::proto::PositionEncoding;
+use aether_path::FilePath;
 use oak_db::File;
 use regex::Regex;
+use stdext::result::ResultExt;
 use stdext::unwrap;
 use stdext::unwrap::IntoResult;
+use tower_lsp::lsp_types::Range;
 use tree_sitter::Node;
 use tree_sitter::Query;
 use url::Url;
@@ -47,7 +52,7 @@ pub enum IndexEntryData {
 /// A position in a file as a tree-sitter point: zero-based row, and column in
 /// bytes within that row. Encoding-free, so the per-file index stays a pure
 /// salsa query. Consumers that need an LSP position convert via the file's
-/// line index and the session encoding (see `symbols.rs`).
+/// line index and the session encoding (see `index_range_to_lsp_range`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
 pub struct IndexPoint {
     pub row: u32,
@@ -74,6 +79,37 @@ pub struct IndexEntry {
     pub key: String,
     pub range: IndexRange,
     pub data: IndexEntryData,
+}
+
+/// Convert an index entry's tree-sitter point range to an LSP range, resolving
+/// the file's line index from the db. Returns `None` if the file is no longer
+/// in the db or the points fall outside it, in which case the symbol is
+/// dropped from the results.
+pub(crate) fn index_range_to_lsp_range(
+    db: &dyn ArkDb,
+    uri: &Url,
+    range: IndexRange,
+    encoding: PositionEncoding,
+) -> Option<Range> {
+    let file = db.file_by_path(&FilePath::from_url(uri))?;
+    let line_index = file.line_index(db);
+
+    let to_position = |point: IndexPoint| {
+        to_proto::position_from_line_col(
+            biome_line_index::LineCol {
+                line: point.row,
+                col: point.column,
+            },
+            line_index,
+            encoding,
+        )
+        .log_err()
+    };
+
+    Some(Range::new(
+        to_position(range.start)?,
+        to_position(range.end)?,
+    ))
 }
 
 pub static RE_COMMENT_SECTION: LazyLock<Regex> =

--- a/crates/ark/src/lsp/indexer.rs
+++ b/crates/ark/src/lsp/indexer.rs
@@ -131,7 +131,7 @@ pub(crate) fn index_file(
     file: oak_db::File,
     encoding: PositionEncoding,
 ) -> anyhow::Result<()> {
-    let url = file.url(db).to_url();
+    let url = file.path(db).to_url();
 
     // Defensive, callers are expected to filter virtual doc URIs before queuing
     if !ExtUrl::is_indexable(&url) {

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -187,6 +187,11 @@ struct AuxiliaryState {
     client: Client,
     auxiliary_event_rx: TokioUnboundedReceiver<AuxiliaryEvent>,
     tasks: TaskList<Option<AuxiliaryEvent>>,
+    /// Last diagnostics published per file. A refresh re-runs every open file,
+    /// but most runs produce the same result, so we skip the publish when it
+    /// matches what the client already has. Mirrors rust-analyzer's
+    /// `DiagnosticCollection`: only changed files go on the wire.
+    published_diagnostics: HashMap<Url, Vec<Diagnostic>>,
 }
 
 impl GlobalState {
@@ -314,6 +319,14 @@ impl GlobalState {
     ///   the state.
     async fn handle_event(&mut self, event: Event) -> anyhow::Result<()> {
         let loop_tick = std::time::Instant::now();
+
+        // Diagnostics read the oak database (workspace symbols, imports,
+        // resolved definitions), so any handler that writes to oak invalidates
+        // them. Rather than have each write site remember to refresh, we watch
+        // the oak revision across the whole tick: if a handler advanced it,
+        // refresh centrally. Config and console state live outside oak, so
+        // handlers that mutate those still refresh explicitly.
+        let old_revision = salsa::plumbing::current_revision(&self.world.db);
 
         match event {
             Event::Lsp(msg) => match msg {
@@ -474,20 +487,17 @@ impl GlobalState {
                     scan,
                     &editor_owned,
                 );
-                if followups.is_empty() {
-                    // The scan settled (no more follow-ups). `apply_scan_completed()`
-                    // is an oak write that changed the workspace symbols diagnostics
-                    // resolve against, so recompute diagnostics for the open files.
-                    diagnostics_refresh_all(&self.world);
-                } else {
-                    dispatch_scan_requests(&self.events_tx, followups);
-                }
+                dispatch_scan_requests(&self.events_tx, followups);
             },
         }
 
         // TODO Make this threshold configurable by the client
         if loop_tick.elapsed() > std::time::Duration::from_millis(50) {
             lsp::log_info!("Handler took {}ms", loop_tick.elapsed().as_millis());
+        }
+
+        if salsa::plumbing::current_revision(&self.world.db) != old_revision {
+            diagnostics_refresh_all(&self.world);
         }
 
         Ok(())
@@ -667,6 +677,7 @@ impl AuxiliaryState {
             client,
             auxiliary_event_rx,
             tasks,
+            published_diagnostics: HashMap::new(),
         }
     }
 
@@ -680,9 +691,7 @@ impl AuxiliaryState {
                 AuxiliaryEvent::Log(level, message) => self.log(level, message).await,
                 AuxiliaryEvent::SpawnedTask(handle) => self.tasks.push(Box::pin(handle)),
                 AuxiliaryEvent::PublishDiagnostics(uri, diagnostics, version) => {
-                    self.client
-                        .publish_diagnostics(uri, diagnostics, version)
-                        .await
+                    self.publish_diagnostics(uri, diagnostics, version).await
                 },
                 AuxiliaryEvent::Shutdown => break,
             }
@@ -715,6 +724,26 @@ impl AuxiliaryState {
                 },
             }
         }
+    }
+
+    /// Publish diagnostics for `uri`, skipping the client round-trip when the
+    /// set is identical to what we last sent for that file. Clearing (going to
+    /// an empty set) still publishes, since empty differs from a prior non-empty
+    /// set.
+    async fn publish_diagnostics(
+        &mut self,
+        uri: Url,
+        diagnostics: Vec<Diagnostic>,
+        version: Option<i32>,
+    ) {
+        if self.published_diagnostics.get(&uri) == Some(&diagnostics) {
+            return;
+        }
+        self.published_diagnostics
+            .insert(uri.clone(), diagnostics.clone());
+        self.client
+            .publish_diagnostics(uri, diagnostics, version)
+            .await
     }
 
     async fn log(&self, level: MessageType, message: String) {
@@ -875,8 +904,17 @@ static DIAGNOSTICS_QUEUE: LazyLock<tokio::sync::mpsc::UnboundedSender<RefreshDia
 /// Process diagnostics refresh tasks.
 ///
 /// Tasks are batched and deduplicated per URL (only the last task per URL is
-/// processed), so stale-version diagnostics get superseded. The frontend
-/// receives results in order because the queue processes one batch at a time.
+/// processed), so stale-version diagnostics get superseded within a batch.
+///
+/// Batches triggered by an oak write can't publish out of order. Each pass
+/// holds a db snapshot, and a salsa write blocks until all snapshots drop, so
+/// by the time the write completes and the newer batch is enqueued, any older
+/// pass has either unwound with `Cancelled` or already produced its result.
+///
+/// FIXME: Batches triggered without an oak write (console inputs, diagnostics
+/// config) have no such barrier. An older pass can run concurrently with the
+/// newer one and publish last, leaving diagnostics computed from the older
+/// console scopes or config until the next refresh.
 async fn process_diagnostics_queue(mut rx: mpsc::UnboundedReceiver<RefreshDiagnosticsTask>) {
     while let Some(task) = rx.recv().await {
         let mut batch = vec![task];
@@ -938,13 +976,7 @@ fn refresh_diagnostics(task: RefreshDiagnosticsTask) -> RefreshDiagnosticsResult
 
 /// Run `f`, swallowing a salsa cancellation as `None`. Any other panic propagates.
 fn catch_cancellation<T>(f: impl FnOnce() -> T) -> Option<T> {
-    match salsa::Cancelled::catch(std::panic::AssertUnwindSafe(f)) {
-        Ok(value) => Some(value),
-        Err(cancelled) => {
-            log::trace!("Salsa query {cancelled}");
-            None
-        },
-    }
+    salsa::Cancelled::catch(std::panic::AssertUnwindSafe(f)).ok()
 }
 
 pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
@@ -1015,5 +1047,21 @@ mod tests {
             state: snapshot,
         };
         assert!(catch_cancellation(|| refresh_diagnostics(task)).is_none());
+    }
+
+    /// The central diagnostics refresh keys off the oak revision advancing
+    /// across a loop tick, so an oak write must bump the revision. This pins
+    /// that assumption: if a salsa upgrade changed it, the refresh would
+    /// silently stop firing.
+    #[test]
+    fn test_oak_write_advances_revision() {
+        let mut state = WorldState::default();
+        let before = salsa::plumbing::current_revision(&state.db);
+        state.db.upsert_editor(
+            FilePath::from_url(&Url::parse("file:///a.R").unwrap()),
+            "x <- 1".to_string(),
+        );
+        let after = salsa::plumbing::current_revision(&state.db);
+        assert_ne!(before, after);
     }
 }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -16,11 +16,9 @@ use std::sync::atomic::Ordering;
 use std::sync::LazyLock;
 use std::sync::RwLock;
 
-use aether_lsp_utils::proto::PositionEncoding;
 use aether_path::FilePath;
 use anyhow::anyhow;
 use futures::StreamExt;
-use oak_db::Db;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use oak_scan::ScanCompleted;
@@ -49,7 +47,6 @@ use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
 use crate::lsp::diagnostics::generate_diagnostics;
 use crate::lsp::handlers;
-use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers;
 use crate::lsp::state_handlers::ConsoleInputs;
@@ -95,10 +92,6 @@ pub(crate) enum Event {
     Lsp(LspMessage),
     Kernel(KernelNotification),
     OakScanCompleted(ScanCompleted),
-    /// Re-run a workspace root's index pass. Emitted when a concurrent oak
-    /// write cancelled the pass partway, so the cancelled pass isn't silently
-    /// dropped (see [`index_root_files`]).
-    ReindexRoot(oak_db::Root),
 }
 
 #[derive(Debug)]
@@ -476,57 +469,19 @@ impl GlobalState {
                 // kicked off. The buffer-drain inside `apply_scan_completed` uses
                 // this set as its watcher-event `skip` argument.
                 let editor_owned: HashSet<FilePath> = self.world.documents.keys().cloned().collect();
-                let root = scan.root();
                 let followups = self.lsp_state.oak_scheduler.apply_scan_completed(
                     &mut self.world.db,
                     scan,
                     &editor_owned,
                 );
                 if followups.is_empty() {
-                    // Wait until the root is idle (no more follow-up scans
-                    // queued) before feeding the legacy index and refreshing
-                    // diagnostics, so we don't index a scan that's about to be
-                    // superseded.
-                    if root.kind(&self.world.db) == oak_db::RootKind::Workspace {
-                        // Index the root's files into the legacy index that
-                        // powers completions, workspace symbols, and
-                        // diagnostics. The pass refreshes diagnostics once it
-                        // finishes (see `index_root_files`), so they read a
-                        // fully-built index instead of racing it.
-                        let files = root_files(&self.world.db, root);
-                        index_scanned_files(
-                            root,
-                            files,
-                            editor_owned,
-                            self.world.clone(),
-                            self.events_tx.clone(),
-                        );
-                    } else {
-                        // Library roots don't feed the legacy index, but
-                        // `apply_scan_completed()` changed the oak imports and
-                        // exports diagnostics resolve against. There's no index
-                        // pass to wait on, so refresh directly.
-                        diagnostics_refresh_all(&self.world);
-                    }
+                    // The scan settled (no more follow-ups). `apply_scan_completed()`
+                    // is an oak write that changed the workspace symbols diagnostics
+                    // resolve against, so recompute diagnostics for the open files.
+                    diagnostics_refresh_all(&self.world);
                 } else {
                     dispatch_scan_requests(&self.events_tx, followups);
                 }
-            },
-
-            Event::ReindexRoot(root) => {
-                // Recompute editor-owned files at apply time, same as
-                // `OakScanCompleted`: buffers may have opened or closed since
-                // the cancelled pass kicked off.
-                let editor_owned: HashSet<FilePath> =
-                    self.world.documents.keys().cloned().collect();
-                let files = root_files(&self.world.db, root);
-                index_scanned_files(
-                    root,
-                    files,
-                    editor_owned,
-                    self.world.clone(),
-                    self.events_tx.clone(),
-                );
             },
         }
 
@@ -895,29 +850,6 @@ impl std::fmt::Debug for TraceKernelNotification<'_> {
 }
 
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant)]
-pub(crate) enum IndexerQueueTask {
-    Indexer(IndexerTask),
-    Diagnostics(RefreshDiagnosticsTask),
-}
-
-#[derive(Debug)]
-pub(crate) enum IndexerTask {
-    Index {
-        uri: Url,
-        db: OakDatabase,
-        encoding: PositionEncoding,
-    },
-    Delete {
-        uri: Url,
-    },
-    Rename {
-        uri: Url,
-        new: Url,
-    },
-}
-
-#[derive(Debug)]
 pub(crate) struct RefreshDiagnosticsTask {
     /// Snapshot carrying the live oak plus the session context the diagnostics
     /// walk reads. See [`WorldState::diagnostics_snapshot`].
@@ -933,133 +865,25 @@ struct RefreshDiagnosticsResult {
     version: Option<i32>,
 }
 
-fn summarize_indexer_task(batch: &[IndexerTask]) -> String {
-    let mut counts = std::collections::HashMap::new();
-    for task in batch {
-        let type_name = match task {
-            IndexerTask::Index { .. } => "Index",
-            IndexerTask::Delete { .. } => "Delete",
-            IndexerTask::Rename { .. } => "Rename",
-        };
-        *counts.entry(type_name).or_insert(0) += 1;
-    }
-
-    let mut summary = String::new();
-    for (task_type, count) in counts.iter() {
-        use std::fmt::Write;
-        let _ = write!(summary, "{task_type}: {count} ");
-    }
-
-    summary.trim_end().to_string()
-}
-
-static INDEXER_QUEUE: LazyLock<tokio::sync::mpsc::UnboundedSender<IndexerQueueTask>> =
+static DIAGNOSTICS_QUEUE: LazyLock<tokio::sync::mpsc::UnboundedSender<RefreshDiagnosticsTask>> =
     LazyLock::new(|| {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        tokio::spawn(process_indexer_queue(rx));
+        tokio::spawn(process_diagnostics_queue(rx));
         tx
     });
 
-/// Process indexer and diagnostics tasks
+/// Process diagnostics refresh tasks.
 ///
-/// Diagnostics need an up-to-date index to be accurate, so we synchronise
-/// indexing and diagnostics tasks using a simple queue.
-///
-/// - We make sure to refresh diagnostics after every indexer updates.
-/// - Indexer tasks are batched together, same for diagnostics tasks.
-/// - Cancellation is simply dealt with by deduplicating tasks for the same URI,
-///   retaining only the most recent one.
-///
-/// Ideally we'd process indexer tasks continually without making them dependent
-/// on diagnostics tasks. The current setup blocks the queue loop while
-/// diagnostics are running, but it has the benefit that rounds of diagnostic
-/// refreshes don't race against each other. The frontend will receive all
-/// results in order, ensuring that diagnostics for an outdated version are
-/// eventually replaced by the most up-to-date diagnostics.
-///
-/// Note that this setup will be entirely replaced in the future by Salsa
-/// dependencies. Diagnostics refreshes will depend on indexer results in a
-/// natural way and they will be cancelled automatically as document updates
-/// arrive.
-async fn process_indexer_queue(mut rx: mpsc::UnboundedReceiver<IndexerQueueTask>) {
-    let mut diagnostics_batch = Vec::new();
-    let mut indexer_batch = Vec::new();
-
+/// Tasks are batched and deduplicated per URL (only the last task per URL is
+/// processed), so stale-version diagnostics get superseded. The frontend
+/// receives results in order because the queue processes one batch at a time.
+async fn process_diagnostics_queue(mut rx: mpsc::UnboundedReceiver<RefreshDiagnosticsTask>) {
     while let Some(task) = rx.recv().await {
-        let mut tasks = vec![task];
-
-        // Process diagnostics at least every 10 iterations if indexer tasks
-        // keep coming in, so the user gets intermediate diagnostics refreshes
-        for _ in 0..10 {
-            while let Ok(task) = rx.try_recv() {
-                tasks.push(task);
-            }
-
-            // Separate by type
-            for task in std::mem::take(&mut tasks) {
-                match task {
-                    IndexerQueueTask::Indexer(indexer_task) => indexer_batch.push(indexer_task),
-                    IndexerQueueTask::Diagnostics(diagnostic_task) => {
-                        diagnostics_batch.push(diagnostic_task)
-                    },
-                }
-            }
-
-            // No more indexer tasks, let's do diagnostics
-            if indexer_batch.is_empty() {
-                break;
-            }
-
-            // Process indexer tasks first so diagnostics tasks work with an
-            // up-to-date index
-            process_indexer_batch(std::mem::take(&mut indexer_batch)).await;
+        let mut batch = vec![task];
+        while let Ok(task) = rx.try_recv() {
+            batch.push(task);
         }
-
-        process_diagnostics_batch(std::mem::take(&mut diagnostics_batch));
-    }
-}
-
-async fn process_indexer_batch(batch: Vec<IndexerTask>) {
-    tracing::trace!(
-        "Processing {n} indexer tasks ({summary})",
-        n = batch.len(),
-        summary = summarize_indexer_task(&batch)
-    );
-
-    for task in batch {
-        let result: anyhow::Result<()> = match &task {
-            IndexerTask::Index { uri, db, encoding } => {
-                // This is running on a separate task than the main loop, so
-                // Salsa cancellations are possible. Catch cancellation inline
-                // rather than through the `spawn_blocking()` funnel because
-                // this batch must finish before diagnostics are queued (see
-                // `process_indexer_queue()`) and it can't be fire-and-forget.
-                // On cancel we drop the pass and let the oak write that
-                // cancelled it re-enqueue.
-                let Some(result) = catch_cancellation(|| {
-                    let key = FilePath::from_url(uri);
-                    match db.file_by_path(&key) {
-                        Some(file) => indexer::index_file(db, file, *encoding),
-                        None => Err(anyhow!("No `oak_db` file for URI {uri}")),
-                    }
-                }) else {
-                    continue;
-                };
-                result
-            },
-
-            IndexerTask::Delete { uri } => indexer::delete(uri),
-
-            IndexerTask::Rename {
-                uri: old_uri,
-                new: new_uri,
-            } => indexer::rename(old_uri, new_uri),
-        };
-
-        if let Err(err) = result {
-            tracing::warn!("Can't process indexer task: {err}");
-            continue;
-        }
+        process_diagnostics_batch(batch);
     }
 }
 
@@ -1123,153 +947,6 @@ fn catch_cancellation<T>(f: impl FnOnce() -> T) -> Option<T> {
     }
 }
 
-pub(crate) fn index_update(uris: Vec<Url>, state: WorldState) {
-    for uri in uris {
-        if !ExtUrl::is_indexable(&uri) {
-            continue;
-        }
-
-        INDEXER_QUEUE
-            .send(IndexerQueueTask::Indexer(IndexerTask::Index {
-                uri,
-                db: state.db.clone(),
-                encoding: state.config.position_encoding,
-            }))
-            .unwrap_or_else(|err| lsp::log_error!("Failed to queue index update: {err}"));
-    }
-
-    // Refresh all diagnostics since the indexer results for one file may affect
-    // other files
-    diagnostics_refresh_all(&state);
-}
-
-/// Index all workspace files freshly scanned into `state.db`.
-///
-/// Called from the `OakScanCompleted` hook with a single `WorldState` clone
-/// for the whole root, not one clone per file. Runs on a blocking thread
-/// mirroring `process_diagnostics_batch`, since indexing parses every file
-/// in the root. `skip` carries the editor-owned URLs whose index comes from
-/// `did_open` / `did_change`, so we don't index them twice.
-fn index_scanned_files(
-    root: oak_db::Root,
-    files: Vec<oak_db::File>,
-    skip: HashSet<FilePath>,
-    state: WorldState,
-    events_tx: TokioUnboundedSender<Event>,
-) {
-    spawn_blocking(move || {
-        index_root_files(root, files, &skip, &state, &events_tx);
-        Ok(None)
-    });
-}
-
-/// Run a workspace root's index pass, then act on how it ended.
-///
-/// On `Completed`, refresh diagnostics. They read the legacy workspace index
-/// (`indexer::map` in `generate_diagnostics`), so they have to run after the
-/// pass builds it. Refreshing earlier races the index and flashes false
-/// "undefined symbol" positives that nothing corrects.
-///
-/// On `Cancelled` (a concurrent oak write armed the salsa token mid-pass),
-/// bounce a [`Event::ReindexRoot`] back to the main loop rather than retry
-/// inline. The cancelling write runs to completion on the main loop before the
-/// event is handled, so the retry sees a settled db. A burst of writes can
-/// cancel the retry too, but each cancel re-enqueues, so the pass converges
-/// once the writes stop.
-fn index_root_files(
-    root: oak_db::Root,
-    files: Vec<oak_db::File>,
-    skip: &HashSet<FilePath>,
-    state: &WorldState,
-    events_tx: &TokioUnboundedSender<Event>,
-) {
-    match index_files(&state.db, files, skip, state.config.position_encoding) {
-        IndexPass::Completed => diagnostics_refresh_all(state),
-        IndexPass::Cancelled => {
-            events_tx.send(Event::ReindexRoot(root)).log_err();
-        },
-    }
-}
-
-/// Whether a root index pass ran to completion or was cut short by a salsa
-/// cancellation. A pass parses every file in the root, so a concurrent oak
-/// write (an edit, a follow-up scan) can cancel it partway. `Cancelled` lets
-/// the caller re-enqueue the root instead of leaving a half-built index.
-#[derive(Debug, PartialEq, Eq)]
-enum IndexPass {
-    Completed,
-    Cancelled,
-}
-
-/// Index every file in `files` that isn't editor-owned, into the legacy index.
-///
-/// Salsa queries inside `index_file` unwind with `Cancelled` when a concurrent
-/// write arms the token, so we wrap the whole loop in `catch_cancellation`: a
-/// cancellation aborts the pass and reports `Cancelled` rather than indexing
-/// the remaining files against a db that's about to change.
-fn index_files(
-    db: &OakDatabase,
-    files: Vec<oak_db::File>,
-    skip: &HashSet<FilePath>,
-    encoding: PositionEncoding,
-) -> IndexPass {
-    let completed = catch_cancellation(|| {
-        for file in files {
-            if skip.contains(file.path(db)) {
-                continue;
-            }
-            if let Err(err) = indexer::index_file(db, file, encoding) {
-                tracing::warn!("Can't index scanned file: {err:?}");
-            }
-        }
-    });
-
-    match completed {
-        Some(()) => IndexPass::Completed,
-        None => IndexPass::Cancelled,
-    }
-}
-
-/// Collect every R file under one root: top-level scripts plus each package's
-/// loadable files and non-loadable scripts (`tests/`, `inst/`, ...). Unlike
-/// `oak_db::all_files`, which walks all live roots, this stays scoped to the
-/// single root that just finished scanning.
-fn root_files(db: &OakDatabase, root: oak_db::Root) -> Vec<oak_db::File> {
-    let mut files: Vec<oak_db::File> = root.scripts(db).to_vec();
-    for &pkg in root.packages(db) {
-        files.extend(pkg.files(db));
-        files.extend(pkg.scripts(db));
-    }
-    files
-}
-
-pub(crate) fn index_delete(uris: Vec<Url>, state: WorldState) {
-    for uri in uris {
-        INDEXER_QUEUE
-            .send(IndexerQueueTask::Indexer(IndexerTask::Delete { uri }))
-            .unwrap_or_else(|err| lsp::log_error!("Failed to queue index update: {err}"));
-    }
-
-    // Refresh all diagnostics since the indexer results for one file may affect
-    // other files
-    diagnostics_refresh_all(&state);
-}
-
-pub(crate) fn index_rename(uris: Vec<(Url, Url)>, state: WorldState) {
-    for (old, new) in uris {
-        INDEXER_QUEUE
-            .send(IndexerQueueTask::Indexer(IndexerTask::Rename {
-                uri: old,
-                new,
-            }))
-            .unwrap_or_else(|err| lsp::log_error!("Failed to queue index update: {err}"));
-    }
-
-    // Refresh all diagnostics since the indexer results for one file may affect
-    // other files
-    diagnostics_refresh_all(&state);
-}
-
 pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
     tracing::trace!(
         "Refreshing diagnostics for {n} documents",
@@ -1289,40 +966,26 @@ pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
             },
         };
 
-        INDEXER_QUEUE
-            .send(IndexerQueueTask::Diagnostics(RefreshDiagnosticsTask {
+        DIAGNOSTICS_QUEUE
+            .send(RefreshDiagnosticsTask {
                 file,
                 state: state.diagnostics_snapshot(),
-            }))
+            })
             .unwrap_or_else(|err| lsp::log_error!("Failed to queue diagnostics refresh: {err}"));
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use aether_path::FilePath;
-    use oak_db::File;
-    use oak_db::OakDatabase;
-    use oak_db::Root;
-    use oak_db::RootKind;
     use oak_scan::DbScan;
     use salsa::Database;
-    use tokio::sync::mpsc::unbounded_channel;
     use url::Url;
 
     use super::catch_cancellation;
-    use super::index_root_files;
-    use super::process_indexer_batch;
     use super::refresh_diagnostics;
-    use super::Event;
-    use super::IndexerTask;
     use super::RefreshDiagnosticsTask;
-    use crate::fixtures::TEST_ENCODING;
     use crate::lsp::document::Document;
-    use crate::lsp::indexer;
-    use crate::lsp::indexer::ResetIndexerGuard;
     use crate::lsp::state::WorldState;
 
     /// A salsa cancellation during the pass is swallowed into `None` by
@@ -1352,95 +1015,5 @@ mod tests {
             state: snapshot,
         };
         assert!(catch_cancellation(|| refresh_diagnostics(task)).is_none());
-    }
-
-    /// `IndexerTask::Index` resolves its file through `db.file_by_path()`, so it
-    /// can only index a file the oak db already knows about. `did_create_files`
-    /// enqueues an `Index` task for a freshly created file, but that file isn't
-    /// in the db until the watcher scans it in, so the task hits the `None` arm
-    /// and the file never reaches the legacy index. Both URIs below carry the
-    /// same symbol; only the one present in the db gets indexed, so a single
-    /// `find()` tells the two cases apart.
-    #[tokio::test]
-    async fn test_index_task_requires_file_in_db() {
-        let _guard = ResetIndexerGuard;
-
-        // Present in the db, so `file_by_path()` resolves and it gets indexed.
-        // `upsert_editor` attaches the file to the orphan root; a bare
-        // `File::new` would not be reachable through `file_by_path`.
-        let mut present_db = OakDatabase::new();
-        let present = Url::parse("file:///present.R").unwrap();
-        present_db.upsert_editor(FilePath::from_url(&present), "sym <- 1".to_string());
-        process_indexer_batch(vec![IndexerTask::Index {
-            uri: present,
-            db: present_db,
-            encoding: TEST_ENCODING,
-        }])
-        .await;
-        assert!(indexer::find("sym").is_some());
-
-        indexer::indexer_clear();
-
-        // Absent from the db: the `did_create_files` case. The same contents
-        // sit on disk, but `Index` never reads disk, so the symbol is lost.
-        let absent_db = OakDatabase::new();
-        let absent = Url::parse("file:///absent.R").unwrap();
-        process_indexer_batch(vec![IndexerTask::Index {
-            uri: absent,
-            db: absent_db,
-            encoding: TEST_ENCODING,
-        }])
-        .await;
-        assert!(indexer::find("sym").is_none());
-    }
-
-    /// A root index pass cancelled by a concurrent oak write re-enqueues the
-    /// root through [`Event::ReindexRoot`], so a cancelled pass isn't silently
-    /// dropped and left as a half-built index. Arming
-    /// `cancellation_token().cancel()` makes the first salsa query in
-    /// `index_file` unwind with `Cancelled`, the same payload a concurrent
-    /// `set_*` produces.
-    #[test]
-    fn test_cancelled_root_pass_reschedules_reindex() {
-        let mut state = WorldState::default();
-        let uri = Url::parse("file:///scanned.R").unwrap();
-        let file = state
-            .db
-            .upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
-        let root = workspace_root(&state.db, file);
-
-        state.db.cancellation_token().cancel();
-
-        let (events_tx, mut events_rx) = unbounded_channel::<Event>();
-        index_root_files(root, vec![file], &HashSet::new(), &state, &events_tx);
-
-        match events_rx.try_recv() {
-            Ok(Event::ReindexRoot(rescheduled)) => assert_eq!(rescheduled, root),
-            other => panic!("expected ReindexRoot, got {other:?}"),
-        }
-    }
-
-    /// A pass that runs to completion indexes its files and emits no event.
-    #[test]
-    fn test_completed_root_pass_does_not_reschedule() {
-        let _guard = ResetIndexerGuard;
-
-        let mut state = WorldState::default();
-        let uri = Url::parse("file:///scanned.R").unwrap();
-        let file = state
-            .db
-            .upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
-        let root = workspace_root(&state.db, file);
-
-        let (events_tx, mut events_rx) = unbounded_channel::<Event>();
-        index_root_files(root, vec![file], &HashSet::new(), &state, &events_tx);
-
-        assert!(indexer::find("sym").is_some());
-        assert!(events_rx.try_recv().is_err());
-    }
-
-    fn workspace_root(db: &OakDatabase, file: File) -> Root {
-        let path = FilePath::from_url(&Url::parse("file:///ws").unwrap());
-        Root::new(db, path, RootKind::Workspace, vec![file], vec![])
     }
 }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -95,6 +95,10 @@ pub(crate) enum Event {
     Lsp(LspMessage),
     Kernel(KernelNotification),
     OakScanCompleted(ScanCompleted),
+    /// Re-run a workspace root's index pass. Emitted when a concurrent oak
+    /// write cancelled the pass partway, so the cancelled pass isn't silently
+    /// dropped (see [`index_root_files`]).
+    ReindexRoot(oak_db::Root),
 }
 
 #[derive(Debug)]
@@ -485,7 +489,13 @@ impl GlobalState {
                 // covering the user's workspace.
                 if root.kind(&self.world.db) == oak_db::RootKind::Workspace {
                     let files = root_files(&self.world.db, root);
-                    index_scanned_files(files, editor_owned, self.world.clone());
+                    index_scanned_files(
+                        root,
+                        files,
+                        editor_owned,
+                        self.world.clone(),
+                        self.events_tx.clone(),
+                    );
                 }
 
                 if followups.is_empty() {
@@ -498,6 +508,22 @@ impl GlobalState {
                 } else {
                     dispatch_scan_requests(&self.events_tx, followups);
                 }
+            },
+
+            Event::ReindexRoot(root) => {
+                // Recompute editor-owned files at apply time, same as
+                // `OakScanCompleted`: buffers may have opened or closed since
+                // the cancelled pass kicked off.
+                let editor_owned: HashSet<FilePath> =
+                    self.world.documents.keys().cloned().collect();
+                let files = root_files(&self.world.db, root);
+                index_scanned_files(
+                    root,
+                    files,
+                    editor_owned,
+                    self.world.clone(),
+                    self.events_tx.clone(),
+                );
             },
         }
 
@@ -1121,11 +1147,37 @@ pub(crate) fn index_update(uris: Vec<Url>, state: WorldState) {
 /// mirroring `process_diagnostics_batch`, since indexing parses every file
 /// in the root. `skip` carries the editor-owned URLs whose index comes from
 /// `did_open` / `did_change`, so we don't index them twice.
-fn index_scanned_files(files: Vec<oak_db::File>, skip: HashSet<FilePath>, state: WorldState) {
+fn index_scanned_files(
+    root: oak_db::Root,
+    files: Vec<oak_db::File>,
+    skip: HashSet<FilePath>,
+    state: WorldState,
+    events_tx: TokioUnboundedSender<Event>,
+) {
     spawn_blocking(move || {
-        index_files(&state.db, files, &skip, state.config.position_encoding);
+        index_root_files(root, files, &skip, &state, &events_tx);
         Ok(None)
     });
+}
+
+/// Run a workspace root's index pass, re-enqueueing the root if a concurrent
+/// oak write cancelled it.
+///
+/// On `Cancelled` we bounce a [`Event::ReindexRoot`] back to the main loop
+/// rather than retry inline. The cancelling write runs to completion on the
+/// main loop before the event is handled, so the retry sees a settled db. A
+/// burst of writes can cancel the retry too, but each cancel re-enqueues, so
+/// the pass converges once the writes stop.
+fn index_root_files(
+    root: oak_db::Root,
+    files: Vec<oak_db::File>,
+    skip: &HashSet<FilePath>,
+    state: &WorldState,
+    events_tx: &TokioUnboundedSender<Event>,
+) {
+    if index_files(&state.db, files, skip, state.config.position_encoding) == IndexPass::Cancelled {
+        events_tx.send(Event::ReindexRoot(root)).log_err();
+    }
 }
 
 /// Whether a root index pass ran to completion or was cut short by a salsa
@@ -1240,16 +1292,20 @@ mod tests {
     use std::collections::HashSet;
 
     use aether_path::FilePath;
+    use oak_db::File;
     use oak_db::OakDatabase;
+    use oak_db::Root;
+    use oak_db::RootKind;
     use oak_scan::DbScan;
     use salsa::Database;
+    use tokio::sync::mpsc::unbounded_channel;
     use url::Url;
 
     use super::catch_cancellation;
-    use super::index_files;
+    use super::index_root_files;
     use super::process_indexer_batch;
     use super::refresh_diagnostics;
-    use super::IndexPass;
+    use super::Event;
     use super::IndexerTask;
     use super::RefreshDiagnosticsTask;
     use crate::fixtures::TEST_ENCODING;
@@ -1327,33 +1383,53 @@ mod tests {
         assert!(indexer::find("sym").is_none());
     }
 
-    /// A root index pass cancelled by a concurrent oak write reports
-    /// `Cancelled`, so the caller can re-enqueue the root instead of leaving a
-    /// half-built index. Arming `cancellation_token().cancel()` makes the first
-    /// salsa query in `index_file` unwind with `Cancelled`, the same payload a
-    /// concurrent `set_*` produces.
+    /// A root index pass cancelled by a concurrent oak write re-enqueues the
+    /// root through [`Event::ReindexRoot`], so a cancelled pass isn't silently
+    /// dropped and left as a half-built index. Arming
+    /// `cancellation_token().cancel()` makes the first salsa query in
+    /// `index_file` unwind with `Cancelled`, the same payload a concurrent
+    /// `set_*` produces.
     #[test]
-    fn test_cancelled_index_pass_reports_cancellation() {
-        let mut db = OakDatabase::new();
+    fn test_cancelled_root_pass_reschedules_reindex() {
+        let mut state = WorldState::default();
         let uri = Url::parse("file:///scanned.R").unwrap();
-        let file = db.upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
+        let file = state
+            .db
+            .upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
+        let root = workspace_root(&state.db, file);
 
-        db.cancellation_token().cancel();
+        state.db.cancellation_token().cancel();
 
-        let outcome = index_files(&db, vec![file], &HashSet::new(), TEST_ENCODING);
-        assert_eq!(outcome, IndexPass::Cancelled);
+        let (events_tx, mut events_rx) = unbounded_channel::<Event>();
+        index_root_files(root, vec![file], &HashSet::new(), &state, &events_tx);
+
+        match events_rx.try_recv() {
+            Ok(Event::ReindexRoot(rescheduled)) => assert_eq!(rescheduled, root),
+            other => panic!("expected ReindexRoot, got {other:?}"),
+        }
     }
 
+    /// A pass that runs to completion indexes its files and emits no event.
     #[test]
-    fn test_completed_index_pass_reports_completion() {
+    fn test_completed_root_pass_does_not_reschedule() {
         let _guard = ResetIndexerGuard;
 
-        let mut db = OakDatabase::new();
+        let mut state = WorldState::default();
         let uri = Url::parse("file:///scanned.R").unwrap();
-        let file = db.upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
+        let file = state
+            .db
+            .upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
+        let root = workspace_root(&state.db, file);
 
-        let outcome = index_files(&db, vec![file], &HashSet::new(), TEST_ENCODING);
-        assert_eq!(outcome, IndexPass::Completed);
+        let (events_tx, mut events_rx) = unbounded_channel::<Event>();
+        index_root_files(root, vec![file], &HashSet::new(), &state, &events_tx);
+
         assert!(indexer::find("sym").is_some());
+        assert!(events_rx.try_recv().is_err());
+    }
+
+    fn workspace_root(db: &OakDatabase, file: File) -> Root {
+        let path = FilePath::from_url(&Url::parse("file:///ws").unwrap());
+        Root::new(db, path, RootKind::Workspace, vec![file], vec![])
     }
 }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -472,7 +472,7 @@ impl GlobalState {
                 // kicked off. The buffer-drain inside `apply_scan_completed` uses
                 // this set as its watcher-event `skip` argument.
                 let editor_owned: HashSet<FilePath> = self.world.documents.keys().cloned().collect();
-                let root = scan.root;
+                let root = scan.root();
                 let followups = self.lsp_state.oak_scheduler.apply_scan_completed(
                     &mut self.world.db,
                     scan,
@@ -1009,7 +1009,7 @@ async fn process_indexer_batch(batch: Vec<IndexerTask>) {
                 // cancelled it re-enqueue.
                 let Some(result) = catch_cancellation(|| {
                     let key = FilePath::from_url(uri);
-                    match db.file_by_url(&key) {
+                    match db.file_by_path(&key) {
                         Some(file) => indexer::index_file(db, file, *encoding),
                         None => Err(anyhow!("No `oak_db` file for URI {uri}")),
                     }
@@ -1127,7 +1127,7 @@ fn index_scanned_files(files: Vec<oak_db::File>, skip: HashSet<FilePath>, state:
         let encoding = state.config.position_encoding;
 
         for file in files {
-            if skip.contains(file.url(db)) {
+            if skip.contains(file.path(db)) {
                 continue;
             }
             if let Err(err) = indexer::index_file(db, file, encoding) {

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -482,29 +482,32 @@ impl GlobalState {
                     scan,
                     &editor_owned,
                 );
-                // Now that we've included this root's files into the Oak
-                // database, we can safely process them with the legacy Ark
-                // indexer that powers completions, workspace symbols, and
-                // diagnostics. We skip library roots since the indexer is only
-                // covering the user's workspace.
-                if root.kind(&self.world.db) == oak_db::RootKind::Workspace {
-                    let files = root_files(&self.world.db, root);
-                    index_scanned_files(
-                        root,
-                        files,
-                        editor_owned,
-                        self.world.clone(),
-                        self.events_tx.clone(),
-                    );
-                }
-
                 if followups.is_empty() {
-                    // The scan settled (no more follow-ups). `apply_scan_completed()`
-                    // was an oak write: it cancelled in-flight diagnostics and changed
-                    // the workspace symbols diagnostics resolve against. Recompute
-                    // diagnostics for the open files so they reflect the indexed
-                    // workspace and any cancelled pass is refreshed.
-                    diagnostics_refresh_all(&self.world);
+                    // Wait until the root is idle (no more follow-up scans
+                    // queued) before feeding the legacy index and refreshing
+                    // diagnostics, so we don't index a scan that's about to be
+                    // superseded.
+                    if root.kind(&self.world.db) == oak_db::RootKind::Workspace {
+                        // Index the root's files into the legacy index that
+                        // powers completions, workspace symbols, and
+                        // diagnostics. The pass refreshes diagnostics once it
+                        // finishes (see `index_root_files`), so they read a
+                        // fully-built index instead of racing it.
+                        let files = root_files(&self.world.db, root);
+                        index_scanned_files(
+                            root,
+                            files,
+                            editor_owned,
+                            self.world.clone(),
+                            self.events_tx.clone(),
+                        );
+                    } else {
+                        // Library roots don't feed the legacy index, but
+                        // `apply_scan_completed()` changed the oak imports and
+                        // exports diagnostics resolve against. There's no index
+                        // pass to wait on, so refresh directly.
+                        diagnostics_refresh_all(&self.world);
+                    }
                 } else {
                     dispatch_scan_requests(&self.events_tx, followups);
                 }
@@ -1160,14 +1163,19 @@ fn index_scanned_files(
     });
 }
 
-/// Run a workspace root's index pass, re-enqueueing the root if a concurrent
-/// oak write cancelled it.
+/// Run a workspace root's index pass, then act on how it ended.
 ///
-/// On `Cancelled` we bounce a [`Event::ReindexRoot`] back to the main loop
-/// rather than retry inline. The cancelling write runs to completion on the
-/// main loop before the event is handled, so the retry sees a settled db. A
-/// burst of writes can cancel the retry too, but each cancel re-enqueues, so
-/// the pass converges once the writes stop.
+/// On `Completed`, refresh diagnostics. They read the legacy workspace index
+/// (`indexer::map` in `generate_diagnostics`), so they have to run after the
+/// pass builds it. Refreshing earlier races the index and flashes false
+/// "undefined symbol" positives that nothing corrects.
+///
+/// On `Cancelled` (a concurrent oak write armed the salsa token mid-pass),
+/// bounce a [`Event::ReindexRoot`] back to the main loop rather than retry
+/// inline. The cancelling write runs to completion on the main loop before the
+/// event is handled, so the retry sees a settled db. A burst of writes can
+/// cancel the retry too, but each cancel re-enqueues, so the pass converges
+/// once the writes stop.
 fn index_root_files(
     root: oak_db::Root,
     files: Vec<oak_db::File>,
@@ -1175,8 +1183,11 @@ fn index_root_files(
     state: &WorldState,
     events_tx: &TokioUnboundedSender<Event>,
 ) {
-    if index_files(&state.db, files, skip, state.config.position_encoding) == IndexPass::Cancelled {
-        events_tx.send(Event::ReindexRoot(root)).log_err();
+    match index_files(&state.db, files, skip, state.config.position_encoding) {
+        IndexPass::Completed => diagnostics_refresh_all(state),
+        IndexPass::Cancelled => {
+            events_tx.send(Event::ReindexRoot(root)).log_err();
+        },
     }
 }
 

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -47,6 +47,7 @@ use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
 use crate::lsp::diagnostics::generate_diagnostics;
 use crate::lsp::handlers;
+use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers;
 use crate::lsp::state_handlers::ConsoleInputs;
@@ -487,6 +488,14 @@ impl GlobalState {
                     &editor_owned,
                 );
                 dispatch_scan_requests(&self.events_tx, followups);
+
+                // Warm the workspace index once the scan settles. Editor
+                // writes don't need to re-warm: they imply an open document,
+                // and the diagnostics passes they trigger force the same
+                // memos.
+                if !self.lsp_state.oak_scheduler.has_pending_scans() {
+                    warm_workspace_index(self.world.db.clone());
+                }
             },
         }
 
@@ -1016,6 +1025,25 @@ pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
             })
             .unwrap_or_else(|err| lsp::log_error!("Failed to queue diagnostics refresh: {err}"));
     }
+}
+
+/// Build the per-file workspace symbol indexes on a background thread so
+/// main-loop consumers triggered by the user (workspace symbols, workspace
+/// completions) find them already computed. The first run after a workspace
+/// scan does the real work, parsing and walking each file. Later runs only
+/// revalidate the per-file memos.
+///
+/// Mirrors rust-analyzer's cache warming: spawned when a workspace scan
+/// settles, the analogue of r-a's transitions to quiescence (initial VFS scan,
+/// workspace reload, etc). Unlike r-a we don't restart a warmup that gets
+/// cancelled (`spawn_blocking()` swallows the unwind). A cancelling write can
+/// only come from an editor buffer, so a document is open, and the diagnostics
+/// passes spawned by that same write force the same memos and finish the job.
+fn warm_workspace_index(db: OakDatabase) {
+    spawn_blocking(move || {
+        indexer::warm(&db);
+        Ok(None)
+    })
 }
 
 #[cfg(test)]

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -358,15 +358,6 @@ impl GlobalState {
                         LspNotification::DidCloseTextDocument(params) => {
                             state_handlers::did_close(params, &mut self.lsp_state, &mut self.world)?;
                         },
-                        LspNotification::DidCreateFiles(params) => {
-                            state_handlers::did_create_files(params, &self.world)?;
-                        },
-                        LspNotification::DidDeleteFiles(params) => {
-                            state_handlers::did_delete_files(params, &self.world)?;
-                        },
-                        LspNotification::DidRenameFiles(params) => {
-                            state_handlers::did_rename_files(params, &mut self.world)?;
-                        },
                     }
                 },
 

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -187,10 +187,9 @@ struct AuxiliaryState {
     client: Client,
     auxiliary_event_rx: TokioUnboundedReceiver<AuxiliaryEvent>,
     tasks: TaskList<Option<AuxiliaryEvent>>,
-    /// Last diagnostics published per file. A refresh re-runs every open file,
-    /// but most runs produce the same result, so we skip the publish when it
-    /// matches what the client already has. Mirrors rust-analyzer's
-    /// `DiagnosticCollection`: only changed files go on the wire.
+    /// Last non-empty diagnostics published per file. A refresh re-runs every
+    /// open file, but most runs produce the same result, so we skip the publish
+    /// when it matches what the client already has.
     published_diagnostics: HashMap<Url, Vec<Diagnostic>>,
 }
 
@@ -727,20 +726,32 @@ impl AuxiliaryState {
     }
 
     /// Publish diagnostics for `uri`, skipping the client round-trip when the
-    /// set is identical to what we last sent for that file. Clearing (going to
-    /// an empty set) still publishes, since empty differs from a prior non-empty
-    /// set.
+    /// set is identical to what we last sent for that file. Only non-empty
+    /// sets are remembered, and an absent entry counts as empty. So an empty
+    /// result is published only when it clears diagnostics the client is
+    /// currently showing, and the map stays bounded by the files on screen
+    /// with diagnostics.
     async fn publish_diagnostics(
         &mut self,
         uri: Url,
         diagnostics: Vec<Diagnostic>,
         version: Option<i32>,
     ) {
-        if self.published_diagnostics.get(&uri) == Some(&diagnostics) {
+        let unchanged = match self.published_diagnostics.get(&uri) {
+            Some(old) => diagnostics == *old,
+            None => diagnostics.is_empty(),
+        };
+        if unchanged {
             return;
         }
-        self.published_diagnostics
-            .insert(uri.clone(), diagnostics.clone());
+
+        if diagnostics.is_empty() {
+            self.published_diagnostics.remove(&uri);
+        } else {
+            self.published_diagnostics
+                .insert(uri.clone(), diagnostics.clone());
+        }
+
         self.client
             .publish_diagnostics(uri, diagnostics, version)
             .await

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -1123,9 +1123,34 @@ pub(crate) fn index_update(uris: Vec<Url>, state: WorldState) {
 /// `did_open` / `did_change`, so we don't index them twice.
 fn index_scanned_files(files: Vec<oak_db::File>, skip: HashSet<FilePath>, state: WorldState) {
     spawn_blocking(move || {
-        let db = &state.db;
-        let encoding = state.config.position_encoding;
+        index_files(&state.db, files, &skip, state.config.position_encoding);
+        Ok(None)
+    });
+}
 
+/// Whether a root index pass ran to completion or was cut short by a salsa
+/// cancellation. A pass parses every file in the root, so a concurrent oak
+/// write (an edit, a follow-up scan) can cancel it partway. `Cancelled` lets
+/// the caller re-enqueue the root instead of leaving a half-built index.
+#[derive(Debug, PartialEq, Eq)]
+enum IndexPass {
+    Completed,
+    Cancelled,
+}
+
+/// Index every file in `files` that isn't editor-owned, into the legacy index.
+///
+/// Salsa queries inside `index_file` unwind with `Cancelled` when a concurrent
+/// write arms the token, so we wrap the whole loop in `catch_cancellation`: a
+/// cancellation aborts the pass and reports `Cancelled` rather than indexing
+/// the remaining files against a db that's about to change.
+fn index_files(
+    db: &OakDatabase,
+    files: Vec<oak_db::File>,
+    skip: &HashSet<FilePath>,
+    encoding: PositionEncoding,
+) -> IndexPass {
+    let completed = catch_cancellation(|| {
         for file in files {
             if skip.contains(file.path(db)) {
                 continue;
@@ -1134,9 +1159,12 @@ fn index_scanned_files(files: Vec<oak_db::File>, skip: HashSet<FilePath>, state:
                 tracing::warn!("Can't index scanned file: {err:?}");
             }
         }
-
-        Ok(None)
     });
+
+    match completed {
+        Some(()) => IndexPass::Completed,
+        None => IndexPass::Cancelled,
+    }
 }
 
 /// Collect every R file under one root: top-level scripts plus each package's
@@ -1209,15 +1237,25 @@ pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use aether_path::FilePath;
+    use oak_db::OakDatabase;
     use oak_scan::DbScan;
     use salsa::Database;
     use url::Url;
 
     use super::catch_cancellation;
+    use super::index_files;
+    use super::process_indexer_batch;
     use super::refresh_diagnostics;
+    use super::IndexPass;
+    use super::IndexerTask;
     use super::RefreshDiagnosticsTask;
+    use crate::fixtures::TEST_ENCODING;
     use crate::lsp::document::Document;
+    use crate::lsp::indexer;
+    use crate::lsp::indexer::ResetIndexerGuard;
     use crate::lsp::state::WorldState;
 
     /// A salsa cancellation during the pass is swallowed into `None` by
@@ -1247,5 +1285,75 @@ mod tests {
             state: snapshot,
         };
         assert!(catch_cancellation(|| refresh_diagnostics(task)).is_none());
+    }
+
+    /// `IndexerTask::Index` resolves its file through `db.file_by_path()`, so it
+    /// can only index a file the oak db already knows about. `did_create_files`
+    /// enqueues an `Index` task for a freshly created file, but that file isn't
+    /// in the db until the watcher scans it in, so the task hits the `None` arm
+    /// and the file never reaches the legacy index. Both URIs below carry the
+    /// same symbol; only the one present in the db gets indexed, so a single
+    /// `find()` tells the two cases apart.
+    #[tokio::test]
+    async fn test_index_task_requires_file_in_db() {
+        let _guard = ResetIndexerGuard;
+
+        // Present in the db, so `file_by_path()` resolves and it gets indexed.
+        // `upsert_editor` attaches the file to the orphan root; a bare
+        // `File::new` would not be reachable through `file_by_path`.
+        let mut present_db = OakDatabase::new();
+        let present = Url::parse("file:///present.R").unwrap();
+        present_db.upsert_editor(FilePath::from_url(&present), "sym <- 1".to_string());
+        process_indexer_batch(vec![IndexerTask::Index {
+            uri: present,
+            db: present_db,
+            encoding: TEST_ENCODING,
+        }])
+        .await;
+        assert!(indexer::find("sym").is_some());
+
+        indexer::indexer_clear();
+
+        // Absent from the db: the `did_create_files` case. The same contents
+        // sit on disk, but `Index` never reads disk, so the symbol is lost.
+        let absent_db = OakDatabase::new();
+        let absent = Url::parse("file:///absent.R").unwrap();
+        process_indexer_batch(vec![IndexerTask::Index {
+            uri: absent,
+            db: absent_db,
+            encoding: TEST_ENCODING,
+        }])
+        .await;
+        assert!(indexer::find("sym").is_none());
+    }
+
+    /// A root index pass cancelled by a concurrent oak write reports
+    /// `Cancelled`, so the caller can re-enqueue the root instead of leaving a
+    /// half-built index. Arming `cancellation_token().cancel()` makes the first
+    /// salsa query in `index_file` unwind with `Cancelled`, the same payload a
+    /// concurrent `set_*` produces.
+    #[test]
+    fn test_cancelled_index_pass_reports_cancellation() {
+        let mut db = OakDatabase::new();
+        let uri = Url::parse("file:///scanned.R").unwrap();
+        let file = db.upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
+
+        db.cancellation_token().cancel();
+
+        let outcome = index_files(&db, vec![file], &HashSet::new(), TEST_ENCODING);
+        assert_eq!(outcome, IndexPass::Cancelled);
+    }
+
+    #[test]
+    fn test_completed_index_pass_reports_completion() {
+        let _guard = ResetIndexerGuard;
+
+        let mut db = OakDatabase::new();
+        let uri = Url::parse("file:///scanned.R").unwrap();
+        let file = db.upsert_editor(FilePath::from_url(&uri), "sym <- 1".to_string());
+
+        let outcome = index_files(&db, vec![file], &HashSet::new(), TEST_ENCODING);
+        assert_eq!(outcome, IndexPass::Completed);
+        assert!(indexer::find("sym").is_some());
     }
 }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -16,9 +16,11 @@ use std::sync::atomic::Ordering;
 use std::sync::LazyLock;
 use std::sync::RwLock;
 
+use aether_lsp_utils::proto::PositionEncoding;
 use aether_path::FilePath;
 use anyhow::anyhow;
 use futures::StreamExt;
+use oak_db::Db;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use oak_scan::ScanCompleted;
@@ -46,7 +48,6 @@ use crate::lsp::backend::LspResponse;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
 use crate::lsp::diagnostics::generate_diagnostics;
-use crate::lsp::document::Document;
 use crate::lsp::handlers;
 use crate::lsp::indexer;
 use crate::lsp::state::WorldState;
@@ -471,11 +472,22 @@ impl GlobalState {
                 // kicked off. The buffer-drain inside `apply_scan_completed` uses
                 // this set as its watcher-event `skip` argument.
                 let editor_owned: HashSet<FilePath> = self.world.documents.keys().cloned().collect();
+                let root = scan.root;
                 let followups = self.lsp_state.oak_scheduler.apply_scan_completed(
                     &mut self.world.db,
                     scan,
                     &editor_owned,
                 );
+                // Now that we've included this root's files into the Oak
+                // database, we can safely process them with the legacy Ark
+                // indexer that powers completions, workspace symbols, and
+                // diagnostics. We skip library roots since the indexer is only
+                // covering the user's workspace.
+                if root.kind(&self.world.db) == oak_db::RootKind::Workspace {
+                    let files = root_files(&self.world.db, root);
+                    index_scanned_files(files, editor_owned, self.world.clone());
+                }
+
                 if followups.is_empty() {
                     // The scan settled (no more follow-ups). `apply_scan_completed()`
                     // was an oak write: it cancelled in-flight diagnostics and changed
@@ -861,11 +873,19 @@ pub(crate) enum IndexerQueueTask {
 }
 
 #[derive(Debug)]
-pub enum IndexerTask {
-    Create { uri: Url },
-    Delete { uri: Url },
-    Rename { uri: Url, new: Url },
-    Update { uri: Url, document: Document },
+pub(crate) enum IndexerTask {
+    Index {
+        uri: Url,
+        db: OakDatabase,
+        encoding: PositionEncoding,
+    },
+    Delete {
+        uri: Url,
+    },
+    Rename {
+        uri: Url,
+        new: Url,
+    },
 }
 
 #[derive(Debug)]
@@ -888,10 +908,9 @@ fn summarize_indexer_task(batch: &[IndexerTask]) -> String {
     let mut counts = std::collections::HashMap::new();
     for task in batch {
         let type_name = match task {
-            IndexerTask::Create { .. } => "Create",
+            IndexerTask::Index { .. } => "Index",
             IndexerTask::Delete { .. } => "Delete",
             IndexerTask::Rename { .. } => "Rename",
-            IndexerTask::Update { .. } => "Update",
         };
         *counts.entry(type_name).or_insert(0) += 1;
     }
@@ -979,31 +998,34 @@ async fn process_indexer_batch(batch: Vec<IndexerTask>) {
     );
 
     for task in batch {
-        let result: anyhow::Result<()> = async {
-            match &task {
-                IndexerTask::Create { uri } => {
-                    indexer::create(uri)?;
-                },
+        let result: anyhow::Result<()> = match &task {
+            IndexerTask::Index { uri, db, encoding } => {
+                // This is running on a separate task than the main loop, so
+                // Salsa cancellations are possible. Catch cancellation inline
+                // rather than through the `spawn_blocking()` funnel because
+                // this batch must finish before diagnostics are queued (see
+                // `process_indexer_queue()`) and it can't be fire-and-forget.
+                // On cancel we drop the pass and let the oak write that
+                // cancelled it re-enqueue.
+                let Some(result) = catch_cancellation(|| {
+                    let key = FilePath::from_url(uri);
+                    match db.file_by_url(&key) {
+                        Some(file) => indexer::index_file(db, file, *encoding),
+                        None => Err(anyhow!("No `oak_db` file for URI {uri}")),
+                    }
+                }) else {
+                    continue;
+                };
+                result
+            },
 
-                IndexerTask::Update { uri, document } => {
-                    indexer::update(document, uri)?;
-                },
+            IndexerTask::Delete { uri } => indexer::delete(uri),
 
-                IndexerTask::Delete { uri } => {
-                    indexer::delete(uri)?;
-                },
-
-                IndexerTask::Rename {
-                    uri: old_uri,
-                    new: new_uri,
-                } => {
-                    indexer::rename(old_uri, new_uri)?;
-                },
-            }
-
-            Ok(())
-        }
-        .await;
+            IndexerTask::Rename {
+                uri: old_uri,
+                new: new_uri,
+            } => indexer::rename(old_uri, new_uri),
+        };
 
         if let Err(err) = result {
             tracing::warn!("Can't process indexer task: {err}");
@@ -1072,73 +1094,17 @@ fn catch_cancellation<T>(f: impl FnOnce() -> T) -> Option<T> {
     }
 }
 
-pub(crate) fn index_start(folders: Vec<String>, state: WorldState) {
-    lsp::log_info!("Initial indexing started");
-
-    let uris: Vec<Url> = folders
-        .into_iter()
-        .flat_map(|folder| {
-            walkdir::WalkDir::new(folder)
-                .into_iter()
-                .filter_entry(indexer::filter_entry)
-                .filter_map(|entry| {
-                    let entry = match entry {
-                        Ok(e) => e,
-                        Err(_) => return None,
-                    };
-
-                    if !entry.file_type().is_file() {
-                        return None;
-                    }
-                    let path = entry.path();
-
-                    // Only index R files
-                    let ext = path.extension().unwrap_or_default();
-                    if ext != "r" && ext != "R" {
-                        return None;
-                    }
-
-                    if let Ok(uri) = url::Url::from_file_path(path) {
-                        Some(uri)
-                    } else {
-                        tracing::warn!("Can't convert path to URI: {:?}", path);
-                        None
-                    }
-                })
-        })
-        .collect();
-
-    index_create(uris, state);
-}
-
-pub(crate) fn index_create(uris: Vec<Url>, state: WorldState) {
-    for uri in uris {
-        INDEXER_QUEUE
-            .send(IndexerQueueTask::Indexer(IndexerTask::Create { uri }))
-            .unwrap_or_else(|err| crate::lsp::log_error!("Failed to queue index create: {err}"));
-    }
-
-    diagnostics_refresh_all(&state);
-}
-
 pub(crate) fn index_update(uris: Vec<Url>, state: WorldState) {
     for uri in uris {
         if !ExtUrl::is_indexable(&uri) {
             continue;
         }
 
-        let document = match state.get_document(&FilePath::from_url(&uri)) {
-            Ok(doc) => doc.clone(),
-            Err(err) => {
-                tracing::warn!("Can't get document '{uri}' for indexing: {err:?}");
-                continue;
-            },
-        };
-
         INDEXER_QUEUE
-            .send(IndexerQueueTask::Indexer(IndexerTask::Update {
-                document,
+            .send(IndexerQueueTask::Indexer(IndexerTask::Index {
                 uri,
+                db: state.db.clone(),
+                encoding: state.config.position_encoding,
             }))
             .unwrap_or_else(|err| lsp::log_error!("Failed to queue index update: {err}"));
     }
@@ -1146,6 +1112,44 @@ pub(crate) fn index_update(uris: Vec<Url>, state: WorldState) {
     // Refresh all diagnostics since the indexer results for one file may affect
     // other files
     diagnostics_refresh_all(&state);
+}
+
+/// Index all workspace files freshly scanned into `state.db`.
+///
+/// Called from the `OakScanCompleted` hook with a single `WorldState` clone
+/// for the whole root, not one clone per file. Runs on a blocking thread
+/// mirroring `process_diagnostics_batch`, since indexing parses every file
+/// in the root. `skip` carries the editor-owned URLs whose index comes from
+/// `did_open` / `did_change`, so we don't index them twice.
+fn index_scanned_files(files: Vec<oak_db::File>, skip: HashSet<FilePath>, state: WorldState) {
+    spawn_blocking(move || {
+        let db = &state.db;
+        let encoding = state.config.position_encoding;
+
+        for file in files {
+            if skip.contains(file.url(db)) {
+                continue;
+            }
+            if let Err(err) = indexer::index_file(db, file, encoding) {
+                tracing::warn!("Can't index scanned file: {err:?}");
+            }
+        }
+
+        Ok(None)
+    });
+}
+
+/// Collect every R file under one root: top-level scripts plus each package's
+/// loadable files and non-loadable scripts (`tests/`, `inst/`, ...). Unlike
+/// `oak_db::all_files`, which walks all live roots, this stays scoped to the
+/// single root that just finished scanning.
+fn root_files(db: &OakDatabase, root: oak_db::Root) -> Vec<oak_db::File> {
+    let mut files: Vec<oak_db::File> = root.scripts(db).to_vec();
+    for &pkg in root.packages(db) {
+        files.extend(pkg.files(db));
+        files.extend(pkg.scripts(db));
+    }
+    files
 }
 
 pub(crate) fn index_delete(uris: Vec<Url>, state: WorldState) {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_comment_section.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_comment_section.snap
@@ -5,14 +5,14 @@ expression: entries
 [
     IndexEntry {
         key: "Section 1",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 1,
+                column: 0,
             },
-            end: Position {
-                line: 1,
-                character: 16,
+            end: IndexPoint {
+                row: 1,
+                column: 16,
             },
         },
         data: Section {
@@ -22,14 +22,14 @@ expression: entries
     },
     IndexEntry {
         key: "x",
-        range: Range {
-            start: Position {
-                line: 2,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 2,
+                column: 0,
             },
-            end: Position {
-                line: 2,
-                character: 1,
+            end: IndexPoint {
+                row: 2,
+                column: 1,
             },
         },
         data: Variable {
@@ -38,14 +38,14 @@ expression: entries
     },
     IndexEntry {
         key: "Subsection",
-        range: Range {
-            start: Position {
-                line: 4,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 4,
+                column: 0,
             },
-            end: Position {
-                line: 4,
-                character: 20,
+            end: IndexPoint {
+                row: 4,
+                column: 20,
             },
         },
         data: Section {
@@ -55,14 +55,14 @@ expression: entries
     },
     IndexEntry {
         key: "y",
-        range: Range {
-            start: Position {
-                line: 5,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 5,
+                column: 0,
             },
-            end: Position {
-                line: 5,
-                character: 1,
+            end: IndexPoint {
+                row: 5,
+                column: 1,
             },
         },
         data: Variable {
@@ -71,14 +71,14 @@ expression: entries
     },
     IndexEntry {
         key: "x",
-        range: Range {
-            start: Position {
-                line: 7,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 7,
+                column: 0,
             },
-            end: Position {
-                line: 7,
-                character: 1,
+            end: IndexPoint {
+                row: 7,
+                column: 1,
             },
         },
         data: Function {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_function.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_function.snap
@@ -5,14 +5,14 @@ expression: entries
 [
     IndexEntry {
         key: "my_function",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 1,
+                column: 0,
             },
-            end: Position {
-                line: 1,
-                character: 11,
+            end: IndexPoint {
+                row: 1,
+                column: 11,
             },
         },
         data: Function {
@@ -25,14 +25,14 @@ expression: entries
     },
     IndexEntry {
         key: "my_variable",
-        range: Range {
-            start: Position {
-                line: 11,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 11,
+                column: 0,
             },
-            end: Position {
-                line: 11,
-                character: 11,
+            end: IndexPoint {
+                row: 11,
+                column: 11,
             },
         },
         data: Variable {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_r6class.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_r6class.snap
@@ -5,14 +5,14 @@ expression: entries
 [
     IndexEntry {
         key: "initialize",
-        range: Range {
-            start: Position {
-                line: 3,
-                character: 8,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 3,
+                column: 8,
             },
-            end: Position {
-                line: 3,
-                character: 18,
+            end: IndexPoint {
+                row: 3,
+                column: 18,
             },
         },
         data: Method {
@@ -21,14 +21,14 @@ expression: entries
     },
     IndexEntry {
         key: "public_method",
-        range: Range {
-            start: Position {
-                line: 6,
-                character: 8,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 6,
+                column: 8,
             },
-            end: Position {
-                line: 6,
-                character: 21,
+            end: IndexPoint {
+                row: 6,
+                column: 21,
             },
         },
         data: Method {
@@ -37,14 +37,14 @@ expression: entries
     },
     IndexEntry {
         key: "private_method",
-        range: Range {
-            start: Position {
-                line: 12,
-                character: 8,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 12,
+                column: 8,
             },
-            end: Position {
-                line: 12,
-                character: 22,
+            end: IndexPoint {
+                row: 12,
+                column: 22,
             },
         },
         data: Method {
@@ -53,14 +53,14 @@ expression: entries
     },
     IndexEntry {
         key: "class",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 1,
+                column: 0,
             },
-            end: Position {
-                line: 1,
-                character: 5,
+            end: IndexPoint {
+                row: 1,
+                column: 5,
             },
         },
         data: Variable {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_r6class_namespaced.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_r6class_namespaced.snap
@@ -5,14 +5,14 @@ expression: entries
 [
     IndexEntry {
         key: "initialize",
-        range: Range {
-            start: Position {
-                line: 3,
-                character: 8,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 3,
+                column: 8,
             },
-            end: Position {
-                line: 3,
-                character: 18,
+            end: IndexPoint {
+                row: 3,
+                column: 18,
             },
         },
         data: Method {
@@ -21,14 +21,14 @@ expression: entries
     },
     IndexEntry {
         key: "class",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 1,
+                column: 0,
             },
-            end: Position {
-                line: 1,
-                character: 5,
+            end: IndexPoint {
+                row: 1,
+                column: 5,
             },
         },
         data: Variable {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_s7_methods.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_s7_methods.snap
@@ -5,14 +5,14 @@ expression: entries
 [
     IndexEntry {
         key: "Class",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 1,
+                column: 0,
             },
-            end: Position {
-                line: 1,
-                character: 5,
+            end: IndexPoint {
+                row: 1,
+                column: 5,
             },
         },
         data: Variable {
@@ -21,14 +21,14 @@ expression: entries
     },
     IndexEntry {
         key: "generic",
-        range: Range {
-            start: Position {
-                line: 2,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 2,
+                column: 0,
             },
-            end: Position {
-                line: 2,
-                character: 7,
+            end: IndexPoint {
+                row: 2,
+                column: 7,
             },
         },
         data: Variable {
@@ -37,14 +37,14 @@ expression: entries
     },
     IndexEntry {
         key: "method(generic, Class)",
-        range: Range {
-            start: Position {
-                line: 7,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 7,
+                column: 0,
             },
-            end: Position {
-                line: 7,
-                character: 22,
+            end: IndexPoint {
+                row: 7,
+                column: 22,
             },
         },
         data: Function {

--- a/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_variable.snap
+++ b/crates/ark/src/lsp/snapshots/ark__lsp__indexer__tests__index_variable.snap
@@ -5,14 +5,14 @@ expression: entries
 [
     IndexEntry {
         key: "x",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 1,
+                column: 0,
             },
-            end: Position {
-                line: 1,
-                character: 1,
+            end: IndexPoint {
+                row: 1,
+                column: 1,
             },
         },
         data: Variable {
@@ -21,14 +21,14 @@ expression: entries
     },
     IndexEntry {
         key: "y",
-        range: Range {
-            start: Position {
-                line: 2,
-                character: 0,
+        range: IndexRange {
+            start: IndexPoint {
+                row: 2,
+                column: 0,
             },
-            end: Position {
-                line: 2,
-                character: 1,
+            end: IndexPoint {
+                row: 2,
+                column: 1,
             },
         },
         data: Variable {

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -277,9 +277,9 @@ pub(crate) fn did_open(
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
 
-    // Index the freshly opened buffer. Workspace indexing skips editor-owned
-    // files, so editor handlers own index creation and updating.
-    lsp::main_loop::index_update(vec![uri], state.clone());
+    // The freshly opened buffer's contents are now in the db via `upsert_editor`
+    // above, and the workspace index reads the db, so just refresh diagnostics.
+    lsp::main_loop::diagnostics_refresh_all(state.clone());
 
     Ok(())
 }
@@ -304,7 +304,7 @@ pub(crate) fn did_change(
     let path = FilePath::from_url(uri);
     state.db.upsert_editor(path, new_contents);
 
-    lsp::main_loop::index_update(vec![uri.clone()], state.clone());
+    lsp::main_loop::diagnostics_refresh_all(state.clone());
 
     // Notify console about document change to invalidate breakpoints.
     lsp_state
@@ -354,52 +354,37 @@ pub(crate) fn did_close(
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_create_files(
-    params: CreateFilesParams,
+    _params: CreateFilesParams,
     state: &WorldState,
 ) -> anyhow::Result<()> {
-    let uris = params
-        .files
-        .iter()
-        .filter_map(|file| parse_uri_or_none(&file.uri))
-        .collect();
-
-    lsp::main_loop::index_update(uris, state.clone());
-
+    // Disk-side file events reach oak through `did_change_watched_files`,
+    // which the workspace index reads. Here we only refresh diagnostics for
+    // open documents.
+    lsp::main_loop::diagnostics_refresh_all(state.clone());
     Ok(())
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_delete_files(
-    params: DeleteFilesParams,
+    _params: DeleteFilesParams,
     state: &WorldState,
 ) -> anyhow::Result<()> {
-    let uris = params
-        .files
-        .iter()
-        .filter_map(|file| parse_uri_or_none(&file.uri))
-        .collect();
-
-    lsp::main_loop::index_delete(uris, state.clone());
-
+    // Disk-side file events reach oak through `did_change_watched_files`,
+    // which the workspace index reads. Here we only refresh diagnostics for
+    // open documents.
+    lsp::main_loop::diagnostics_refresh_all(state.clone());
     Ok(())
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_rename_files(
-    params: RenameFilesParams,
+    _params: RenameFilesParams,
     state: &mut WorldState,
 ) -> anyhow::Result<()> {
-    let uri_pairs = params
-        .files
-        .iter()
-        .filter_map(|file| {
-            let old_url = parse_uri_or_none(&file.old_uri)?;
-            let new_url = parse_uri_or_none(&file.new_uri)?;
-            Some((old_url, new_url))
-        })
-        .collect();
-
-    lsp::main_loop::index_rename(uri_pairs, state.clone());
+    // Disk-side file events reach oak through `did_change_watched_files`,
+    // which the workspace index reads. Here we only refresh diagnostics for
+    // open documents.
+    lsp::main_loop::diagnostics_refresh_all(state.clone());
     Ok(())
 }
 
@@ -473,16 +458,6 @@ pub(crate) fn did_change_workspace_folders(
             .set_workspace_paths(&mut state.db, &workspace_paths, &editor_owned);
     dispatch_scan_requests(events_tx, requests);
     Ok(())
-}
-
-fn parse_uri_or_none(uri: &str) -> Option<url::Url> {
-    match url::Url::parse(uri) {
-        Ok(url) => Some(url),
-        Err(err) => {
-            log::warn!("Failed to parse URI '{uri}': {err}");
-            None
-        },
-    }
 }
 
 pub(crate) async fn did_change_configuration(

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -139,11 +139,7 @@ pub(crate) fn initialize(
         }
     }
 
-    // Kick off the first workspace scan. The resulting `OakScanCompleted`
-    // events drive workspace indexing, so there's no separate directory walk
-    // here anymore. `state.documents` is empty at init since no `didOpen` has
-    // fired yet, but build the set through the same shape we use elsewhere so
-    // the call site reads consistently.
+    // Kick off the initial workspace scan
     let editor_owned: HashSet<FilePath> = state.documents.keys().cloned().collect();
     let requests =
         lsp_state
@@ -277,8 +273,6 @@ pub(crate) fn did_open(
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
 
-    // `upsert_editor` advanced the oak revision, so the main loop refreshes
-    // diagnostics for us (see `GlobalState::handle_event`).
     Ok(())
 }
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -103,7 +103,6 @@ pub(crate) fn initialize(
     lsp_state.capabilities = Capabilities::new(params.capabilities);
 
     // Initialize the workspace folders
-    let mut folders: Vec<String> = Vec::new();
     let mut workspace_paths: Vec<PathBuf> = Vec::new();
 
     for uri in workspace_uris {
@@ -137,22 +136,20 @@ pub(crate) fn initialize(
                     },
                 }
             }
-            if let Some(path_str) = path.to_str() {
-                folders.push(path_str.to_string());
-            }
         }
     }
 
-    // Start first round of indexing. `state.documents` is empty at init since
-    // no `didOpen` has fired yet, but build the set through the same shape we
-    // use elsewhere so the call site reads consistently.
+    // Kick off the first workspace scan. The resulting `OakScanCompleted`
+    // events drive workspace indexing, so there's no separate directory walk
+    // here anymore. `state.documents` is empty at init since no `didOpen` has
+    // fired yet, but build the set through the same shape we use elsewhere so
+    // the call site reads consistently.
     let editor_owned: HashSet<FilePath> = state.documents.keys().cloned().collect();
     let requests =
         lsp_state
             .oak_scheduler
             .set_workspace_paths(&mut state.db, &workspace_paths, &editor_owned);
     dispatch_scan_requests(events_tx, requests);
-    lsp::main_loop::index_start(folders, state.clone());
 
     let result = InitializeResult {
         server_info: Some(ServerInfo {
@@ -280,7 +277,9 @@ pub(crate) fn did_open(
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
 
-    lsp::main_loop::diagnostics_refresh_all(state);
+    // Index the freshly opened buffer. Workspace indexing skips editor-owned
+    // files, so editor handlers own index creation and updating.
+    lsp::main_loop::index_update(vec![uri], state.clone());
 
     Ok(())
 }
@@ -364,7 +363,7 @@ pub(crate) fn did_create_files(
         .filter_map(|file| parse_uri_or_none(&file.uri))
         .collect();
 
-    lsp::main_loop::index_create(uris, state.clone());
+    lsp::main_loop::index_update(uris, state.clone());
 
     Ok(())
 }

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -18,8 +18,6 @@ use stdext::result::ResultExt;
 use tower_lsp::lsp_types;
 use tower_lsp::lsp_types::CompletionOptions;
 use tower_lsp::lsp_types::CompletionOptionsCompletionItem;
-use tower_lsp::lsp_types::CreateFilesParams;
-use tower_lsp::lsp_types::DeleteFilesParams;
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 use tower_lsp::lsp_types::DidChangeTextDocumentParams;
 use tower_lsp::lsp_types::DidChangeWatchedFilesParams;
@@ -29,10 +27,6 @@ use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 use tower_lsp::lsp_types::DocumentOnTypeFormattingOptions;
 use tower_lsp::lsp_types::ExecuteCommandOptions;
 use tower_lsp::lsp_types::FileChangeType;
-use tower_lsp::lsp_types::FileOperationFilter;
-use tower_lsp::lsp_types::FileOperationPattern;
-use tower_lsp::lsp_types::FileOperationPatternKind;
-use tower_lsp::lsp_types::FileOperationRegistrationOptions;
 use tower_lsp::lsp_types::FoldingRangeProviderCapability;
 use tower_lsp::lsp_types::FormattingOptions;
 use tower_lsp::lsp_types::HoverProviderCapability;
@@ -40,7 +34,6 @@ use tower_lsp::lsp_types::ImplementationProviderCapability;
 use tower_lsp::lsp_types::InitializeParams;
 use tower_lsp::lsp_types::InitializeResult;
 use tower_lsp::lsp_types::OneOf;
-use tower_lsp::lsp_types::RenameFilesParams;
 use tower_lsp::lsp_types::RenameOptions;
 use tower_lsp::lsp_types::SelectionRangeProviderCapability;
 use tower_lsp::lsp_types::ServerCapabilities;
@@ -200,28 +193,11 @@ pub(crate) fn initialize(
                     supported: Some(true),
                     change_notifications: Some(OneOf::Left(true)),
                 }),
-                file_operations: {
-                    let r_file_filter = FileOperationFilter {
-                        scheme: Some(String::from("file")),
-                        pattern: FileOperationPattern {
-                            glob: String::from("**/*.{r,R}"),
-                            matches: Some(FileOperationPatternKind::File),
-                            options: None,
-                        },
-                    };
-                    Some(lsp_types::WorkspaceFileOperationsServerCapabilities {
-                        did_create: Some(FileOperationRegistrationOptions {
-                            filters: vec![r_file_filter.clone()],
-                        }),
-                        did_delete: Some(FileOperationRegistrationOptions {
-                            filters: vec![r_file_filter.clone()],
-                        }),
-                        did_rename: Some(FileOperationRegistrationOptions {
-                            filters: vec![r_file_filter],
-                        }),
-                        ..Default::default()
-                    })
-                },
+                // We don't register `file_operations`. Disk changes reach us
+                // through `didChangeWatchedFiles` from every source (editor, git,
+                // terminal), so it's the single channel that keeps the index
+                // current. A rename arrives there as delete + create.
+                file_operations: None,
             }),
             document_on_type_formatting_provider: Some(DocumentOnTypeFormattingOptions {
                 first_trigger_character: String::from("\n"),
@@ -337,53 +313,23 @@ pub(crate) fn did_close(
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn did_create_files(
-    _params: CreateFilesParams,
-    _state: &WorldState,
-) -> anyhow::Result<()> {
-    Ok(())
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn did_delete_files(
-    _params: DeleteFilesParams,
-    _state: &WorldState,
-) -> anyhow::Result<()> {
-    Ok(())
-}
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) fn did_rename_files(
-    _params: RenameFilesParams,
-    _state: &mut WorldState,
-) -> anyhow::Result<()> {
-    Ok(())
-}
-
-#[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_change_watched_files(
     params: DidChangeWatchedFilesParams,
     state: &mut WorldState,
     lsp_state: &mut LspState,
     events_tx: &TokioUnboundedSender<Event>,
 ) -> anyhow::Result<()> {
-    // Editor owns the contents of files it has open: Oak should ignore
-    // disk-side events for those URLs.
+    // Editor owns the contents of files it has open: ignore disk-side events
+    // for those URLs. Their content comes from `did_open` / `did_change`.
     let editor_owned: HashSet<FilePath> = state.documents.keys().cloned().collect();
 
     let events: Vec<FileEvent> = params
         .changes
-        .into_iter()
-        .filter_map(|e| {
-            let kind = match e.typ {
-                FileChangeType::CREATED => FileEventKind::Created,
-                FileChangeType::CHANGED => FileEventKind::Changed,
-                FileChangeType::DELETED => FileEventKind::Deleted,
-                _ => return None,
-            };
+        .iter()
+        .filter_map(|change| {
             Some(FileEvent {
-                path: FilePath::from_url(&e.uri),
-                kind,
+                path: FilePath::from_url(&change.uri),
+                kind: file_event_kind(change.typ)?,
             })
         })
         .collect();
@@ -393,7 +339,17 @@ pub(crate) fn did_change_watched_files(
             .oak_scheduler
             .apply_watcher_events(&mut state.db, events, &editor_owned);
     dispatch_scan_requests(events_tx, requests);
+
     Ok(())
+}
+
+fn file_event_kind(kind: FileChangeType) -> Option<FileEventKind> {
+    match kind {
+        FileChangeType::CREATED => Some(FileEventKind::Created),
+        FileChangeType::CHANGED => Some(FileEventKind::Changed),
+        FileChangeType::DELETED => Some(FileEventKind::Deleted),
+        _ => None,
+    }
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -337,18 +337,10 @@ pub(crate) fn did_close(
     let path = FilePath::from_url(&uri);
     state.db.close_editor(&path);
 
-    // `close_editor` advanced the oak revision, so the main loop refreshes the
-    // remaining open files. The closed file isn't refreshed (it was removed
-    // above) but we cleared it with the empty publish.
     lsp::log_info!("did_close(): closed document with URI: '{uri}'.");
 
     Ok(())
 }
-
-// Disk-side create, delete, and rename reach oak through the file watcher
-// (`did_change_watched_files`), which writes the change and so triggers a
-// diagnostics refresh through the oak revision. These notifications carry no
-// extra information oak needs, so there's nothing to do here.
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_create_files(

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -277,10 +277,8 @@ pub(crate) fn did_open(
     // NOTE: Do we need to call `update_config()` here?
     // update_config(vec![uri]).await;
 
-    // The freshly opened buffer's contents are now in the db via `upsert_editor`
-    // above, and the workspace index reads the db, so just refresh diagnostics.
-    lsp::main_loop::diagnostics_refresh_all(state.clone());
-
+    // `upsert_editor` advanced the oak revision, so the main loop refreshes
+    // diagnostics for us (see `GlobalState::handle_event`).
     Ok(())
 }
 
@@ -303,8 +301,6 @@ pub(crate) fn did_change(
     let new_contents = document.contents.to_string();
     let path = FilePath::from_url(uri);
     state.db.upsert_editor(path, new_contents);
-
-    lsp::main_loop::diagnostics_refresh_all(state.clone());
 
     // Notify console about document change to invalidate breakpoints.
     lsp_state
@@ -341,50 +337,40 @@ pub(crate) fn did_close(
     let path = FilePath::from_url(&uri);
     state.db.close_editor(&path);
 
-    // `close_editor` is an oak write, so it cancels any diagnostics pass in
-    // flight for the other open files. Re-enqueue them so a cancelled pass
-    // isn't silently dropped. The closed file was removed above, so it isn't
-    // refreshed (we already cleared it with the empty publish).
-    lsp::main_loop::diagnostics_refresh_all(state);
-
+    // `close_editor` advanced the oak revision, so the main loop refreshes the
+    // remaining open files. The closed file isn't refreshed (it was removed
+    // above) but we cleared it with the empty publish.
     lsp::log_info!("did_close(): closed document with URI: '{uri}'.");
 
     Ok(())
 }
 
+// Disk-side create, delete, and rename reach oak through the file watcher
+// (`did_change_watched_files`), which writes the change and so triggers a
+// diagnostics refresh through the oak revision. These notifications carry no
+// extra information oak needs, so there's nothing to do here.
+
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_create_files(
     _params: CreateFilesParams,
-    state: &WorldState,
+    _state: &WorldState,
 ) -> anyhow::Result<()> {
-    // Disk-side file events reach oak through `did_change_watched_files`,
-    // which the workspace index reads. Here we only refresh diagnostics for
-    // open documents.
-    lsp::main_loop::diagnostics_refresh_all(state.clone());
     Ok(())
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_delete_files(
     _params: DeleteFilesParams,
-    state: &WorldState,
+    _state: &WorldState,
 ) -> anyhow::Result<()> {
-    // Disk-side file events reach oak through `did_change_watched_files`,
-    // which the workspace index reads. Here we only refresh diagnostics for
-    // open documents.
-    lsp::main_loop::diagnostics_refresh_all(state.clone());
     Ok(())
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn did_rename_files(
     _params: RenameFilesParams,
-    state: &mut WorldState,
+    _state: &mut WorldState,
 ) -> anyhow::Result<()> {
-    // Disk-side file events reach oak through `did_change_watched_files`,
-    // which the workspace index reads. Here we only refresh diagnostics for
-    // open documents.
-    lsp::main_loop::diagnostics_refresh_all(state.clone());
     Ok(())
 }
 

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -9,6 +9,9 @@
 
 use std::result::Result::Ok;
 
+use aether_lsp_utils::proto::to_proto;
+use aether_lsp_utils::proto::PositionEncoding;
+use aether_path::FilePath;
 use stdext::unwrap::IntoResult;
 use tower_lsp::lsp_types::DocumentSymbol;
 use tower_lsp::lsp_types::DocumentSymbolParams;
@@ -18,6 +21,7 @@ use tower_lsp::lsp_types::SymbolInformation;
 use tower_lsp::lsp_types::SymbolKind;
 use tower_lsp::lsp_types::WorkspaceSymbolParams;
 use tree_sitter::Node;
+use url::Url;
 
 use crate::lsp::ark_file::ArkFile;
 use crate::lsp::db::ArkDb;
@@ -60,12 +64,18 @@ pub(crate) fn symbols(
     state: &WorldState,
 ) -> anyhow::Result<Vec<SymbolInformation>> {
     let query = &params.query;
+    let db = &state.db;
+    let encoding = state.config.position_encoding;
     let mut info: Vec<SymbolInformation> = Vec::new();
 
-    indexer::map(|uri, symbol, entry| {
+    indexer::map(db, |uri, symbol, entry| {
         if !symbol.fuzzy_matches(query) {
             return;
         }
+
+        let Some(range) = index_range_to_lsp_range(db, uri, entry.range, encoding) else {
+            return;
+        };
 
         match &entry.data {
             IndexEntryData::Function { name, arguments: _ } => {
@@ -74,7 +84,7 @@ pub(crate) fn symbols(
                     kind: SymbolKind::FUNCTION,
                     location: Location {
                         uri: uri.clone(),
-                        range: entry.range,
+                        range,
                     },
                     tags: None,
                     deprecated: None,
@@ -89,7 +99,7 @@ pub(crate) fn symbols(
                         kind: SymbolKind::STRING,
                         location: Location {
                             uri: uri.clone(),
-                            range: entry.range,
+                            range,
                         },
                         tags: None,
                         deprecated: None,
@@ -104,7 +114,7 @@ pub(crate) fn symbols(
                     kind: SymbolKind::VARIABLE,
                     location: Location {
                         uri: uri.clone(),
-                        range: entry.range,
+                        range,
                     },
                     tags: None,
                     deprecated: None,
@@ -118,7 +128,7 @@ pub(crate) fn symbols(
                     kind: SymbolKind::METHOD,
                     location: Location {
                         uri: uri.clone(),
-                        range: entry.range,
+                        range,
                     },
                     tags: None,
                     deprecated: None,
@@ -129,6 +139,37 @@ pub(crate) fn symbols(
     });
 
     Ok(info)
+}
+
+/// Convert an index entry's tree-sitter point range to an LSP range, resolving
+/// the file's line index from the db. Returns `None` if the file is no longer
+/// in the db or the points fall outside it, in which case the symbol is
+/// dropped from the results.
+fn index_range_to_lsp_range(
+    db: &dyn ArkDb,
+    uri: &Url,
+    range: indexer::IndexRange,
+    encoding: PositionEncoding,
+) -> Option<Range> {
+    let file = db.file_by_path(&FilePath::from_url(uri))?;
+    let line_index = file.line_index(db);
+
+    let to_position = |point: indexer::IndexPoint| {
+        to_proto::position_from_line_col(
+            biome_line_index::LineCol {
+                line: point.row,
+                col: point.column,
+            },
+            line_index,
+            encoding,
+        )
+        .ok()
+    };
+
+    Some(Range::new(
+        to_position(range.start)?,
+        to_position(range.end)?,
+    ))
 }
 
 /// Represents a section in the document with its title, level, range, and children
@@ -778,12 +819,12 @@ pub(crate) fn parse_comment_as_section(comment: &str) -> Option<(usize, String)>
 
 #[cfg(test)]
 mod tests {
+    use oak_scan::DbScan;
     use tower_lsp::lsp_types::Position;
 
     use super::*;
     use crate::lsp::config::LspConfig;
     use crate::lsp::config::WorkspaceSymbolsConfig;
-    use crate::lsp::indexer::ResetIndexerGuard;
     use crate::lsp::util::test_path;
 
     fn test_symbol(code: &str) -> Vec<DocumentSymbol> {
@@ -1166,8 +1207,6 @@ outer <- 4
     #[test]
     fn test_workspace_symbols_include_comment_sections() {
         fn run(include_comment_sections: bool) -> Vec<String> {
-            let _guard = ResetIndexerGuard;
-
             let code = "# Section ----\nfoo <- 1";
 
             let config = LspConfig {
@@ -1176,20 +1215,15 @@ outer <- 4
                 },
                 ..Default::default()
             };
-            let state = WorldState {
+            let mut state = WorldState {
                 config,
                 ..Default::default()
             };
-
-            // Index the file off an `oak_db::File`, the same entry point the
-            // scan and editor paths use.
-            let db = oak_db::OakDatabase::new();
             let uri = test_path("test.R");
-            let key = aether_path::FilePath::from_url(&uri);
-            let file = oak_db::File::new(&db, key, code.to_string(), None);
-            indexer::index_file(&db, file, crate::fixtures::TEST_ENCODING).unwrap();
+            state
+                .db
+                .upsert_editor(aether_path::FilePath::from_url(&uri), code.to_string());
 
-            // Query for all symbols
             let params = WorkspaceSymbolParams {
                 query: "Section".to_string(),
                 ..Default::default()

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -783,7 +783,6 @@ mod tests {
     use super::*;
     use crate::lsp::config::LspConfig;
     use crate::lsp::config::WorkspaceSymbolsConfig;
-    use crate::lsp::document::Document;
     use crate::lsp::indexer::ResetIndexerGuard;
     use crate::lsp::util::test_path;
 
@@ -1182,10 +1181,13 @@ outer <- 4
                 ..Default::default()
             };
 
-            // Index the document
-            let doc = Document::new(code, None);
+            // Index the file off an `oak_db::File`, the same entry point the
+            // scan and editor paths use.
+            let db = oak_db::OakDatabase::new();
             let uri = test_path("test.R");
-            indexer::update(&doc, &uri).unwrap();
+            let key = aether_path::FilePath::from_url(&uri);
+            let file = oak_db::File::new(&db, key, code.to_string(), None);
+            indexer::index_file(&db, file, crate::fixtures::TEST_ENCODING).unwrap();
 
             // Query for all symbols
             let params = WorkspaceSymbolParams {

--- a/crates/ark/src/lsp/symbols.rs
+++ b/crates/ark/src/lsp/symbols.rs
@@ -9,9 +9,6 @@
 
 use std::result::Result::Ok;
 
-use aether_lsp_utils::proto::to_proto;
-use aether_lsp_utils::proto::PositionEncoding;
-use aether_path::FilePath;
 use stdext::unwrap::IntoResult;
 use tower_lsp::lsp_types::DocumentSymbol;
 use tower_lsp::lsp_types::DocumentSymbolParams;
@@ -21,7 +18,6 @@ use tower_lsp::lsp_types::SymbolInformation;
 use tower_lsp::lsp_types::SymbolKind;
 use tower_lsp::lsp_types::WorkspaceSymbolParams;
 use tree_sitter::Node;
-use url::Url;
 
 use crate::lsp::ark_file::ArkFile;
 use crate::lsp::db::ArkDb;
@@ -73,7 +69,7 @@ pub(crate) fn symbols(
             return;
         }
 
-        let Some(range) = index_range_to_lsp_range(db, uri, entry.range, encoding) else {
+        let Some(range) = indexer::index_range_to_lsp_range(db, uri, entry.range, encoding) else {
             return;
         };
 
@@ -139,37 +135,6 @@ pub(crate) fn symbols(
     });
 
     Ok(info)
-}
-
-/// Convert an index entry's tree-sitter point range to an LSP range, resolving
-/// the file's line index from the db. Returns `None` if the file is no longer
-/// in the db or the points fall outside it, in which case the symbol is
-/// dropped from the results.
-fn index_range_to_lsp_range(
-    db: &dyn ArkDb,
-    uri: &Url,
-    range: indexer::IndexRange,
-    encoding: PositionEncoding,
-) -> Option<Range> {
-    let file = db.file_by_path(&FilePath::from_url(uri))?;
-    let line_index = file.line_index(db);
-
-    let to_position = |point: indexer::IndexPoint| {
-        to_proto::position_from_line_col(
-            biome_line_index::LineCol {
-                line: point.row,
-                col: point.column,
-            },
-            line_index,
-            encoding,
-        )
-        .ok()
-    };
-
-    Some(Range::new(
-        to_position(range.start)?,
-        to_position(range.end)?,
-    ))
 }
 
 /// Represents a section in the document with its title, level, range, and children

--- a/crates/ark/src/url.rs
+++ b/crates/ark/src/url.rs
@@ -22,16 +22,9 @@ pub fn file_path_from_code_location(loc: &CodeLocation) -> FilePath {
 pub struct ExtUrl;
 
 impl ExtUrl {
-    /// Whether this URI should be indexed. Currently uses an exclude list:
+    /// Whether this URI should get diagnostics. Currently uses an exclude list:
     /// only `ark://` virtual documents are excluded since they show foreign
     /// code the user can't edit.
-    pub fn is_indexable(uri: &Url) -> bool {
-        !Self::is_ark_virtual_doc(uri)
-    }
-
-    /// Whether this URI should get diagnostics. Currently uses the same
-    /// exclude list as [`Self::is_indexable`] but kept separate so the
-    /// criteria can diverge independently.
     pub fn should_diagnose(uri: &Url) -> bool {
         !Self::is_ark_virtual_doc(uri)
     }
@@ -54,18 +47,6 @@ mod tests {
 
         let file_uri = Url::parse("file:///home/user/test.R").unwrap();
         assert!(!ExtUrl::is_ark_virtual_doc(&file_uri));
-    }
-
-    #[test]
-    fn test_is_indexable() {
-        let file_uri = Url::parse("file:///home/user/test.R").unwrap();
-        assert!(ExtUrl::is_indexable(&file_uri));
-
-        let git_uri = Url::parse("git:///home/user/test.R?ref=HEAD").unwrap();
-        assert!(ExtUrl::is_indexable(&git_uri));
-
-        let ark_uri = Url::parse("ark://namespace/test.R").unwrap();
-        assert!(!ExtUrl::is_indexable(&ark_uri));
     }
 
     #[test]

--- a/crates/oak_db/src/db.rs
+++ b/crates/oak_db/src/db.rs
@@ -150,29 +150,29 @@ pub fn all_files(db: &dyn Db) -> Vec<File> {
 /// Files eligible for the workspace symbol index: workspace-root scripts and
 /// package files, plus orphan editor buffers. Library roots are excluded, so
 /// installed package symbols don't leak into completions or workspace symbols.
-/// Mirrors [`all_files`] but skips `LiveRoot::Library`.
 #[salsa::tracked(returns(ref))]
 pub fn workspace_files(db: &dyn Db) -> Vec<File> {
     let mut files: Vec<File> = Vec::new();
 
     for &root in db.live_roots() {
         match root {
-            LiveRoot::Workspace(r) => {
-                let owned = |f: File| root_by_file(db, f) == Some(r);
-                files.extend(r.scripts(db).iter().copied().filter(|&f| owned(f)));
-                for &pkg in r.packages(db) {
-                    let pkg_files = pkg.files(db).iter().chain(pkg.scripts(db));
-                    files.extend(pkg_files.copied().filter(|&f| owned(f)));
-                }
-            },
+            LiveRoot::Workspace(r) => collect_root_files(db, &mut files, r),
             LiveRoot::Library(_) => {},
-            LiveRoot::Orphan(orphan) => {
-                files.extend(orphan.files(db).iter().copied());
-            },
+            LiveRoot::Orphan(orphan) => files.extend(orphan.files(db).iter().copied()),
         }
     }
 
     files
+}
+
+fn collect_root_files(db: &dyn Db, files: &mut Vec<File>, r: Root) {
+    let owned = |f: File| root_by_file(db, f) == Some(r);
+    files.extend(r.scripts(db).iter().copied().filter(|&f| owned(f)));
+
+    for &pkg in r.packages(db) {
+        let pkg_files = pkg.files(db).iter().chain(pkg.scripts(db));
+        files.extend(pkg_files.copied().filter(|&f| owned(f)));
+    }
 }
 
 /// Implementation of [`Db::file_by_path`]. Walks the per-root indices.

--- a/crates/oak_db/src/db.rs
+++ b/crates/oak_db/src/db.rs
@@ -149,7 +149,7 @@ pub fn all_files(db: &dyn Db) -> Vec<File> {
 
 /// Files eligible for the workspace symbol index: workspace-root scripts and
 /// package files, plus orphan editor buffers. Library roots are excluded, so
-/// installed package symbols don't leak into completions or workspace symbols.
+/// installed package symbols don't leak into e.g. workspace symbols.
 #[salsa::tracked(returns(ref))]
 pub fn workspace_files(db: &dyn Db) -> Vec<File> {
     let mut files: Vec<File> = Vec::new();

--- a/crates/oak_db/src/db.rs
+++ b/crates/oak_db/src/db.rs
@@ -147,6 +147,34 @@ pub fn all_files(db: &dyn Db) -> Vec<File> {
     files
 }
 
+/// Files eligible for the workspace symbol index: workspace-root scripts and
+/// package files, plus orphan editor buffers. Library roots are excluded, so
+/// installed package symbols don't leak into completions or workspace symbols.
+/// Mirrors [`all_files`] but skips `LiveRoot::Library`.
+#[salsa::tracked(returns(ref))]
+pub fn workspace_files(db: &dyn Db) -> Vec<File> {
+    let mut files: Vec<File> = Vec::new();
+
+    for &root in db.live_roots() {
+        match root {
+            LiveRoot::Workspace(r) => {
+                let owned = |f: File| root_by_file(db, f) == Some(r);
+                files.extend(r.scripts(db).iter().copied().filter(|&f| owned(f)));
+                for &pkg in r.packages(db) {
+                    let pkg_files = pkg.files(db).iter().chain(pkg.scripts(db));
+                    files.extend(pkg_files.copied().filter(|&f| owned(f)));
+                }
+            },
+            LiveRoot::Library(_) => {},
+            LiveRoot::Orphan(orphan) => {
+                files.extend(orphan.files(db).iter().copied());
+            },
+        }
+    }
+
+    files
+}
+
 /// Implementation of [`Db::file_by_path`]. Walks the per-root indices.
 ///
 /// Not itself salsa-tracked (its `&FilePath` argument isn't a salsa

--- a/crates/oak_db/src/lib.rs
+++ b/crates/oak_db/src/lib.rs
@@ -16,6 +16,7 @@ mod storage;
 mod tests;
 
 pub use db::all_files;
+pub use db::workspace_files;
 pub use db::Db;
 pub use db::DbInputs;
 pub use definition::Definition;

--- a/crates/oak_scan/src/scheduler.rs
+++ b/crates/oak_scan/src/scheduler.rs
@@ -111,10 +111,6 @@ pub struct ScanCompleted {
 }
 
 impl ScanCompleted {
-    pub fn root(&self) -> Root {
-        self.root
-    }
-
     /// Push the scan's output into salsa inputs for `self.root`.
     ///
     /// Atomic full-replacement of the root's packages and scripts.

--- a/crates/oak_scan/src/scheduler.rs
+++ b/crates/oak_scan/src/scheduler.rs
@@ -111,6 +111,10 @@ pub struct ScanCompleted {
 }
 
 impl ScanCompleted {
+    pub fn root(&self) -> Root {
+        self.root
+    }
+
     /// Push the scan's output into salsa inputs for `self.root`.
     ///
     /// Atomic full-replacement of the root's packages and scripts.


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1264
Progress towards https://github.com/posit-dev/ark/issues/1212

With this PR the Ark indexer that currently powers legacy workspace symbols, completions, and diagnostics is migrated to sources from the Oak DB, instead of walking the disk and watching.

Benefits:

- Single source of truth
- Less memory consumption
- Reactivity to changes for workspace files that are not opened in the editor

This last property is quite nice when changing git branches or editing files with an agent. The changes used to be ignored until the file was opened, but now the IDE reacts instantly.

https://github.com/user-attachments/assets/0b99be22-54a8-4522-b233-164b02be979f


- Building a file index is now a Salsa query over `oak_db::File`. Making it a query per file is especially nice during initial workspace scans where Salsa cancellations don't invalidate finished work per file, they remain cached across edits without having to finish building the entire index. This replaces the old global mutable index.

- New `workspace_files()` helper that collects, as the name says, all workspace files. Unlike `all_files()`, library roots are excluded. This is what `indexer::find()` and `map()` use to walk over files.

- Dropped the combined indexer + diagnostics queue. Now diagnostics query the index, so the ordering we used to enforce by hand (finish indexing, then run diagnostics) just falls out of the pull model. I've kept diagnostics batching and deduping as these are still useful.

- Now that the indexer is a query, it's fully lazy. That's a good property in principle but can lead to user-visible delays when requesting workspace symbols in an empty workspace on startup. If a file is opened, diagnostics will query the index and warm it up, but if none are opened, nothing drives that.

  To fix this issue, we now warm up the index manually after the initial workspace scan has settled. This mirrors how Rust-Analyser warms up its own general-purpose queries after the language server reaches "quiescence" (after the initial scan, after a workspace refresh caused by changing Cargo.toml, etc). There is no such mechanism in ty, it's fully on-demand. I opted to go the r-a way as it's closer to what we had before.

- Diagnostics triggering is now simplified by looking at `salsa::plumbing::current_revision()` from the main loop. Rust-Analyser uses it too, ty doesn't (they have a different pull model for diagnostics that I didn't investigate much yet, our push model is closer to R-A's).

- The indexer was the only consumer of the rename events. We now watch files purely through `DidChangeWatchedFiles`, which is consistent which is also what ty and r-a do.
 
  The one event we might want to subscribe later on is `WillRename`. This would be useful to e.g. update `source()` paths when a file is renamed.