### PR TITLE
Add release notes template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+
+### Positron Release Notes
+
+<!--
+  These notes are typically filled by the Positron team. If you are an external
+  contributor, you may leave the `N/A` bullets in place.
+-->
+
+#### New Features
+
+- N/A
+
+#### Bug Fixes
+
+- N/A


### PR DESCRIPTION
For use with the `bump-ark` skill (https://github.com/posit-dev/positron/pull/14676).