### PR TITLE
Add Watch Pane support for the notebook debugger

### DIFF
--- a/crates/ark/src/console.rs
+++ b/crates/ark/src/console.rs
@@ -166,6 +166,7 @@ use crate::r_task::BoxFuture;
 use crate::r_task::QueuedRTask;
 use crate::r_task::RTaskStartInfo;
 use crate::r_task::RTaskStatus;
+use crate::r_task::TryIdleTask;
 use crate::repos::apply_default_repos;
 use crate::repos::DefaultRepos;
 use crate::request::debug_request_command;
@@ -238,6 +239,7 @@ pub struct Console {
     tasks_interrupt_rx: Receiver<QueuedRTask>,
     tasks_idle_rx: Receiver<QueuedRTask>,
     tasks_idle_any_rx: Receiver<QueuedRTask>,
+    try_idle_rx: Receiver<TryIdleTask>,
     pending_futures: HashMap<Uuid, (BoxFuture<'static, ()>, RTaskStartInfo, Option<String>)>,
 
     /// The UI comm, stored separately from `comms` so that `ui_comm()` can

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -20,6 +20,7 @@ use crate::dap::dap_notebook;
 use crate::data_explorer::r_data_explorer::POSITRON_DATA_EXPLORER_MIME;
 use crate::r_task::QueuedRTask;
 use crate::r_task::RTask;
+use crate::r_task::TryIdleTask;
 use crate::request::DebugRequest;
 
 static RE_DEBUG_PROMPT: Lazy<Regex> = Lazy::new(|| Regex::new(r"Browse\[\d+\]").unwrap());
@@ -375,13 +376,15 @@ impl Console {
             };
         }
 
-        let (tasks_interrupt_rx, tasks_idle_rx, tasks_idle_any_rx) = r_task::take_receivers();
+        let (tasks_interrupt_rx, tasks_idle_rx, tasks_idle_any_rx, try_idle_rx) =
+            r_task::take_receivers();
 
         CONSOLE.set(UnsafeCell::new(Console::new(
             r_home,
             tasks_interrupt_rx,
             tasks_idle_rx,
             tasks_idle_any_rx,
+            try_idle_rx,
             comm_event_tx,
             r_request_rx,
             stdin_request_tx,
@@ -616,6 +619,7 @@ impl Console {
         tasks_interrupt_rx: Receiver<QueuedRTask>,
         tasks_idle_rx: Receiver<QueuedRTask>,
         tasks_idle_any_rx: Receiver<QueuedRTask>,
+        try_idle_rx: Receiver<TryIdleTask>,
         comm_event_tx: Sender<CommEvent>,
         r_request_rx: Receiver<RRequest>,
         stdin_request_tx: Sender<StdInRequest>,
@@ -651,6 +655,7 @@ impl Console {
             tasks_interrupt_rx,
             tasks_idle_rx,
             tasks_idle_any_rx,
+            try_idle_rx,
             pending_futures: HashMap::new(),
             session_mode,
             positron_ns: None,
@@ -759,6 +764,7 @@ impl Console {
             let (_, tasks_interrupt_rx) = crossbeam::channel::unbounded();
             let (_, tasks_idle_rx) = crossbeam::channel::unbounded();
             let (_, tasks_idle_any_rx) = crossbeam::channel::unbounded();
+            let (_, try_idle_rx) = crossbeam::channel::unbounded();
             let (comm_event_tx, _) = crossbeam::channel::unbounded();
             let (r_request_tx, r_request_rx) = crossbeam::channel::unbounded();
             let (stdin_request_tx, _) = crossbeam::channel::unbounded();
@@ -772,6 +778,7 @@ impl Console {
                 tasks_interrupt_rx,
                 tasks_idle_rx,
                 tasks_idle_any_rx,
+                try_idle_rx,
                 comm_event_tx,
                 r_request_rx,
                 stdin_request_tx,
@@ -1088,6 +1095,7 @@ impl Console {
         let tasks_interrupt_rx = self.tasks_interrupt_rx.clone();
         let tasks_idle_rx = self.tasks_idle_rx.clone();
         let tasks_idle_any_rx = self.tasks_idle_any_rx.clone();
+        let try_idle_rx = self.try_idle_rx.clone();
 
         // Process R's polled events regularly while waiting for console input.
         // We used to poll every 200ms but that lead to visible delays for the
@@ -1127,6 +1135,12 @@ impl Console {
             } else {
                 None
             };
+
+        let try_idle_index = if matches!(info.kind, PromptKind::TopLevel | PromptKind::Browser) {
+            Some(select.recv(&try_idle_rx))
+        } else {
+            None
+        };
 
         loop {
             // If an interrupt was signaled and we are waiting for user
@@ -1222,6 +1236,13 @@ impl Console {
                 i if Some(i) == tasks_idle_any_index => {
                     let task = oper.recv(&tasks_idle_any_rx).unwrap();
                     self.handle_task(task);
+                },
+
+                // A try-idle task woke us up
+                i if Some(i) == try_idle_index => {
+                    let task = oper.recv(&try_idle_rx).unwrap();
+                    let mut capture = self.start_capture();
+                    (task.fun)(&mut capture);
                 },
 
                 // It's time to run R's polled events

--- a/crates/ark/src/dap/dap_jupyter_handler.rs
+++ b/crates/ark/src/dap/dap_jupyter_handler.rs
@@ -24,7 +24,9 @@ use amalthea::wire::debug_event::DebugEvent;
 use crossbeam::channel::Sender;
 use dap::base_message::BaseMessage;
 use dap::base_message::Sendable;
+use dap::requests::EvaluateArguments;
 use dap::requests::Request;
+use dap::responses::ResponseBody;
 use stdext::result::ResultExt;
 
 use crate::dap::dap_notebook;
@@ -34,6 +36,7 @@ use crate::dap::dap_state::Breakpoint;
 use crate::dap::dap_state::BreakpointState;
 use crate::dap::dap_state::Dap;
 use crate::dap::dap_state::THREAD_ID;
+use crate::r_task;
 use crate::request::RRequest;
 
 pub struct DapJupyterHandler {
@@ -78,10 +81,12 @@ impl DapJupyterHandler {
         log::trace!("Jupyter DAP: Handling `{command}` (seq={seq})");
 
         // Handle Jupyter Debug Protocol extensions and commands not in the
-        // `dap` crate's `Command` enum.
+        // `dap` crate's `Command` enum, plus `evaluate` which requires
+        // running R code via `try_idle_task`.
         let result = match command {
             "dumpCell" => Some(self.handle_dump_cell(seq, request)),
             "debugInfo" => Some(self.handle_debug_info(seq)),
+            "evaluate" => Some(self.handle_evaluate(seq, request)),
             "configurationDone" => Some(Ok(self.success_response(
                 seq,
                 "configurationDone",
@@ -118,6 +123,39 @@ impl DapJupyterHandler {
                 log::warn!("Jupyter DAP: Failed to parse `{command}`: {err:?}");
                 self.error_response(seq, command, &format!("Failed to parse request: {err}"))
             },
+        }
+    }
+
+    fn handle_evaluate(
+        &self,
+        seq: i64,
+        request: &serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let args: EvaluateArguments =
+            serde_json::from_value(request.get("arguments").cloned().unwrap_or_default())?;
+
+        let state = self.handler.state.clone();
+        let expression = args.expression;
+        let frame_id = args.frame_id;
+
+        // This only returns `Some()` if R is idle. Even though we stopped at
+        // some point, causing the Evaluate request, R could be busy evaluating
+        // the next expression already.
+        let result = r_task::try_idle_task(move |capture| {
+            DapHandler::evaluate(&state, &expression, frame_id, capture)
+        });
+
+        match result {
+            None => Ok(self.error_response(seq, "evaluate", "R is busy")),
+            // The task raised an R error, caught by the sandbox on the R thread.
+            Some(Err(err)) => Ok(self.error_response(seq, "evaluate", &format!("{err}"))),
+            Some(Ok(Ok(body))) => {
+                let ResponseBody::Evaluate(eval) = body else {
+                    return Err(anyhow::anyhow!("Unexpected response body from evaluate"));
+                };
+                Ok(self.success_response(seq, "evaluate", serde_json::to_value(eval)?))
+            },
+            Some(Ok(Err(err))) => Ok(self.error_response(seq, "evaluate", &format!("{err}"))),
         }
     }
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -462,8 +462,10 @@ impl DapHandler {
         drop(state);
 
         let console_events = if is_debugging {
+            log::trace!("DAP: Disconnect while debugging, injecting `Quit` to exit the browser");
             vec![DapConsoleEvent::DebugCommand(DebugRequest::Quit)]
         } else {
+            log::trace!("DAP: Disconnect while not debugging, no `Quit` needed");
             vec![]
         };
 

--- a/crates/ark/src/dap/dap_server.rs
+++ b/crates/ark/src/dap/dap_server.rs
@@ -43,6 +43,7 @@ use super::dap_state::Dap;
 use super::dap_state::DapBackendEvent;
 use super::dap_state::THREAD_ID;
 use crate::console::Console;
+use crate::console::ConsoleOutputCapture;
 use crate::console::FrameInfo;
 use crate::console::FrameSource;
 use crate::dap::dap_variables::object_variables;
@@ -124,8 +125,10 @@ impl DapHandler {
 
     /// Dispatch a parsed DAP request to the appropriate handler.
     ///
-    /// `Evaluate` is intentionally not handled here because it requires
-    /// transport-specific async response delivery.
+    /// `Evaluate` is not handled here because `dispatch()` returns
+    /// synchronously, while Evaluate requires an async round-trip through the
+    /// R thread. Each transport calls [`DapHandler::evaluate()`] directly
+    /// inside its own async mechanism.
     pub fn dispatch(&self, req: Request) -> DapOutput {
         let cmd = req.command.clone();
 
@@ -670,6 +673,52 @@ impl DapHandler {
             console_events: vec![DapConsoleEvent::Interrupt],
         })
     }
+
+    /// Core evaluate logic, must be called on the R thread.
+    pub(crate) fn evaluate(
+        state: &Mutex<Dap>,
+        expression: &str,
+        frame_id: Option<i64>,
+        capture: &mut ConsoleOutputCapture,
+    ) -> anyhow::Result<ResponseBody> {
+        if expression == SELECTED_FRAME_EXPRESSION {
+            log::trace!("DAP: Received frame selection sentinel, frame_id: {frame_id:?}");
+            Console::get_mut().set_debug_selected_frame_id(frame_id);
+            return Ok(ResponseBody::Evaluate(EvaluateResponse {
+                result: String::new(),
+                type_field: None,
+                presentation_hint: None,
+                variables_reference: 0,
+                named_variables: None,
+                indexed_variables: None,
+                memory_reference: None,
+            }));
+        }
+
+        let (expr, print) = match expression.strip_prefix("/print ") {
+            Some(expr) => (expr, true),
+            None => (expression, false),
+        };
+
+        // Resolve the frame environment under the lock, then release it before
+        // evaluating. The `Dap` lock must not be held across R evaluation: an R
+        // error longjumps over this frame and skips the guard's `Drop`, which
+        // would leave the mutex locked forever. The env stays valid without the
+        // lock because its owning `RObject` remains in the state's map, which
+        // only the R thread mutates.
+        let env = state
+            .lock()
+            .unwrap()
+            .frame_env(frame_id)
+            .map_err(|err| anyhow::anyhow!("{err}"))?;
+
+        let capture = if print { Some(capture) } else { None };
+        let variable = Dap::evaluate(expr, env, capture)?;
+        log::trace!("DAP: Evaluate completed");
+
+        let response = state.lock().unwrap().into_evaluate_response(variable);
+        Ok(ResponseBody::Evaluate(response))
+    }
 }
 
 // TODO: Handle comm close to shut down the DAP server thread.
@@ -962,36 +1011,9 @@ impl<R: Read, W: Write> DapServer<R, W> {
         r_task::spawn(RTask::send_idle_any_prompt(async move |mut capture| {
             log::trace!("DAP: Idle task started for evaluate");
 
-            // If expression starts with "/print ", evaluate and print result
-            let (expr, print) = match expression.strip_prefix("/print ") {
-                Some(expr) => (expr, true),
-                None => (expression.as_str(), false),
-            };
-
-            let rsp = if expression == SELECTED_FRAME_EXPRESSION {
-                log::trace!("DAP: Received frame selection sentinel, frame_id: {frame_id:?}");
-                Console::get_mut().set_debug_selected_frame_id(frame_id);
-                req.success(ResponseBody::Evaluate(EvaluateResponse {
-                    result: String::new(),
-                    type_field: None,
-                    presentation_hint: None,
-                    variables_reference: 0,
-                    named_variables: None,
-                    indexed_variables: None,
-                    memory_reference: None,
-                }))
-            } else {
-                let capture = if print { Some(&mut capture) } else { None };
-                let result = state.lock().unwrap().evaluate(expr, frame_id, capture);
-                log::trace!("DAP: Evaluate completed, success: {}", result.is_ok());
-
-                match result {
-                    Ok(variable) => {
-                        let response = state.lock().unwrap().into_evaluate_response(variable);
-                        req.success(ResponseBody::Evaluate(response))
-                    },
-                    Err(err) => req.error(&format!("Error: {err}")),
-                }
+            let rsp = match DapHandler::evaluate(&state, &expression, frame_id, &mut capture) {
+                Ok(body) => req.success(body),
+                Err(err) => req.error(&format!("Error: {err}")),
             };
 
             responses_tx.send(rsp).log_err();

--- a/crates/ark/src/dap/dap_state.rs
+++ b/crates/ark/src/dap/dap_state.rs
@@ -640,32 +640,6 @@ impl Dap {
         }
     }
 
-    pub(crate) fn evaluate(
-        &self,
-        expression: &str,
-        frame_id: Option<i64>,
-        capture: Option<&mut ConsoleOutputCapture>,
-    ) -> Result<RVariable, String> {
-        let env = self.frame_env(frame_id)?;
-
-        match harp::parse_eval0(expression, harp::RObject::view(env)) {
-            Ok(value) => {
-                if let Some(capture) = capture {
-                    harp::utils::r_print(value.sexp);
-                    Ok(RVariable {
-                        name: String::new(),
-                        value: capture.take().trim_end().to_string(),
-                        type_field: None,
-                        variables_reference_object: None,
-                    })
-                } else {
-                    Ok(object_variable(String::new(), value.sexp))
-                }
-            },
-            Err(err) => Err(evaluate_error_message(err)),
-        }
-    }
-
     pub(crate) fn frame_env(&self, frame_id: Option<i64>) -> Result<libr::SEXP, String> {
         let Some(frame_id) = frame_id else {
             return Ok(R_ENVS.global);
@@ -906,6 +880,36 @@ impl Dap {
         };
         bp.hit_count += 1;
         bp.hit_count
+    }
+
+    /// Evaluate `expression` in `env` and build a DAP variable from the result.
+    ///
+    /// Takes a bare `env` SEXP rather than `&Dap` so an off-thread caller (e.g.
+    /// the DAP server) can resolve the frame environment under the `Dap` lock
+    /// and then release it before calling here. The lock must not be held
+    /// across this call since `evaluate()` might longjump over the mutex
+    /// guard..
+    pub(crate) fn evaluate(
+        expression: &str,
+        env: libr::SEXP,
+        capture: Option<&mut ConsoleOutputCapture>,
+    ) -> anyhow::Result<RVariable> {
+        match harp::parse_eval0(expression, harp::RObject::view(env)) {
+            Ok(value) => {
+                if let Some(capture) = capture {
+                    harp::utils::r_print(value.sexp);
+                    Ok(RVariable {
+                        name: String::new(),
+                        value: capture.take().trim_end().to_string(),
+                        type_field: None,
+                        variables_reference_object: None,
+                    })
+                } else {
+                    Ok(object_variable(String::new(), value.sexp))
+                }
+            },
+            Err(err) => Err(anyhow!(evaluate_error_message(err))),
+        }
     }
 }
 

--- a/crates/ark/src/dap/dap_state.rs
+++ b/crates/ark/src/dap/dap_state.rs
@@ -884,11 +884,11 @@ impl Dap {
 
     /// Evaluate `expression` in `env` and build a DAP variable from the result.
     ///
-    /// Takes a bare `env` SEXP rather than `&Dap` so an off-thread caller (e.g.
-    /// the DAP server) can resolve the frame environment under the `Dap` lock
-    /// and then release it before calling here. The lock must not be held
-    /// across this call since `evaluate()` might longjump over the mutex
-    /// guard..
+    /// Takes a bare `env` SEXP rather than `&Dap` so the caller can resolve the
+    /// frame environment under the `Dap` lock and release it before calling
+    /// here. The lock must not be held across this call: evaluating user code
+    /// can re-enter the debugger (a breakpoint or `browser()` fires), which
+    /// locks the same `Dap` again and would deadlock.
     pub(crate) fn evaluate(
         expression: &str,
         env: libr::SEXP,
@@ -897,7 +897,8 @@ impl Dap {
         match harp::parse_eval0(expression, harp::RObject::view(env)) {
             Ok(value) => {
                 if let Some(capture) = capture {
-                    harp::utils::r_print(value.sexp);
+                    harp::utils::r_print(&value)
+                        .map_err(|err| anyhow!(evaluate_error_message(err)))?;
                     Ok(RVariable {
                         name: String::new(),
                         value: capture.take().trim_end().to_string(),

--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -16,8 +16,10 @@ use crossbeam::channel::bounded;
 use crossbeam::channel::unbounded;
 use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
+use harp::exec::r_sandbox;
 #[cfg(debug_assertions)]
 use libr::SEXP;
+use stdext::result::ResultExt;
 use uuid::Uuid;
 
 use crate::console::Console;
@@ -33,6 +35,17 @@ static IDLE_TASKS: LazyLock<TaskChannels> = LazyLock::new(TaskChannels::new);
 /// Task channels for idle tasks that run at any idle prompt (top-level or browser)
 static IDLE_ANY_TASKS: LazyLock<TaskChannels> = LazyLock::new(TaskChannels::new);
 
+/// Rendezvous channel for try-idle tasks. `bounded(0)` means `try_send`
+/// succeeds only when the receiver is already parked in `Select`, giving
+/// an atomic check-and-wake with no race window.
+static TRY_IDLE: LazyLock<TryIdleChannels> = LazyLock::new(|| {
+    let (tx, rx) = bounded::<TryIdleTask>(0);
+    TryIdleChannels {
+        tx,
+        rx: Mutex::new(Some(rx)),
+    }
+});
+
 // Compared to `futures::BoxFuture`, this doesn't require the future to be Send.
 // We don't need this bound since the executor runs on only on the R thread
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
@@ -43,6 +56,15 @@ type SharedOption<T> = Arc<Mutex<Option<T>>>;
 struct TaskChannels {
     tx: Sender<QueuedRTask>,
     rx: Mutex<Option<Receiver<QueuedRTask>>>,
+}
+
+struct TryIdleChannels {
+    tx: Sender<TryIdleTask>,
+    rx: Mutex<Option<Receiver<TryIdleTask>>>,
+}
+
+pub(crate) struct TryIdleTask {
+    pub(crate) fun: Box<dyn FnOnce(&mut ConsoleOutputCapture) + Send>,
 }
 
 impl TaskChannels {
@@ -64,19 +86,58 @@ impl TaskChannels {
     }
 }
 
-/// Returns receivers for interrupt, idle, and debug-idle tasks.
+/// Returns receivers for interrupt, idle, debug-idle, and try-idle tasks.
 /// Initializes the task channels if they haven't been initialized yet.
 /// Can only be called once (intended for `Console` during init).
 pub(crate) fn take_receivers() -> (
     Receiver<QueuedRTask>,
     Receiver<QueuedRTask>,
     Receiver<QueuedRTask>,
+    Receiver<TryIdleTask>,
 ) {
     (
         INTERRUPT_TASKS.take_rx(),
         IDLE_TASKS.take_rx(),
         IDLE_ANY_TASKS.take_rx(),
+        TRY_IDLE.rx.lock().unwrap().take().unwrap(),
     )
+}
+
+/// Attempt to run `f` on the R thread if it is currently idle at a prompt.
+///
+/// Returns `None` if R was busy. Otherwise returns `Some` with the outcome:
+/// `Ok` if `f` ran cleanly, `Err` if it raised an R error. The bounded(0)
+/// channel guarantees atomicity: `try_send` succeeds only when the event
+/// loop's `Select` is parked waiting.
+pub(crate) fn try_idle_task<F, T>(f: F) -> Option<harp::Result<T>>
+where
+    F: FnOnce(&mut ConsoleOutputCapture) -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let result: SharedOption<harp::Result<T>> = Arc::new(Mutex::new(None));
+    let (done_tx, done_rx) = bounded::<()>(1);
+
+    let result_clone = Arc::clone(&result);
+    let task = TryIdleTask {
+        fun: Box::new(move |capture| {
+            // Run `f` inside `r_sandbox` so an R error longjumps back to here
+            // rather than unwinding past this frame. The `done` signal must
+            // stay outside the sandbox: a longjump skips everything between
+            // the error and the sandbox `setjmp`, so signalling inside would
+            // strand the caller forever in `recv()`.
+            let res = r_sandbox(|| f(capture));
+            *result_clone.lock().unwrap() = Some(res);
+            let _ = done_tx.send(());
+        }),
+    };
+
+    // Try sending the task to the Console idle event loop. This only succeeds
+    // if the event loop is listening.
+    TRY_IDLE.tx.try_send(task).ok()?;
+
+    done_rx.recv().log_err()?;
+    let out = result.lock().unwrap().take();
+    out
 }
 
 pub enum QueuedRTask {

--- a/crates/ark/src/r_task.rs
+++ b/crates/ark/src/r_task.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use crossbeam::channel::bounded;
 use crossbeam::channel::unbounded;
 use crossbeam::channel::Receiver;
+use crossbeam::channel::SendTimeoutError;
 use crossbeam::channel::Sender;
 use harp::exec::r_sandbox;
 #[cfg(debug_assertions)]
@@ -103,12 +104,21 @@ pub(crate) fn take_receivers() -> (
     )
 }
 
+/// An idle R is not parked in its event loop continuously. It wakes every 50ms
+/// for the polled-events tick (see `console_repl.rs`), runs the events, then
+/// re-enters the `Select`. It also has a short gap right after an execution
+/// while it sends the idle status and rebuilds the `Select`. We wait longer
+/// than one tick to give a chance to ReadConsole to pick up the TryIdle task.
+const TRY_IDLE_TIMEOUT: Duration = Duration::from_millis(200);
+
 /// Attempt to run `f` on the R thread if it is currently idle at a prompt.
 ///
 /// Returns `None` if R was busy. Otherwise returns `Some` with the outcome:
-/// `Ok` if `f` ran cleanly, `Err` if it raised an R error. The bounded(0)
-/// channel guarantees atomicity: `try_send` succeeds only when the event
-/// loop's `Select` is parked waiting.
+/// `Ok` if `f` ran cleanly, `Err` if it raised an R error.
+///
+/// On the bounded(0) channel, `send_timeout` only hands off the task when the
+/// event loop's `Select` is parked receiving, so the task runs iff R is idle.
+/// Waiting up to `TRY_IDLE_TIMEOUT`.
 pub(crate) fn try_idle_task<F, T>(f: F) -> Option<harp::Result<T>>
 where
     F: FnOnce(&mut ConsoleOutputCapture) -> T + Send + 'static,
@@ -131,9 +141,16 @@ where
         }),
     };
 
-    // Try sending the task to the Console idle event loop. This only succeeds
-    // if the event loop is listening.
-    TRY_IDLE.tx.try_send(task).ok()?;
+    // Hand the task to the Console idle event loop. This only succeeds if the
+    // event loop parks in its `Select` within the timeout.
+    match TRY_IDLE.tx.send_timeout(task, TRY_IDLE_TIMEOUT) {
+        Ok(()) => {},
+        Err(SendTimeoutError::Timeout(_)) => return None,
+        Err(SendTimeoutError::Disconnected(_)) => {
+            log::error!("`try_idle_task`: `TRY_IDLE` is disconnected");
+            return None;
+        },
+    }
 
     done_rx.recv().log_err()?;
     let out = result.lock().unwrap().take();

--- a/crates/ark/tests/integration/dap_evaluate.rs
+++ b/crates/ark/tests/integration/dap_evaluate.rs
@@ -390,6 +390,44 @@ outer()
     dap.recv_continued();
 }
 
+/// A print method that raises an R error longjumps out of `Rf_PrintValue`. The
+/// evaluation must surface that as an error and leave the `Dap` state usable, so
+/// a follow-up evaluate still succeeds. Console and notebook share
+/// `DapHandler::evaluate`; this checks the console (TCP) path, the notebook path
+/// is checked in `test_notebook_evaluate_erroring_print_does_not_deadlock`.
+#[test]
+fn test_dap_evaluate_erroring_print_does_not_deadlock() {
+    let frontend = DummyArkFrontend::lock();
+    let mut dap = frontend.start_dap();
+
+    // Define an S3 object whose print method errors.
+    frontend.send_execute_request(
+        "print.boom <- function(x, ...) stop('kaboom'); obj <- structure(1, class = 'boom')",
+        Default::default(),
+    );
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    frontend.debug_send_browser();
+    dap.recv_stopped();
+
+    let stack = dap.stack_trace();
+    let frame_id = stack[0].id;
+
+    // Printing `obj` dispatches `print.boom`, which longjumps out of R.
+    let err = dap.evaluate_error("/print obj", Some(frame_id));
+    assert!(err.contains("kaboom"), "got: {err}");
+
+    // A follow-up evaluate still succeeds: the `Dap` state is left usable.
+    let result = dap.evaluate("1 + 1", Some(frame_id));
+    assert_eq!(result, "2");
+
+    frontend.debug_send_quit();
+    dap.recv_continued();
+}
+
 #[test]
 fn test_dap_evaluate_unknown_frame_id() {
     let frontend = DummyArkFrontend::lock();

--- a/crates/ark/tests/integration/dap_notebook.rs
+++ b/crates/ark/tests/integration/dap_notebook.rs
@@ -21,6 +21,43 @@ fn find_debug_event<'a>(msgs: &'a [Message], event: &str) -> &'a serde_json::Val
         .unwrap_or_else(|| panic!("No DebugEvent with event={event:?} found"))
 }
 
+/// Send an `evaluate` `debug_request` and return the reply.
+///
+/// `evaluate` runs through `try_idle_task()`, which waits for the R thread to
+/// park in its read-console `Select`. Once R is at a prompt a single attempt
+/// lands. The only time it reports "R is busy" here is cold start, before R has
+/// reached its first prompt, so we re-send until it's ready. The kernel-side
+/// wait paces each attempt, so no sleep is needed. The control thread brackets
+/// each attempt with busy/idle on IOPub, and the R-thread evaluation emits
+/// nothing there (printed output is captured), so each is the same busy/reply/
+/// idle as any other control-only request.
+fn notebook_evaluate(
+    frontend: &DummyArkFrontendNotebook,
+    seq: i64,
+    expression: &str,
+) -> serde_json::Value {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        frontend.send_debug_request(serde_json::json!({
+            "type": "request",
+            "seq": seq,
+            "command": "evaluate",
+            "arguments": { "expression": expression }
+        }));
+        frontend.recv_iopub_busy();
+        let reply = frontend.recv_debug_reply();
+        frontend.recv_iopub_idle();
+
+        let busy = reply["success"] == false && reply["message"] == "R is busy";
+        if !busy {
+            return reply;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("`evaluate` kept returning \"R is busy\"; R never reached a prompt");
+        }
+    }
+}
+
 #[test]
 fn test_notebook_debug_info() {
     let frontend = DummyArkFrontendNotebook::lock();
@@ -912,4 +949,73 @@ fn test_notebook_debug_info_echoes_verbatim_breakpoint_path() {
         .find(|group| group["source"].as_str() == Some(sent_path.as_str()))
         .expect("debugInfo did not echo the verbatim breakpoint path");
     assert_eq!(group["breakpoints"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn test_notebook_evaluate() {
+    let frontend = DummyArkFrontendNotebook::lock();
+
+    let reply = notebook_evaluate(&frontend, 1, "1 + 1");
+    assert_eq!(reply["success"], true);
+    assert_eq!(reply["command"], "evaluate");
+    assert_eq!(reply["body"]["result"], "2");
+}
+
+#[test]
+fn test_notebook_evaluate_print() {
+    let frontend = DummyArkFrontendNotebook::lock();
+
+    // The `/print ` prefix evaluates and returns the captured print output.
+    let reply = notebook_evaluate(&frontend, 1, "/print 1:3");
+    assert_eq!(reply["success"], true);
+    let result = reply["body"]["result"].as_str().unwrap();
+    assert!(result.contains("[1] 1 2 3"), "got: {result}");
+}
+
+#[test]
+fn test_notebook_evaluate_error() {
+    let frontend = DummyArkFrontendNotebook::lock();
+
+    // An R error during evaluation comes back as a failed reply, not a crash.
+    let reply = notebook_evaluate(&frontend, 1, "stop('boom')");
+    assert_eq!(reply["success"], false);
+    let message = reply["message"].as_str().unwrap();
+    assert!(message.contains("boom"), "got: {message}");
+
+    // The kernel is still responsive afterwards.
+    let reply = notebook_evaluate(&frontend, 2, "1 + 1");
+    assert_eq!(reply["success"], true);
+    assert_eq!(reply["body"]["result"], "2");
+}
+
+/// A print method that raises an R error longjumps out of `Rf_PrintValue`. The
+/// evaluation must surface that as an error and leave both the try-idle
+/// handshake and the `Dap` state intact, so a follow-up evaluate still succeeds.
+/// The console (TCP) path is checked in
+/// `test_dap_evaluate_erroring_print_does_not_deadlock`.
+#[test]
+fn test_notebook_evaluate_erroring_print_does_not_deadlock() {
+    let frontend = DummyArkFrontendNotebook::lock();
+
+    // Define an S3 object whose print method errors.
+    frontend.send_execute_request(
+        "print.boom <- function(x, ...) stop('kaboom'); obj <- structure(1, class = 'boom')",
+        ExecuteRequestOptions::default(),
+    );
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    // Printing `obj` dispatches `print.boom`, which longjumps out of R.
+    let reply = notebook_evaluate(&frontend, 1, "/print obj");
+    assert_eq!(reply["success"], false);
+    let message = reply["message"].as_str().unwrap();
+    assert!(message.contains("kaboom"), "got: {message}");
+
+    // A follow-up evaluate still succeeds: the handshake completed and the `Dap`
+    // state is left usable.
+    let reply = notebook_evaluate(&frontend, 2, "40 + 2");
+    assert_eq!(reply["success"], true);
+    assert_eq!(reply["body"]["result"], "42");
 }

--- a/crates/harp/src/utils.rs
+++ b/crates/harp/src/utils.rs
@@ -702,10 +702,8 @@ pub fn push_rds(x: SEXP, path: &str, context: &str) {
     res.unwrap();
 }
 
-pub fn r_print(x: impl Into<SEXP>) {
-    unsafe {
-        Rf_PrintValue(x.into());
-    }
+pub fn r_print(x: &RObject) -> harp::Result<()> {
+    harp::try_catch(|| unsafe { Rf_PrintValue(x.sexp) })
 }
 
 pub fn r_printf(x: &str) {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/13323

<img width="503" height="426" alt="Screenshot 2026-06-23 at 09 31 46" src="https://github.com/user-attachments/assets/64d78401-3833-4257-b0f1-feb05eb4c742" />

The debugger support for notebooks and other Jupyter apps implemented in https://github.com/posit-dev/ark/pull/1170 and https://github.com/posit-dev/ark/pull/1171 was quite comprehensive except for one handler: `evaluate`, which powers the Watch Pane.

The reason it was delayed is that this handler was written for the Console path with an asynchronous approach. The handler needs to evaluate R code in the console and, by the time we get the Evaluate DAP request when the frontend refreshes the Wath Pane contents after R stops at a breakpoint (or `browser()` call), R might have resumed evaluation already. That could be either because the user typed `n` very fast or because they evaluated multiple top-level expresssions in one go and R stops at each of them. To support this case gracefully, the Evaluate handler is executed via an Idle task that only fires when R is no longer busy. Once it completes, a response is sent to the frontend with the result. This happens asynchronously: other DAP requests might come in and be handled while the Evaluate idle task is in flight.

This approach did not work out for the Jupyter layer because the handling happens on the Control socket (used for interrupts, shutdowns, and DAP messaging) and expects a quick response right away. While the protocol is silent on whether responses can be asynchronous, reference implementations assume serial handling, both on the frontend side (e.g. VS Code) and the backend side (ipykernel).

This PR solves this by adding a new "try-idle" R task that fires under 200ms if R becomes idle in that time frame, and use that in the Jupyter handler for Evaluate. In my initial implementation there was no timeout and the task would only succeed if the Console was parked in its event loop right at that moment. However that approach had two races that the timeout-waiting fixes:

- If we get the evaluate request a bit too early, before the console has time to drop in the event loop, we'd spuriously treat R as busy.
- If the event loop processes polled events right at that time (it does so every 50ms), we'd also miss the idleness.

I picked 200ms arbitrarily, it felt like the maximum amount of time that is reasonable to defer other important Control messages like interrupts or shut downs when R is truly busy and can't service our request.