### PR TITLE
Simplify ownership of the list of comms

### DIFF
--- a/crates/ark/src/comm_handler.rs
+++ b/crates/ark/src/comm_handler.rs
@@ -101,7 +101,6 @@ pub enum EnvironmentChanged {
 
 /// A registered comm in the Console's comm table.
 pub(crate) struct ConsoleComm {
-    pub(crate) comm_id: String,
     pub(crate) handler: DebugRefCell<Box<dyn CommHandler>>,
     pub(crate) ctx: CommHandlerContext,
 }

--- a/crates/ark/src/console.rs
+++ b/crates/ark/src/console.rs
@@ -243,9 +243,9 @@ pub struct Console {
     try_idle_rx: Receiver<TryIdleTask>,
     pending_futures: HashMap<Uuid, (BoxFuture<'static, ()>, RTaskStartInfo, Option<String>)>,
 
-    /// The UI comm, stored separately from `comms` so that `ui_comm()` can
-    /// borrow it independently of the comms map.
-    ui_comm: DebugRefCell<Option<ConsoleComm>>,
+    /// Comm ID of the UI comm, if connected. The comm itself lives in `comms`
+    /// like any other.
+    ui_comm_id: DebugRefCell<Option<String>>,
 
     /// Error captured by our global condition handler during the last iteration
     /// of the REPL.
@@ -355,7 +355,11 @@ pub struct Console {
     read_console_env_stack: DebugRefCell<Vec<RObject>>,
 
     /// Comm handlers registered on the R thread (keyed by comm ID).
-    comms: DebugRefCell<HashMap<String, ConsoleComm>>,
+    ///
+    /// Entries are `Rc` so dispatch can clone one out and drop the map borrow
+    /// before running the handler. That keeps the map free for the handler to
+    /// reenter (e.g. a data explorer opening a child comm).
+    comms: DebugRefCell<HashMap<String, Rc<ConsoleComm>>>,
 
     /// Graphics device state (plot recording, rendering, comm management).
     device_context: Rc<DeviceContext>,

--- a/crates/ark/src/console/console_comm.rs
+++ b/crates/ark/src/console/console_comm.rs
@@ -4,6 +4,8 @@
 // Copyright (C) 2026 Posit Software, PBC. All rights reserved.
 //
 
+use std::rc::Rc;
+
 use amalthea::comm::comm_channel::CommMsg;
 use amalthea::comm::event::CommEvent;
 use amalthea::socket::comm::CommInitiator;
@@ -22,42 +24,31 @@ use crate::ui::UI_COMM_NAME;
 
 // All methods take `&self`.
 //
-// Regular comms use a take/remove pattern: we take the comm out of the
-// `comms` HashMap before calling the handler, so no `borrow_mut()` guard
-// is held during the call. This prevents panics if the handler reenters
-// the HashMap. For instance, a data explorer handler calls
-// `comm_open_backend` to open a child explorer for a column, which
-// needs to `borrow_mut()` the same HashMap to insert.
+// Dispatch clones the comm's `Rc` out of `comms` via `lookup_comm()` and drops
+// the map borrow before calling the handler. Two things fall out of that:
 //
-// The UI comm uses a different strategy: the handler is in its own
-// `DebugRefCell` inside the `ConsoleComm`, and we borrow the outer
-// `ui_comm: DebugRefCell<Option<ConsoleComm>>` with a shared `&` ref during
-// dispatch. This keeps the `CommHandlerContext` (and thus the outgoing channel)
-// visible to reentrant code that calls `ui_comm()`, e.g. R hooks that send
-// fire-and-forget events via `try_ui_comm()?.send_event()`.
+// 1. The map is free while the handler runs, so a handler that reenters the
+//    map is fine. For instance, a data explorer handler calls
+//    `comm_open_backend` to open a child explorer for a column, which
+//    `borrow_mut()`s the map to insert.
+//
+// 2. Unlike a take approach that moves the comm out of the map and passes by
+//    value to the handler, the comm stays in the map for the whole dispatch, and
+//    is reachable by the Console the whole time. The UI comm relies on this: R
+//    hooks send fire-and-forget events via `try_ui_comm()?.send_event().
 impl Console {
     pub(super) fn comm_handle_msg(&self, comm_id: &str, msg: CommMsg) {
-        if self.is_ui_comm(comm_id) {
-            self.with_ui_handler_mut(|handler, ctx| {
-                handler.handle_msg(msg, ctx);
-            });
+        let Some(comm) = self.lookup_comm(comm_id) else {
+            log::warn!("Received message for unknown registered comm {comm_id}");
             return;
-        }
-
-        self.with_comm_mut(comm_id, |comm| {
-            comm.handler.get_mut().handle_msg(msg, &comm.ctx);
-        });
+        };
+        comm.handler.borrow_mut().handle_msg(msg, &comm.ctx);
         self.drain_closed();
     }
 
     pub(super) fn comm_handle_close(&self, comm_id: &str) {
-        if let Some(ui) = self.take_ui_comm_if(comm_id) {
-            ui.handler.into_inner().handle_close(&ui.ctx);
-            return;
-        }
-
-        if let Some(comm) = self.take_comm(comm_id) {
-            comm.handler.into_inner().handle_close(&comm.ctx);
+        if let Some(comm) = self.remove_comm(comm_id) {
+            comm.handler.borrow_mut().handle_close(&comm.ctx);
         }
     }
 
@@ -89,13 +80,13 @@ impl Console {
         let ctx = CommHandlerContext::new(comm.outgoing_tx.clone(), self.comm_event_tx.clone());
         handler.handle_open(&ctx);
 
-        self.comms
-            .borrow_mut()
-            .insert(comm_id.clone(), ConsoleComm {
-                comm_id: comm_id.clone(),
+        self.comms.borrow_mut().insert(
+            comm_id.clone(),
+            Rc::new(ConsoleComm {
                 handler: DebugRefCell::new(handler),
                 ctx,
-            });
+            }),
+        );
 
         // Block until Shell has processed the open, ensuring the `comm_open`
         // message is on IOPub before we return. Any updates the caller sends
@@ -125,98 +116,67 @@ impl Console {
         handler.handle_open(&ctx);
 
         if comm_name == UI_COMM_NAME {
-            if let Some(old) = self.take_ui_comm() {
-                log::info!("Replacing an existing UI comm.");
-                old.handler.into_inner().handle_close(&old.ctx);
-            }
-            self.set_ui_comm(ConsoleComm {
-                comm_id,
+            self.close_ui_comm();
+            *self.ui_comm_id.borrow_mut() = Some(comm_id.clone());
+        }
+
+        self.comms.borrow_mut().insert(
+            comm_id,
+            Rc::new(ConsoleComm {
                 handler: DebugRefCell::new(handler),
                 ctx,
-            });
-        } else {
-            self.comms
-                .borrow_mut()
-                .insert(comm_id.clone(), ConsoleComm {
-                    comm_id,
-                    handler: DebugRefCell::new(handler),
-                    ctx,
-                });
-        }
+            }),
+        );
     }
 
     pub(super) fn comm_notify_environment_changed(&self, event: &EnvironmentChanged) {
-        self.with_ui_handler_mut(|handler, ctx| {
-            handler.handle_environment(event, ctx);
-        });
-
-        let ids: Vec<String> = self.comms.borrow().keys().cloned().collect();
-        for id in ids {
-            self.with_comm_mut(&id, |comm| {
-                comm.handler.get_mut().handle_environment(event, &comm.ctx);
-            });
+        // Snapshot the `Rc`s so the `comms` borrow is dropped before we run any
+        // handler (a handler may reenter `self.comms`).
+        let comms: Vec<Rc<ConsoleComm>> = self.comms.borrow().values().map(Rc::clone).collect();
+        for comm in comms {
+            comm.handler
+                .borrow_mut()
+                .handle_environment(event, &comm.ctx);
         }
         self.drain_closed();
     }
 
-    // -- UI comm helpers --------------------------------------------------
-
-    fn is_ui_comm(&self, comm_id: &str) -> bool {
-        self.ui_comm
-            .borrow()
-            .as_ref()
-            .is_some_and(|ui| ui.comm_id == comm_id)
-    }
-
-    /// Borrow the UI comm with `&`, then borrow the handler with `&mut`.
-    ///
-    /// Because the outer `RefCell` is only borrowed by shared ref, `ui_comm()`
-    /// remains functional during handler dispatch and R code that calls
-    /// back into Rust (e.g. `navigateToFile` from a `frontend_ready`
-    /// hook) can still send events on the UI comm.
-    fn with_ui_handler_mut(&self, f: impl FnOnce(&mut Box<dyn CommHandler>, &CommHandlerContext)) {
-        let guard = self.ui_comm.borrow();
-        let Some(ui) = guard.as_ref() else {
-            log::warn!("UI comm is absent during dispatch (reentrant call?)");
-            return;
-        };
-        let mut handler = ui.handler.borrow_mut();
-        f(&mut handler, &ui.ctx);
-    }
-
-    fn take_ui_comm(&self) -> Option<ConsoleComm> {
-        self.ui_comm.borrow_mut().take()
-    }
-
-    /// Take the UI comm only if its `comm_id` matches. Checks and takes
-    /// in a single `borrow_mut()` so there is no TOCTOU gap.
-    fn take_ui_comm_if(&self, comm_id: &str) -> Option<ConsoleComm> {
-        let mut guard = self.ui_comm.borrow_mut();
-        if guard.as_ref().is_some_and(|ui| ui.comm_id == comm_id) {
-            guard.take()
-        } else {
-            None
-        }
-    }
-
-    fn set_ui_comm(&self, ui: ConsoleComm) {
-        *self.ui_comm.borrow_mut() = Some(ui);
-    }
-
     // -- Comms map helpers ------------------------------------------------
 
-    /// Take a comm out, call `f`, put it back.
-    fn with_comm_mut(&self, comm_id: &str, f: impl FnOnce(&mut ConsoleComm)) {
-        let Some(mut comm) = self.take_comm(comm_id) else {
-            log::warn!("Received message for unknown registered comm {comm_id}");
-            return;
-        };
-        f(&mut comm);
-        self.comms.borrow_mut().insert(comm.comm_id.clone(), comm);
+    fn lookup_comm(&self, comm_id: &str) -> Option<Rc<ConsoleComm>> {
+        self.comms.borrow().get(comm_id).map(Rc::clone)
     }
 
-    fn take_comm(&self, comm_id: &str) -> Option<ConsoleComm> {
-        self.comms.borrow_mut().remove(comm_id)
+    pub(super) fn lookup_ui_comm(&self) -> Option<Rc<ConsoleComm>> {
+        let comm_id = self.ui_comm_id.borrow();
+        let comm_id = comm_id.as_deref()?;
+        self.lookup_comm(comm_id)
+    }
+
+    /// Remove a comm from the map, keeping the UI index in sync.
+    fn remove_comm(&self, comm_id: &str) -> Option<Rc<ConsoleComm>> {
+        let comm = self.comms.borrow_mut().remove(comm_id)?;
+
+        let mut ui_comm_id = self.ui_comm_id.borrow_mut();
+        if ui_comm_id.as_deref() == Some(comm_id) {
+            *ui_comm_id = None;
+        }
+
+        Some(comm)
+    }
+
+    /// Close and drop the currently registered UI comm, if any.
+    fn close_ui_comm(&self) {
+        let Some(old) = self
+            .ui_comm_id
+            .borrow_mut()
+            .take()
+            .and_then(|old_id| self.comms.borrow_mut().remove(&old_id))
+        else {
+            return;
+        };
+        log::info!("Replacing an existing UI comm.");
+        old.handler.borrow_mut().handle_close(&old.ctx);
     }
 
     fn drain_closed(&self) {
@@ -229,7 +189,7 @@ impl Console {
             .collect();
 
         for comm_id in closed_ids {
-            if let Some(comm) = self.take_comm(&comm_id) {
+            if let Some(comm) = self.remove_comm(&comm_id) {
                 self.comm_notify_closed(&comm_id, &comm);
             }
         }

--- a/crates/ark/src/console/console_comm.rs
+++ b/crates/ark/src/console/console_comm.rs
@@ -116,7 +116,11 @@ impl Console {
         handler.handle_open(&ctx);
 
         if comm_name == UI_COMM_NAME {
-            self.close_ui_comm();
+            let old_id = self.ui_comm_id.borrow().clone();
+            if let Some(old_id) = old_id {
+                log::info!("Replacing an existing UI comm.");
+                self.comm_handle_close(&old_id);
+            }
             *self.ui_comm_id.borrow_mut() = Some(comm_id.clone());
         }
 
@@ -163,20 +167,6 @@ impl Console {
         }
 
         Some(comm)
-    }
-
-    /// Close and drop the currently registered UI comm, if any.
-    fn close_ui_comm(&self) {
-        let Some(old) = self
-            .ui_comm_id
-            .borrow_mut()
-            .take()
-            .and_then(|old_id| self.comms.borrow_mut().remove(&old_id))
-        else {
-            return;
-        };
-        log::info!("Replacing an existing UI comm.");
-        old.handler.borrow_mut().handle_close(&old.ctx);
     }
 
     fn drain_closed(&self) {

--- a/crates/ark/src/console/console_integration.rs
+++ b/crates/ark/src/console/console_integration.rs
@@ -7,7 +7,7 @@
 
 //! Help, LSP, UI comm, and frontend method integration for the R console.
 
-use stdext::cell::DebugRef;
+use std::rc::Rc;
 
 use super::*;
 use crate::data_explorer::r_data_explorer::DataExplorerMode;
@@ -23,10 +23,9 @@ impl Console {
     }
 
     pub(crate) fn ui_comm(&self) -> Option<UiCommRef<'_>> {
-        let guard = self.ui_comm.borrow();
-        let guard = DebugRef::filter_map(guard, |opt| opt.as_ref())?;
+        let comm = self.lookup_ui_comm()?;
         Some(UiCommRef {
-            guard,
+            comm,
             originator: self
                 .active_request
                 .as_ref()
@@ -229,14 +228,14 @@ impl Console {
 ///
 /// Existence of this value guarantees the comm is connected.
 pub(crate) struct UiCommRef<'a> {
-    guard: DebugRef<'a, ConsoleComm>,
+    comm: Rc<ConsoleComm>,
     originator: Option<&'a Originator>,
     stdin_request_tx: &'a Sender<StdInRequest>,
 }
 
 impl UiCommRef<'_> {
     pub(crate) fn send_event(&self, event: &UiFrontendEvent) {
-        self.guard.ctx.send_event(event);
+        self.comm.ctx.send_event(event);
     }
 
     pub(crate) fn busy(&self, busy: bool) {

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -671,7 +671,7 @@ impl Console {
             comm_msg_originator: None,
             execution_count: 0,
             autoprint_output: String::new(),
-            ui_comm: DebugRefCell::new(None),
+            ui_comm_id: DebugRefCell::new(None),
             last_error: None,
             help_event_tx: None,
             help_port: None,


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/689 and https://github.com/posit-dev/ark/issues/691
Follow-up to https://github.com/posit-dev/ark/pull/1161 (see `console_comm.rs` changes)

See https://github.com/posit-dev/ark/pull/1075 for context: we're moving comms out of their own threads to run on the R thread, to simplify the concurrency structure of Ark and remove the risk of concurrent R evaluations which are UB (although these are now also tackled under a different angle, see https://github.com/posit-dev/ark/pull/1222).

In #1161 I made progress towards phasing out unsafe mutation on Console state (see https://github.com/posit-dev/ark/issues/1145) by using interior mutability in Console methods. To manage comm state in particular, I went for a take/move approach that removes a comm from the map of comms owned by the Console, and passes the moved comm by value to its handlers. This allowed data explorer comm handlers to manipulate the comm map and insert new explorer comms (when an inline explorer gets promoted to a full explorer).

Moving the comm was awkward with the UI comm though, which needed to be pinned down because its handlers might cause Console events that themselves require the UI comm (e.g. to send a message to the frontend). For this reason the UI comm used a different dispatch strategy with a shared borrow, that required ad hoc infrastructure.

The Help comm is also accessible from Console methods and is going to need a similar setup, so I thought I'd go ahead and try to simplify this:

- All comms now live in the map, including the UI comm. But they are now wrapped in an `Rc`.

- The dispatcher now holds an `Rc` clone of the comm rather than an exclusively owned value. The comm stays in the Console-owned map during dispatch, which is how they remain accessible for reentrancy while a handler is running. Thanks to the Rc wrapping and cloning, the comm map remains fully owned by the Console during dispatch and can be manipulated while a handler is running, allowing data explorers to clone/promote themselves.

  Note that the handler's `&mut` comes from interior mutability of the comm handler inside the `ConsoleComm`. So the one invariant we need to guarantee is that we never dispatch a comm's handler reentrantly.

- The UI comm still gets some ad hoc handling because of its "pinned" nature (there can only be one UI comm at any time, so opening a new one drops the old comm if any).

