### PR TITLE
(3) Extract out `oak_srcref` for srcref rebuilding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,6 +2762,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oak_srcref"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "log",
+ "oak_cache",
+ "oak_fs",
+ "oak_r_process",
+ "sha2 0.11.0",
+ "tempfile",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ oak_scan = { path = "crates/oak_scan" }
 oak_semantic = { path = "crates/oak_semantic" }
 oak_source = { path = "crates/oak_source" }
 oak_sources = { path = "crates/oak_sources" }
+oak_srcref = { path = "crates/oak_srcref" }
 once_cell = "1.21.4"
 parking_lot = "0.12.5"
 paste = "1.0.15"

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -1610,6 +1610,7 @@ foo
                 imports: vec![],
                 repository: None,
                 priority: None,
+                built: None,
                 fields: Dcf::new(),
             };
             let package = Package::from_parts(PathBuf::from("/mock/path"), description, namespace);
@@ -1705,6 +1706,7 @@ foo
                 imports: vec![],
                 repository: None,
                 priority: None,
+                built: None,
                 fields: Dcf::new(),
             };
             let package1 =
@@ -1723,6 +1725,7 @@ foo
                 imports: vec![],
                 repository: None,
                 priority: None,
+                built: None,
                 fields: Dcf::new(),
             };
             let package2 =
@@ -1782,6 +1785,7 @@ foo
                 imports: vec![],
                 repository: None,
                 priority: None,
+                built: None,
                 fields: Dcf::new(),
             };
             let package = Package::from_parts(PathBuf::from("/mock/path"), description, namespace);

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -23,6 +23,7 @@ pub(crate) trait SourceHandler: Send + Sync {
 pub(crate) struct SourceRequest {
     name: String,
     version: String,
+    built: String,
     library_path: PathBuf,
 }
 
@@ -139,6 +140,13 @@ impl SourceRequest {
             ));
         };
 
+        let Some(built) = package.built(db).to_owned() else {
+            // Only ever runs on installed packages, which always carry a `Built:` field
+            return Err(anyhow::anyhow!(
+                "Package {name} is missing a `Built` field to provide sources for."
+            ));
+        };
+
         let library_path = match package.description_path(db) {
             FilePath::File(path) => {
                 match path.as_path().as_std_path().parent().and_then(Path::parent) {
@@ -160,6 +168,7 @@ impl SourceRequest {
         Ok(Self {
             name,
             version,
+            built,
             library_path,
         })
     }
@@ -174,6 +183,12 @@ impl SourceRequest {
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn version(&self) -> &str {
         &self.version
+    }
+
+    // TODO!: Remove when we have a production `SourceHandler`
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn built(&self) -> &str {
+        &self.built
     }
 
     // TODO!: Remove when we have a production `SourceHandler`

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -165,6 +165,7 @@ async fn test_source_pipeline_ingests_package_sources() {
         assert_eq!(recorded.len(), 1);
         assert_eq!(recorded[0].name(), "donor");
         assert_eq!(recorded[0].version(), "0.0.0");
+        assert_eq!(recorded[0].built(), "dummy");
         assert_eq!(recorded[0].library_path(), lib.path());
     }
 

--- a/crates/ark/src/lsp/tests/utils.rs
+++ b/crates/ark/src/lsp/tests/utils.rs
@@ -46,7 +46,7 @@ pub(super) fn write_description(dir: &Path, name: &str) {
     std::fs::create_dir_all(dir).unwrap();
     std::fs::write(
         dir.join("DESCRIPTION"),
-        format!("Package: {name}\nVersion: 0.0.0\n"),
+        format!("Package: {name}\nVersion: 0.0.0\nBuilt: dummy\n"),
     )
     .unwrap();
 }

--- a/crates/oak_db/src/package.rs
+++ b/crates/oak_db/src/package.rs
@@ -140,6 +140,18 @@ impl Package {
             .map(|description| description.version.clone())
     }
 
+    /// The package's `Built:`, parsed lazily from `DESCRIPTION`. `None` when
+    /// the file is missing or has no `Built:` field (only installed packages have one).
+    ///
+    /// Build timestamps change on every install, so backdating probably isn't that
+    /// important here, but having the field easily accessible is nice.
+    #[salsa::tracked(returns(ref))]
+    pub fn built(self, db: &dyn Db) -> Option<String> {
+        self.description(db)
+            .as_ref()
+            .and_then(|description| description.built.clone())
+    }
+
     /// The basename order from `DESCRIPTION`'s `Collate:` field, parsed
     /// lazily. `None` when the field (or the file) is absent. Narrow query
     /// over [`Package::description`], same backdating story as

--- a/crates/oak_db/src/package.rs
+++ b/crates/oak_db/src/package.rs
@@ -144,8 +144,7 @@ impl Package {
     /// the file is missing or has no `Built:` field (only installed packages have one).
     ///
     /// Build timestamps change on every install, so backdating probably isn't that
-    /// important here, but having the field easily accessible is nice.
-    #[salsa::tracked(returns(ref))]
+    /// important here, so we don't track this method.
     pub fn built(self, db: &dyn Db) -> Option<String> {
         self.description(db)
             .as_ref()

--- a/crates/oak_package_metadata/src/description.rs
+++ b/crates/oak_package_metadata/src/description.rs
@@ -16,6 +16,9 @@ pub struct Description {
 
     pub priority: Option<Priority>,
 
+    /// Only present for installed packages
+    pub built: Option<String>,
+
     /// Raw DCF fields
     pub fields: Dcf,
 }
@@ -81,6 +84,8 @@ impl Description {
             None
         });
 
+        let built = fields.get("Built").map(str::to_string);
+
         Ok(Description {
             name,
             version,
@@ -88,6 +93,7 @@ impl Description {
             imports,
             repository,
             priority,
+            built,
             fields,
         })
     }
@@ -230,6 +236,23 @@ Collate:
 Version: 1.0.0"#;
         let parsed = Description::parse(desc).unwrap();
         assert_eq!(parsed.collate(), None);
+    }
+
+    #[test]
+    fn parses_description_with_built() {
+        let desc = r#"Package: mypackage
+Version: 1.0.0
+Built: R 4.5.0; ; 2025-01-15 12:34:56 UTC; unix"#;
+        let parsed = Description::parse(desc).unwrap();
+        assert_eq!(
+            parsed.built.as_deref(),
+            Some("R 4.5.0; ; 2025-01-15 12:34:56 UTC; unix")
+        );
+
+        let desc = r#"Package: mypackage
+Version: 1.0.0"#;
+        let parsed = Description::parse(desc).unwrap();
+        assert_eq!(parsed.built, None);
     }
 
     #[test]

--- a/crates/oak_srcref/Cargo.toml
+++ b/crates/oak_srcref/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oak_srcref"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+hex.workspace = true
+log.workspace = true
+oak_cache.workspace = true
+oak_fs.workspace = true
+oak_r_process.workspace = true
+sha2.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oak_srcref/scripts/srcrefs.R
+++ b/crates/oak_srcref/scripts/srcrefs.R
@@ -1,0 +1,104 @@
+# Extract source code from an installed R package using srcref metadata.
+#
+# See also `lobstr::src()`:
+# https://github.com/r-lib/lobstr/blob/85dd18d43e4612f98b05bb93019a7b12fb0bbf6b/R/src.R#L205
+#
+# Arguments (via commandArgs):
+#   1. package - Package name
+#   2. version - Expected package version
+#
+# Library paths have been set ahead of time via the `R_LIBS` environment
+# variable.
+#
+# On success: prints the concatenated source lines (with `#line` directives) to
+# stdout.
+#
+# On failure: exits with code 1 (package unexpectedly not installed, version
+# mismatch) or 2 (no srcrefs).
+
+args <- commandArgs(trailingOnly = TRUE)
+
+if (length(args) != 2L) {
+    message("'package' and 'version' are required arguments.")
+    quit(status = 1L)
+}
+
+package <- args[[1L]]
+version <- args[[2L]]
+
+# Make sure package is installed
+path <- find.package(package, quiet = TRUE)
+if (length(path) == 0L) {
+    message(paste0("Package '", package, "' is not installed"))
+    quit(status = 1L)
+}
+
+# Make sure installed version matches the requested version.
+# Normalize both to `package_version`s to handle versions like sf's 1.1-1.
+version <- as.character(package_version(version))
+installed_version <- as.character(packageVersion(package))
+if (installed_version != version) {
+    message(paste0(
+        "Version mismatch for '",
+        package,
+        "': ",
+        "installed ",
+        installed_version,
+        ", requested ",
+        version
+    ))
+    quit(status = 1L)
+}
+
+# Get the package namespace and find a function object.
+# Functions will contain the srcrefs if srcrefs have been kept, and are what we
+# can back out the full file structure from.
+ns <- asNamespace(package)
+exports <- getNamespaceExports(ns)
+
+fn <- NULL
+for (name in exports) {
+    candidate <- get0(name, envir = ns, mode = "function")
+    if (!is.null(candidate)) {
+        fn <- candidate
+        break
+    }
+}
+
+if (is.null(fn)) {
+    message(paste0("No functions found for package '", package, "'"))
+    quit(status = 2L)
+}
+
+extract_lines <- function(fn) {
+    srcref <- attr(fn, "srcref")
+    if (is.null(srcref)) {
+        return(NULL)
+    }
+
+    srcfile <- attr(srcref, "srcfile")
+    if (is.null(srcfile)) {
+        return(NULL)
+    }
+
+    original <- srcfile$original
+    if (is.null(original)) {
+        return(NULL)
+    }
+
+    lines <- original$lines
+    if (is.null(lines)) {
+        return(NULL)
+    }
+
+    lines
+}
+
+lines <- extract_lines(fn)
+
+if (is.null(lines)) {
+    message(paste0("No srcrefs found for package '", package, "'"))
+    quit(status = 2L)
+}
+
+cat(lines, sep = "\n")

--- a/crates/oak_srcref/src/lib.rs
+++ b/crates/oak_srcref/src/lib.rs
@@ -1,0 +1,97 @@
+//! Recover an installed R package's sources from `srcref` metadata
+//!
+//! [`SrcrefCache`] is a thin wrapper over an [`oak_cache::Cache`] rooted at
+//! `srcref/v1/`. Each entry is a flat directory of `.R` files recovered from the
+//! `srcref` attributes of an installed package, via a sidecar R session.
+
+mod srcref;
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use oak_cache::Cache;
+use sha2::Digest;
+use sha2::Sha256;
+
+/// Cache version
+const CACHE_VERSION: &str = "v1";
+
+/// LRU capacity for the cache
+const CACHE_CAPACITY: usize = 200;
+
+/// Recovers and caches an installed package's sources from `srcref` metadata
+#[derive(Debug)]
+pub struct SrcrefCache {
+    /// Path to an R executable used to run the recovery script
+    r: PathBuf,
+    cache: Cache,
+}
+
+impl SrcrefCache {
+    pub fn new(r: PathBuf) -> anyhow::Result<Self> {
+        Ok(Self {
+            r,
+            cache: Cache::open(&format!("srcref/{CACHE_VERSION}"), CACHE_CAPACITY)?,
+        })
+    }
+
+    /// Get cached srcref sources if already present
+    pub fn get(&self, name: &str, version: &str, built: &str) -> Option<PathBuf> {
+        self.cache.get(&key(name, version, built))
+    }
+
+    /// Recover and cache srcref sources for an installed package
+    ///
+    /// Returns `None` if the package wasn't installed with srcrefs preserved, or recovery
+    /// fails for any other reason.
+    pub fn insert(
+        &self,
+        name: &str,
+        version: &str,
+        built: &str,
+        library_path: &Path,
+    ) -> Option<PathBuf> {
+        self.cache
+            .insert(&key(name, version, built), |dir| {
+                srcref::populate(&self.r, name, version, library_path, dir)
+            })
+            .unwrap_or_else(|err| {
+                log::error!("Failed to recover srcref sources for '{name}' {version}: {err:?}");
+                None
+            })
+    }
+}
+
+/// Cache key `{name}_{version}_{built_hash}`
+///
+/// The `Built:` hash disambiguates reinstalls! A build timestamp changes on every
+/// rebuild, so a rebuilt package gets a fresh key.
+fn key(name: &str, version: &str, built: &str) -> String {
+    let built_hash = hash(built);
+    format!("{name}_{version}_{built_hash}")
+}
+
+/// First 8 hex characters of the SHA-256 of `contents`
+fn hash(contents: &str) -> String {
+    let mut hash = hex::encode(Sha256::digest(contents));
+    hash.truncate(8);
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::key;
+
+    #[test]
+    fn key_is_name_version_and_built_hash() {
+        let key = key("generics", "0.1.4", "dummy");
+
+        let (prefix, built_hash) = key.rsplit_once('_').unwrap();
+        assert_eq!(prefix, "generics_0.1.4");
+        assert_eq!(built_hash.len(), 8);
+
+        // Same `Built:` is stable, a different `Built:` yields a different key
+        assert_eq!(crate::key("generics", "0.1.4", "dummy"), key);
+        assert_ne!(crate::key("generics", "0.1.4", "dummy2"), key);
+    }
+}

--- a/crates/oak_srcref/src/lib.rs
+++ b/crates/oak_srcref/src/lib.rs
@@ -31,7 +31,17 @@ impl SrcrefCache {
     pub fn new(r: PathBuf) -> anyhow::Result<Self> {
         Ok(Self {
             r,
-            cache: Cache::open(&format!("srcref/{CACHE_VERSION}"), CACHE_CAPACITY)?,
+            cache: Cache::new(&format!("srcref/{CACHE_VERSION}"), CACHE_CAPACITY)?,
+        })
+    }
+
+    /// Open a `SrcrefCache` rooted at an explicit directory instead of the shared cache
+    ///
+    /// Useful for integration tests that don't want to touch the real on disk cache.
+    pub fn new_in(root: PathBuf, r: PathBuf) -> anyhow::Result<Self> {
+        Ok(Self {
+            r,
+            cache: Cache::new_in(root, CACHE_CAPACITY)?,
         })
     }
 

--- a/crates/oak_srcref/src/srcref.rs
+++ b/crates/oak_srcref/src/srcref.rs
@@ -1,0 +1,265 @@
+use std::path::Path;
+
+const SCRIPT: &str = include_str!("../scripts/srcrefs.R");
+
+/// Recover an installed package's sources from `srcref` metadata into `dir`
+///
+/// Launches a sidecar R session to read the srcrefs from the installed package, then
+/// writes a flat directory of `.R` files. Files are marked read only to discourage
+/// accidental edits.
+///
+/// Returns `Ok(false)` if the package wasn't installed with srcrefs preserved, which we
+/// treat as "source unavailable" rather than an error.
+pub(crate) fn populate(
+    r: &Path,
+    name: &str,
+    version: &str,
+    library_path: &Path,
+    dir: &Path,
+) -> anyhow::Result<bool> {
+    let args = &[name, version];
+
+    // Set `R_LIBS` so the sidecar session finds the package in the same library it was
+    // discovered in (see `?R_LIBS`)
+    let library_path = library_path.to_string_lossy();
+    let env = &[("R_LIBS", library_path.as_ref())];
+
+    let output = oak_r_process::run_text(r, SCRIPT, args, env)?;
+
+    let code = output.status.code().unwrap_or(1);
+
+    // Exit code 2 means no srcrefs
+    if code == 2 {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::trace!("R script returned with exit code {code} for {name} {version}: {stderr}");
+        return Ok(false);
+    }
+
+    // Any other unexpected failure (unexpectedly not installed or wrong version)
+    if code != 0 {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!(
+            "R script failed with exit code {code} for {name} {version}: {stderr}"
+        ));
+    }
+
+    let stdout = String::from_utf8(output.stdout).map_err(|err| {
+        anyhow::anyhow!("R script output was not valid UTF-8 for {name} {version}: {err}")
+    })?;
+
+    for (file, contents) in parse_output(&stdout) {
+        let path = dir.join(file);
+        std::fs::write(&path, contents)?;
+        oak_fs::permissions::set_readonly(&path)?;
+    }
+
+    Ok(true)
+}
+
+/// Parses the concatenated srcref output into individual files.
+///
+/// The output format uses `#line 1 "<path>"` directives to separate files:
+///
+/// ```text
+/// #line 1 "</install/path>/pkg/R/aaa.R"
+/// <contents of aaa.R>
+/// #line 1 "</install/path>/pkg/R/bbb.R"
+/// <contents of bbb.R>
+/// ```
+fn parse_output(output: &str) -> Vec<(String, String)> {
+    let mut files: Vec<(String, String)> = Vec::new();
+    let mut current_name: Option<String> = None;
+    let mut current_lines: Vec<&str> = Vec::new();
+
+    // This discards any lines before the first line directive, like this line, which
+    // isn't part of the package sources `.packageName <- "vctrs"`
+    for line in output.lines() {
+        if let Some(name) = parse_line_directive(line) {
+            // Flush the previous file
+            if let Some(current_name) = current_name.take() {
+                files.push((current_name, current_lines.join("\n")));
+                current_lines.clear();
+            }
+            current_name = Some(name);
+        } else if current_name.is_some() {
+            current_lines.push(line);
+        }
+    }
+
+    // Flush the last file
+    if let Some(name) = current_name.take() {
+        files.push((name, current_lines.join("\n")));
+    }
+
+    files
+}
+
+/// Extracts the filename from a line directive, keeping just the basename.
+///
+/// For example, `line 1 "</install/path>/pkg/R/aaa.R"` becomes `aaa.R`.
+///
+/// Does not have a way to fail on malformed line directives. If for some reason one is
+/// malformed and doesn't have our expected prefix/suffix, then we would end up treating
+/// it like a comment within a file.
+fn parse_line_directive(line: &str) -> Option<String> {
+    let path = line.strip_prefix("#line 1 \"")?;
+    let path = path.strip_suffix('"')?;
+    let file_name = Path::new(path).file_name()?;
+    Some(file_name.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_output_single_file() {
+        let output = "\
+#line 1 \"/path/to/pkg/R/aaa.R\"
+fn_a <- function() {
+  1 + 1
+}";
+        let files = parse_output(output);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "aaa.R");
+        assert_eq!(files[0].1, "fn_a <- function() {\n  1 + 1\n}");
+    }
+
+    #[test]
+    fn test_parse_output_multiple_files() {
+        let output = "\
+#line 1 \"/path/to/pkg/R/aaa.R\"
+fn_a <- function() { }
+#line 1 \"/path/to/pkg/R/bbb.R\"
+fn_b <- function() { }";
+        let files = parse_output(output);
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].0, "aaa.R");
+        assert_eq!(files[0].1, "fn_a <- function() { }");
+        assert_eq!(files[1].0, "bbb.R");
+        assert_eq!(files[1].1, "fn_b <- function() { }");
+    }
+
+    #[test]
+    fn test_parse_output_leading_text() {
+        let output = "\
+packageName <- \"vctrs\"
+#line 1 \"/path/to/pkg/R/aaa.R\"
+fn_a <- function() {
+  1 + 1
+}";
+        let files = parse_output(output);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "aaa.R");
+        assert_eq!(files[0].1, "fn_a <- function() {\n  1 + 1\n}");
+    }
+
+    #[test]
+    fn test_parse_output_empty() {
+        let files = parse_output("");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_output_no_directives() {
+        let files = parse_output("just some text\nwith no directives");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_line_directive() {
+        assert_eq!(
+            parse_line_directive("#line 1 \"/path/to/file.R\""),
+            Some(String::from("file.R"))
+        );
+        assert_eq!(parse_line_directive("not a directive"), None);
+        assert_eq!(parse_line_directive("#line 2 \"/path/to/file.R\""), None);
+        assert_eq!(parse_line_directive("#line 1 missing-quotes"), None);
+    }
+
+    /// Requires R on the PATH and internet access
+    ///
+    /// Installs source version of {generics} from CRAN into a temporary library, then
+    /// recovers the R source files via srcref metadata. We use {generics} because it
+    /// is very easy to install from source and lightweight.
+    #[test]
+    fn test_srcref_extraction() {
+        use std::process::Command;
+
+        // Find R on PATH.
+        // On Windows, `which` (from Git) returns POSIX paths that `Command::new()` can't
+        // resolve. Use `where` which returns native paths.
+        let output = Command::new(if cfg!(windows) { "where" } else { "which" })
+            .arg("R")
+            .output()
+            .unwrap_or_else(|err| panic!("Failed to find R: {err}"));
+        assert!(output.status.success());
+
+        // Parse (`where` on Windows can return multiple matches, take the first)
+        let r = PathBuf::from(
+            String::from_utf8(output.stdout)
+                .expect("Non-UTF8 R path")
+                .trim()
+                .lines()
+                .next()
+                .expect("R should exist"),
+        );
+
+        // Temporary library for installing generics
+        let library = tempfile::TempDir::new().unwrap();
+
+        // Use forward slashes so the path is safe inside R string literals on Windows
+        // (backslashes would be interpreted as escape sequences).
+        let library_for_interpolation = library.path().display().to_string().replace('\\', "/");
+
+        // Install generics from CRAN source with srcrefs preserved
+        let output = oak_r_process::run_text(
+            &r,
+            &format!(
+                r#"install.packages("generics", lib = "{library_for_interpolation}", repos = "https://cran.r-project.org", type = "source", INSTALL_opts = "--with-keep.source")"#,
+            ),
+            &[],
+            &[],
+        )
+        .expect("Failed to run install.packages()");
+        assert!(output.status.success());
+
+        // Query the installed generics version
+        let output = oak_r_process::run_text(
+            &r,
+            &format!(
+                r#"cat(as.character(packageVersion("generics", lib.loc = "{library_for_interpolation}")))"#,
+            ),
+            &[],
+            &[],
+        )
+        .expect("Failed to get generics version");
+        assert!(output.status.success());
+
+        let version = String::from_utf8(output.stdout)
+            .expect("Non-UTF8 version")
+            .trim()
+            .to_string();
+
+        // Recover sources into a destination directory
+        let destination = tempfile::TempDir::new().unwrap();
+
+        let ok = populate(&r, "generics", &version, library.path(), destination.path()).unwrap();
+        assert!(ok);
+
+        // Verify R source files were written flat into the destination
+        let entries: Vec<_> = std::fs::read_dir(destination.path())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(!entries.is_empty());
+
+        // Verify files are readonly
+        for entry in &entries {
+            let metadata = entry.metadata().unwrap();
+            assert!(metadata.permissions().readonly());
+        }
+    }
+}


### PR DESCRIPTION
Part of #1234
Branched from #1299 

Not much to see here, exact same srcref mechanism as before. Just extracted into its own crate.