### PR TITLE
Bump Salsa revision manually for non-Salsa updates

### DIFF
--- a/crates/ark/src/lsp.rs
+++ b/crates/ark/src/lsp.rs
@@ -68,6 +68,5 @@ pub(crate) use _log;
 pub(crate) use log_error;
 pub(crate) use log_info;
 pub(crate) use log_warn;
-pub(crate) use main_loop::diagnostics_refresh_all;
 pub(crate) use main_loop::publish_diagnostics;
 pub(crate) use main_loop::spawn_blocking;

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -384,8 +384,9 @@ impl GlobalState {
         // resolved definitions), so any handler that writes to oak invalidates
         // them. Rather than have each write site remember to refresh, we watch
         // the oak revision across the whole tick: if a handler advanced it,
-        // refresh centrally. Config and console state live outside oak, so
-        // handlers that mutate those still refresh explicitly.
+        // refresh centrally. Config and console state live outside oak, so the
+        // handlers that mutate those advance the revision synthetically (see
+        // `WorldState::bump_revision`) to route through this same path.
         let old_revision = salsa::plumbing::current_revision(&self.world.db);
 
         match event {
@@ -1021,15 +1022,12 @@ static DIAGNOSTICS_QUEUE: LazyLock<tokio::sync::mpsc::UnboundedSender<RefreshDia
 /// Tasks are batched and deduplicated per URL (only the last task per URL is
 /// processed), so stale-version diagnostics get superseded within a batch.
 ///
-/// Batches triggered by an oak write can't publish out of order. Each pass
-/// holds a db snapshot, and a salsa write blocks until all snapshots drop, so
-/// by the time the write completes and the newer batch is enqueued, any older
-/// pass has either unwound with `Cancelled` or already produced its result.
-///
-/// FIXME: Batches triggered without an oak write (console inputs, diagnostics
-/// config) have no such barrier. An older pass can run concurrently with the
-/// newer one and publish last, leaving diagnostics computed from the older
-/// console scopes or config until the next refresh.
+/// Batches can't publish out of order. Each pass holds a db snapshot, and a
+/// salsa write blocks until all snapshots drop, so by the time the write
+/// completes and the newer batch is enqueued, any older pass has either unwound
+/// with `Cancelled` or already produced its result. Changes to state that lives
+/// outside oak (console inputs, diagnostics config) get the same barrier by
+/// advancing the revision synthetically (see `WorldState::bump_revision`).
 async fn process_diagnostics_queue(mut rx: mpsc::UnboundedReceiver<RefreshDiagnosticsTask>) {
     while let Some(task) = rx.recv().await {
         let mut batch = vec![task];
@@ -1239,6 +1237,18 @@ mod tests {
             FilePath::from_url(&Url::parse("file:///a.R").unwrap()),
             "x <- 1".to_string(),
         );
+        let after = salsa::plumbing::current_revision(&state.db);
+        assert_ne!(before, after);
+    }
+
+    /// Console-scope and config changes live outside oak, so they lean on
+    /// `bump_revision` to advance the revision and trigger the same central
+    /// refresh. This pins that the synthetic write actually moves the revision.
+    #[test]
+    fn test_bump_revision_advances_revision() {
+        let mut state = WorldState::default();
+        let before = salsa::plumbing::current_revision(&state.db);
+        state.bump_revision();
         let after = salsa::plumbing::current_revision(&state.db);
         assert_ne!(before, after);
     }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -1027,7 +1027,7 @@ static DIAGNOSTICS_QUEUE: LazyLock<tokio::sync::mpsc::UnboundedSender<RefreshDia
 /// completes and the newer batch is enqueued, any older pass has either unwound
 /// with `Cancelled` or already produced its result. Changes to state that lives
 /// outside oak (console inputs, diagnostics config) get the same barrier by
-/// advancing the revision synthetically (see `WorldState::bump_revision`).
+/// advancing the revision synthetically (see [`WorldState::bump_revision`]).
 async fn process_diagnostics_queue(mut rx: mpsc::UnboundedReceiver<RefreshDiagnosticsTask>) {
     while let Some(task) = rx.recv().await {
         let mut batch = vec![task];

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -4,6 +4,7 @@ use aether_path::FilePath;
 use anyhow::anyhow;
 use oak_db::File;
 use oak_db::OakDatabase;
+use salsa::Database;
 use url::Url;
 
 use crate::lsp::config::LspConfig;
@@ -104,6 +105,16 @@ impl WorldState {
             open_files: HashMap::new(),
             workspace: Workspace::default(),
         }
+    }
+
+    /// Advance the oak revision without changing any oak input.
+    ///
+    /// Currently used for state that lives on `WorldState` but not in the Oak
+    /// DB (e.g. console scopes and the diagnostics config). The revision bump
+    /// invalidates in-flight background workers (e.g. diagnostics), and
+    /// triggers a diagnostic refresh.
+    pub(crate) fn bump_revision(&mut self) {
+        self.db.synthetic_write(salsa::Durability::LOW);
     }
 
     pub(crate) fn open_file_mut(&mut self, uri: &Url) -> anyhow::Result<&mut OpenFile> {

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -477,10 +477,11 @@ async fn update_config(
         }
     }
 
-    // Refresh diagnostics if the configuration changed
+    // Refresh diagnostics if the configuration changed. The config lives
+    // outside Oak so we bump the revision manually.
     if state.config.diagnostics != diagnostics_config {
         tracing::info!("Refreshing diagnostics after configuration changed");
-        lsp::main_loop::diagnostics_refresh_all(state);
+        state.bump_revision();
     }
 
     Ok(())
@@ -497,8 +498,9 @@ pub(crate) fn did_change_console_inputs(
     // We currently rely on global console scopes for diagnostics, in particular
     // during package development in conjunction with `devtools::load_all()`.
     // Ideally diagnostics would not rely on these though, and we wouldn't need
-    // to refresh from here.
-    lsp::diagnostics_refresh_all(state);
+    // to refresh from here. The scopes live outside oak so we bump the revision
+    // manually.
+    state.bump_revision();
 
     Ok(())
 }

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -478,9 +478,10 @@ async fn update_config(
     }
 
     // Refresh diagnostics if the configuration changed. The config lives
-    // outside Oak so we bump the revision manually.
+    // outside Oak so we bump the revision manually, causing diagnostics
+    // to refresh on the next tick.
     if state.config.diagnostics != diagnostics_config {
-        tracing::info!("Refreshing diagnostics after configuration changed");
+        tracing::info!("Bumping salsa revision after configuration changed");
         state.bump_revision();
     }
 
@@ -499,7 +500,7 @@ pub(crate) fn did_change_console_inputs(
     // during package development in conjunction with `devtools::load_all()`.
     // Ideally diagnostics would not rely on these though, and we wouldn't need
     // to refresh from here. The scopes live outside oak so we bump the revision
-    // manually.
+    // manually, causing diagnostics to get refreshed on the next tick.
     state.bump_revision();
 
     Ok(())

--- a/crates/ark/src/lsp/tests/state_handlers.rs
+++ b/crates/ark/src/lsp/tests/state_handlers.rs
@@ -34,8 +34,10 @@ use crate::lsp::main_loop::LspState;
 use crate::lsp::main_loop::TokioUnboundedSender;
 use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
+use crate::lsp::state_handlers::did_change_console_inputs;
 use crate::lsp::state_handlers::did_close;
 use crate::lsp::state_handlers::effective_workspace_uris;
+use crate::lsp::state_handlers::ConsoleInputs;
 
 /// Local sync wrappers around the async-shaped scheduler API. Tests
 /// don't need the timing flexibility, so each operation kicks off
@@ -660,4 +662,27 @@ fn test_did_close_releases_orphan_file_to_stale() {
         event,
         AuxiliaryEvent::PublishDiagnostics(u, diags, _) if u == url && diags.is_empty()
     ));
+}
+
+/// A console-inputs push carries no oak write, but diagnostics read the console
+/// scopes it updates. The handler advances the oak revision so the main loop's
+/// central refresh (and its snapshot barrier) fires. Pin that: reverting to a
+/// direct refresh that doesn't bump the revision would silently stop the
+/// central refresh and let a stale-scope pass publish last.
+#[test]
+fn test_console_inputs_advance_revision() {
+    let mut state = WorldState::default();
+    let before = salsa::plumbing::current_revision(&state.db);
+
+    did_change_console_inputs(
+        ConsoleInputs {
+            console_scopes: vec![vec!["foo".to_string()]],
+            installed_packages: vec![],
+        },
+        &mut state,
+    )
+    .unwrap();
+
+    let after = salsa::plumbing::current_revision(&state.db);
+    assert_ne!(before, after);
 }


### PR DESCRIPTION
Branched from https://github.com/posit-dev/ark/pull/1314
Part of https://github.com/posit-dev/ark/issues/1212

Removes a FIXME that I left for non-Salsa inputs, like console inputs and diagnostics config. These updates manually triggered diagnostics out-of-band, which had the issue that ongoing diagnostics did not get cancelled by a Salsa bump. The concurrent diagnostics could publish out of order, resulting in stale results.

It's actually easy to bump the revision manually, which both cancels in flight diagnostics and ensures ordering. That's because the synthetic write:

- Causes Salsa to trigger cancellation and park the caller until all readers are dropped
- Refreshes diagnostics automatically via the revision check at the end of the main loop.