### PR TITLE
(7) Allow `Package::resolve()` to skip the namespace export check for `base`

### DIFF
--- a/crates/oak_db/src/package_resolve.rs
+++ b/crates/oak_db/src/package_resolve.rs
@@ -55,7 +55,11 @@ impl<'db> Package {
         name: Name<'db>,
         visibility: PackageVisibility,
     ) -> Vec<Definition<'db>> {
+        // When resolving an export, the `name` must be present in the `NAMESPACE`
+        // exports. If the package is `base`, there is no `NAMESPACE`, but all top-level
+        // bindings in `base` are visible by construction, so we skip this check entirely.
         if visibility == PackageVisibility::Exported &&
+            self.name(db) != "base" &&
             !self
                 .namespace(db)
                 .exports

--- a/crates/oak_db/src/tests/package_resolve.rs
+++ b/crates/oak_db/src/tests/package_resolve.rs
@@ -273,3 +273,23 @@ fn test_same_name_defined_in_multiple_files_returns_each() {
     assert!(target_files.contains(&files[0]));
     assert!(target_files.contains(&files[1]));
 }
+
+#[test]
+fn test_base_exports_every_top_level_binding() {
+    // `base` doesn't have a `NAMESPACE`, so there are no namespace exports for it.
+    // Instead, `PackageVisibility::Exported` lookups on `base` skip the export check and
+    // fall straight through to looking for a top-level binding anywhere in the `base`
+    // source files.
+    //
+    // Note that this won't find primitives! These have no top-level binding.
+    let mut db = TestDb::new();
+    let (pkg, files) = setup_package(&mut db, "base", &[], &[(
+        "workspace/base/R/a.R",
+        "foo <- function() 1\n",
+    )]);
+
+    let defs = pkg.resolve(&db, name(&db, "foo"), PackageVisibility::Exported);
+    assert_eq!(defs.len(), 1);
+    assert_eq!(defs[0].file(&db), files[0]);
+    assert_eq!(defs[0].name(&db).text(&db).as_str(), "foo");
+}


### PR DESCRIPTION
Branched from #1303 
Closes https://github.com/posit-dev/ark/issues/1303

I took a look at this and this seems to be the one place we use `namespace().exports` right now. Everything works as is if we just skip the gating check for `base` in particular. This works because _every_ top level assignment in base is an export by construction, so we don't really need to check this anyways.

If we find ourself getting burned by this in other places, we can reconsider, but right now this feels way cleaner than trying to reconstruct a fake namespace for base. It seems like we simply don't need it!