### PR TITLE
Set R >=4.6.0's `help.htmltoc`option to `FALSE`

### DIFF
--- a/crates/ark/src/modules/positron/options.R
+++ b/crates/ark/src/modules/positron/options.R
@@ -55,6 +55,12 @@ initialize_options <- function() {
     # Enable HTML help
     set_default("help_type", "html")
 
+    # Disable the R >=4.6.0 HTML table of contents displayed in help pages. This
+    # was added for CRAN's HTML view of package documentation, but is not useful
+    # for Positron and results in mangled HTML for us, since we don't handle the
+    # `R-nav.css` file that accompanies it (posit-dev/positron#12840).
+    set_default("help.htmltoc", FALSE)
+
     set_default("viewer", viewer_option_handler)
 
     # Show Shiny applications in the viewer. This is technically redundant with

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -90,6 +90,7 @@ These base R options have non-`NULL` defaults, so we can't detect user overrides
 These options are only set when the user has *not* already defined them (e.g. in `.Rprofile`). This allows users to simply set the option to any value to override Positron's default. They can also be listed in `ark.protected_options` to keep the option as `NULL`.
 
 - **`help_type`** — Set to `"html"`. Displays help pages as HTML rather than plain text.
+- **`help.htmltoc`** - Set to `FALSE`. If left unset, would result in a poorly styled table of contents being generated in Positron's Help pane. Only applicable in R >=4.6.0.
 - **`viewer`** — Displays HTML content in Positron's Viewer pane. Used by htmlwidgets, Shiny gadgets, etc.
 - **`shiny.launch.browser`** — Set to a function that shows the Shiny app URL in Positron's Viewer pane. Set `options(shiny.launch.browser = TRUE)` in your `.Rprofile` to open Shiny apps in the system browser instead. Note that `TRUE` causes Shiny to use the `browser` option, which defaults to Positron's viewer, so you may also want to protect `browser`.
 - **`plumber.docs.callback`** — Set to a function that shows Plumber API docs in Positron's Viewer pane.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12840

Relevant R commits:
- https://github.com/wch/r-source/commit/2022aa9cd39e7fa2bbea87c33a96c0282952b1c7
- https://github.com/wch/r-source/commit/3484008e6ea7d94ef882bbfebb07b48e52602e82

R 4.6.0 added a new `help.htmltoc` global option. The point of this was to help add a TOC on the left hand side of CRAN's new HTML page for R package docs: https://cran.r-project.org/web/packages/vctrs/refman/vctrs.html

It's on for "dynamic help", i.e. when you go through `httpd()` which calls `Rd2HTML(dynamic = TRUE, toc = getOption("help.htmltoc", TRUE))`, and we of course use `httpd()` for installed package help.

(Notably its not broken for "preview" R package help, i.e. for development version docs, since we control the `Rd2HTML()` call there and don't supply `toc`, see `.ps.Rd2HTML()`).

---

We have two options:

- Turn it off using the only hook we have, the `help.htmltoc` global option
- Try to use it, by adapting to the new `R-nav.css` stylesheet, which weirdly feels like `R.css` with some extra additions? https://github.com/wch/r-source/blob/d5e28ead42751bc5a46bef44b3f351642c4d60d3/doc/html/R-nav.css#L2-L6

I think trying to use `R-nav.css` is probably a mistake, the TOC won't get us much, and is supposed to be hidden on narrow screens anyways. Since the Help pane is usually narrow, it would pretty much always be hidden.

So instead the best option is to just turn it off on load.

---

I have confirmed locally that this fixes the mangled help issue.