### PR TITLE
(Sources-1) Teach `SemanticIndex` about `NamespacedAccess`es

### DIFF
--- a/crates/oak_core/src/syntax_ext.rs
+++ b/crates/oak_core/src/syntax_ext.rs
@@ -1,3 +1,4 @@
+use aether_syntax::AnyRSelector;
 use aether_syntax::RIdentifier;
 use aether_syntax::RStringValue;
 use biome_rowan::AstNode;
@@ -37,6 +38,26 @@ impl RStringValueExt for RStringValue {
         let token = self.value_token().ok()?;
         let text = token.text_trimmed();
         Some(text[1..text.len() - 1].to_string())
+    }
+}
+
+pub trait AnyRSelectorExt {
+    /// Uses [RIdentifierExt::name_text()] and [RStringValueExt::string_text()] to report
+    /// the name without backticks or quotes
+    ///
+    /// Returns [None] for [aether_syntax::AnyRSelector::RDotDotI] and
+    /// [aether_syntax::AnyRSelector::RDots], which we don't consider standard
+    /// identifiers.
+    fn identifier_text(&self) -> Option<String>;
+}
+
+impl AnyRSelectorExt for AnyRSelector {
+    fn identifier_text(&self) -> Option<String> {
+        match self {
+            AnyRSelector::RIdentifier(node) => Some(node.name_text()),
+            AnyRSelector::RStringValue(node) => node.string_text(),
+            AnyRSelector::RDots(_) | AnyRSelector::RDotDotI(_) => None,
+        }
     }
 }
 

--- a/crates/oak_db/src/identifier.rs
+++ b/crates/oak_db/src/identifier.rs
@@ -1,4 +1,3 @@
-use aether_syntax::AnyRSelector;
 use aether_syntax::RExtractExpression;
 use aether_syntax::RNamespaceExpression;
 use aether_syntax::RSyntaxKind;
@@ -8,8 +7,7 @@ use biome_rowan::AstNode;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
 use biome_rowan::TokenAtOffset;
-use oak_core::syntax_ext::RIdentifierExt;
-use oak_core::syntax_ext::RStringValueExt;
+use oak_core::syntax_ext::AnyRSelectorExt;
 
 use crate::Db;
 use crate::Definition;
@@ -158,12 +156,12 @@ impl<'db> File {
                 if op_kind != kind {
                     return None;
                 }
-                let rhs = extract.right().ok()?;
-                let (member_name, range) = selector_name_and_range(&rhs)?;
-                if member_name != name {
+                let right = extract.right().ok()?;
+                let right_name = right.identifier_text()?;
+                if right_name != name {
                     return None;
                 }
-                Some(range)
+                Some(right.syntax().text_trimmed_range())
             })
             .collect()
     }
@@ -177,16 +175,16 @@ impl<'db> File {
             .filter_map(RNamespaceExpression::cast)
             .filter_map(|namespace_expr| {
                 let left = namespace_expr.left().ok()?;
-                let (lhs_name, _) = selector_name_and_range(&left)?;
-                if lhs_name != namespace {
+                let left_name = left.identifier_text()?;
+                if left_name != namespace {
                     return None;
                 }
-                let rhs = namespace_expr.right().ok()?;
-                let (member_name, range) = selector_name_and_range(&rhs)?;
-                if member_name != name {
+                let right = namespace_expr.right().ok()?;
+                let right_name = right.identifier_text()?;
+                if right_name != name {
                     return None;
                 }
-                Some(range)
+                Some(right.syntax().text_trimmed_range())
             })
             .collect()
     }
@@ -211,9 +209,11 @@ fn classify_member(token: &RSyntaxToken) -> Option<(String, MemberKind, TextRang
         _ => return None,
     };
 
-    let rhs = extract.right().ok()?;
-    let (name, name_range) = selector_name_and_range(&rhs)?;
-    Some((name, kind, op.text_trimmed_range(), name_range))
+    let right = extract.right().ok()?;
+    let name = right.identifier_text()?;
+    let range = right.syntax().text_trimmed_range();
+
+    Some((name, kind, op.text_trimmed_range(), range))
 }
 
 /// Check whether `token` is part of a `pkg::sym` / `pkg:::sym` namespace
@@ -238,22 +238,13 @@ fn classify_namespace(
     };
 
     let left = namespace_expr.left().ok()?;
-    let (namespace, _) = selector_name_and_range(&left)?;
+    let namespace = left.identifier_text()?;
 
-    let rhs = namespace_expr.right().ok()?;
-    let (name, name_range) = selector_name_and_range(&rhs)?;
-    Some((namespace, name, part, op.text_trimmed_range(), name_range))
-}
+    let right = namespace_expr.right().ok()?;
+    let name = right.identifier_text()?;
+    let range = right.syntax().text_trimmed_range();
 
-fn selector_name_and_range(selector: &AnyRSelector) -> Option<(String, TextRange)> {
-    match selector {
-        AnyRSelector::RIdentifier(ident) => {
-            Some((ident.name_text(), ident.syntax().text_trimmed_range()))
-        },
-        AnyRSelector::RStringValue(s) => Some((s.string_text()?, s.syntax().text_trimmed_range())),
-        // Dots are not regular identifiers so we intentionally exclude them here
-        AnyRSelector::RDotDotI(_) | AnyRSelector::RDots(_) => None,
-    }
+    Some((namespace, name, part, op.text_trimmed_range(), range))
 }
 
 /// The name token the cursor is on, after snapping to the nearest name-token

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -35,8 +35,8 @@ use crate::semantic_index::DefinitionId;
 use crate::semantic_index::DefinitionKind;
 use crate::semantic_index::EnclosingSnapshotId;
 use crate::semantic_index::EnclosingSnapshotKey;
-use crate::semantic_index::NamespacedAccess;
-use crate::semantic_index::NamespacedAccessKind;
+use crate::semantic_index::NamespaceAccess;
+use crate::semantic_index::NamespaceAccessKind;
 use crate::semantic_index::Scope;
 use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
@@ -73,7 +73,7 @@ struct SemanticIndexBuilder<R: ImportsResolver> {
     pre_scans: IndexVec<ScopeId, PreScanScope>,
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
     semantic_calls: Vec<SemanticCall>,
-    namespaced_accesses: Vec<NamespacedAccess>,
+    namespace_accesses: Vec<NamespaceAccess>,
     resolver: R,
 }
 
@@ -115,7 +115,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             pre_scans,
             enclosing_snapshots: FxHashMap::default(),
             semantic_calls: Vec::new(),
-            namespaced_accesses: Vec::new(),
+            namespace_accesses: Vec::new(),
             resolver,
         }
     }
@@ -403,7 +403,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             },
 
             AnyRExpression::RNamespaceExpression(expr) => {
-                self.collect_namespaced_access(expr);
+                self.collect_namespace_access(expr);
             },
 
             AnyRExpression::RForStatement(stmt) => {
@@ -698,13 +698,13 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
-    fn collect_namespaced_access(&mut self, expr: &RNamespaceExpression) {
+    fn collect_namespace_access(&mut self, expr: &RNamespaceExpression) {
         let Ok(operator) = expr.operator() else {
             return;
         };
         let kind = match operator.kind() {
-            RSyntaxKind::COLON2 => NamespacedAccessKind::Export,
-            RSyntaxKind::COLON3 => NamespacedAccessKind::Internal,
+            RSyntaxKind::COLON2 => NamespaceAccessKind::Export,
+            RSyntaxKind::COLON3 => NamespaceAccessKind::Internal,
             _ => return,
         };
         let Some(package) = expr
@@ -722,8 +722,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             return;
         };
         let offset = expr.syntax().text_trimmed_range().start();
-        self.namespaced_accesses
-            .push(NamespacedAccess::new(package, symbol, kind, offset));
+        self.namespace_accesses
+            .push(NamespaceAccess::new(package, symbol, kind, offset));
     }
 
     fn collect_semantic_call(&mut self, call: &aether_syntax::RCall) {
@@ -927,7 +927,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             use_def_maps,
             self.enclosing_snapshots,
             self.semantic_calls,
-            self.namespaced_accesses,
+            self.namespace_accesses,
             file_final_bindings,
         )
     }

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -8,6 +8,7 @@ use aether_syntax::RArgumentList;
 use aether_syntax::RBinaryExpression;
 use aether_syntax::RExpressionList;
 use aether_syntax::RFunctionDefinition;
+use aether_syntax::RNamespaceExpression;
 use aether_syntax::RParameter;
 use aether_syntax::RParameters;
 use aether_syntax::RRoot;
@@ -20,6 +21,7 @@ use biome_rowan::AstSeparatedList;
 use biome_rowan::SyntaxNodeCast;
 use biome_rowan::TextRange;
 use biome_rowan::WalkEvent;
+use oak_core::syntax_ext::AnyRSelectorExt;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
 use oak_index_vec::Idx;
@@ -33,6 +35,8 @@ use crate::semantic_index::DefinitionId;
 use crate::semantic_index::DefinitionKind;
 use crate::semantic_index::EnclosingSnapshotId;
 use crate::semantic_index::EnclosingSnapshotKey;
+use crate::semantic_index::NamespacedAccess;
+use crate::semantic_index::NamespacedAccessKind;
 use crate::semantic_index::Scope;
 use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
@@ -69,6 +73,7 @@ struct SemanticIndexBuilder<R: ImportsResolver> {
     pre_scans: IndexVec<ScopeId, PreScanScope>,
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
     semantic_calls: Vec<SemanticCall>,
+    namespaced_accesses: Vec<NamespacedAccess>,
     resolver: R,
 }
 
@@ -110,6 +115,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             pre_scans,
             enclosing_snapshots: FxHashMap::default(),
             semantic_calls: Vec::new(),
+            namespaced_accesses: Vec::new(),
             resolver,
         }
     }
@@ -396,9 +402,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 }
             },
 
-            AnyRExpression::RNamespaceExpression(_) => {
-                // In `pkg::fn` or `pkg:::fn`, both sides are selectors, not
-                // variable references in the current scope
+            AnyRExpression::RNamespaceExpression(expr) => {
+                self.collect_namespaced_access(expr);
             },
 
             AnyRExpression::RForStatement(stmt) => {
@@ -693,6 +698,34 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
+    fn collect_namespaced_access(&mut self, expr: &RNamespaceExpression) {
+        let Ok(operator) = expr.operator() else {
+            return;
+        };
+        let kind = match operator.kind() {
+            RSyntaxKind::COLON2 => NamespacedAccessKind::Export,
+            RSyntaxKind::COLON3 => NamespacedAccessKind::Internal,
+            _ => return,
+        };
+        let Some(package) = expr
+            .left()
+            .ok()
+            .and_then(|selector| selector.identifier_text())
+        else {
+            return;
+        };
+        let Some(symbol) = expr
+            .right()
+            .ok()
+            .and_then(|selector| selector.identifier_text())
+        else {
+            return;
+        };
+        let offset = expr.syntax().text_trimmed_range().start();
+        self.namespaced_accesses
+            .push(NamespacedAccess::new(package, symbol, kind, offset));
+    }
+
     fn collect_semantic_call(&mut self, call: &aether_syntax::RCall) {
         let Ok(AnyRExpression::RIdentifier(ident)) = call.function() else {
             return;
@@ -894,6 +927,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             use_def_maps,
             self.enclosing_snapshots,
             self.semantic_calls,
+            self.namespaced_accesses,
             file_final_bindings,
         )
     }

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -718,14 +718,14 @@ impl SemanticCall {
 /// `package:::symbol`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NamespaceAccess {
-    package: String,
-    symbol: String,
-    kind: NamespaceAccessKind,
-    offset: TextSize,
+    pub(crate) package: String,
+    pub(crate) symbol: String,
+    pub(crate) kind: NamespaceAccessKind,
+    pub(crate) offset: TextSize,
 }
 
 impl NamespaceAccess {
-    pub fn new(
+    pub(crate) fn new(
         package: String,
         symbol: String,
         kind: NamespaceAccessKind,

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -81,9 +81,9 @@ pub struct SemanticIndex {
     // attachments or `source()` injections.
     semantic_calls: Vec<SemanticCall>,
 
-    // Namespaced accesses recorded during indexing, i.e. `package::symbol` or
+    // Namespace accesses recorded during indexing, i.e. `package::symbol` or
     // `package:::symbol`
-    namespaced_accesses: Vec<NamespacedAccess>,
+    namespace_accesses: Vec<NamespaceAccess>,
 
     // The file scope's exit flow state: for each top-level symbol, the
     // definitions still in effect once the file has run top to bottom. This is
@@ -101,7 +101,7 @@ impl SemanticIndex {
         use_def_maps: IndexVec<ScopeId, Arc<UseDefMap>>,
         enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
         semantic_calls: Vec<SemanticCall>,
-        namespaced_accesses: Vec<NamespacedAccess>,
+        namespace_accesses: Vec<NamespaceAccess>,
         final_bindings: IndexVec<SymbolId, Bindings>,
     ) -> Self {
         Self {
@@ -112,7 +112,7 @@ impl SemanticIndex {
             use_def_maps,
             enclosing_snapshots,
             semantic_calls,
-            namespaced_accesses,
+            namespace_accesses,
             final_bindings,
         }
     }
@@ -184,10 +184,10 @@ impl SemanticIndex {
         &self.semantic_calls
     }
 
-    /// Namespaced accesses recorded during indexing, i.e. `package::symbol` or
+    /// Namespace accesses recorded during indexing, i.e. `package::symbol` or
     /// `package:::symbol`
-    pub fn namespaced_accesses(&self) -> &[NamespacedAccess] {
-        &self.namespaced_accesses
+    pub fn namespace_accesses(&self) -> &[NamespaceAccess] {
+        &self.namespace_accesses
     }
 
     /// Find the innermost scope containing `offset`.
@@ -714,21 +714,21 @@ impl SemanticCall {
     }
 }
 
-/// Namespaced access recorded during indexing, i.e. `package::symbol` or
+/// Namespace access recorded during indexing, i.e. `package::symbol` or
 /// `package:::symbol`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NamespacedAccess {
+pub struct NamespaceAccess {
     package: String,
     symbol: String,
-    kind: NamespacedAccessKind,
+    kind: NamespaceAccessKind,
     offset: TextSize,
 }
 
-impl NamespacedAccess {
+impl NamespaceAccess {
     pub fn new(
         package: String,
         symbol: String,
-        kind: NamespacedAccessKind,
+        kind: NamespaceAccessKind,
         offset: TextSize,
     ) -> Self {
         Self {
@@ -747,7 +747,7 @@ impl NamespacedAccess {
         &self.symbol
     }
 
-    pub fn kind(&self) -> NamespacedAccessKind {
+    pub fn kind(&self) -> NamespaceAccessKind {
         self.kind
     }
 
@@ -757,7 +757,7 @@ impl NamespacedAccess {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NamespacedAccessKind {
+pub enum NamespaceAccessKind {
     /// `::`
     Export,
     /// `:::`

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -81,6 +81,10 @@ pub struct SemanticIndex {
     // attachments or `source()` injections.
     semantic_calls: Vec<SemanticCall>,
 
+    // Namespaced accesses recorded during indexing, i.e. `package::symbol` or
+    // `package:::symbol`
+    namespaced_accesses: Vec<NamespacedAccess>,
+
     // The file scope's exit flow state: for each top-level symbol, the
     // definitions still in effect once the file has run top to bottom. This is
     // the file's exports (see `exports()`). Only the file scope's exit state is
@@ -97,6 +101,7 @@ impl SemanticIndex {
         use_def_maps: IndexVec<ScopeId, Arc<UseDefMap>>,
         enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, (ScopeId, EnclosingSnapshotId)>,
         semantic_calls: Vec<SemanticCall>,
+        namespaced_accesses: Vec<NamespacedAccess>,
         final_bindings: IndexVec<SymbolId, Bindings>,
     ) -> Self {
         Self {
@@ -107,6 +112,7 @@ impl SemanticIndex {
             use_def_maps,
             enclosing_snapshots,
             semantic_calls,
+            namespaced_accesses,
             final_bindings,
         }
     }
@@ -176,6 +182,12 @@ impl SemanticIndex {
     /// during indexing.
     pub fn semantic_calls(&self) -> &[SemanticCall] {
         &self.semantic_calls
+    }
+
+    /// Namespaced accesses recorded during indexing, i.e. `package::symbol` or
+    /// `package:::symbol`
+    pub fn namespaced_accesses(&self) -> &[NamespacedAccess] {
+        &self.namespaced_accesses
     }
 
     /// Find the innermost scope containing `offset`.
@@ -700,6 +712,56 @@ impl SemanticCall {
     pub fn scope(&self) -> ScopeId {
         self.scope
     }
+}
+
+/// Namespaced access recorded during indexing, i.e. `package::symbol` or
+/// `package:::symbol`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespacedAccess {
+    package: String,
+    symbol: String,
+    kind: NamespacedAccessKind,
+    offset: TextSize,
+}
+
+impl NamespacedAccess {
+    pub fn new(
+        package: String,
+        symbol: String,
+        kind: NamespacedAccessKind,
+        offset: TextSize,
+    ) -> Self {
+        Self {
+            package,
+            symbol,
+            kind,
+            offset,
+        }
+    }
+
+    pub fn package(&self) -> &str {
+        &self.package
+    }
+
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+
+    pub fn kind(&self) -> NamespacedAccessKind {
+        self.kind
+    }
+
+    pub fn offset(&self) -> TextSize {
+        self.offset
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamespacedAccessKind {
+    /// `::`
+    Export,
+    /// `:::`
+    Internal,
 }
 
 // --- Iterators ---

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -4,7 +4,6 @@ use aether_syntax::RSyntaxKind;
 use oak_semantic::build_index;
 use oak_semantic::semantic_index::DefinitionId;
 use oak_semantic::semantic_index::DefinitionKind;
-use oak_semantic::semantic_index::NamespaceAccess;
 use oak_semantic::semantic_index::NamespaceAccessKind;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::ScopeKind;
@@ -1509,68 +1508,91 @@ fn test_source_call_emitted_without_resolver() {
     assert_eq!(index.semantic_calls().len(), 1);
 }
 
-fn export(package: &str, symbol: &str, offset: u32) -> NamespaceAccess {
-    NamespaceAccess::new(
-        package.into(),
-        symbol.into(),
-        NamespaceAccessKind::Export,
-        biome_rowan::TextSize::from(offset),
-    )
-}
-
-fn internal(package: &str, symbol: &str, offset: u32) -> NamespaceAccess {
-    NamespaceAccess::new(
-        package.into(),
-        symbol.into(),
-        NamespaceAccessKind::Internal,
-        biome_rowan::TextSize::from(offset),
-    )
+/// Project each access into a comparable tuple via the public accessors.
+fn accesses(index: &SemanticIndex) -> Vec<(&str, &str, NamespaceAccessKind, u32)> {
+    index
+        .namespace_accesses()
+        .iter()
+        .map(|access| {
+            (
+                access.package(),
+                access.symbol(),
+                access.kind(),
+                access.offset().into(),
+            )
+        })
+        .collect()
 }
 
 #[test]
 fn test_namespace_access_export() {
     let index = index("dplyr::filter");
-    assert_eq!(index.namespace_accesses(), [export("dplyr", "filter", 0)]);
+    assert_eq!(accesses(&index), [(
+        "dplyr",
+        "filter",
+        NamespaceAccessKind::Export,
+        0
+    )]);
 }
 
 #[test]
 fn test_namespace_access_internal() {
     let index = index("rlang:::abort");
-    assert_eq!(index.namespace_accesses(), [internal("rlang", "abort", 0)]);
+    assert_eq!(accesses(&index), [(
+        "rlang",
+        "abort",
+        NamespaceAccessKind::Internal,
+        0
+    )]);
 }
 
 #[test]
 fn test_namespace_access_backtick_quoted() {
     let index = index("`my pkg`::`my fn`");
-    assert_eq!(index.namespace_accesses(), [export("my pkg", "my fn", 0)]);
+    assert_eq!(accesses(&index), [(
+        "my pkg",
+        "my fn",
+        NamespaceAccessKind::Export,
+        0
+    )]);
 }
 
 #[test]
 fn test_namespace_access_string_selectors() {
     let index = index("dplyr::\"filter\"");
-    assert_eq!(index.namespace_accesses(), [export("dplyr", "filter", 0)]);
+    assert_eq!(accesses(&index), [(
+        "dplyr",
+        "filter",
+        NamespaceAccessKind::Export,
+        0
+    )]);
 }
 
 #[test]
 fn test_namespace_accesses_in_order() {
     let index = index("dplyr::filter\nrlang:::abort\ntidyr::pivot_longer");
-    assert_eq!(index.namespace_accesses(), [
-        export("dplyr", "filter", 0),
-        internal("rlang", "abort", 14),
-        export("tidyr", "pivot_longer", 28),
+    assert_eq!(accesses(&index), [
+        ("dplyr", "filter", NamespaceAccessKind::Export, 0),
+        ("rlang", "abort", NamespaceAccessKind::Internal, 14),
+        ("tidyr", "pivot_longer", NamespaceAccessKind::Export, 28),
     ]);
 }
 
 #[test]
 fn test_namespace_access_inside_call() {
     let index = index("dplyr::filter(x, y > 1)");
-    assert_eq!(index.namespace_accesses(), [export("dplyr", "filter", 0)]);
+    assert_eq!(accesses(&index), [(
+        "dplyr",
+        "filter",
+        NamespaceAccessKind::Export,
+        0
+    )]);
 }
 
 #[test]
 fn test_no_namespace_accesses() {
     let index = index("x <- 1\nf(y)");
-    assert_eq!(index.namespace_accesses(), Vec::<NamespaceAccess>::new());
+    assert!(accesses(&index).is_empty());
 }
 
 #[test]

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -4,8 +4,8 @@ use aether_syntax::RSyntaxKind;
 use oak_semantic::build_index;
 use oak_semantic::semantic_index::DefinitionId;
 use oak_semantic::semantic_index::DefinitionKind;
-use oak_semantic::semantic_index::NamespacedAccess;
-use oak_semantic::semantic_index::NamespacedAccessKind;
+use oak_semantic::semantic_index::NamespaceAccess;
+use oak_semantic::semantic_index::NamespaceAccessKind;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::ScopeKind;
 use oak_semantic::semantic_index::SemanticCallKind;
@@ -1509,52 +1509,52 @@ fn test_source_call_emitted_without_resolver() {
     assert_eq!(index.semantic_calls().len(), 1);
 }
 
-fn export(package: &str, symbol: &str, offset: u32) -> NamespacedAccess {
-    NamespacedAccess::new(
+fn export(package: &str, symbol: &str, offset: u32) -> NamespaceAccess {
+    NamespaceAccess::new(
         package.into(),
         symbol.into(),
-        NamespacedAccessKind::Export,
+        NamespaceAccessKind::Export,
         biome_rowan::TextSize::from(offset),
     )
 }
 
-fn internal(package: &str, symbol: &str, offset: u32) -> NamespacedAccess {
-    NamespacedAccess::new(
+fn internal(package: &str, symbol: &str, offset: u32) -> NamespaceAccess {
+    NamespaceAccess::new(
         package.into(),
         symbol.into(),
-        NamespacedAccessKind::Internal,
+        NamespaceAccessKind::Internal,
         biome_rowan::TextSize::from(offset),
     )
 }
 
 #[test]
-fn test_namespaced_access_export() {
+fn test_namespace_access_export() {
     let index = index("dplyr::filter");
-    assert_eq!(index.namespaced_accesses(), [export("dplyr", "filter", 0)]);
+    assert_eq!(index.namespace_accesses(), [export("dplyr", "filter", 0)]);
 }
 
 #[test]
-fn test_namespaced_access_internal() {
+fn test_namespace_access_internal() {
     let index = index("rlang:::abort");
-    assert_eq!(index.namespaced_accesses(), [internal("rlang", "abort", 0)]);
+    assert_eq!(index.namespace_accesses(), [internal("rlang", "abort", 0)]);
 }
 
 #[test]
-fn test_namespaced_access_backtick_quoted() {
+fn test_namespace_access_backtick_quoted() {
     let index = index("`my pkg`::`my fn`");
-    assert_eq!(index.namespaced_accesses(), [export("my pkg", "my fn", 0)]);
+    assert_eq!(index.namespace_accesses(), [export("my pkg", "my fn", 0)]);
 }
 
 #[test]
-fn test_namespaced_access_string_selectors() {
+fn test_namespace_access_string_selectors() {
     let index = index("dplyr::\"filter\"");
-    assert_eq!(index.namespaced_accesses(), [export("dplyr", "filter", 0)]);
+    assert_eq!(index.namespace_accesses(), [export("dplyr", "filter", 0)]);
 }
 
 #[test]
-fn test_namespaced_accesses_in_order() {
+fn test_namespace_accesses_in_order() {
     let index = index("dplyr::filter\nrlang:::abort\ntidyr::pivot_longer");
-    assert_eq!(index.namespaced_accesses(), [
+    assert_eq!(index.namespace_accesses(), [
         export("dplyr", "filter", 0),
         internal("rlang", "abort", 14),
         export("tidyr", "pivot_longer", 28),
@@ -1562,15 +1562,15 @@ fn test_namespaced_accesses_in_order() {
 }
 
 #[test]
-fn test_namespaced_access_inside_call() {
+fn test_namespace_access_inside_call() {
     let index = index("dplyr::filter(x, y > 1)");
-    assert_eq!(index.namespaced_accesses(), [export("dplyr", "filter", 0)]);
+    assert_eq!(index.namespace_accesses(), [export("dplyr", "filter", 0)]);
 }
 
 #[test]
-fn test_no_namespaced_accesses() {
+fn test_no_namespace_accesses() {
     let index = index("x <- 1\nf(y)");
-    assert_eq!(index.namespaced_accesses(), Vec::<NamespacedAccess>::new());
+    assert_eq!(index.namespace_accesses(), Vec::<NamespaceAccess>::new());
 }
 
 #[test]

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -4,6 +4,8 @@ use aether_syntax::RSyntaxKind;
 use oak_semantic::build_index;
 use oak_semantic::semantic_index::DefinitionId;
 use oak_semantic::semantic_index::DefinitionKind;
+use oak_semantic::semantic_index::NamespacedAccess;
+use oak_semantic::semantic_index::NamespacedAccessKind;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::ScopeKind;
 use oak_semantic::semantic_index::SemanticCallKind;
@@ -523,12 +525,15 @@ fn test_at_extraction() {
 
 #[test]
 fn test_namespace_expression_no_uses() {
+    // Both sides of `::` are selectors, not variable references in the current
+    // scope, so neither the package nor the symbol becomes a use or a symbol.
     let index = index("dplyr::filter");
     let file = ScopeId::from(0);
 
     assert!(index.symbols(file).get("dplyr").is_none());
     assert!(index.symbols(file).get("filter").is_none());
     assert_eq!(index.symbols(file).len(), 0);
+    assert_eq!(index.uses(file).len(), 0);
 }
 
 #[test]
@@ -1502,6 +1507,70 @@ fn test_source_call_emitted_without_resolver() {
     let file_scope = ScopeId::from(0);
     assert_eq!(index.definitions(file_scope).iter().count(), 0);
     assert_eq!(index.semantic_calls().len(), 1);
+}
+
+fn export(package: &str, symbol: &str, offset: u32) -> NamespacedAccess {
+    NamespacedAccess::new(
+        package.into(),
+        symbol.into(),
+        NamespacedAccessKind::Export,
+        biome_rowan::TextSize::from(offset),
+    )
+}
+
+fn internal(package: &str, symbol: &str, offset: u32) -> NamespacedAccess {
+    NamespacedAccess::new(
+        package.into(),
+        symbol.into(),
+        NamespacedAccessKind::Internal,
+        biome_rowan::TextSize::from(offset),
+    )
+}
+
+#[test]
+fn test_namespaced_access_export() {
+    let index = index("dplyr::filter");
+    assert_eq!(index.namespaced_accesses(), [export("dplyr", "filter", 0)]);
+}
+
+#[test]
+fn test_namespaced_access_internal() {
+    let index = index("rlang:::abort");
+    assert_eq!(index.namespaced_accesses(), [internal("rlang", "abort", 0)]);
+}
+
+#[test]
+fn test_namespaced_access_backtick_quoted() {
+    let index = index("`my pkg`::`my fn`");
+    assert_eq!(index.namespaced_accesses(), [export("my pkg", "my fn", 0)]);
+}
+
+#[test]
+fn test_namespaced_access_string_selectors() {
+    let index = index("dplyr::\"filter\"");
+    assert_eq!(index.namespaced_accesses(), [export("dplyr", "filter", 0)]);
+}
+
+#[test]
+fn test_namespaced_accesses_in_order() {
+    let index = index("dplyr::filter\nrlang:::abort\ntidyr::pivot_longer");
+    assert_eq!(index.namespaced_accesses(), [
+        export("dplyr", "filter", 0),
+        internal("rlang", "abort", 14),
+        export("tidyr", "pivot_longer", 28),
+    ]);
+}
+
+#[test]
+fn test_namespaced_access_inside_call() {
+    let index = index("dplyr::filter(x, y > 1)");
+    assert_eq!(index.namespaced_accesses(), [export("dplyr", "filter", 0)]);
+}
+
+#[test]
+fn test_no_namespaced_accesses() {
+    let index = index("x <- 1\nf(y)");
+    assert_eq!(index.namespaced_accesses(), Vec::<NamespacedAccess>::new());
 }
 
 #[test]


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1234

The `SemanticIndex` now records instances of `::` and `:::` in its CST walk.

This is going to be useful as one of many ways to detect which packages are used by a workspace.

They are recorded as

```rust
pub struct NamespacedAccess {
    package: String,
    symbol: String,
    kind: NamespacedAccessKind,
    offset: TextSize,
}
```

_Realllllly_ for package source requests we only need `package`, but my hypothesis is that the rest of this information is going to be useful in the future as well, and I think they should be pretty small. And if you take a step back, it also seems like it would be a bit weird for the `SemanticIndex` to expose the package list, but not where it originated from.