### PR TITLE
(Sources-4) Implement `Event::SourceCompleted` for installed package sources

### DIFF
--- a/crates/ark/src/lsp.rs
+++ b/crates/ark/src/lsp.rs
@@ -32,6 +32,7 @@ pub mod inputs;
 pub mod main_loop;
 pub mod markdown;
 pub(crate) mod open_file;
+pub mod sources;
 
 pub mod find_references;
 pub mod rename;

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -53,6 +53,8 @@ use crate::lsp::diagnostics::generate_diagnostics;
 use crate::lsp::handlers;
 use crate::lsp::indexer;
 use crate::lsp::open_file::OpenFile;
+use crate::lsp::sources::SourceCompleted;
+use crate::lsp::sources::SourceManager;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers;
 use crate::lsp::state_handlers::ConsoleInputs;
@@ -98,6 +100,7 @@ pub(crate) enum Event {
     Lsp(LspMessage),
     Kernel(KernelNotification),
     OakScanCompleted(ScanCompleted),
+    SourceCompleted(SourceCompleted),
 }
 
 #[derive(Debug)]
@@ -189,6 +192,24 @@ pub(crate) struct LspState {
     /// main-loop handlers. Must be out of [`WorldState`] because the scheduler
     /// is not clonable.
     pub(crate) oak_scheduler: ScanScheduler,
+
+    /// Manager of [crate::lsp::sources::SourceRequest]s. Dispatches and source
+    /// consumption all happen from the main loop.
+    pub(crate) source_manager: SourceManager,
+}
+
+impl LspState {
+    pub(crate) fn new(
+        console_notification_tx: TokioUnboundedSender<ConsoleNotification>,
+        source_manager: SourceManager,
+    ) -> Self {
+        Self {
+            capabilities: Capabilities::default(),
+            console_notification_tx,
+            oak_scheduler: ScanScheduler::new(),
+            source_manager,
+        }
+    }
 }
 
 /// State for the auxiliary loop
@@ -246,28 +267,19 @@ impl GlobalState {
 
         Self::from_parts(
             client,
-            console_notification_tx,
             WorldState::new(db, library),
+            LspState::new(console_notification_tx, SourceManager::new(None)),
         )
     }
 
-    /// Assemble the state around an already-built `WorldState`. Splitting this
-    /// out from [`GlobalState::new`] lets tests construct a state without the
-    /// R `.libPaths()` lookup that `new` does.
-    fn from_parts(
-        client: Client,
-        console_notification_tx: TokioUnboundedSender<ConsoleNotification>,
-        world: WorldState,
-    ) -> Self {
+    /// Assemble the state around an already-built [`WorldState`] and
+    /// [`LspState`]. Splitting this out from [`GlobalState::new`] lets tests
+    /// construct a state without the R `.libPaths()` lookup that `new` does, and
+    /// with a db / provider configured up front.
+    pub(crate) fn from_parts(client: Client, world: WorldState, lsp_state: LspState) -> Self {
         // Transmission channel for the main loop events. Shared with the
         // tower-lsp backend and the Jupyter kernel.
         let (events_tx, events_rx) = tokio_unbounded_channel::<Event>();
-
-        let lsp_state = LspState {
-            capabilities: Capabilities::default(),
-            console_notification_tx,
-            oak_scheduler: ScanScheduler::new(),
-        };
 
         Self {
             world,
@@ -544,6 +556,12 @@ impl GlobalState {
                     warm_workspace_index(self.world.db.clone());
                 }
             },
+
+            Event::SourceCompleted(SourceCompleted { package, response }) => {
+                if let Some(directory) = self.lsp_state.source_manager.finish(package, response) {
+                    self.world.db.set_package_sources(package, &directory);
+                }
+            },
         }
         lsp::log_info!("Finished handling event in {}ms", loop_tick.elapsed().as_millis());
 
@@ -555,6 +573,9 @@ impl GlobalState {
         if salsa::plumbing::current_revision(&self.world.db) != old_revision {
             lsp::log_info!("World state revision advanced");
             diagnostics_refresh_all(&self.world);
+            self.lsp_state
+                .source_manager
+                .dispatch(&self.world.db, &self.events_tx);
         }
 
         Ok(())
@@ -587,21 +608,15 @@ impl GlobalState {
 /// real `handle_event()` and the private channels rather than a reconstruction.
 #[cfg(test)]
 impl GlobalState {
-    /// Build a state with an empty db and no R library paths. Takes a `client`
-    /// because the struct holds one, but the event paths exercised in tests
-    /// never touch it.
-    pub(crate) fn new_test(client: Client) -> Self {
-        let (console_notification_tx, _) = tokio_unbounded_channel::<ConsoleNotification>();
-        let world = WorldState::new(OakDatabase::new(), Library::new(vec![]));
-        Self::from_parts(client, console_notification_tx, world)
-    }
-
-    /// Run `event` through the real `handle_event`, then pump the scan
-    /// completions it spawns until the scheduler goes idle. This is what
-    /// `main_loop()` does, minus the surrounding `loop`.
+    /// Run `event` through the real `handle_event`, then pump any pending
+    /// events until we reach quiescence. This includes:
+    /// - Pending oak scans
+    /// - Pending source requests
     pub(crate) async fn handle_event_to_quiescence(&mut self, event: Event) {
         self.handle_event(event).await.unwrap();
-        while self.lsp_state.oak_scheduler.has_pending_scans() {
+        while self.lsp_state.oak_scheduler.has_pending_scans() ||
+            self.lsp_state.source_manager.has_pending()
+        {
             let event = self.next_event().await;
             self.handle_event(event).await.unwrap();
         }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -54,7 +54,7 @@ use crate::lsp::handlers;
 use crate::lsp::indexer;
 use crate::lsp::open_file::OpenFile;
 use crate::lsp::sources::SourceCompleted;
-use crate::lsp::sources::SourceManager;
+use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers;
 use crate::lsp::state_handlers::ConsoleInputs;
@@ -193,21 +193,21 @@ pub(crate) struct LspState {
     /// is not clonable.
     pub(crate) oak_scheduler: ScanScheduler,
 
-    /// Manager of [crate::lsp::sources::SourceRequest]s. Dispatches and source
+    /// Scheduler of [crate::lsp::sources::SourceRequest]s. Scheduling and source
     /// consumption all happen from the main loop.
-    pub(crate) source_manager: SourceManager,
+    pub(crate) source_scheduler: SourceScheduler,
 }
 
 impl LspState {
     pub(crate) fn new(
         console_notification_tx: TokioUnboundedSender<ConsoleNotification>,
-        source_manager: SourceManager,
+        source_scheduler: SourceScheduler,
     ) -> Self {
         Self {
             capabilities: Capabilities::default(),
             console_notification_tx,
             oak_scheduler: ScanScheduler::new(),
-            source_manager,
+            source_scheduler,
         }
     }
 }
@@ -268,7 +268,7 @@ impl GlobalState {
         Self::from_parts(
             client,
             WorldState::new(db, library),
-            LspState::new(console_notification_tx, SourceManager::new(None)),
+            LspState::new(console_notification_tx, SourceScheduler::new(None)),
         )
     }
 
@@ -558,7 +558,7 @@ impl GlobalState {
             },
 
             Event::SourceCompleted(SourceCompleted { package, response }) => {
-                if let Some(directory) = self.lsp_state.source_manager.finish(package, response) {
+                if let Some(directory) = self.lsp_state.source_scheduler.finish(package, response) {
                     self.world.db.set_package_sources(package, &directory);
                 }
             },
@@ -574,8 +574,8 @@ impl GlobalState {
             lsp::log_info!("World state revision advanced");
             diagnostics_refresh_all(&self.world);
             self.lsp_state
-                .source_manager
-                .dispatch(&self.world.db, &self.events_tx);
+                .source_scheduler
+                .schedule(&self.world.db, &self.events_tx);
         }
 
         Ok(())
@@ -615,7 +615,7 @@ impl GlobalState {
     pub(crate) async fn handle_event_to_quiescence(&mut self, event: Event) {
         self.handle_event(event).await.unwrap();
         while self.lsp_state.oak_scheduler.has_pending_scans() ||
-            self.lsp_state.source_manager.has_pending()
+            self.lsp_state.source_scheduler.has_pending()
         {
             let event = self.next_event().await;
             self.handle_event(event).await.unwrap();

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -11,12 +11,12 @@ use stdext::result::ResultExt;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::TokioUnboundedSender;
 
-/// Provide R source files for an installed package
+/// Handle source requests to provide R source files for an installed package
 ///
 /// Implementations live outside of oak, oak is only in charge of ingesting the
 /// returned directory.
-pub(crate) trait SourceProvider: Send + Sync {
-    fn provide(&self, request: &SourceRequest) -> SourceResponse;
+pub(crate) trait SourceHandler: Send + Sync {
+    fn handle(&self, request: &SourceRequest) -> SourceResponse;
 }
 
 #[derive(Debug, Clone)]
@@ -26,7 +26,7 @@ pub(crate) struct SourceRequest {
     library_path: PathBuf,
 }
 
-// TODO!: Remove when we have a production `SourceProvider`
+// TODO!: Remove when we have a production `SourceHandler`
 #[cfg_attr(not(test), expect(dead_code))]
 #[derive(Debug)]
 pub(crate) enum SourceResponse {
@@ -49,21 +49,21 @@ enum SourceState {
 }
 
 pub(crate) struct SourceManager {
-    // TODO!: Remove the `Option<>` when we implement a production `SourceProvider`
-    provider: Option<Arc<dyn SourceProvider>>,
+    // TODO!: Remove the `Option<>` when we implement a production `SourceHandler`
+    handler: Option<Arc<dyn SourceHandler>>,
     state: HashMap<Package, SourceState>,
 }
 
 impl SourceManager {
-    pub(crate) fn new(provider: Option<Arc<dyn SourceProvider>>) -> Self {
+    pub(crate) fn new(handler: Option<Arc<dyn SourceHandler>>) -> Self {
         Self {
-            provider,
+            handler,
             state: HashMap::new(),
         }
     }
 
     pub(crate) fn dispatch(&mut self, db: &dyn Db, events_tx: &TokioUnboundedSender<Event>) {
-        let Some(provider) = &self.provider else {
+        let Some(handler) = &self.handler else {
             return;
         };
 
@@ -82,14 +82,14 @@ impl SourceManager {
                 continue;
             };
 
-            let provider = Arc::clone(provider);
+            let handler = Arc::clone(handler);
             let tx = events_tx.clone();
 
             // Set to `Pending` after all possible early exits
             self.state.insert(package, SourceState::Pending);
 
             crate::lsp::spawn_blocking(move || {
-                let response = provider.provide(&request);
+                let response = handler.handle(&request);
 
                 tx.send(Event::SourceCompleted(SourceCompleted {
                     package,
@@ -170,19 +170,19 @@ impl SourceRequest {
         })
     }
 
-    // TODO!: Remove when we have a production `SourceProvider`
+    // TODO!: Remove when we have a production `SourceHandler`
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn name(&self) -> &str {
         &self.name
     }
 
-    // TODO!: Remove when we have a production `SourceProvider`
+    // TODO!: Remove when we have a production `SourceHandler`
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn version(&self) -> &str {
         &self.version
     }
 
-    // TODO!: Remove when we have a production `SourceProvider`
+    // TODO!: Remove when we have a production `SourceHandler`
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn library_path(&self) -> &Path {
         &self.library_path

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -1,0 +1,190 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aether_path::FilePath;
+use oak_db::Db;
+use oak_db::Package;
+use stdext::result::ResultExt;
+
+use crate::lsp::main_loop::Event;
+use crate::lsp::main_loop::TokioUnboundedSender;
+
+/// Provide R source files for an installed package
+///
+/// Implementations live outside of oak, oak is only in charge of ingesting the
+/// returned directory.
+pub(crate) trait SourceProvider: Send + Sync {
+    fn provide(&self, request: &SourceRequest) -> SourceResponse;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceRequest {
+    name: String,
+    version: String,
+    library_path: PathBuf,
+}
+
+// TODO!: Remove when we have a production `SourceProvider`
+#[cfg_attr(not(test), expect(dead_code))]
+#[derive(Debug)]
+pub(crate) enum SourceResponse {
+    Success(PathBuf),
+    Failed,
+    Retry,
+}
+
+#[derive(Debug)]
+pub(crate) struct SourceCompleted {
+    pub(crate) package: Package,
+    pub(crate) response: SourceResponse,
+}
+
+enum SourceState {
+    Pending,
+    Success,
+    Failed,
+    Retry,
+}
+
+pub(crate) struct SourceManager {
+    // TODO!: Remove the `Option<>` when we implement a production `SourceProvider`
+    provider: Option<Arc<dyn SourceProvider>>,
+    state: HashMap<Package, SourceState>,
+}
+
+impl SourceManager {
+    pub(crate) fn new(provider: Option<Arc<dyn SourceProvider>>) -> Self {
+        Self {
+            provider,
+            state: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn dispatch(&mut self, db: &dyn Db, events_tx: &TokioUnboundedSender<Event>) {
+        let Some(provider) = &self.provider else {
+            return;
+        };
+
+        // For each package used by the workspace, request its sources if we have never
+        // seen it before (or if it needs a retry)
+        for package in oak_db::workspace_dependencies(db) {
+            if !self.should_dispatch(package) {
+                continue;
+            }
+
+            let package = *package;
+
+            let Some(request) = SourceRequest::from_package(db, &package).log_err() else {
+                // Never retry this package if we couldn't convert it to a source request
+                self.state.insert(package, SourceState::Failed);
+                continue;
+            };
+
+            let provider = Arc::clone(provider);
+            let tx = events_tx.clone();
+
+            // Set to `Pending` after all possible early exits
+            self.state.insert(package, SourceState::Pending);
+
+            crate::lsp::spawn_blocking(move || {
+                let response = provider.provide(&request);
+
+                tx.send(Event::SourceCompleted(SourceCompleted {
+                    package,
+                    response,
+                }))
+                .log_err();
+
+                Ok(None)
+            });
+        }
+    }
+
+    fn should_dispatch(&self, package: &Package) -> bool {
+        match self.state.get(package) {
+            Some(state) => match state {
+                SourceState::Pending => false,
+                SourceState::Success => false,
+                SourceState::Failed => false,
+                SourceState::Retry => true,
+            },
+            None => true,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn finish(&mut self, package: Package, response: SourceResponse) -> Option<PathBuf> {
+        let (next, directory) = match response {
+            SourceResponse::Success(directory) => (SourceState::Success, Some(directory)),
+            SourceResponse::Failed => (SourceState::Failed, None),
+            SourceResponse::Retry => (SourceState::Retry, None),
+        };
+        self.state.insert(package, next);
+        directory
+    }
+
+    /// Whether any source request is in flight. Allows tests to deterministically "wait"
+    /// for pending source requests to finish.
+    #[cfg(test)]
+    pub(crate) fn has_pending(&self) -> bool {
+        self.state
+            .values()
+            .any(|state| matches!(state, SourceState::Pending))
+    }
+}
+
+impl SourceRequest {
+    fn from_package(db: &dyn Db, package: &Package) -> anyhow::Result<Self> {
+        let name = package.name(db).clone();
+
+        let Some(version) = package.version(db).to_owned() else {
+            return Err(anyhow::anyhow!(
+                "Package {name} is missing a version to provide sources for."
+            ));
+        };
+
+        let library_path = match package.description_path(db) {
+            FilePath::File(path) => {
+                match path.as_path().as_std_path().parent().and_then(Path::parent) {
+                    Some(library_path) => library_path.to_path_buf(),
+                    None => {
+                        return Err(anyhow::anyhow!(
+                            "Package {name} does not have an associated library path."
+                        ))
+                    },
+                }
+            },
+            FilePath::Virtual(uri) => {
+                return Err(anyhow::anyhow!(
+                    "Package {name} is unexpectedly a virtual uri {uri}."
+                ))
+            },
+        };
+
+        Ok(Self {
+            name,
+            version,
+            library_path,
+        })
+    }
+
+    // TODO!: Remove when we have a production `SourceProvider`
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    // TODO!: Remove when we have a production `SourceProvider`
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn version(&self) -> &str {
+        &self.version
+    }
+
+    // TODO!: Remove when we have a production `SourceProvider`
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn library_path(&self) -> &Path {
+        &self.library_path
+    }
+}

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -48,13 +48,13 @@ enum SourceState {
     Retry,
 }
 
-pub(crate) struct SourceManager {
+pub(crate) struct SourceScheduler {
     // TODO!: Remove the `Option<>` when we implement a production `SourceHandler`
     handler: Option<Arc<dyn SourceHandler>>,
     state: HashMap<Package, SourceState>,
 }
 
-impl SourceManager {
+impl SourceScheduler {
     pub(crate) fn new(handler: Option<Arc<dyn SourceHandler>>) -> Self {
         Self {
             handler,
@@ -62,7 +62,7 @@ impl SourceManager {
         }
     }
 
-    pub(crate) fn dispatch(&mut self, db: &dyn Db, events_tx: &TokioUnboundedSender<Event>) {
+    pub(crate) fn schedule(&mut self, db: &dyn Db, events_tx: &TokioUnboundedSender<Event>) {
         let Some(handler) = &self.handler else {
             return;
         };
@@ -70,7 +70,7 @@ impl SourceManager {
         // For each package used by the workspace, request its sources if we have never
         // seen it before (or if it needs a retry)
         for package in oak_db::workspace_dependencies(db) {
-            if !self.should_dispatch(package) {
+            if !self.should_schedule(package) {
                 continue;
             }
 
@@ -102,7 +102,7 @@ impl SourceManager {
         }
     }
 
-    fn should_dispatch(&self, package: &Package) -> bool {
+    fn should_schedule(&self, package: &Package) -> bool {
         match self.state.get(package) {
             Some(state) => match state {
                 SourceState::Pending => false,

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -31,8 +31,7 @@ pub(crate) struct SourceRequest {
 #[derive(Debug)]
 pub(crate) enum SourceResponse {
     Success(PathBuf),
-    Failed,
-    Retry,
+    Failure,
 }
 
 #[derive(Debug)]
@@ -41,11 +40,18 @@ pub(crate) struct SourceCompleted {
     pub(crate) response: SourceResponse,
 }
 
+/// State of a particular [Package]'s [SourceRequest]
+///
+/// There is also a 3rd implied state of "we've never seen this package before" if it
+/// isn't in the `state` hash map.
 enum SourceState {
+    /// The [SourceRequest] is in flight
     Pending,
-    Success,
-    Failed,
-    Retry,
+
+    /// We have received a [SourceResponse]. Regardless of [SourceResponse::Success] or
+    /// [SourceResponse::Failure], we mark the package as `Finished` so we never request
+    /// it again.
+    Finished,
 }
 
 pub(crate) struct SourceScheduler {
@@ -68,24 +74,26 @@ impl SourceScheduler {
         };
 
         // For each package used by the workspace, request its sources if we have never
-        // seen it before (or if it needs a retry)
+        // seen it before
         for package in oak_db::workspace_dependencies(db) {
-            if !self.should_schedule(package) {
+            if self.state.contains_key(package) {
+                // If we've seen this package before, don't request sources again!
                 continue;
             }
 
             let package = *package;
 
             let Some(request) = SourceRequest::from_package(db, &package).log_err() else {
-                // Never retry this package if we couldn't convert it to a source request
-                self.state.insert(package, SourceState::Failed);
+                // Go straight to `Finished` if we can't generate the source request,
+                // something is structurally wrong
+                self.state.insert(package, SourceState::Finished);
                 continue;
             };
 
             let handler = Arc::clone(handler);
             let tx = events_tx.clone();
 
-            // Set to `Pending` after all possible early exits
+            // Mark as `Pending` just before launching the tokio task
             self.state.insert(package, SourceState::Pending);
 
             crate::lsp::spawn_blocking(move || {
@@ -102,27 +110,13 @@ impl SourceScheduler {
         }
     }
 
-    fn should_schedule(&self, package: &Package) -> bool {
-        match self.state.get(package) {
-            Some(state) => match state {
-                SourceState::Pending => false,
-                SourceState::Success => false,
-                SourceState::Failed => false,
-                SourceState::Retry => true,
-            },
-            None => true,
-        }
-    }
-
     #[must_use]
     pub(crate) fn finish(&mut self, package: Package, response: SourceResponse) -> Option<PathBuf> {
-        let (next, directory) = match response {
-            SourceResponse::Success(directory) => (SourceState::Success, Some(directory)),
-            SourceResponse::Failed => (SourceState::Failed, None),
-            SourceResponse::Retry => (SourceState::Retry, None),
-        };
-        self.state.insert(package, next);
-        directory
+        self.state.insert(package, SourceState::Finished);
+        match response {
+            SourceResponse::Success(directory) => Some(directory),
+            SourceResponse::Failure => None,
+        }
     }
 
     /// Whether any source request is in flight. Allows tests to deterministically "wait"

--- a/crates/ark/src/lsp/tests.rs
+++ b/crates/ark/src/lsp/tests.rs
@@ -4,6 +4,7 @@ mod find_references;
 mod goto_definition;
 mod main_loop;
 mod rename;
+mod sources;
 mod state;
 mod state_handlers;
 mod utils;

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -7,67 +7,25 @@
 //! own wiring: which arm calls which handler, and the apply-and-redispatch
 //! step. The scheduler's policy is unit tested without tokio in `oak_scan`.
 
-use std::path::Path;
-
 use oak_db::DbInputs;
+use oak_db::OakDatabase;
+use oak_semantic::library::Library;
 use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
-use tower_lsp::lsp_types::InitializeParams;
-use tower_lsp::lsp_types::InitializeResult;
 use tower_lsp::lsp_types::WorkspaceFolder;
 use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
-use tower_lsp::Client;
-use tower_lsp::LanguageServer;
-use tower_lsp::LspService;
 use url::Url;
 
+use super::utils::test_client;
+use super::utils::write_description;
+use super::utils::write_sources;
 use crate::lsp::backend::LspMessage;
 use crate::lsp::backend::LspNotification;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
-
-/// Get a real `Client` without a live connection. `LspService::new` hands a
-/// `Client` to its init closure; we capture it and drop the service. The
-/// client's sends go nowhere, which is fine since the event paths under test
-/// never use it.
-fn test_client() -> Client {
-    struct Dummy;
-
-    #[tower_lsp::async_trait]
-    impl LanguageServer for Dummy {
-        async fn initialize(
-            &self,
-            _: InitializeParams,
-        ) -> tower_lsp::jsonrpc::Result<InitializeResult> {
-            Ok(InitializeResult::default())
-        }
-        async fn shutdown(&self) -> tower_lsp::jsonrpc::Result<()> {
-            Ok(())
-        }
-    }
-
-    let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
-    let sink = std::sync::Arc::clone(&captured);
-    let (_service, _socket) = LspService::new(move |client| {
-        *sink.lock().unwrap() = Some(client);
-        Dummy
-    });
-
-    // Bind first so the `MutexGuard` temporary drops at the `;`, not at the
-    // end of the block.
-    let client = captured.lock().unwrap().take();
-    client.unwrap()
-}
-
-fn write_package(dir: &Path, name: &str, basename: &str, contents: &str) {
-    std::fs::create_dir_all(dir.join("R")).unwrap();
-    std::fs::write(
-        dir.join("DESCRIPTION"),
-        format!("Package: {name}\nVersion: 0.0.0\n"),
-    )
-    .unwrap();
-    std::fs::write(dir.join("R").join(basename), contents).unwrap();
-}
+use crate::lsp::main_loop::LspState;
+use crate::lsp::sources::SourceManager;
+use crate::lsp::state::WorldState;
 
 /// Drive `didChangeWorkspaceFolders` through the real `handle_event`, including
 /// the real `OakScanCompleted` arm, to check that the main loop wires scan
@@ -75,10 +33,19 @@ fn write_package(dir: &Path, name: &str, basename: &str, contents: &str) {
 #[tokio::test]
 async fn test_workspace_folder_scan_drives_through_main_loop() {
     let _aux = init_aux_for_test();
-    let mut state = GlobalState::new_test(test_client());
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(OakDatabase::new(), Library::new(vec![])),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceManager::new(None),
+        ),
+    );
 
     let tmp = tempfile::tempdir().unwrap();
-    write_package(&tmp.path().join("pkg"), "pkg", "a.R", "x <- 1\n");
+    let pkg = tmp.path().join("pkg");
+    write_description(&pkg, "pkg");
+    write_sources(&pkg.join("R"), &[("a.R", "x <- 1\n")]);
 
     let params = DidChangeWorkspaceFoldersParams {
         event: WorkspaceFoldersChangeEvent {

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -24,7 +24,7 @@ use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
-use crate::lsp::sources::SourceManager;
+use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 
 /// Drive `didChangeWorkspaceFolders` through the real `handle_event`, including
@@ -38,7 +38,7 @@ async fn test_workspace_folder_scan_drives_through_main_loop() {
         WorldState::new(OakDatabase::new(), Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(None),
+            SourceScheduler::new(None),
         ),
     );
 

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -41,7 +41,7 @@ struct TestSourceHandler {
     sources: tempfile::TempDir,
     /// Per-package canned behavior.
     behavior: HashMap<String, TestBehavior>,
-    /// Each request passed to `provide`, in call order.
+    /// Each request passed to `handle`, in call order.
     calls: Mutex<Vec<SourceRequest>>,
 }
 
@@ -62,7 +62,7 @@ impl TestSourceHandler {
         }
     }
 
-    /// The requests passed to `provide`, in call order, for the test to assert on.
+    /// The requests passed to `handle`, in call order, for the test to assert on.
     fn calls(&self) -> &Mutex<Vec<SourceRequest>> {
         &self.calls
     }

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -27,14 +27,14 @@ use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::sources::SourceHandler;
-use crate::lsp::sources::SourceManager;
 use crate::lsp::sources::SourceRequest;
 use crate::lsp::sources::SourceResponse;
+use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 
 /// A test [`SourceHandler`] that serves canned behavior per package name and
 /// records every call, so tests can assert dispatch, dedup, and retry policy.
-/// The handler is shared (as the `Arc<dyn SourceHandler>` the `SourceManager`
+/// The handler is shared (as the `Arc<dyn SourceHandler>` the `SourceScheduler`
 /// holds and the clone the test keeps), so `calls` is a plain `Mutex`.
 struct TestSourceHandler {
     /// Owns the cache directory that `Success` writes per-package sources into.
@@ -145,7 +145,7 @@ async fn test_source_pipeline_ingests_package_sources() {
         WorldState::new(db, Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(Some(handler.clone())),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 
@@ -198,7 +198,7 @@ async fn test_failed_source_is_not_retried() {
         WorldState::new(db, Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(Some(handler.clone())),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 
@@ -248,7 +248,7 @@ async fn test_retry_source_redispatches_on_next_edit() {
         WorldState::new(db, Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(Some(handler.clone())),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -1,0 +1,284 @@
+//! Tests that drive the source request pipeline through the real [`GlobalState`]
+//! event loop.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use oak_db::Db;
+use oak_db::OakDatabase;
+use oak_scan::DbScan;
+use oak_semantic::library::Library;
+use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
+use tower_lsp::lsp_types::DidOpenTextDocumentParams;
+use tower_lsp::lsp_types::TextDocumentItem;
+use tower_lsp::lsp_types::WorkspaceFolder;
+use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
+use url::Url;
+
+use super::utils::test_client;
+use super::utils::write_description;
+use super::utils::write_sources;
+use crate::lsp::backend::LspMessage;
+use crate::lsp::backend::LspNotification;
+use crate::lsp::main_loop::init_aux_for_test;
+use crate::lsp::main_loop::Event;
+use crate::lsp::main_loop::GlobalState;
+use crate::lsp::main_loop::LspState;
+use crate::lsp::sources::SourceManager;
+use crate::lsp::sources::SourceProvider;
+use crate::lsp::sources::SourceRequest;
+use crate::lsp::sources::SourceResponse;
+use crate::lsp::state::WorldState;
+
+/// A test [`SourceProvider`] that serves canned behavior per package name and
+/// records every call, so tests can assert dispatch, dedup, and retry policy.
+/// The provider is shared (as the `Arc<dyn SourceProvider>` the `SourceManager`
+/// holds and the clone the test keeps), so `calls` is a plain `Mutex`.
+struct TestProvider {
+    /// Owns the cache directory that `Success` writes per-package sources into.
+    sources: tempfile::TempDir,
+    /// Per-package canned behavior.
+    behavior: HashMap<String, TestBehavior>,
+    /// Each request passed to `provide`, in call order.
+    calls: Mutex<Vec<SourceRequest>>,
+}
+
+// Canned behavior to perform when a particular package is requested
+enum TestBehavior {
+    /// Write these `(basename, contents)` files into the package's source dir
+    /// and return `Success(dir)`.
+    Success(Vec<(&'static str, &'static str)>),
+    Failed,
+    Retry,
+}
+
+impl TestProvider {
+    fn new(behavior: HashMap<String, TestBehavior>) -> Self {
+        Self {
+            sources: tempfile::tempdir().unwrap(),
+            behavior,
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The requests passed to `provide`, in call order, for the test to assert on.
+    fn calls(&self) -> &Mutex<Vec<SourceRequest>> {
+        &self.calls
+    }
+}
+
+impl SourceProvider for TestProvider {
+    fn provide(&self, request: &SourceRequest) -> SourceResponse {
+        self.calls.lock().unwrap().push(request.clone());
+
+        match self.behavior.get(request.name()) {
+            Some(TestBehavior::Success(files)) => {
+                let dir = self.sources.path().join(request.name());
+                write_sources(&dir, files);
+                SourceResponse::Success(dir)
+            },
+            Some(TestBehavior::Retry) => SourceResponse::Retry,
+            Some(TestBehavior::Failed) | None => SourceResponse::Failed,
+        }
+    }
+}
+
+fn did_change_workspace_folders(path: &Path) -> Event {
+    Event::Lsp(LspMessage::Notification(
+        LspNotification::DidChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams {
+            event: WorkspaceFoldersChangeEvent {
+                added: vec![WorkspaceFolder {
+                    uri: Url::from_file_path(path).unwrap(),
+                    name: String::new(),
+                }],
+                removed: vec![],
+            },
+        }),
+    ))
+}
+
+fn did_open(path: &Path, contents: &str) -> Event {
+    Event::Lsp(LspMessage::Notification(
+        LspNotification::DidOpenTextDocument(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: Url::from_file_path(path).unwrap(),
+                language_id: String::from("r"),
+                version: 0,
+                text: contents.to_string(),
+            },
+        }),
+    ))
+}
+
+/// The package names passed to the provider, in call order.
+fn dispatched_names(calls: &Mutex<Vec<SourceRequest>>) -> Vec<String> {
+    calls
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|request| request.name().to_string())
+        .collect()
+}
+
+/// The happy path end to end: a workspace uses an installed library package via
+/// `::`, so the revision-advance check dispatches a source request, the provider
+/// returns a directory, and the main loop ingests it into the library package.
+#[tokio::test]
+async fn test_source_pipeline_ingests_package_sources() {
+    let _aux = init_aux_for_test();
+
+    let provider = Arc::new(TestProvider::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    // An installed library package with no `R/` sources of its own
+    let lib = tempfile::tempdir().unwrap();
+    write_description(&lib.path().join("donor"), "donor");
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(db, Library::new(vec![])),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceManager::new(Some(provider.clone())),
+        ),
+    );
+
+    // A workspace package that uses `donor` via `::`.
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    write_description(&myproj, "myproj");
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+
+    // The provider was asked exactly once, with the package's name, version, and
+    // library path extracted from the db on the main loop.
+    {
+        let recorded = provider.calls().lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].name(), "donor");
+        assert_eq!(recorded[0].version(), "0.0.0");
+        assert_eq!(recorded[0].library_path(), lib.path());
+    }
+
+    // `donor` now carries the ingested source file, readable from disk.
+    let db = &state.world().db;
+    let donor = db.package_by_name("donor").unwrap();
+    let files = donor.files(db).clone();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].source_text(db).contains("foo <- function()"));
+}
+
+/// A `Failed` fetch is terminal! Here, a later edit advances the revision, but the
+/// package is not dispatched again.
+#[tokio::test]
+async fn test_failed_source_is_not_retried() {
+    let _aux = init_aux_for_test();
+
+    let provider = Arc::new(TestProvider::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Failed,
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    write_description(&lib.path().join("donor"), "donor");
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(db, Library::new(vec![])),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceManager::new(Some(provider.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    write_description(&myproj, "myproj");
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+
+    // Ensure that we got the request once
+    assert_eq!(dispatched_names(provider.calls()), vec![String::from(
+        "donor"
+    )]);
+
+    // A later edit advances the revision, but the package is not retried.
+    state
+        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "1 + 1\n"))
+        .await;
+
+    // Ensure that we haven't gotten a second request
+    assert_eq!(dispatched_names(provider.calls()), vec![String::from(
+        "donor"
+    )]);
+}
+
+/// A `Retry` fetch is transient. It writes nothing, and the package is
+/// re-dispatched on the next revision-advancing edit.
+#[tokio::test]
+async fn test_retry_source_redispatches_on_next_edit() {
+    let _aux = init_aux_for_test();
+
+    let provider = Arc::new(TestProvider::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Retry,
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    write_description(&lib.path().join("donor"), "donor");
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(db, Library::new(vec![])),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceManager::new(Some(provider.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    write_description(&myproj, "myproj");
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+
+    // Got the first one
+    assert_eq!(dispatched_names(provider.calls()), vec![String::from(
+        "donor"
+    )]);
+
+    // The next edit re-dispatches the transient `Retry`.
+    state
+        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "1 + 1\n"))
+        .await;
+
+    // Now we have two due to the retry
+    assert_eq!(dispatched_names(provider.calls()), vec![
+        String::from("donor"),
+        String::from("donor")
+    ]);
+
+    // `Retry` never writes sources.
+    let db = &state.world().db;
+    let donor = db.package_by_name("donor").unwrap();
+    assert!(donor.files(db).is_empty());
+}

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -26,17 +26,17 @@ use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
+use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceManager;
-use crate::lsp::sources::SourceProvider;
 use crate::lsp::sources::SourceRequest;
 use crate::lsp::sources::SourceResponse;
 use crate::lsp::state::WorldState;
 
-/// A test [`SourceProvider`] that serves canned behavior per package name and
+/// A test [`SourceHandler`] that serves canned behavior per package name and
 /// records every call, so tests can assert dispatch, dedup, and retry policy.
-/// The provider is shared (as the `Arc<dyn SourceProvider>` the `SourceManager`
+/// The handler is shared (as the `Arc<dyn SourceHandler>` the `SourceManager`
 /// holds and the clone the test keeps), so `calls` is a plain `Mutex`.
-struct TestProvider {
+struct TestSourceHandler {
     /// Owns the cache directory that `Success` writes per-package sources into.
     sources: tempfile::TempDir,
     /// Per-package canned behavior.
@@ -54,7 +54,7 @@ enum TestBehavior {
     Retry,
 }
 
-impl TestProvider {
+impl TestSourceHandler {
     fn new(behavior: HashMap<String, TestBehavior>) -> Self {
         Self {
             sources: tempfile::tempdir().unwrap(),
@@ -69,8 +69,8 @@ impl TestProvider {
     }
 }
 
-impl SourceProvider for TestProvider {
-    fn provide(&self, request: &SourceRequest) -> SourceResponse {
+impl SourceHandler for TestSourceHandler {
+    fn handle(&self, request: &SourceRequest) -> SourceResponse {
         self.calls.lock().unwrap().push(request.clone());
 
         match self.behavior.get(request.name()) {
@@ -112,7 +112,7 @@ fn did_open(path: &Path, contents: &str) -> Event {
     ))
 }
 
-/// The package names passed to the provider, in call order.
+/// The package names passed to the handler, in call order.
 fn dispatched_names(calls: &Mutex<Vec<SourceRequest>>) -> Vec<String> {
     calls
         .lock()
@@ -123,13 +123,13 @@ fn dispatched_names(calls: &Mutex<Vec<SourceRequest>>) -> Vec<String> {
 }
 
 /// The happy path end to end: a workspace uses an installed library package via
-/// `::`, so the revision-advance check dispatches a source request, the provider
+/// `::`, so the revision-advance check dispatches a source request, the handler
 /// returns a directory, and the main loop ingests it into the library package.
 #[tokio::test]
 async fn test_source_pipeline_ingests_package_sources() {
     let _aux = init_aux_for_test();
 
-    let provider = Arc::new(TestProvider::new(HashMap::from([(
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
         String::from("donor"),
         TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
     )])));
@@ -145,7 +145,7 @@ async fn test_source_pipeline_ingests_package_sources() {
         WorldState::new(db, Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(Some(provider.clone())),
+            SourceManager::new(Some(handler.clone())),
         ),
     );
 
@@ -159,10 +159,10 @@ async fn test_source_pipeline_ingests_package_sources() {
         .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
         .await;
 
-    // The provider was asked exactly once, with the package's name, version, and
+    // The handler was asked exactly once, with the package's name, version, and
     // library path extracted from the db on the main loop.
     {
-        let recorded = provider.calls().lock().unwrap();
+        let recorded = handler.calls().lock().unwrap();
         assert_eq!(recorded.len(), 1);
         assert_eq!(recorded[0].name(), "donor");
         assert_eq!(recorded[0].version(), "0.0.0");
@@ -183,7 +183,7 @@ async fn test_source_pipeline_ingests_package_sources() {
 async fn test_failed_source_is_not_retried() {
     let _aux = init_aux_for_test();
 
-    let provider = Arc::new(TestProvider::new(HashMap::from([(
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
         String::from("donor"),
         TestBehavior::Failed,
     )])));
@@ -198,7 +198,7 @@ async fn test_failed_source_is_not_retried() {
         WorldState::new(db, Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(Some(provider.clone())),
+            SourceManager::new(Some(handler.clone())),
         ),
     );
 
@@ -212,7 +212,7 @@ async fn test_failed_source_is_not_retried() {
         .await;
 
     // Ensure that we got the request once
-    assert_eq!(dispatched_names(provider.calls()), vec![String::from(
+    assert_eq!(dispatched_names(handler.calls()), vec![String::from(
         "donor"
     )]);
 
@@ -222,7 +222,7 @@ async fn test_failed_source_is_not_retried() {
         .await;
 
     // Ensure that we haven't gotten a second request
-    assert_eq!(dispatched_names(provider.calls()), vec![String::from(
+    assert_eq!(dispatched_names(handler.calls()), vec![String::from(
         "donor"
     )]);
 }
@@ -233,7 +233,7 @@ async fn test_failed_source_is_not_retried() {
 async fn test_retry_source_redispatches_on_next_edit() {
     let _aux = init_aux_for_test();
 
-    let provider = Arc::new(TestProvider::new(HashMap::from([(
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
         String::from("donor"),
         TestBehavior::Retry,
     )])));
@@ -248,7 +248,7 @@ async fn test_retry_source_redispatches_on_next_edit() {
         WorldState::new(db, Library::new(vec![])),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceManager::new(Some(provider.clone())),
+            SourceManager::new(Some(handler.clone())),
         ),
     );
 
@@ -262,7 +262,7 @@ async fn test_retry_source_redispatches_on_next_edit() {
         .await;
 
     // Got the first one
-    assert_eq!(dispatched_names(provider.calls()), vec![String::from(
+    assert_eq!(dispatched_names(handler.calls()), vec![String::from(
         "donor"
     )]);
 
@@ -272,7 +272,7 @@ async fn test_retry_source_redispatches_on_next_edit() {
         .await;
 
     // Now we have two due to the retry
-    assert_eq!(dispatched_names(provider.calls()), vec![
+    assert_eq!(dispatched_names(handler.calls()), vec![
         String::from("donor"),
         String::from("donor")
     ]);

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -32,10 +32,10 @@ use crate::lsp::sources::SourceResponse;
 use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 
-/// A test [`SourceHandler`] that serves canned behavior per package name and
-/// records every call, so tests can assert dispatch, dedup, and retry policy.
-/// The handler is shared (as the `Arc<dyn SourceHandler>` the `SourceScheduler`
-/// holds and the clone the test keeps), so `calls` is a plain `Mutex`.
+/// A test [`SourceHandler`] that serves canned behavior per package name and records
+/// every call, so tests can count the number of calls. The handler is shared (as the
+/// `Arc<dyn SourceHandler>` the `SourceScheduler` holds and the clone the test keeps), so
+/// `calls` is a plain `Mutex`.
 struct TestSourceHandler {
     /// Owns the cache directory that `Success` writes per-package sources into.
     sources: tempfile::TempDir,
@@ -50,8 +50,7 @@ enum TestBehavior {
     /// Write these `(basename, contents)` files into the package's source dir
     /// and return `Success(dir)`.
     Success(Vec<(&'static str, &'static str)>),
-    Failed,
-    Retry,
+    Failure,
 }
 
 impl TestSourceHandler {
@@ -79,8 +78,8 @@ impl SourceHandler for TestSourceHandler {
                 write_sources(&dir, files);
                 SourceResponse::Success(dir)
             },
-            Some(TestBehavior::Retry) => SourceResponse::Retry,
-            Some(TestBehavior::Failed) | None => SourceResponse::Failed,
+            Some(TestBehavior::Failure) => SourceResponse::Failure,
+            None => panic!("Unknown test package {}", request.name()),
         }
     }
 }
@@ -177,7 +176,7 @@ async fn test_source_pipeline_ingests_package_sources() {
     assert!(files[0].source_text(db).contains("foo <- function()"));
 }
 
-/// A `Failed` fetch is terminal! Here, a later edit advances the revision, but the
+/// A `Failure` fetch is terminal! Here, a later edit advances the revision, but the
 /// package is not dispatched again.
 #[tokio::test]
 async fn test_failed_source_is_not_retried() {
@@ -185,7 +184,7 @@ async fn test_failed_source_is_not_retried() {
 
     let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
         String::from("donor"),
-        TestBehavior::Failed,
+        TestBehavior::Failure,
     )])));
 
     let lib = tempfile::tempdir().unwrap();
@@ -225,60 +224,4 @@ async fn test_failed_source_is_not_retried() {
     assert_eq!(dispatched_names(handler.calls()), vec![String::from(
         "donor"
     )]);
-}
-
-/// A `Retry` fetch is transient. It writes nothing, and the package is
-/// re-dispatched on the next revision-advancing edit.
-#[tokio::test]
-async fn test_retry_source_redispatches_on_next_edit() {
-    let _aux = init_aux_for_test();
-
-    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
-        String::from("donor"),
-        TestBehavior::Retry,
-    )])));
-
-    let lib = tempfile::tempdir().unwrap();
-    write_description(&lib.path().join("donor"), "donor");
-    let mut db = OakDatabase::new();
-    db.set_library_paths(&[lib.path().to_path_buf()]);
-
-    let mut state = GlobalState::from_parts(
-        test_client(),
-        WorldState::new(db, Library::new(vec![])),
-        LspState::new(
-            tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler.clone())),
-        ),
-    );
-
-    let workspace = tempfile::tempdir().unwrap();
-    let myproj = workspace.path().join("myproj");
-    write_description(&myproj, "myproj");
-    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
-
-    state
-        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
-        .await;
-
-    // Got the first one
-    assert_eq!(dispatched_names(handler.calls()), vec![String::from(
-        "donor"
-    )]);
-
-    // The next edit re-dispatches the transient `Retry`.
-    state
-        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "1 + 1\n"))
-        .await;
-
-    // Now we have two due to the retry
-    assert_eq!(dispatched_names(handler.calls()), vec![
-        String::from("donor"),
-        String::from("donor")
-    ]);
-
-    // `Retry` never writes sources.
-    let db = &state.world().db;
-    let donor = db.package_by_name("donor").unwrap();
-    assert!(donor.files(db).is_empty());
 }

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -32,7 +32,7 @@ use crate::lsp::main_loop::AuxiliaryEvent;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::main_loop::TokioUnboundedSender;
-use crate::lsp::sources::SourceManager;
+use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers::did_close;
 use crate::lsp::state_handlers::effective_workspace_uris;
@@ -127,7 +127,7 @@ where
 fn test_lsp_state() -> LspState {
     LspState::new(
         tokio::sync::mpsc::unbounded_channel().0,
-        SourceManager::new(None),
+        SourceScheduler::new(None),
     )
 }
 

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -26,13 +26,13 @@ use tower_lsp::lsp_types::WorkspaceFolder;
 use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
 use url::Url;
 
-use crate::lsp::capabilities::Capabilities;
 use crate::lsp::main_loop::dispatch_scan_requests;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::AuxiliaryEvent;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::main_loop::TokioUnboundedSender;
+use crate::lsp::sources::SourceManager;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers::did_close;
 use crate::lsp::state_handlers::effective_workspace_uris;
@@ -125,11 +125,10 @@ where
 }
 
 fn test_lsp_state() -> LspState {
-    LspState {
-        capabilities: Capabilities::default(),
-        console_notification_tx: tokio::sync::mpsc::unbounded_channel().0,
-        oak_scheduler: ScanScheduler::new(),
-    }
+    LspState::new(
+        tokio::sync::mpsc::unbounded_channel().0,
+        SourceManager::new(None),
+    )
 }
 
 /// Inline drain loop: oak_scan keeps its equivalent crate-private so

--- a/crates/ark/src/lsp/tests/utils.rs
+++ b/crates/ark/src/lsp/tests/utils.rs
@@ -1,8 +1,62 @@
+use std::path::Path;
+
 use aether_path::FilePath;
 use oak_scan::DbScan;
 use tower_lsp::lsp_types;
+use tower_lsp::Client;
+use tower_lsp::LanguageServer;
+use tower_lsp::LspService;
 
 use crate::lsp::state::WorldState;
+
+/// Get a real `Client` without a live connection. `LspService::new` hands a
+/// `Client` to its init closure; we capture it and drop the service. The
+/// client's sends go nowhere, which is fine since the event paths under test
+/// never use it.
+pub(super) fn test_client() -> Client {
+    struct Dummy;
+
+    #[tower_lsp::async_trait]
+    impl LanguageServer for Dummy {
+        async fn initialize(
+            &self,
+            _: lsp_types::InitializeParams,
+        ) -> tower_lsp::jsonrpc::Result<lsp_types::InitializeResult> {
+            Ok(lsp_types::InitializeResult::default())
+        }
+        async fn shutdown(&self) -> tower_lsp::jsonrpc::Result<()> {
+            Ok(())
+        }
+    }
+
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let sink = std::sync::Arc::clone(&captured);
+    let (_service, _socket) = LspService::new(move |client| {
+        *sink.lock().unwrap() = Some(client);
+        Dummy
+    });
+
+    // Bind first so the `MutexGuard` temporary drops at the `;`, not at the
+    // end of the block.
+    let client = captured.lock().unwrap().take();
+    client.unwrap()
+}
+
+pub(super) fn write_description(dir: &Path, name: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("DESCRIPTION"),
+        format!("Package: {name}\nVersion: 0.0.0\n"),
+    )
+    .unwrap();
+}
+
+pub(super) fn write_sources(dir: &Path, files: &[(&str, &str)]) {
+    std::fs::create_dir_all(dir).unwrap();
+    for (basename, contents) in files {
+        std::fs::write(dir.join(basename), contents).unwrap();
+    }
+}
 
 pub(super) fn make_state(uri: &lsp_types::Url, contents: &str) -> WorldState {
     let mut state = WorldState::default();


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1234
Branched from https://github.com/posit-dev/ark/pull/1288

This PR sets up the `main_loop.rs` handling for package sources.

Here is the set up:

- The database changes via a `revision` bump
- We `dispatch()` a series of `SourceRequest`s via `lsp::spawn_blocking()`. One `SourceRequest` is made per package currently used by the workspace (removing any packages we've already requested sources for).
- On the tokio task, an implementer of `trait SourceProvider` is called to `provide()` sources for a package. On success, it sends the `directory` of the sources back to the main loop via a new `Event::SourceCompleted` event.
    - Note that this all happens on a task, not blocking the main loop while we are creating these sources.
- The main loop picks this `Event` up and calls `db.set_package_sources(package, &directory)` for that package, which actually loads the files from the directory.
- The next `revision` of the `db` can now use these `package.files()` in LSP requests

I purposefully have not hooked up a live production level implementer of `trait SourceProvider`. Instead we have a `TestProvider` that is used to verify that all of this infrastructure is working, but for production this is all set to `None` and no `SourceRequest`s are ever sent out, so it is safe to merge.

If we agree on the shape of all of this, then in the next PRs I can hook up the real source provider.