### PR TITLE
(2) Extract out `oak_source` for CRAN downloads of R packages and R versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_source"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "log",
+ "oak_cache",
+ "oak_fs",
+ "tar",
+ "tempfile",
+ "ureq",
+]
+
+[[package]]
 name = "oak_sources"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ oak_package_metadata = { path = "crates/oak_package_metadata" }
 oak_r_process = { path = "crates/oak_r_process" }
 oak_scan = { path = "crates/oak_scan" }
 oak_semantic = { path = "crates/oak_semantic" }
+oak_source = { path = "crates/oak_source" }
 oak_sources = { path = "crates/oak_sources" }
 once_cell = "1.21.4"
 parking_lot = "0.12.5"

--- a/crates/oak_fs/src/lib.rs
+++ b/crates/oak_fs/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod file_lock;
+pub mod permissions;

--- a/crates/oak_fs/src/permissions.rs
+++ b/crates/oak_fs/src/permissions.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+/// Mark a file as read only
+pub fn set_readonly(path: &Path) -> std::io::Result<()> {
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_readonly(true);
+    std::fs::set_permissions(path, permissions)
+}

--- a/crates/oak_source/Cargo.toml
+++ b/crates/oak_source/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oak_source"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+flate2.workspace = true
+log.workspace = true
+oak_cache.workspace = true
+oak_fs.workspace = true
+tar.workspace = true
+ureq.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oak_source/src/cran.rs
+++ b/crates/oak_source/src/cran.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+
+use crate::download::download_with_mirrors;
+use crate::download::Outcome;
+use crate::download::MIRRORS;
+use crate::extract;
+
+/// Download an R package's source tarball from CRAN and unpack it into `dir`
+///
+/// The tarball's top-level `{name}/` directory is stripped, so the package's files land
+/// directly under `dir` (e.g. `dir/R/`, `dir/DESCRIPTION`).
+///
+/// Returns `Ok(false)` if the package isn't on CRAN, which we treat as "source
+/// unavailable" rather than an error.
+pub(crate) fn populate(name: &str, version: &str, dir: &Path) -> anyhow::Result<bool> {
+    match download(name, version)? {
+        Outcome::Success(response) => {
+            extract::extract(response.into_body().into_reader(), dir)?;
+            Ok(true)
+        },
+        Outcome::NotFound => Ok(false),
+    }
+}
+
+fn download(name: &str, version: &str) -> anyhow::Result<Outcome> {
+    // Try released version
+    let outcome = download_with_mirrors(&format!("src/contrib/{name}_{version}.tar.gz"), MIRRORS)?;
+
+    if matches!(outcome, Outcome::Success(_)) {
+        return Ok(outcome);
+    }
+
+    // Try archive
+    download_with_mirrors(
+        &format!("src/contrib/Archive/{name}/{name}_{version}.tar.gz"),
+        MIRRORS,
+    )
+}

--- a/crates/oak_source/src/download.rs
+++ b/crates/oak_source/src/download.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+
+const HTTP_NOT_FOUND: u16 = 404;
+const HTTP_SERVICE_UNAVAILABLE: u16 = 503;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const GLOBAL_TIMEOUT: Duration = Duration::from_secs(40);
+
+/// CRAN mirrors to try, in order
+pub(crate) const MIRRORS: &[&str] = &["https://cran.r-project.org", "https://cran.rstudio.com"];
+
+/// Outcome of a CRAN mirror HTTP request
+pub(crate) enum Outcome {
+    Success(ureq::http::Response<ureq::Body>),
+    NotFound,
+}
+
+pub(crate) fn download_with_mirrors(suffix: &str, mirrors: &[&str]) -> anyhow::Result<Outcome> {
+    if mirrors.is_empty() {
+        panic!("`mirrors` can't be empty.");
+    }
+
+    let mut last_error = None;
+
+    for mirror in mirrors {
+        let url = format!("{mirror}/{suffix}");
+
+        let request = ureq::get(&url)
+            .config()
+            .timeout_connect(Some(CONNECT_TIMEOUT))
+            .timeout_global(Some(GLOBAL_TIMEOUT))
+            .build();
+
+        match request.call() {
+            Ok(response) => return Ok(Outcome::Success(response)),
+
+            // Known to be not there, don't try any other mirrors
+            Err(ureq::Error::StatusCode(HTTP_NOT_FOUND)) => return Ok(Outcome::NotFound),
+
+            // Try next mirror, this one is temporarily unavailable
+            Err(ureq::Error::StatusCode(HTTP_SERVICE_UNAVAILABLE)) => {
+                last_error = Some(Err(ureq::Error::StatusCode(HTTP_SERVICE_UNAVAILABLE).into()));
+                continue;
+            },
+
+            // Try next mirror, this one timed out
+            Err(ureq::Error::Timeout(timeout)) => {
+                last_error = Some(Err(ureq::Error::Timeout(timeout).into()));
+                continue;
+            },
+
+            // Some unhandled error occurred, bail
+            Err(err) => return Err(err.into()),
+        };
+    }
+
+    // Every mirror returned `HTTP_SERVICE_UNAVAILABLE` or timed out
+    last_error.expect("`mirrors` was non-empty and we always set `last_error`")
+}

--- a/crates/oak_source/src/extract.rs
+++ b/crates/oak_source/src/extract.rs
@@ -1,0 +1,76 @@
+use std::collections::HashSet;
+use std::io::Read;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+use flate2::read::GzDecoder;
+
+/// Unpack a gzipped tarball into `dir`, dropping its top-level directory and marking
+/// every file read only
+///
+/// CRAN package tarballs and R source tarballs both wrap their content in a single
+/// top-level directory (`{package}/` or `R-{version}/`). We strip it so the content lands
+/// directly under `dir`.
+///
+/// Files are marked as read only to discourage accidental edits.
+pub(crate) fn extract(reader: impl Read, dir: &Path) -> anyhow::Result<()> {
+    let gz = GzDecoder::new(reader);
+    let mut archive = tar::Archive::new(gz);
+
+    // Parent directories we've already created
+    let mut created: HashSet<PathBuf> = HashSet::new();
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let is_file = entry.header().entry_type().is_file();
+
+        let path = entry.path()?.into_owned();
+        let Some(relative) = strip_top_level(&path) else {
+            // The top-level directory entry itself, or an unsafe path, nothing to unpack
+            continue;
+        };
+
+        let destination = dir.join(relative);
+
+        // We must create parent directories before unpacking into them. We remember ones
+        // we've already created to avoid thousands of redundant `create_dir_all()` calls.
+        if let Some(parent) = destination.parent() {
+            if !created.contains(parent) {
+                std::fs::create_dir_all(parent)?;
+                created.insert(parent.to_path_buf());
+            }
+        }
+
+        entry.unpack(&destination)?;
+
+        if is_file {
+            oak_fs::permissions::set_readonly(&destination)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Strip the single top-level directory from a tarball entry path
+///
+/// Returns `None` for the top-level directory entry itself, or for any unsafe path
+/// (absolute, or containing `..`) that could escape the destination.
+fn strip_top_level(path: &Path) -> Option<&Path> {
+    let mut components = path.components();
+    components.next()?;
+
+    let rest = components.as_path();
+
+    if rest.as_os_str().is_empty() {
+        // The top-level directory entry itself
+        return None;
+    }
+
+    if !rest.components().all(|c| matches!(c, Component::Normal(_))) {
+        // Something would be strange here!
+        return None;
+    }
+
+    Some(rest)
+}

--- a/crates/oak_source/src/lib.rs
+++ b/crates/oak_source/src/lib.rs
@@ -1,0 +1,164 @@
+//! Download and cache whole R package and R version source trees
+//!
+//! [`SourceCache`] is a thin wrapper over two [`oak_cache::Cache`] instances pointing
+//! into:
+//!
+//! - `source/v1/cran/{name}_{version}/`, a full unpacked CRAN package tarball
+//! - `source/v1/r/{version}/`, a full unpacked R version source tarball
+//!
+//! Both keep the entire downloaded tree, unpacked eagerly with files marked read only.
+//! Each method returns the cached folder. Navigation is left to the caller, who knows the
+//! layout.
+
+mod cran;
+mod download;
+mod extract;
+mod r;
+
+use std::path::PathBuf;
+
+use oak_cache::Cache;
+
+/// Cache version
+const CACHE_VERSION: &str = "v1";
+
+/// LRU capacity for cached CRAN package source trees
+const CRAN_CAPACITY: usize = 200;
+
+/// LRU capacity for cached R version source trees, kept small because each is large
+const R_CAPACITY: usize = 5;
+
+/// Downloads and caches whole package / R version source trees
+///
+/// Each cache holds its shared root lock for the life of this `SourceCache`, so any path
+/// handed out stays valid as long as the `SourceCache` lives.
+#[derive(Debug)]
+pub struct SourceCache {
+    cran: Cache,
+    r: Cache,
+}
+
+impl SourceCache {
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            cran: Cache::open(&format!("source/{CACHE_VERSION}/cran"), CRAN_CAPACITY)?,
+            r: Cache::open(&format!("source/{CACHE_VERSION}/r"), R_CAPACITY)?,
+        })
+    }
+
+    /// Get cached CRAN package source tree if already present
+    pub fn get_cran(&self, name: &str, version: &str) -> Option<PathBuf> {
+        self.cran.get(&format!("{name}_{version}"))
+    }
+
+    /// Download and cache CRAN package source tree
+    ///
+    /// Returns `None` if the package isn't on CRAN or the download fails.
+    pub fn insert_cran(&self, name: &str, version: &str) -> Option<PathBuf> {
+        self.cran
+            .insert(&format!("{name}_{version}"), |dir| {
+                cran::populate(name, version, dir)
+            })
+            .unwrap_or_else(|err| {
+                log::error!("Failed to download '{name}' {version} from CRAN: {err:?}");
+                None
+            })
+    }
+
+    /// Get cached R source tree if already present
+    pub fn get_r(&self, version: &str) -> Option<PathBuf> {
+        self.r.get(version)
+    }
+
+    /// Download and cache R source tree
+    ///
+    /// Returns `None` if the tarball isn't on CRAN or the download fails.
+    pub fn insert_r(&self, version: &str) -> Option<PathBuf> {
+        self.r
+            .insert(version, |dir| r::populate(version, dir))
+            .unwrap_or_else(|err| {
+                log::error!("Failed to download R {version} source: {err:?}");
+                None
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oak_cache::Cache;
+    use tempfile::TempDir;
+
+    use crate::SourceCache;
+    use crate::CRAN_CAPACITY;
+    use crate::R_CAPACITY;
+
+    /// A `SourceCache` rooted in a temp dir so tests don't touch the real cache.
+    fn source_in(dir: &TempDir) -> SourceCache {
+        SourceCache {
+            cran: Cache::open_in(dir.path().join("cran"), CRAN_CAPACITY).unwrap(),
+            r: Cache::open_in(dir.path().join("r"), R_CAPACITY).unwrap(),
+        }
+    }
+
+    /// Requires internet access
+    #[test]
+    fn test_cran_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let source = source_in(&dir);
+
+        // Miss before insert
+        assert_eq!(source.get_cran("vctrs", "0.7.2"), None);
+
+        let root = source.insert_cran("vctrs", "0.7.2").unwrap();
+
+        // The top-level `vctrs/` is stripped, so content lands directly under `root`
+        assert!(root.join("R").is_dir());
+        assert!(root.join("DESCRIPTION").is_file());
+
+        // Unpacked files are read only
+        for entry in std::fs::read_dir(root.join("R")).unwrap() {
+            let metadata = entry.unwrap().metadata().unwrap();
+            assert!(metadata.permissions().readonly());
+        }
+
+        // A second lookup is a cache hit returning the same dir
+        assert_eq!(source.get_cran("vctrs", "0.7.2"), Some(root));
+    }
+
+    /// Requires internet access
+    #[test]
+    fn test_cran_not_found() {
+        let dir = TempDir::new().unwrap();
+        let source = source_in(&dir);
+        assert_eq!(
+            source.insert_cran("definitely_not_a_package", "0.0.0"),
+            None
+        );
+    }
+
+    /// Requires internet access and downloads a large tarball of the R sources
+    #[ignore = "Downloads a large R source tarball"]
+    #[test]
+    fn test_r_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let source = source_in(&dir);
+
+        let root = source.insert_r("4.5.0").unwrap();
+
+        // The top-level `R-4.5.0/` is stripped. Spot check: `utils` has a well-known
+        // `help.R` file inside the unpacked tree.
+        let help = root.join("src/library/utils/R/help.R");
+        assert!(help.is_file());
+        assert!(help.metadata().unwrap().permissions().readonly());
+
+        assert_eq!(source.get_r("4.5.0"), Some(root));
+    }
+
+    /// Requires internet access
+    #[test]
+    fn test_r_unknown_version() {
+        let dir = TempDir::new().unwrap();
+        let source = source_in(&dir);
+        assert_eq!(source.insert_r("0.0.0"), None);
+    }
+}

--- a/crates/oak_source/src/lib.rs
+++ b/crates/oak_source/src/lib.rs
@@ -41,8 +41,17 @@ pub struct SourceCache {
 impl SourceCache {
     pub fn new() -> anyhow::Result<Self> {
         Ok(Self {
-            cran: Cache::open(&format!("source/{CACHE_VERSION}/cran"), CRAN_CAPACITY)?,
-            r: Cache::open(&format!("source/{CACHE_VERSION}/r"), R_CAPACITY)?,
+            cran: Cache::new(&format!("source/{CACHE_VERSION}/cran"), CRAN_CAPACITY)?,
+            r: Cache::new(&format!("source/{CACHE_VERSION}/r"), R_CAPACITY)?,
+        })
+    }
+
+    /// Like [`SourceCache::new`], but rooted at an explicit `root` rather than the shared
+    /// cache directory. Only useful for testing against a temp directory.
+    pub fn new_in(root: PathBuf) -> anyhow::Result<Self> {
+        Ok(Self {
+            cran: Cache::new_in(root.join("cran"), CRAN_CAPACITY)?,
+            r: Cache::new_in(root.join("r"), R_CAPACITY)?,
         })
     }
 
@@ -85,26 +94,15 @@ impl SourceCache {
 
 #[cfg(test)]
 mod tests {
-    use oak_cache::Cache;
     use tempfile::TempDir;
 
     use crate::SourceCache;
-    use crate::CRAN_CAPACITY;
-    use crate::R_CAPACITY;
-
-    /// A `SourceCache` rooted in a temp dir so tests don't touch the real cache.
-    fn source_in(dir: &TempDir) -> SourceCache {
-        SourceCache {
-            cran: Cache::open_in(dir.path().join("cran"), CRAN_CAPACITY).unwrap(),
-            r: Cache::open_in(dir.path().join("r"), R_CAPACITY).unwrap(),
-        }
-    }
 
     /// Requires internet access
     #[test]
     fn test_cran_round_trip() {
         let dir = TempDir::new().unwrap();
-        let source = source_in(&dir);
+        let source = SourceCache::new_in(dir.path().to_path_buf()).unwrap();
 
         // Miss before insert
         assert_eq!(source.get_cran("vctrs", "0.7.2"), None);
@@ -129,7 +127,7 @@ mod tests {
     #[test]
     fn test_cran_not_found() {
         let dir = TempDir::new().unwrap();
-        let source = source_in(&dir);
+        let source = SourceCache::new_in(dir.path().to_path_buf()).unwrap();
         assert_eq!(
             source.insert_cran("definitely_not_a_package", "0.0.0"),
             None
@@ -141,7 +139,7 @@ mod tests {
     #[test]
     fn test_r_round_trip() {
         let dir = TempDir::new().unwrap();
-        let source = source_in(&dir);
+        let source = SourceCache::new_in(dir.path().to_path_buf()).unwrap();
 
         let root = source.insert_r("4.5.0").unwrap();
 
@@ -158,7 +156,7 @@ mod tests {
     #[test]
     fn test_r_unknown_version() {
         let dir = TempDir::new().unwrap();
-        let source = source_in(&dir);
+        let source = SourceCache::new_in(dir.path().to_path_buf()).unwrap();
         assert_eq!(source.insert_r("0.0.0"), None);
     }
 }

--- a/crates/oak_source/src/r.rs
+++ b/crates/oak_source/src/r.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use crate::download::download_with_mirrors;
+use crate::download::Outcome;
+use crate::download::MIRRORS;
+use crate::extract;
+
+/// Download the R source tarball for R `version` from CRAN and unpack it into `dir`
+///
+/// The base R packages aren't distributed at the standard `src/contrib/` location. They
+/// live inside the R source tarball at `src/base/R-{major}/R-{version}.tar.gz`. The
+/// tarball's top-level `R-{version}/` directory is stripped, so they land under
+/// `dir/src/library/{name}/`.
+///
+/// Returns `Ok(false)` if the tarball isn't on CRAN (e.g. a development R version), which
+/// we treat as "source unavailable" rather than an error.
+pub(crate) fn populate(version: &str, dir: &Path) -> anyhow::Result<bool> {
+    let major = version
+        .split('.')
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Invalid R version for source download: {version}"))?;
+
+    let suffix = format!("src/base/R-{major}/R-{version}.tar.gz");
+
+    match download_with_mirrors(&suffix, MIRRORS)? {
+        Outcome::Success(response) => {
+            extract::extract(response.into_body().into_reader(), dir)?;
+            Ok(true)
+        },
+        Outcome::NotFound => Ok(false),
+    }
+}


### PR DESCRIPTION
Part of #1234 
Branched from #1298 

Similar to the old cache model for CRAN sources, so not a ton to review. The main structural differences are:

- For R packages, we have `get_cran()` and `insert_cran()` 
- For R versions, we have `get_r()` and `insert_r()`

Where both of these now download and keep _the whole thing_ rather than trying to extract out only `R/`, which I think is going to pay off in the long run.