### PR TITLE
(6) Goto definition tests for workspace package `import()` and `importFrom()`

### DIFF
--- a/crates/ark/src/lsp/tests.rs
+++ b/crates/ark/src/lsp/tests.rs
@@ -4,6 +4,7 @@ mod find_references;
 mod goto_definition;
 mod main_loop;
 mod rename;
+mod source_handler;
 mod sources;
 mod state;
 mod state_handlers;

--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -1,14 +1,32 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use aether_path::FilePath;
 use assert_matches::assert_matches;
+use oak_db::Db;
+use oak_db::OakDatabase;
+use oak_scan::DbScan;
+use oak_semantic::library::Library;
 use tower_lsp::lsp_types;
 use tower_lsp::lsp_types::GotoDefinitionParams;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use url::Url;
 
+use super::source_handler::TestBehavior;
+use super::source_handler::TestSourceHandler;
+use super::utils::did_change_workspace_folders;
 use super::utils::insert_file;
 use super::utils::make_state;
 use super::utils::range;
+use super::utils::test_client;
+use super::utils::write_sources;
+use super::utils::DescriptionWriter;
+use super::utils::NamespaceWriter;
 use crate::lsp::goto_definition::goto_definition;
+use crate::lsp::main_loop::init_aux_for_test;
+use crate::lsp::main_loop::GlobalState;
+use crate::lsp::main_loop::LspState;
+use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 use crate::lsp::util::test_path;
 
@@ -211,6 +229,138 @@ fn test_sourced_file_with_sequential_redef_offers_runtime_winner() {
             assert_eq!(links.len(), 1);
             assert_eq!(links[0].target_uri, helpers_uri);
             assert_eq!(links[0].target_range, range((1, 0), (1, 2)));
+        }
+    );
+}
+
+/// Goto-def from a bare `foo()` through to `foopkg::foo()`'s definition via the
+/// workspace package's `import(foopkg)`
+#[tokio::test]
+async fn test_goto_definition_resolves_unqualified_import_into_package() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("foopkg"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    // Set up the library that our "installed" package lives in
+    let library = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("foopkg")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&library.path().join("foopkg"));
+    NamespaceWriter::new()
+        .export("foo")
+        .write(&library.path().join("foopkg"));
+
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[library.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(db, Library::new(vec![])),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler)),
+        ),
+    );
+
+    // The workspace folder is itself the package that imports `foo`.
+    let workspace = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("mypackage")
+        .version("0.0.0")
+        .imports(&["foopkg"])
+        .write(workspace.path());
+    NamespaceWriter::new()
+        .import("foopkg")
+        .write(workspace.path());
+    let use_path = workspace.path().join("R").join("use.R");
+    let use_uri = Url::from_file_path(&use_path).unwrap();
+    write_sources(&workspace.path().join("R"), &[("use.R", "foo()\n")]);
+
+    // Open the workspace folder, triggering a workspace scan
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+
+    let world = state.world();
+    let foo_file = world.db.package_by_name("foopkg").unwrap().files(&world.db)[0];
+
+    assert_matches!(
+        goto_definition(make_params(use_uri, 0, 0), world).unwrap(),
+        Some(GotoDefinitionResponse::Link(ref links)) => {
+            assert_eq!(links.len(), 1);
+            assert_eq!(links[0].target_uri, world.wire_url(foo_file));
+            assert_eq!(links[0].target_range, range((0, 0), (0, 3)));
+        }
+    );
+}
+
+/// Goto-def from a bare `bar()` through to `barpkg::bar()`'s definition via the
+/// workspace package's `importFrom(barpkg, bar)`
+#[tokio::test]
+async fn test_goto_definition_resolves_unqualified_import_from_into_package() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("barpkg"),
+        TestBehavior::Success(vec![("bar.R", "bar <- function() 2\n")]),
+    )])));
+
+    // Set up the library that our "installed" package lives in
+    let library = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("barpkg")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&library.path().join("barpkg"));
+    NamespaceWriter::new()
+        .export("bar")
+        .write(&library.path().join("barpkg"));
+
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[library.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(db, Library::new(vec![])),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler)),
+        ),
+    );
+
+    // The workspace folder is itself the package that imports `bar`.
+    let workspace = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("mypackage")
+        .version("0.0.0")
+        .imports(&["barpkg"])
+        .write(workspace.path());
+    NamespaceWriter::new()
+        .import_from("barpkg", "bar")
+        .write(workspace.path());
+    let use_path = workspace.path().join("R").join("use.R");
+    let use_uri = Url::from_file_path(&use_path).unwrap();
+    write_sources(&workspace.path().join("R"), &[("use.R", "bar()\n")]);
+
+    // Open the workspace folder, triggering a workspace scan
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+
+    let world = state.world();
+    let bar_file = world.db.package_by_name("barpkg").unwrap().files(&world.db)[0];
+
+    assert_matches!(
+        goto_definition(make_params(use_uri, 0, 0), world).unwrap(),
+        Some(GotoDefinitionResponse::Link(ref links)) => {
+            assert_eq!(links.len(), 1);
+            assert_eq!(links[0].target_uri, world.wire_url(bar_file));
+            assert_eq!(links[0].target_range, range((0, 0), (0, 3)));
         }
     );
 }

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -16,8 +16,8 @@ use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
 use url::Url;
 
 use super::utils::test_client;
-use super::utils::write_description;
 use super::utils::write_sources;
+use super::utils::DescriptionWriter;
 use crate::lsp::backend::LspMessage;
 use crate::lsp::backend::LspNotification;
 use crate::lsp::main_loop::init_aux_for_test;
@@ -44,7 +44,10 @@ async fn test_workspace_folder_scan_drives_through_main_loop() {
 
     let tmp = tempfile::tempdir().unwrap();
     let pkg = tmp.path().join("pkg");
-    write_description(&pkg, "pkg");
+    DescriptionWriter::new()
+        .package("pkg")
+        .version("0.0.0")
+        .write(&pkg);
     write_sources(&pkg.join("R"), &[("a.R", "x <- 1\n")]);
 
     let params = DidChangeWorkspaceFoldersParams {

--- a/crates/ark/src/lsp/tests/source_handler.rs
+++ b/crates/ark/src/lsp/tests/source_handler.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::utils::write_sources;
+use crate::lsp::sources::SourceHandler;
+use crate::lsp::sources::SourceRequest;
+use crate::lsp::sources::SourceResponse;
+
+/// A test [`SourceHandler`] that serves canned behavior per package name and records
+/// every call, so tests can count the number of calls. The handler is shared (as the
+/// `Arc<dyn SourceHandler>` the `SourceScheduler` holds and the clone the test keeps), so
+/// `calls` is a plain `Mutex`.
+pub(super) struct TestSourceHandler {
+    /// Owns the cache directory that `Success` writes per-package sources into.
+    sources: tempfile::TempDir,
+    /// Per-package canned behavior.
+    behavior: HashMap<String, TestBehavior>,
+    /// Each request passed to `handle`, in call order.
+    calls: Mutex<Vec<SourceRequest>>,
+}
+
+// Canned behavior to perform when a particular package is requested
+pub(super) enum TestBehavior {
+    /// Write these `(basename, contents)` files into the package's source dir
+    /// and return `Success(dir)`.
+    Success(Vec<(&'static str, &'static str)>),
+    Failure,
+}
+
+impl TestSourceHandler {
+    pub(super) fn new(behavior: HashMap<String, TestBehavior>) -> Self {
+        Self {
+            sources: tempfile::tempdir().unwrap(),
+            behavior,
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The requests passed to `handle`, in call order, for the test to assert on.
+    pub(super) fn calls(&self) -> &Mutex<Vec<SourceRequest>> {
+        &self.calls
+    }
+}
+
+impl SourceHandler for TestSourceHandler {
+    fn handle(&self, request: &SourceRequest) -> SourceResponse {
+        self.calls.lock().unwrap().push(request.clone());
+
+        match self.behavior.get(request.name()) {
+            Some(TestBehavior::Success(files)) => {
+                let dir = self.sources.path().join(request.name());
+                write_sources(&dir, files);
+                SourceResponse::Success(dir)
+            },
+            Some(TestBehavior::Failure) => SourceResponse::Failure,
+            None => panic!("Unknown test package {}", request.name()),
+        }
+    }
+}

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -2,7 +2,6 @@
 //! event loop.
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -11,107 +10,22 @@ use oak_db::Db;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use oak_semantic::library::Library;
-use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
-use tower_lsp::lsp_types::DidOpenTextDocumentParams;
-use tower_lsp::lsp_types::TextDocumentItem;
-use tower_lsp::lsp_types::WorkspaceFolder;
-use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
-use url::Url;
 
+use super::source_handler::TestBehavior;
+use super::source_handler::TestSourceHandler;
+use super::utils::did_change_workspace_folders;
+use super::utils::did_open;
 use super::utils::test_client;
-use super::utils::write_description;
 use super::utils::write_sources;
-use crate::lsp::backend::LspMessage;
-use crate::lsp::backend::LspNotification;
+use super::utils::DescriptionWriter;
 use crate::lsp::main_loop::init_aux_for_test;
-use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceRequest;
-use crate::lsp::sources::SourceResponse;
 use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
-
-/// A test [`SourceHandler`] that serves canned behavior per package name and records
-/// every call, so tests can count the number of calls. The handler is shared (as the
-/// `Arc<dyn SourceHandler>` the `SourceScheduler` holds and the clone the test keeps), so
-/// `calls` is a plain `Mutex`.
-struct TestSourceHandler {
-    /// Owns the cache directory that `Success` writes per-package sources into.
-    sources: tempfile::TempDir,
-    /// Per-package canned behavior.
-    behavior: HashMap<String, TestBehavior>,
-    /// Each request passed to `handle`, in call order.
-    calls: Mutex<Vec<SourceRequest>>,
-}
-
-// Canned behavior to perform when a particular package is requested
-enum TestBehavior {
-    /// Write these `(basename, contents)` files into the package's source dir
-    /// and return `Success(dir)`.
-    Success(Vec<(&'static str, &'static str)>),
-    Failure,
-}
-
-impl TestSourceHandler {
-    fn new(behavior: HashMap<String, TestBehavior>) -> Self {
-        Self {
-            sources: tempfile::tempdir().unwrap(),
-            behavior,
-            calls: Mutex::new(Vec::new()),
-        }
-    }
-
-    /// The requests passed to `handle`, in call order, for the test to assert on.
-    fn calls(&self) -> &Mutex<Vec<SourceRequest>> {
-        &self.calls
-    }
-}
-
-impl SourceHandler for TestSourceHandler {
-    fn handle(&self, request: &SourceRequest) -> SourceResponse {
-        self.calls.lock().unwrap().push(request.clone());
-
-        match self.behavior.get(request.name()) {
-            Some(TestBehavior::Success(files)) => {
-                let dir = self.sources.path().join(request.name());
-                write_sources(&dir, files);
-                SourceResponse::Success(dir)
-            },
-            Some(TestBehavior::Failure) => SourceResponse::Failure,
-            None => panic!("Unknown test package {}", request.name()),
-        }
-    }
-}
-
-fn did_change_workspace_folders(path: &Path) -> Event {
-    Event::Lsp(LspMessage::Notification(
-        LspNotification::DidChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams {
-            event: WorkspaceFoldersChangeEvent {
-                added: vec![WorkspaceFolder {
-                    uri: Url::from_file_path(path).unwrap(),
-                    name: String::new(),
-                }],
-                removed: vec![],
-            },
-        }),
-    ))
-}
-
-fn did_open(path: &Path, contents: &str) -> Event {
-    Event::Lsp(LspMessage::Notification(
-        LspNotification::DidOpenTextDocument(DidOpenTextDocumentParams {
-            text_document: TextDocumentItem {
-                uri: Url::from_file_path(path).unwrap(),
-                language_id: String::from("r"),
-                version: 0,
-                text: contents.to_string(),
-            },
-        }),
-    ))
-}
 
 /// The package names passed to the handler, in call order.
 fn dispatched_names(calls: &Mutex<Vec<SourceRequest>>) -> Vec<String> {
@@ -159,7 +73,11 @@ async fn test_source_pipeline_ingests_package_sources() {
 
     // An installed library package with no `R/` sources of its own
     let lib = tempfile::tempdir().unwrap();
-    write_description(&lib.path().join("donor"), "donor");
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
@@ -175,7 +93,10 @@ async fn test_source_pipeline_ingests_package_sources() {
     // A workspace package that uses `donor` via `::`.
     let workspace = tempfile::tempdir().unwrap();
     let myproj = workspace.path().join("myproj");
-    write_description(&myproj, "myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
 
     state
@@ -213,7 +134,11 @@ async fn test_failed_source_is_not_retried() {
     )])));
 
     let lib = tempfile::tempdir().unwrap();
-    write_description(&lib.path().join("donor"), "donor");
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
@@ -228,7 +153,10 @@ async fn test_failed_source_is_not_retried() {
 
     let workspace = tempfile::tempdir().unwrap();
     let myproj = workspace.path().join("myproj");
-    write_description(&myproj, "myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
 
     state
@@ -301,7 +229,10 @@ async fn test_source_pipeline_ingests_real_srcref_sources() {
     // A workspace package that uses {generics} via `::`
     let workspace = tempfile::tempdir().unwrap();
     let myproj = workspace.path().join("myproj");
-    write_description(&myproj, "myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "generics::as.factor()\n")]);
 
     state

--- a/crates/ark/src/lsp/tests/utils/description_writer.rs
+++ b/crates/ark/src/lsp/tests/utils/description_writer.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+/// Assembles a `DESCRIPTION` file from parts
+#[derive(Default)]
+pub(crate) struct DescriptionWriter {
+    fields: Vec<(String, String)>,
+}
+
+impl DescriptionWriter {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn package(self, name: &str) -> Self {
+        self.field("Package", name)
+    }
+
+    pub(crate) fn version(self, version: &str) -> Self {
+        self.field("Version", version)
+    }
+
+    pub(crate) fn built(self, built: &str) -> Self {
+        self.field("Built", built)
+    }
+
+    pub(crate) fn imports(self, imports: &[&str]) -> Self {
+        self.field("Imports", &imports.join(", "))
+    }
+
+    pub(crate) fn field(mut self, key: &str, value: &str) -> Self {
+        self.fields.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Write the assembled `DESCRIPTION` into `dir`.
+    pub(crate) fn write(self, dir: &Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        let contents: String = self
+            .fields
+            .iter()
+            .map(|(key, value)| format!("{key}: {value}\n"))
+            .collect();
+        std::fs::write(dir.join("DESCRIPTION"), contents).unwrap();
+    }
+}

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -1,0 +1,39 @@
+use std::path::Path;
+
+use tower_lsp::lsp_types::DidChangeWorkspaceFoldersParams;
+use tower_lsp::lsp_types::DidOpenTextDocumentParams;
+use tower_lsp::lsp_types::TextDocumentItem;
+use tower_lsp::lsp_types::WorkspaceFolder;
+use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
+use url::Url;
+
+use crate::lsp::backend::LspMessage;
+use crate::lsp::backend::LspNotification;
+use crate::lsp::main_loop::Event;
+
+pub(crate) fn did_change_workspace_folders(path: &Path) -> Event {
+    Event::Lsp(LspMessage::Notification(
+        LspNotification::DidChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams {
+            event: WorkspaceFoldersChangeEvent {
+                added: vec![WorkspaceFolder {
+                    uri: Url::from_file_path(path).unwrap(),
+                    name: String::new(),
+                }],
+                removed: vec![],
+            },
+        }),
+    ))
+}
+
+pub(crate) fn did_open(path: &Path, contents: &str) -> Event {
+    Event::Lsp(LspMessage::Notification(
+        LspNotification::DidOpenTextDocument(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: Url::from_file_path(path).unwrap(),
+                language_id: String::from("r"),
+                version: 0,
+                text: contents.to_string(),
+            },
+        }),
+    ))
+}

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -1,6 +1,14 @@
+mod description_writer;
+mod events;
+mod namespace_writer;
+
 use std::path::Path;
 
 use aether_path::FilePath;
+pub(super) use description_writer::DescriptionWriter;
+pub(super) use events::did_change_workspace_folders;
+pub(super) use events::did_open;
+pub(super) use namespace_writer::NamespaceWriter;
 use oak_scan::DbScan;
 use tower_lsp::lsp_types;
 use tower_lsp::Client;
@@ -40,15 +48,6 @@ pub(super) fn test_client() -> Client {
     // end of the block.
     let client = captured.lock().unwrap().take();
     client.unwrap()
-}
-
-pub(super) fn write_description(dir: &Path, name: &str) {
-    std::fs::create_dir_all(dir).unwrap();
-    std::fs::write(
-        dir.join("DESCRIPTION"),
-        format!("Package: {name}\nVersion: 0.0.0\nBuilt: dummy\n"),
-    )
-    .unwrap();
 }
 
 pub(super) fn write_sources(dir: &Path, files: &[(&str, &str)]) {

--- a/crates/ark/src/lsp/tests/utils/namespace_writer.rs
+++ b/crates/ark/src/lsp/tests/utils/namespace_writer.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+/// Assembles a `NAMESPACE` file
+#[derive(Default)]
+pub(crate) struct NamespaceWriter {
+    directives: Vec<String>,
+}
+
+impl NamespaceWriter {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn export(self, name: &str) -> Self {
+        self.directive(format!("export({name})"))
+    }
+
+    pub(crate) fn import(self, package: &str) -> Self {
+        self.directive(format!("import({package})"))
+    }
+
+    pub(crate) fn import_from(self, package: &str, name: &str) -> Self {
+        self.directive(format!("importFrom({package}, {name})"))
+    }
+
+    fn directive(mut self, directive: String) -> Self {
+        self.directives.push(directive);
+        self
+    }
+
+    /// Write the assembled `NAMESPACE` into `dir`
+    pub(crate) fn write(self, dir: &Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        let contents: String = self
+            .directives
+            .iter()
+            .map(|directive| format!("{directive}\n"))
+            .collect();
+        std::fs::write(dir.join("NAMESPACE"), contents).unwrap();
+    }
+}


### PR DESCRIPTION
Branched from #1302 

With some extracted support infrastructure: `DescriptionWriter`, `NamespaceWriter`, and the generic `TestSourceHandler`

---

Even without any additional changes, just hooking up the production `SourceHandler` has enabled some features we didn't have existing "live" tests for.

One of those is goto def on usage of `foo()` in your workspace package, when `foo()` comes from a NAMESPACE `import()` or `importFrom()`