### PR TITLE
Fix blank Data Explorer when viewing objects piped with `%>%`

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -72,7 +72,8 @@ use harp::r_symbol;
 use harp::table_kind;
 use harp::tbl_get_column;
 use harp::utils::r_is_promise;
-use harp::utils::r_promise_force;
+use harp::utils::r_promise_is_forced;
+use harp::utils::r_promise_value;
 use harp::vector::CharacterVector;
 use harp::vector::Vector;
 use harp::ColumnNames;
@@ -248,15 +249,22 @@ impl RDataExplorer {
             Rf_findVarInFrame(env, sym)
         };
 
-        // A binding can hold a promise rather than a plain value. Most
-        // importantly, the magrittr pipe `df %>% View()` binds the object to
-        // `.` as a promise inside the pipe's environment. Force the promise so
-        // we track and view the underlying value rather than the promise
-        // object, which has no data frame shape and would otherwise make
-        // `get_shape()` fail and close the comm.
+        // A binding can hold a promise rather than a plain value. The magrittr
+        // pipe `df %>% View()` binds the object to `.` as a promise inside the
+        // pipe's environment, and `View()` has already forced that promise to
+        // obtain the value it displays. Here we only read the value of an
+        // already-forced promise; we never force one ourselves. Forcing runs
+        // arbitrary R code that could emit warnings or output, force other
+        // promises, or mutate bindings and options, and such side effects must
+        // never originate from a comm update. If the binding currently holds an
+        // unforced promise, we can't read its value without side effects, so we
+        // leave the current view in place until the binding resolves.
         // See https://github.com/posit-dev/positron/issues/7385.
         let new = if r_is_promise(new) {
-            r_promise_force(new).map_or(new, |value| value.sexp)
+            if !r_promise_is_forced(new) {
+                return Ok(true);
+            }
+            r_promise_value(new)
         } else {
             new
         };

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -71,6 +71,8 @@ use harp::object::RObject;
 use harp::r_symbol;
 use harp::table_kind;
 use harp::tbl_get_column;
+use harp::utils::r_is_promise;
+use harp::utils::r_promise_force;
 use harp::vector::CharacterVector;
 use harp::vector::Vector;
 use harp::ColumnNames;
@@ -244,6 +246,19 @@ impl RDataExplorer {
         let new = unsafe {
             let sym = r_symbol!(binding.name);
             Rf_findVarInFrame(env, sym)
+        };
+
+        // A binding can hold a promise rather than a plain value. Most
+        // importantly, the magrittr pipe `df %>% View()` binds the object to
+        // `.` as a promise inside the pipe's environment. Force the promise so
+        // we track and view the underlying value rather than the promise
+        // object, which has no data frame shape and would otherwise make
+        // `get_shape()` fail and close the comm.
+        // See https://github.com/posit-dev/positron/issues/7385.
+        let new = if r_is_promise(new) {
+            r_promise_force(new).map_or(new, |value| value.sexp)
+        } else {
+            new
         };
 
         let changed = if new == self.table.get().sexp {

--- a/crates/ark/tests/integration/data_explorer.rs
+++ b/crates/ark/tests/integration/data_explorer.rs
@@ -143,51 +143,6 @@ fn open_data_explorer_from_expression(expr: &str, bind: Option<&str>) -> anyhow:
     })
 }
 
-// Open a data explorer whose binding tracks `.` bound to a *promise* in a
-// private environment. This mirrors how the magrittr pipe `df %>% View()`
-// binds the piped object inside its pipe environment, which used to cause the
-// comm to close on the next environment change (posit-dev/positron#7385).
-fn open_data_explorer_with_promise_binding() -> TestSetup {
-    let (iopub_tx, iopub_rx) = bounded::<IOPubMessage>(10);
-
-    let comm_id = uuid::Uuid::new_v4().to_string();
-    let outgoing_tx = CommOutgoingTx::new(comm_id, iopub_tx);
-    let (comm_event_tx, _) = bounded::<CommEvent>(10);
-    let ctx = CommHandlerContext::new(outgoing_tx, comm_event_tx);
-
-    let inner = r_task(|| {
-        let env = harp::parse_eval_global(
-            "local({
-                e <- new.env()
-                delayedAssign(
-                    '.',
-                    data.frame(y = c(3, 2, 1), z = c(4, 5, 6)),
-                    assign.env = e
-                )
-                e
-            })",
-        )
-        .unwrap();
-
-        // Force the promise to obtain the underlying data frame, exactly as
-        // `View()` does before handing the object to the data explorer.
-        let data = RObject::new(unsafe { Rf_eval(r_symbol!("."), env.sexp) });
-
-        let binding = Some(DataObjectEnvInfo {
-            name: String::from("."),
-            env,
-        });
-        let handler =
-            RDataExplorer::new(String::from("obj"), data, binding, DataExplorerMode::Full).unwrap();
-        TestInner(handler, ctx)
-    });
-
-    TestSetup {
-        inner: Mutex::new(inner),
-        iopub_rx,
-    }
-}
-
 // Safety: The inner types contain `RObject` (`!Send`) and `Cell<bool>`
 // (`!Sync`), but in tests we only access them under the R test lock
 // via `r_task`, so cross-thread movement is safe.
@@ -1317,45 +1272,6 @@ fn test_search_filters() {
             assert_eq!(data.columns[1][1], ColumnValue::FormattedValue("2".to_string()));
             assert_eq!(data.columns[1][2], ColumnValue::FormattedValue("3".to_string()));
             assert_eq!(data.columns[1][3], ColumnValue::FormattedValue("4".to_string()));
-        }
-    );
-}
-
-// Regression test for https://github.com/posit-dev/positron/issues/7385.
-//
-// The magrittr pipe `df %>% View()` binds the piped object to `.` as a promise
-// inside magrittr's pipe environment. When the data explorer re-resolves the
-// binding on an environment change, it must force that promise instead of
-// treating the promise object (which has no data frame shape) as a replacement
-// value and closing the comm.
-#[test]
-fn test_promise_binding_does_not_close() {
-    let setup = open_data_explorer_with_promise_binding();
-
-    // Signal an environment change. Before the fix, re-resolving `.` returned
-    // the promise object rather than its value, which caused the comm to close.
-    let closed = r_task(|| {
-        let TestInner(handler, ctx) = &mut *setup.inner.lock().unwrap();
-        handler.handle_environment(
-            &EnvironmentChanged::Execution {
-                input_prompt: String::from("> "),
-                continuation_prompt: String::from("+ "),
-            },
-            ctx,
-        );
-        ctx.is_closed()
-    });
-    assert!(!closed);
-
-    // The comm still serves the underlying data frame (the `y` column), and not
-    // the promise object that the binding resolves to.
-    let req = get_data_values_request(0, 3, vec![0], default_format_options());
-    assert_match!(setup.rpc(req),
-        DataExplorerBackendReply::GetDataValuesReply(data) => {
-            assert_eq!(data.columns.len(), 1);
-            assert_eq!(data.columns[0][0], ColumnValue::FormattedValue("3.00".to_string()));
-            assert_eq!(data.columns[0][1], ColumnValue::FormattedValue("2.00".to_string()));
-            assert_eq!(data.columns[0][2], ColumnValue::FormattedValue("1.00".to_string()));
         }
     );
 }

--- a/crates/ark/tests/integration/data_explorer.rs
+++ b/crates/ark/tests/integration/data_explorer.rs
@@ -143,6 +143,51 @@ fn open_data_explorer_from_expression(expr: &str, bind: Option<&str>) -> anyhow:
     })
 }
 
+// Open a data explorer whose binding tracks `.` bound to a *promise* in a
+// private environment. This mirrors how the magrittr pipe `df %>% View()`
+// binds the piped object inside its pipe environment, which used to cause the
+// comm to close on the next environment change (posit-dev/positron#7385).
+fn open_data_explorer_with_promise_binding() -> TestSetup {
+    let (iopub_tx, iopub_rx) = bounded::<IOPubMessage>(10);
+
+    let comm_id = uuid::Uuid::new_v4().to_string();
+    let outgoing_tx = CommOutgoingTx::new(comm_id, iopub_tx);
+    let (comm_event_tx, _) = bounded::<CommEvent>(10);
+    let ctx = CommHandlerContext::new(outgoing_tx, comm_event_tx);
+
+    let inner = r_task(|| {
+        let env = harp::parse_eval_global(
+            "local({
+                e <- new.env()
+                delayedAssign(
+                    '.',
+                    data.frame(y = c(3, 2, 1), z = c(4, 5, 6)),
+                    assign.env = e
+                )
+                e
+            })",
+        )
+        .unwrap();
+
+        // Force the promise to obtain the underlying data frame, exactly as
+        // `View()` does before handing the object to the data explorer.
+        let data = RObject::new(unsafe { Rf_eval(r_symbol!("."), env.sexp) });
+
+        let binding = Some(DataObjectEnvInfo {
+            name: String::from("."),
+            env,
+        });
+        let handler =
+            RDataExplorer::new(String::from("obj"), data, binding, DataExplorerMode::Full).unwrap();
+        TestInner(handler, ctx)
+    });
+
+    TestSetup {
+        inner: Mutex::new(inner),
+        iopub_rx,
+    }
+}
+
 // Safety: The inner types contain `RObject` (`!Send`) and `Cell<bool>`
 // (`!Sync`), but in tests we only access them under the R test lock
 // via `r_task`, so cross-thread movement is safe.
@@ -1272,6 +1317,45 @@ fn test_search_filters() {
             assert_eq!(data.columns[1][1], ColumnValue::FormattedValue("2".to_string()));
             assert_eq!(data.columns[1][2], ColumnValue::FormattedValue("3".to_string()));
             assert_eq!(data.columns[1][3], ColumnValue::FormattedValue("4".to_string()));
+        }
+    );
+}
+
+// Regression test for https://github.com/posit-dev/positron/issues/7385.
+//
+// The magrittr pipe `df %>% View()` binds the piped object to `.` as a promise
+// inside magrittr's pipe environment. When the data explorer re-resolves the
+// binding on an environment change, it must force that promise instead of
+// treating the promise object (which has no data frame shape) as a replacement
+// value and closing the comm.
+#[test]
+fn test_promise_binding_does_not_close() {
+    let setup = open_data_explorer_with_promise_binding();
+
+    // Signal an environment change. Before the fix, re-resolving `.` returned
+    // the promise object rather than its value, which caused the comm to close.
+    let closed = r_task(|| {
+        let TestInner(handler, ctx) = &mut *setup.inner.lock().unwrap();
+        handler.handle_environment(
+            &EnvironmentChanged::Execution {
+                input_prompt: String::from("> "),
+                continuation_prompt: String::from("+ "),
+            },
+            ctx,
+        );
+        ctx.is_closed()
+    });
+    assert!(!closed);
+
+    // The comm still serves the underlying data frame (the `y` column), and not
+    // the promise object that the binding resolves to.
+    let req = get_data_values_request(0, 3, vec![0], default_format_options());
+    assert_match!(setup.rpc(req),
+        DataExplorerBackendReply::GetDataValuesReply(data) => {
+            assert_eq!(data.columns.len(), 1);
+            assert_eq!(data.columns[0][0], ColumnValue::FormattedValue("3.00".to_string()));
+            assert_eq!(data.columns[0][1], ColumnValue::FormattedValue("2.00".to_string()));
+            assert_eq!(data.columns[0][2], ColumnValue::FormattedValue("1.00".to_string()));
         }
     );
 }

--- a/crates/ark/tests/integration/data_explorer_integration.rs
+++ b/crates/ark/tests/integration/data_explorer_integration.rs
@@ -12,9 +12,16 @@
 use std::time::Duration;
 use std::time::Instant;
 
+use amalthea::comm::data_explorer_comm::ArraySelection;
+use amalthea::comm::data_explorer_comm::ColumnSelection;
+use amalthea::comm::data_explorer_comm::ColumnValue;
 use amalthea::comm::data_explorer_comm::DataExplorerBackendReply;
 use amalthea::comm::data_explorer_comm::DataExplorerBackendRequest;
+use amalthea::comm::data_explorer_comm::DataSelectionRange;
+use amalthea::comm::data_explorer_comm::FormatOptions;
+use amalthea::comm::data_explorer_comm::GetDataValuesParams;
 use amalthea::comm::data_explorer_comm::GetSchemaParams;
+use amalthea::comm::data_explorer_comm::TableData;
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
 use ark_test::DummyArkFrontend;
 
@@ -147,4 +154,173 @@ fn test_open_child_explorer_during_dispatch() {
     assert_eq!(reply, DataExplorerBackendReply::OpenDataExplorerReply());
 
     frontend.recv_iopub_idle();
+}
+
+/// Regression test for https://github.com/posit-dev/positron/issues/7385.
+///
+/// The magrittr pipe `df %>% View()` binds the piped object to `.` as a
+/// promise inside magrittr's pipe environment, and `View()` forces that
+/// promise to display it. When the data explorer re-resolves its binding on a
+/// later environment change, it must read the forced value rather than treat
+/// the promise object (which has no data frame shape) as a replacement value
+/// and close the comm, leaving a blank pane.
+#[test]
+fn test_magrittr_pipe_data_explorer_stays_open() {
+    let frontend = DummyArkFrontend::lock();
+
+    execute_silently(&frontend, "library(magrittr)");
+    execute_silently(
+        &frontend,
+        "mag_df <- data.frame(y = c(3, 2, 1), z = c(4, 5, 6))",
+    );
+
+    // Open the data explorer through the magrittr pipe.
+    frontend.send_execute_request("mag_df %>% View()", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    let comm_open = frontend.recv_iopub_comm_open();
+    assert_eq!(comm_open.target_name, "positron.dataExplorer");
+    let comm_id = comm_open.comm_id;
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    // Trigger an environment change so the explorer re-resolves its binding.
+    // Before the fix, re-resolving `.` returned the promise object and the
+    // comm closed here.
+    frontend.send_execute_request("1 + 1", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_execute_result();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    // No `comm_close` should have arrived while re-resolving the binding.
+    frontend.assert_iopub_empty();
+
+    // The comm is still open and still serves the underlying data frame (the
+    // `y` column), not the promise object.
+    let table = get_data_values(&frontend, &comm_id, 3);
+    assert_eq!(table.columns.len(), 1);
+    assert_eq!(
+        table.columns[0][0],
+        ColumnValue::FormattedValue("3.00".to_string())
+    );
+    assert_eq!(
+        table.columns[0][1],
+        ColumnValue::FormattedValue("2.00".to_string())
+    );
+    assert_eq!(
+        table.columns[0][2],
+        ColumnValue::FormattedValue("1.00".to_string())
+    );
+}
+
+/// Companion to `test_magrittr_pipe_data_explorer_stays_open`: reading a
+/// forced promise's value must not tempt the explorer into *forcing* one.
+///
+/// A watched binding can transition from a plain value to an unforced,
+/// delayed promise. The explorer must never force it, because forcing runs
+/// arbitrary R code from within a comm update. We assert this by watching a
+/// promise whose evaluation sets a flag: after an environment change the flag
+/// stays `FALSE`, and the explorer keeps showing the last resolved value.
+#[test]
+fn test_data_explorer_does_not_force_delayed_binding() {
+    let frontend = DummyArkFrontend::lock();
+
+    execute_silently(&frontend, "edge_df <- data.frame(a = c(1, 2, 3))");
+    let comm_id = frontend.open_data_explorer("edge_df");
+
+    // Replace the watched binding with a delayed promise that records whether
+    // it was ever forced. Assigning it already triggers an environment change,
+    // so the explorer re-resolves the (now unforced) binding here.
+    execute_silently(&frontend, "forced_flag <- FALSE");
+    execute_silently(
+        &frontend,
+        "delayedAssign('edge_df', {
+            forced_flag <<- TRUE
+            data.frame(a = c(4, 5, 6))
+        }, assign.env = globalenv())",
+    );
+
+    // A further environment change, to be sure the explorer had a chance to
+    // re-resolve the delayed binding.
+    frontend.send_execute_request("1 + 1", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_execute_result();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+    frontend.assert_iopub_empty();
+
+    // The explorer must not have forced the promise.
+    frontend.execute_request("forced_flag", |result| {
+        assert_eq!(result, "[1] FALSE");
+    });
+
+    // The comm stays open and keeps serving the last resolved value (`1, 2, 3`)
+    // rather than the delayed promise's value (`4, 5, 6`), which would require
+    // forcing to obtain.
+    let table = get_data_values(&frontend, &comm_id, 3);
+    assert_eq!(table.columns.len(), 1);
+    assert_eq!(
+        table.columns[0][0],
+        ColumnValue::FormattedValue("1.00".to_string())
+    );
+    assert_eq!(
+        table.columns[0][1],
+        ColumnValue::FormattedValue("2.00".to_string())
+    );
+    assert_eq!(
+        table.columns[0][2],
+        ColumnValue::FormattedValue("3.00".to_string())
+    );
+}
+
+/// Run `code` at top level, asserting the standard Busy/Idle message sequence
+/// with no output beyond the execute input.
+fn execute_silently(frontend: &DummyArkFrontend, code: &str) {
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}
+
+/// Send a `get_data_values` RPC for the first `num_rows` rows of column 0 and
+/// return the resulting table data.
+fn get_data_values(frontend: &DummyArkFrontend, comm_id: &str, num_rows: i64) -> TableData {
+    let request = DataExplorerBackendRequest::GetDataValues(GetDataValuesParams {
+        columns: vec![ColumnSelection {
+            column_index: 0,
+            spec: ArraySelection::SelectRange(DataSelectionRange {
+                first_index: 0,
+                last_index: num_rows - 1,
+            }),
+        }],
+        format_options: default_format_options(),
+    });
+    let mut data = serde_json::to_value(&request).unwrap();
+    data["id"] = serde_json::Value::String(String::from("get-data-rpc"));
+
+    frontend.send_shell_comm_msg(comm_id.to_string(), data);
+    frontend.recv_iopub_busy();
+    let msg = frontend.recv_iopub_comm_msg();
+    frontend.recv_iopub_idle();
+
+    assert_eq!(msg.comm_id, comm_id);
+    let reply: DataExplorerBackendReply = serde_json::from_value(msg.data).unwrap();
+    match reply {
+        DataExplorerBackendReply::GetDataValuesReply(table) => table,
+        other => panic!("Expected GetDataValuesReply, got: {other:?}"),
+    }
+}
+
+fn default_format_options() -> FormatOptions {
+    FormatOptions {
+        large_num_digits: 2,
+        small_num_digits: 4,
+        max_integral_digits: 7,
+        thousands_sep: Some(",".to_string()),
+        max_value_length: 100,
+    }
 }


### PR DESCRIPTION
- Closes posit-dev/positron#7385 
- Closes posit-dev/positron#8167 

This PR fixes a blank Data Explorer when viewing a data frame through the magrittr pipe, e.g. `ggplot2::diamonds %>% View()`. Currently the tab opens, shows a loading spinner, and then goes blank because the kernel closes the comm before any data is sent. We originally thought this was something to do with renv, but that seems like it was incorrect. The base pipe (`ggplot2::diamonds |> View()`) was always unaffected.

## Why did this happen?

`View()` registers the Data Explorer against a *variable binding* (a name plus an environment) so the grid can live-update when the underlying object changes. On each top-level execution, `RDataExplorer::update()` re-resolves that binding with `Rf_findVarInFrame()` and compares the result against the object it is currently showing.

The magrittr pipe binds the piped object to `.` inside its private pipe environment, and it stores `.` as a promise rather than a plain value. So the re-resolution returned the promise object (a `PROMSXP`), not the data frame. That promise pointer never equals the forced data frame we are viewing, so `update()` treated it as a replacement value, failed to compute a table shape for it, and closed the comm. The base pipe works because `diamonds |> View()` is pure syntax that rewrites to `View(diamonds)`, and `diamonds` in the global environment is a plain value.

## What changes in this PR

When re-resolving the binding, force the value if it is a promise before comparing and computing its shape. For the magrittr case the promise is already forced, so this is a cached read with no side effects, and the resolved value now equals the data frame we are viewing, so the comm stays open. The change preserves existing behavior for genuine top-level variables: removing a watched variable (`rm(x)`) still resolves to an unbound value and correctly closes the comm.

This seems like a pretty innocuous fix to me, but if you all think we should _not_ take it just for magrittr pipe users, I will not be super offended.


### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed the Data Explorer being blank when viewing objects piped with `%>%` (posit-dev/positron#7385 )
