### PR TITLE
Make it impossible for background threads to mutate Salsa inputs

### DIFF
--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -13,18 +13,18 @@ use crate::lsp::completions::function_context::FunctionContext;
 use crate::lsp::completions::sources::composite::pipe::find_pipe_root;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
 use crate::lsp::document_context::DocumentContext;
-use crate::lsp::state::WorldState;
+use crate::lsp::state::WorldSnapshot;
 use crate::treesitter::node_find_containing_call;
 pub(crate) struct CompletionContext<'a> {
     pub(crate) document_context: &'a DocumentContext<'a>,
-    pub(crate) state: &'a WorldState,
+    pub(crate) state: &'a WorldSnapshot,
     pipe_root_cell: OnceCell<Option<PipeRoot>>,
     containing_call_cell: OnceCell<Option<Node<'a>>>,
     function_context_cell: OnceCell<anyhow::Result<FunctionContext>>,
 }
 
 impl<'a> CompletionContext<'a> {
-    pub fn new(document_context: &'a DocumentContext, state: &'a WorldState) -> Self {
+    pub fn new(document_context: &'a DocumentContext, state: &'a WorldSnapshot) -> Self {
         Self {
             document_context,
             state,

--- a/crates/ark/src/lsp/completions/completion_context.rs
+++ b/crates/ark/src/lsp/completions/completion_context.rs
@@ -13,18 +13,18 @@ use crate::lsp::completions::function_context::FunctionContext;
 use crate::lsp::completions::sources::composite::pipe::find_pipe_root;
 use crate::lsp::completions::sources::composite::pipe::PipeRoot;
 use crate::lsp::document_context::DocumentContext;
-use crate::lsp::state::WorldSnapshot;
+use crate::lsp::state::WorldStateSnapshot;
 use crate::treesitter::node_find_containing_call;
 pub(crate) struct CompletionContext<'a> {
     pub(crate) document_context: &'a DocumentContext<'a>,
-    pub(crate) state: &'a WorldSnapshot,
+    pub(crate) state: &'a WorldStateSnapshot,
     pipe_root_cell: OnceCell<Option<PipeRoot>>,
     containing_call_cell: OnceCell<Option<Node<'a>>>,
     function_context_cell: OnceCell<anyhow::Result<FunctionContext>>,
 }
 
 impl<'a> CompletionContext<'a> {
-    pub fn new(document_context: &'a DocumentContext, state: &'a WorldSnapshot) -> Self {
+    pub fn new(document_context: &'a DocumentContext, state: &'a WorldStateSnapshot) -> Self {
         Self {
             document_context,
             state,

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -11,7 +11,7 @@ use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::composite;
 use crate::lsp::completions::sources::unique;
 use crate::lsp::document_context::DocumentContext;
-use crate::lsp::state::WorldState;
+use crate::lsp::state::WorldSnapshot;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::NodeTypeExt;
 
@@ -19,7 +19,7 @@ use crate::treesitter::NodeTypeExt;
 // Must be within an `r_task()`.
 pub(crate) fn provide_completions(
     document_context: &DocumentContext,
-    state: &WorldState,
+    state: &WorldSnapshot,
 ) -> anyhow::Result<Vec<CompletionItem>> {
     log::info!(
         "provide_completions() - Completion node text: '{node_text}', Node type: '{node_type:?}'",

--- a/crates/ark/src/lsp/completions/provide.rs
+++ b/crates/ark/src/lsp/completions/provide.rs
@@ -11,7 +11,7 @@ use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::sources::composite;
 use crate::lsp::completions::sources::unique;
 use crate::lsp::document_context::DocumentContext;
-use crate::lsp::state::WorldSnapshot;
+use crate::lsp::state::WorldStateSnapshot;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::NodeTypeExt;
 
@@ -19,7 +19,7 @@ use crate::treesitter::NodeTypeExt;
 // Must be within an `r_task()`.
 pub(crate) fn provide_completions(
     document_context: &DocumentContext,
-    state: &WorldSnapshot,
+    state: &WorldStateSnapshot,
 ) -> anyhow::Result<Vec<CompletionItem>> {
     log::info!(
         "provide_completions() - Completion node text: '{node_text}', Node type: '{node_type:?}'",

--- a/crates/ark/src/lsp/completions/sources/composite.rs
+++ b/crates/ark/src/lsp/completions/sources/composite.rs
@@ -252,7 +252,7 @@ mod tests {
             let (text, point) = point_from_cursor("@");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
 
             assert!(context.document_context.node.is_program());
@@ -270,7 +270,7 @@ mod tests {
             let (text, point) = point_from_cursor(code);
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
 
             assert!(context.document_context.node.is_program());

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -94,7 +94,7 @@ fn completions_from_call(
         },
     };
 
-    completions_from_arguments(&context.state.db, document_context, callee, object)
+    completions_from_arguments(context.state.db.read(), document_context, callee, object)
 }
 
 fn get_first_argument(context: &DocumentContext, node: &Node) -> anyhow::Result<Option<RObject>> {
@@ -294,7 +294,7 @@ mod tests {
             let (text, point) = point_from_cursor("match(tab@)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
 
@@ -307,7 +307,7 @@ mod tests {
             let (text, point) = point_from_cursor("match(1, tab@)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
 
@@ -327,7 +327,7 @@ mod tests {
             let (text, point) = point_from_cursor("not_a_known_function(@)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap();
             assert!(completions.is_none());
@@ -347,7 +347,7 @@ mod tests {
             let (text, point) = point_from_cursor("my_fun(@)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
 
@@ -364,7 +364,7 @@ mod tests {
             let (text, point) = point_from_cursor("my_fun@()");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap();
             assert!(completions.is_none());
@@ -373,7 +373,7 @@ mod tests {
             let (text, point) = point_from_cursor("my_fun()@");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap();
             assert!(completions.is_none());
@@ -396,7 +396,7 @@ mod tests {
             let (text, point) = point_from_cursor("my_fun(@)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
             assert_eq!(completions.len(), 0);
@@ -413,7 +413,7 @@ mod tests {
             let (text, point) = point_from_cursor("match(\n  @\n)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
 
@@ -425,7 +425,7 @@ mod tests {
             let (text, point) = point_from_cursor("match(\n  tab@\n)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
 
@@ -437,7 +437,7 @@ mod tests {
             let (text, point) = point_from_cursor("match(\n  1,\n  tab@\n)");
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let context = CompletionContext::new(&document_context, &state);
             let completions = completions_from_call(&context).unwrap().unwrap();
 
@@ -454,7 +454,7 @@ mod tests {
                 let (text, point) = point_from_cursor(code_with_cursor);
                 let doc = TestDocument::new(&text);
                 let document_context = doc.context(point);
-                let state = WorldState::default();
+                let state = WorldState::default().snapshot();
                 let context = CompletionContext::new(&document_context, &state);
                 let completions = completions_from_call(&context).unwrap();
 

--- a/crates/ark/src/lsp/completions/sources/composite/call.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/call.rs
@@ -94,7 +94,7 @@ fn completions_from_call(
         },
     };
 
-    completions_from_arguments(context.state.db.read(), document_context, callee, object)
+    completions_from_arguments(context.state.db(), document_context, callee, object)
 }
 
 fn get_first_argument(context: &DocumentContext, node: &Node) -> anyhow::Result<Option<RObject>> {

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -69,7 +69,7 @@ fn completions_from_workspace(
     let token = token.as_str();
 
     // get entries from the index
-    indexer::map(&state.db, |file, symbol, entry| {
+    indexer::map(state.db.read(), |file, symbol, entry| {
         if !symbol.fuzzy_matches(token) {
             return;
         }

--- a/crates/ark/src/lsp/completions/sources/composite/workspace.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/workspace.rs
@@ -69,7 +69,7 @@ fn completions_from_workspace(
     let token = token.as_str();
 
     // get entries from the index
-    indexer::map(state.db.read(), |file, symbol, entry| {
+    indexer::map(state.db(), |file, symbol, entry| {
         if !symbol.fuzzy_matches(token) {
             return;
         }

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -7,7 +7,7 @@
 
 use std::sync::LazyLock;
 
-use oak_db::Db;
+#[cfg(test)]
 use oak_db::OakDatabase;
 use oak_db::RootKind;
 use regex::Regex;
@@ -22,6 +22,7 @@ use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::completions::types::CompletionData;
+use crate::lsp::db::ArkDb;
 use crate::lsp::document_context::DocumentContext;
 #[cfg(test)]
 use crate::lsp::document_context::TestDocument;
@@ -41,7 +42,7 @@ impl CompletionSource for CommentSource {
     ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_comment(
             completion_context.document_context,
-            &completion_context.state.db,
+            completion_context.state.db.read(),
         )
     }
 }
@@ -51,7 +52,7 @@ static RE_UP_TO_LAST_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r
 
 fn completions_from_comment(
     context: &DocumentContext,
-    db: &OakDatabase,
+    db: &dyn ArkDb,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     let node = context.node;
 

--- a/crates/ark/src/lsp/completions/sources/unique/comment.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/comment.rs
@@ -42,7 +42,7 @@ impl CompletionSource for CommentSource {
     ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
         completions_from_comment(
             completion_context.document_context,
-            completion_context.state.db.read(),
+            completion_context.state.db(),
         )
     }
 }

--- a/crates/ark/src/lsp/completions/sources/unique/custom.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/custom.rs
@@ -217,7 +217,7 @@ mod tests {
     // Helper functions for testing custom completions
     fn assert_has_completion(code_with_cursor: &str, name: &str, expected_insert_text: &str) {
         let (text, point) = point_from_cursor(code_with_cursor);
-        let state = WorldState::default();
+        let state = WorldState::default().snapshot();
         let doc = TestDocument::new(&text);
         let document_context = doc.context(point);
         let context = CompletionContext::new(&document_context, &state);
@@ -235,7 +235,7 @@ mod tests {
 
     fn assert_no_completions(code_with_cursor: &str) {
         let (text, point) = point_from_cursor(code_with_cursor);
-        let state = WorldState::default();
+        let state = WorldState::default().snapshot();
         let doc = TestDocument::new(&text);
         let document_context = doc.context(point);
         let context = CompletionContext::new(&document_context, &state);
@@ -254,7 +254,7 @@ mod tests {
             };
 
             let (text, point) = point_from_cursor("library(@)");
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
             let context = CompletionContext::new(&document_context, &state);
@@ -268,7 +268,7 @@ mod tests {
             assert_eq!(n_compls, n_packages);
 
             let (text, point) = point_from_cursor("library(uti@)");
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let doc = TestDocument::new(&text);
             let document_context = doc.context(point);
             let context = CompletionContext::new(&document_context, &state);

--- a/crates/ark/src/lsp/completions/sources/unique/namespace.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/namespace.rs
@@ -256,7 +256,7 @@ mod tests {
         let (text, point) = point_from_cursor(cursor_text);
         let doc = TestDocument::new(&text);
         let document_context = doc.context(point);
-        let state = WorldState::default();
+        let state = WorldState::default().snapshot();
         let context = CompletionContext::new(&document_context, &state);
 
         completions_from_namespace(&context)

--- a/crates/ark/src/lsp/completions/sources/unique/string.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/string.rs
@@ -132,7 +132,7 @@ mod tests {
             assert_match!(res, Some(items) => { assert!(items.is_empty()) });
 
             // Check for same result when consulting (potentially all) unique sources
-            let state = WorldState::default();
+            let state = WorldState::default().snapshot();
             let completion_context = CompletionContext::new(&context, &state);
             let res = unique::get_completions(&completion_context).unwrap();
 

--- a/crates/ark/src/lsp/completions/tests/utils.rs
+++ b/crates/ark/src/lsp/completions/tests/utils.rs
@@ -18,7 +18,7 @@ pub(crate) fn get_completions_at_cursor(cursor_text: &str) -> anyhow::Result<Vec
     let (text, point) = point_from_cursor(cursor_text);
     let doc = TestDocument::new(&text);
     let document_context = doc.context(point);
-    let state = WorldState::default();
+    let state = WorldState::default().snapshot();
 
     match provide_completions(&document_context, &state) {
         Ok(completions) => Ok(completions),

--- a/crates/ark/src/lsp/db.rs
+++ b/crates/ark/src/lsp/db.rs
@@ -17,6 +17,37 @@ pub(crate) trait ArkDb: oak_db::Db {}
 #[salsa::db]
 impl ArkDb for OakDatabase {}
 
+/// Read-only handle to an `OakDatabase` that acts as a read-only snapshot.
+///
+/// An `Analysis` snapshot holds the DB clone in a private field and lends a
+/// shared ref via `read()`. This prevents a read-only background workers
+/// from reaching DB setters and deadock with the main loop. This is oak's
+/// version of rust-analyzer's `Analysis` facade.
+#[derive(Clone, Debug)]
+pub(crate) struct Analysis {
+    db: OakDatabase,
+}
+
+impl Analysis {
+    pub(crate) fn new(db: OakDatabase) -> Self {
+        Self { db }
+    }
+
+    /// The database as a shared `&dyn ArkDb`. Only lends `&`, so a reader can
+    /// query but can't reach a setter through it.
+    pub(crate) fn read(&self) -> &dyn ArkDb {
+        &self.db
+    }
+
+    /// The database's salsa cancellation token. Read-side only: it observes and
+    /// arms cancellation, it doesn't mutate any input, so it's safe to expose
+    /// on the read-only facade. Only cancellation tests arm it by hand.
+    #[cfg(test)]
+    pub(crate) fn cancellation_token(&self) -> salsa::CancellationToken {
+        salsa::Database::cancellation_token(&self.db)
+    }
+}
+
 /// Extension trait that adds ark-side query methods to `oak_db::File`.
 pub(crate) trait FileArkExt {
     fn tree_sitter(self, db: &dyn ArkDb) -> &tree_sitter::Tree;

--- a/crates/ark/src/lsp/db.rs
+++ b/crates/ark/src/lsp/db.rs
@@ -17,37 +17,6 @@ pub(crate) trait ArkDb: oak_db::Db {}
 #[salsa::db]
 impl ArkDb for OakDatabase {}
 
-/// Read-only handle to an `OakDatabase` that acts as a read-only snapshot.
-///
-/// An `Analysis` snapshot holds the DB clone in a private field and lends a
-/// shared ref via `read()`. This prevents a read-only background workers
-/// from reaching DB setters and deadock with the main loop. This is oak's
-/// version of rust-analyzer's `Analysis` facade.
-#[derive(Clone, Debug)]
-pub(crate) struct Analysis {
-    db: OakDatabase,
-}
-
-impl Analysis {
-    pub(crate) fn new(db: OakDatabase) -> Self {
-        Self { db }
-    }
-
-    /// The database as a shared `&dyn ArkDb`. Only lends `&`, so a reader can
-    /// query but can't reach a setter through it.
-    pub(crate) fn read(&self) -> &dyn ArkDb {
-        &self.db
-    }
-
-    /// The database's salsa cancellation token. Read-side only: it observes and
-    /// arms cancellation, it doesn't mutate any input, so it's safe to expose
-    /// on the read-only facade. Only cancellation tests arm it by hand.
-    #[cfg(test)]
-    pub(crate) fn cancellation_token(&self) -> salsa::CancellationToken {
-        salsa::Database::cancellation_token(&self.db)
-    }
-}
-
 /// Extension trait that adds ark-side query methods to `oak_db::File`.
 pub(crate) trait FileArkExt {
     fn tree_sitter(self, db: &dyn ArkDb) -> &tree_sitter::Tree;

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -14,7 +14,6 @@ use anyhow::bail;
 use anyhow::Result;
 use harp::syntax::is_valid_symbol;
 use harp::syntax::sym_quote_invalid;
-use oak_db::Db;
 use oak_db::File;
 use stdext::*;
 use tower_lsp::lsp_types::Diagnostic;
@@ -30,7 +29,7 @@ use crate::lsp::declarations::top_level_declare;
 use crate::lsp::diagnostics_syntax::syntax_diagnostics;
 use crate::lsp::indexer;
 use crate::lsp::open_file::lsp_range_from_tree_sitter_range;
-use crate::lsp::state::WorldState;
+use crate::lsp::state::WorldSnapshot;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::node_has_error_or_missing;
 use crate::treesitter::BinaryOperatorType;
@@ -134,7 +133,7 @@ impl<'a> DiagnosticContext<'a> {
 
 pub(crate) fn generate_diagnostics(
     file: File,
-    state: WorldState,
+    state: WorldSnapshot,
     testthat: bool,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
@@ -143,7 +142,7 @@ pub(crate) fn generate_diagnostics(
         return diagnostics;
     }
 
-    let db = &state.db;
+    let db = state.db.read();
 
     // Check that diagnostics are not disabled in top-level declarations for
     // this document
@@ -173,7 +172,7 @@ pub(crate) fn generate_diagnostics(
 
     // If this is a package, add imported symbols to workspace
     if let Some(package) = file.package(db) {
-        let namespace = package.namespace(&state.db);
+        let namespace = package.namespace(db);
 
         // Add symbols from `importFrom()` directives
         for import in &namespace.imports {
@@ -182,8 +181,8 @@ pub(crate) fn generate_diagnostics(
 
         // Add symbols from `import()` directives
         for package_import in &namespace.package_imports {
-            if let Some(pkg) = state.db.package_by_name(package_import) {
-                for export in &pkg.namespace(&state.db).exports {
+            if let Some(pkg) = db.package_by_name(package_import) {
+                for export in &pkg.namespace(db).exports {
                     context.workspace_symbols.insert(export.clone());
                 }
             }
@@ -199,8 +198,8 @@ pub(crate) fn generate_diagnostics(
     // want to provide a mechanism for test packages to declare this sort of
     // test files setup.
     if testthat {
-        if let Some(pkg) = state.db.package_by_name("testthat") {
-            for export in &pkg.namespace(&state.db).exports {
+        if let Some(pkg) = db.package_by_name("testthat") {
+            for export in &pkg.namespace(db).exports {
                 context.workspace_symbols.insert(export.clone());
             }
         }
@@ -1192,7 +1191,7 @@ mod tests {
             Some(code.to_string()),
             None,
         );
-        super::generate_diagnostics(file, state, false)
+        super::generate_diagnostics(file, state.snapshot(), false)
     }
 
     fn current_state() -> WorldState {

--- a/crates/ark/src/lsp/diagnostics.rs
+++ b/crates/ark/src/lsp/diagnostics.rs
@@ -29,7 +29,7 @@ use crate::lsp::declarations::top_level_declare;
 use crate::lsp::diagnostics_syntax::syntax_diagnostics;
 use crate::lsp::indexer;
 use crate::lsp::open_file::lsp_range_from_tree_sitter_range;
-use crate::lsp::state::WorldSnapshot;
+use crate::lsp::state::WorldStateSnapshot;
 use crate::lsp::traits::node::NodeExt;
 use crate::treesitter::node_has_error_or_missing;
 use crate::treesitter::BinaryOperatorType;
@@ -133,7 +133,7 @@ impl<'a> DiagnosticContext<'a> {
 
 pub(crate) fn generate_diagnostics(
     file: File,
-    state: WorldSnapshot,
+    state: WorldStateSnapshot,
     testthat: bool,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
@@ -142,7 +142,7 @@ pub(crate) fn generate_diagnostics(
         return diagnostics;
     }
 
-    let db = state.db.read();
+    let db = state.db();
 
     // Check that diagnostics are not disabled in top-level declarations for
     // this document

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -233,10 +233,15 @@ pub(crate) fn handle_completion(
     );
     lsp::log_info!("Completion context: {:#?}", context);
 
-    // TODO(oak/completions): Clone so the closure captures by value. `r_task()`
-    // sends the closure across threads, and `&WorldState` isn't `Send` because
-    // `OakDatabase`'s salsa storage keeps thread-local query state.
-    let state = state.clone();
+    // Snapshot so the closure captures by value. `r_task()` sends the closure
+    // across threads, and `&WorldState` isn't `Send` because `OakDatabase`'s
+    // salsa storage keeps thread-local query state. `snapshot()` hands the
+    // reader a `WorldSnapshot`, so the background thread can query oak but
+    // can't call a setter.
+    // TODO(oak/completions): We don't really need a snapshot here since
+    // completions are serviced from the main loop, it's only needed for the
+    // `r_task()`.
+    let state = state.snapshot();
     let completions = r_task(move || provide_completions(&context, &state))?;
 
     if !completions.is_empty() {

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -236,7 +236,7 @@ pub(crate) fn handle_completion(
     // Snapshot so the closure captures by value. `r_task()` sends the closure
     // across threads, and `&WorldState` isn't `Send` because `OakDatabase`'s
     // salsa storage keeps thread-local query state. `snapshot()` hands the
-    // reader a `WorldSnapshot`, so the background thread can query oak but
+    // reader a `WorldStateSnapshot`, so the background thread can query oak but
     // can't call a setter.
     // TODO(oak/completions): We don't really need a snapshot here since
     // completions are serviced from the main loop, it's only needed for the

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -49,7 +49,6 @@ use crate::lsp::backend::LspRequest;
 use crate::lsp::backend::LspResponse;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
-use crate::lsp::db::Analysis;
 use crate::lsp::diagnostics::generate_diagnostics;
 use crate::lsp::handlers;
 use crate::lsp::indexer;
@@ -58,8 +57,8 @@ use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceCompleted;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceScheduler;
-use crate::lsp::state::WorldSnapshot;
 use crate::lsp::state::WorldState;
+use crate::lsp::state::WorldStateSnapshot;
 use crate::lsp::state_handlers;
 use crate::lsp::state_handlers::ConsoleInputs;
 use crate::url::ExtUrl;
@@ -558,7 +557,7 @@ impl GlobalState {
                 // and the diagnostics passes they trigger force the same
                 // memos.
                 if !self.lsp_state.oak_scheduler.has_pending_scans() {
-                    warm_workspace_index(Analysis::new(self.world.db.clone()));
+                    warm_workspace_index(self.world.snapshot());
                 }
             },
 
@@ -998,7 +997,7 @@ impl std::fmt::Debug for TraceKernelNotification<'_> {
 pub(crate) struct RefreshDiagnosticsTask {
     /// Snapshot carrying the live oak plus the session context the diagnostics
     /// walk reads. See [`WorldState::diagnostics_snapshot`].
-    state: WorldSnapshot,
+    state: WorldStateSnapshot,
     /// The file to diagnose, built against the live oak at enqueue time.
     file: OpenFile,
 }
@@ -1137,11 +1136,11 @@ pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
 /// cancelled (`spawn_blocking()` swallows the unwind). A cancelling write can
 /// only come from an editor buffer, so a document is open, and the diagnostics
 /// passes spawned by that same write force the same memos and finish the job.
-fn warm_workspace_index(analysis: Analysis) {
+fn warm_workspace_index(state: WorldStateSnapshot) {
     spawn_blocking(move || {
         let now = std::time::Instant::now();
         lsp::log_info!("Starting workspace index warmup");
-        indexer::warm(analysis.read());
+        indexer::warm(state.db());
         lsp::log_info!("Finished workspace index warmup ({:.0?})", now.elapsed());
         Ok(None)
     })
@@ -1184,7 +1183,7 @@ mod tests {
 
         let file = state.open_file(&uri).unwrap().clone();
         let snapshot = state.diagnostics_snapshot();
-        snapshot.db.cancellation_token().cancel();
+        snapshot.cancellation_token().cancel();
 
         let task = RefreshDiagnosticsTask {
             file,
@@ -1208,13 +1207,13 @@ mod tests {
 
         let file = state.open_file(&uri).unwrap().clone();
         let snapshot = state.diagnostics_snapshot();
-        snapshot.db.cancellation_token().cancel();
+        snapshot.cancellation_token().cancel();
 
         let (response_tx, mut response_rx) = tokio_unbounded_channel::<RequestResponse>();
         respond(
             response_tx,
             || {
-                let _ = file.tree_sitter(snapshot.db.read());
+                let _ = file.tree_sitter(snapshot.db());
                 Ok(LspResponse::Hover(None))
             },
             |response| response,

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -49,6 +49,7 @@ use crate::lsp::backend::LspRequest;
 use crate::lsp::backend::LspResponse;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
+use crate::lsp::db::Analysis;
 use crate::lsp::diagnostics::generate_diagnostics;
 use crate::lsp::handlers;
 use crate::lsp::indexer;
@@ -57,6 +58,7 @@ use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceCompleted;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceScheduler;
+use crate::lsp::state::WorldSnapshot;
 use crate::lsp::state::WorldState;
 use crate::lsp::state_handlers;
 use crate::lsp::state_handlers::ConsoleInputs;
@@ -556,7 +558,7 @@ impl GlobalState {
                 // and the diagnostics passes they trigger force the same
                 // memos.
                 if !self.lsp_state.oak_scheduler.has_pending_scans() {
-                    warm_workspace_index(self.world.db.clone());
+                    warm_workspace_index(Analysis::new(self.world.db.clone()));
                 }
             },
 
@@ -996,7 +998,7 @@ impl std::fmt::Debug for TraceKernelNotification<'_> {
 pub(crate) struct RefreshDiagnosticsTask {
     /// Snapshot carrying the live oak plus the session context the diagnostics
     /// walk reads. See [`WorldState::diagnostics_snapshot`].
-    state: WorldState,
+    state: WorldSnapshot,
     /// The file to diagnose, built against the live oak at enqueue time.
     file: OpenFile,
 }
@@ -1135,11 +1137,11 @@ pub(crate) fn diagnostics_refresh_all(state: &WorldState) {
 /// cancelled (`spawn_blocking()` swallows the unwind). A cancelling write can
 /// only come from an editor buffer, so a document is open, and the diagnostics
 /// passes spawned by that same write force the same memos and finish the job.
-fn warm_workspace_index(db: OakDatabase) {
+fn warm_workspace_index(analysis: Analysis) {
     spawn_blocking(move || {
         let now = std::time::Instant::now();
         lsp::log_info!("Starting workspace index warmup");
-        indexer::warm(&db);
+        indexer::warm(analysis.read());
         lsp::log_info!("Finished workspace index warmup ({:.0?})", now.elapsed());
         Ok(None)
     })
@@ -1149,7 +1151,6 @@ fn warm_workspace_index(db: OakDatabase) {
 mod tests {
     use aether_path::FilePath;
     use oak_scan::DbScan;
-    use salsa::Database;
     use tower_lsp::jsonrpc;
     use url::Url;
 
@@ -1213,7 +1214,7 @@ mod tests {
         respond(
             response_tx,
             || {
-                let _ = file.tree_sitter(&snapshot.db);
+                let _ = file.tree_sitter(snapshot.db.read());
                 Ok(LspResponse::Hover(None))
             },
             |response| response,

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -7,7 +7,7 @@ use oak_db::OakDatabase;
 use url::Url;
 
 use crate::lsp::config::LspConfig;
-use crate::lsp::db::Analysis;
+use crate::lsp::db::ArkDb;
 use crate::lsp::open_file::OpenFile;
 
 #[derive(Clone, Default, Debug)]
@@ -16,11 +16,10 @@ use crate::lsp::open_file::OpenFile;
 /// structure. It can be cloned and safely sent to other threads.
 ///
 /// The main loop owns and mutates this. Background readers get a
-/// [`WorldSnapshot`] instead, which holds a read-only [`Analysis`] in place of
-/// the writable `OakDatabase`. This prevents background threads from reaching a
-/// Salsa input setter. See [`Self::diagnostics_snapshot`] and
-/// [`Self::snapshot`]. This split mirrors rust-analyzer's `GlobalState`  and
-/// `GlobalStateSnapshot`.
+/// [`WorldStateSnapshot`] instead, which only lends its database out as
+/// `&dyn ArkDb`. This prevents background threads from reaching a Salsa input
+/// setter. See [`Self::diagnostics_snapshot`] and [`Self::snapshot`]. This split
+/// mirrors rust-analyzer's `GlobalState` and `GlobalStateSnapshot`.
 pub(crate) struct WorldState {
     /// Salsa input tree for Oak queries.
     pub(crate) db: OakDatabase,
@@ -79,12 +78,12 @@ impl WorldState {
         }
     }
 
-    /// Full read-only snapshot for a background reader that needs the whole
-    /// world (completions read `open_files` and the workspace). Same shape as
-    /// `self.clone()`, but the db becomes a read-only [`Analysis`].
-    pub(crate) fn snapshot(&self) -> WorldSnapshot {
-        WorldSnapshot {
-            db: Analysis::new(self.db.clone()),
+    /// Full read-only snapshot for a background reader that needs more than the
+    /// db, e.g. completions read `open_files` and the workspace. Same shape as
+    /// `self.clone()`, but the db is only reachable as `&dyn ArkDb`.
+    pub(crate) fn snapshot(&self) -> WorldStateSnapshot {
+        WorldStateSnapshot {
+            db: self.db.clone(),
             console_scopes: self.console_scopes.clone(),
             installed_packages: self.installed_packages.clone(),
             config: self.config.clone(),
@@ -96,9 +95,9 @@ impl WorldState {
     /// Trimmed read-only snapshot for the diagnostics worker, which runs off
     /// the main loop and queries oak. Drops the open-file / workspace maps the
     /// diagnostics pass doesn't read.
-    pub(crate) fn diagnostics_snapshot(&self) -> WorldSnapshot {
-        WorldSnapshot {
-            db: Analysis::new(self.db.clone()),
+    pub(crate) fn diagnostics_snapshot(&self) -> WorldStateSnapshot {
+        WorldStateSnapshot {
+            db: self.db.clone(),
             console_scopes: self.console_scopes.clone(),
             installed_packages: self.installed_packages.clone(),
             config: self.config.clone(),
@@ -106,6 +105,7 @@ impl WorldState {
             workspace: Workspace::default(),
         }
     }
+
     pub(crate) fn open_file_mut(&mut self, uri: &Url) -> anyhow::Result<&mut OpenFile> {
         let key = FilePath::from_url(uri);
         if let Some(open_file) = self.open_files.get_mut(&key) {
@@ -150,13 +150,13 @@ impl WorldState {
 }
 
 /// Read-only snapshot of [`WorldState`] handed to background readers (e.g.
-/// diagnostics). Holds a read-only [`Analysis`] in place of the writable
-/// `OakDatabase`, so a reader thread can't reach Salsa input setters. Carries
-/// only the fields readers actually use. Mirrors rust-analyzer's
+/// diagnostics), so a reader thread can't reach Salsa input setters. Carries only
+/// the fields readers actually use. Mirrors rust-analyzer's
 /// `GlobalStateSnapshot`.
 #[derive(Clone, Debug)]
-pub(crate) struct WorldSnapshot {
-    pub(crate) db: Analysis,
+pub(crate) struct WorldStateSnapshot {
+    /// Private so readers can only reach it through [`Self::db`].
+    db: OakDatabase,
     pub(crate) open_files: HashMap<FilePath, OpenFile>,
     pub(crate) workspace: Workspace,
     pub(crate) console_scopes: Vec<Vec<String>>,
@@ -164,11 +164,25 @@ pub(crate) struct WorldSnapshot {
     pub(crate) config: LspConfig,
 }
 
-impl WorldSnapshot {
-    /// URL to put on the wire for `file`. Same rule as [`WorldState::wire_url`],
-    /// reading through the [`Analysis`] handle.
+impl WorldStateSnapshot {
+    /// Read-only access to the database. Returns `&dyn ArkDb` rather than
+    /// `&OakDatabase` because `dyn ArkDb` is unsized, so a reader can't
+    /// `.clone()` its way to an owned database and call setters on it.
+    pub(crate) fn db(&self) -> &dyn ArkDb {
+        &self.db
+    }
+
+    /// The database's salsa cancellation token. Read-side only: it observes and
+    /// arms cancellation, it doesn't mutate any input. Only cancellation tests
+    /// arm it by hand.
+    #[cfg(test)]
+    pub(crate) fn cancellation_token(&self) -> salsa::CancellationToken {
+        salsa::Database::cancellation_token(&self.db)
+    }
+
+    /// URL to put on the wire for `file`. Same rule as [`WorldState::wire_url`].
     pub(crate) fn wire_url(&self, file: File) -> Url {
-        let path = file.path(self.db.read());
+        let path = file.path(self.db());
         self.open_files
             .get(path)
             .map(|open_file| open_file.wire_url().clone())

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -7,12 +7,20 @@ use oak_db::OakDatabase;
 use url::Url;
 
 use crate::lsp::config::LspConfig;
+use crate::lsp::db::Analysis;
 use crate::lsp::open_file::OpenFile;
 
 #[derive(Clone, Default, Debug)]
 /// The world state, i.e. all the inputs necessary for analysing or refactoring
 /// code. This is a pure value. There is no interior mutability in this data
 /// structure. It can be cloned and safely sent to other threads.
+///
+/// The main loop owns and mutates this. Background readers get a
+/// [`WorldSnapshot`] instead, which holds a read-only [`Analysis`] in place of
+/// the writable `OakDatabase`. This prevents background threads from reaching a
+/// Salsa input setter. See [`Self::diagnostics_snapshot`] and
+/// [`Self::snapshot`]. This split mirrors rust-analyzer's `GlobalState`  and
+/// `GlobalStateSnapshot`.
 pub(crate) struct WorldState {
     /// Salsa input tree for Oak queries.
     pub(crate) db: OakDatabase,
@@ -71,26 +79,39 @@ impl WorldState {
         }
     }
 
+    /// Full read-only snapshot for a background reader that needs the whole
+    /// world (completions read `open_files` and the workspace). Same shape as
+    /// `self.clone()`, but the db becomes a read-only [`Analysis`].
+    pub(crate) fn snapshot(&self) -> WorldSnapshot {
+        WorldSnapshot {
+            db: Analysis::new(self.db.clone()),
+            console_scopes: self.console_scopes.clone(),
+            installed_packages: self.installed_packages.clone(),
+            config: self.config.clone(),
+            open_files: self.open_files.clone(),
+            workspace: self.workspace.clone(),
+        }
+    }
+
+    /// Trimmed read-only snapshot for the diagnostics worker, which runs off
+    /// the main loop and queries oak. Drops the open-file / workspace maps the
+    /// diagnostics pass doesn't read.
+    pub(crate) fn diagnostics_snapshot(&self) -> WorldSnapshot {
+        WorldSnapshot {
+            db: Analysis::new(self.db.clone()),
+            console_scopes: self.console_scopes.clone(),
+            installed_packages: self.installed_packages.clone(),
+            config: self.config.clone(),
+            open_files: HashMap::new(),
+            workspace: Workspace::default(),
+        }
+    }
     pub(crate) fn open_file_mut(&mut self, uri: &Url) -> anyhow::Result<&mut OpenFile> {
         let key = FilePath::from_url(uri);
         if let Some(open_file) = self.open_files.get_mut(&key) {
             Ok(open_file)
         } else {
             Err(anyhow!("Can't find document for URI {uri}"))
-        }
-    }
-
-    /// Snapshot for the diagnostics worker, which runs off the main loop and
-    /// queries oak.
-    pub(crate) fn diagnostics_snapshot(&self) -> WorldState {
-        WorldState {
-            db: self.db.clone(),
-            console_scopes: self.console_scopes.clone(),
-            installed_packages: self.installed_packages.clone(),
-            config: self.config.clone(),
-            open_files: HashMap::new(),
-            virtual_documents: HashMap::new(),
-            workspace: Workspace::default(),
         }
     }
 
@@ -125,6 +146,33 @@ impl WorldState {
         let key = FilePath::from_url(&url);
         let open_file = OpenFile::new(file, version, url);
         self.open_files.insert(key, open_file);
+    }
+}
+
+/// Read-only snapshot of [`WorldState`] handed to background readers (e.g.
+/// diagnostics). Holds a read-only [`Analysis`] in place of the writable
+/// `OakDatabase`, so a reader thread can't reach Salsa input setters. Carries
+/// only the fields readers actually use. Mirrors rust-analyzer's
+/// `GlobalStateSnapshot`.
+#[derive(Clone, Debug)]
+pub(crate) struct WorldSnapshot {
+    pub(crate) db: Analysis,
+    pub(crate) open_files: HashMap<FilePath, OpenFile>,
+    pub(crate) workspace: Workspace,
+    pub(crate) console_scopes: Vec<Vec<String>>,
+    pub(crate) installed_packages: Vec<String>,
+    pub(crate) config: LspConfig,
+}
+
+impl WorldSnapshot {
+    /// URL to put on the wire for `file`. Same rule as [`WorldState::wire_url`],
+    /// reading through the [`Analysis`] handle.
+    pub(crate) fn wire_url(&self, file: File) -> Url {
+        let path = file.path(self.db.read());
+        self.open_files
+            .get(path)
+            .map(|open_file| open_file.wire_url().clone())
+            .unwrap_or_else(|| path.to_url())
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/posit-dev/ark/issues/1212

This approach is taken from Rust-Analyzer where a snapshot is guaranteed to never write to the DB. Having this type-enforced safety is nice because writing to the DB from outside the main loop could deadlock.

- New `WorldSnapshot` type that's the read-only counterpart to `WorldState`. It holds a clone of the Salsa data wrapped in `Analysis`, as well as clones of other world state fields.

- New `Analysis` type that holds the `OakDatabase` in a private field, and lends it only as a shared reference. This is what prevents writes.