### PR TITLE
Always list base packages in `workspace_dependencies()`

### DIFF
--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -157,9 +157,9 @@ impl SourceScheduler {
             return;
         };
 
-        // For each package used by the workspace, request its sources if we have never
-        // seen it before
-        for package in oak_db::workspace_dependencies(db) {
+        // For each package used across all of the workspace roots, request its sources if
+        // we have never seen it before
+        for package in oak_db::all_package_dependencies(db) {
             if self.state.contains_key(package) {
                 // If we've seen this package before, don't request sources again!
                 continue;

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -31,22 +31,6 @@ pub enum ImportLayer {
     Package(Package),
 }
 
-/// The default R search path: packages always attached at startup, in
-/// the order R's `search()` reports them (last attached = searched
-/// first, so `stats` is highest-priority and `base` is lowest).
-/// Materialised as `Package` layers; packages absent from the
-/// workspace and library roots drop out (the LSP fills them in later
-/// via its source handler).
-const DEFAULT_SEARCH_PATH: [&str; 7] = [
-    "stats",
-    "graphics",
-    "grDevices",
-    "utils",
-    "datasets",
-    "methods",
-    "base",
-];
-
 #[salsa::tracked]
 impl File {
     /// The import layers visible to this file at end-of-file, in R's lookup
@@ -395,7 +379,7 @@ fn extend_with_base(db: &dyn Db, layers: &mut Vec<ImportLayer>) {
 }
 
 fn extend_with_default_search_path(db: &dyn Db, layers: &mut Vec<ImportLayer>) {
-    for pkg_name in DEFAULT_SEARCH_PATH {
+    for pkg_name in crate::search::DEFAULT_SEARCH_PATH_PACKAGES {
         if let Some(pkg) = db.package_by_name(pkg_name) {
             layers.push(ImportLayer::Package(pkg));
         }

--- a/crates/oak_db/src/lib.rs
+++ b/crates/oak_db/src/lib.rs
@@ -44,4 +44,4 @@ pub use oak_package_metadata::description::Priority;
 pub use package::Package;
 pub use package_resolve::PackageVisibility;
 pub use storage::OakDatabase;
-pub use workspace::workspace_dependencies;
+pub use workspace::all_package_dependencies;

--- a/crates/oak_db/src/lib.rs
+++ b/crates/oak_db/src/lib.rs
@@ -12,6 +12,7 @@ mod name;
 mod package;
 mod package_resolve;
 mod parse;
+mod search;
 mod storage;
 mod workspace;
 

--- a/crates/oak_db/src/search.rs
+++ b/crates/oak_db/src/search.rs
@@ -3,6 +3,9 @@
 /// Listed in the order R's `search()` reports them (last attached = searched first, so
 /// `stats` is highest-priority and `base` is lowest), which is important for when they
 /// are attached as [crate::ImportLayer::Package] layers.
+///
+/// One day we may want to retrieve these from R's `R_DEFAULT_PACKAGES` environment
+/// variable, or via `getOption("defaultPackages")`.
 pub(crate) const DEFAULT_SEARCH_PATH_PACKAGES: [&str; 7] = [
     "stats",
     "graphics",

--- a/crates/oak_db/src/search.rs
+++ b/crates/oak_db/src/search.rs
@@ -1,0 +1,14 @@
+/// The default R search path packages always attached at startup
+///
+/// Listed in the order R's `search()` reports them (last attached = searched first, so
+/// `stats` is highest-priority and `base` is lowest), which is important for when they
+/// are attached as [crate::ImportLayer::Package] layers.
+pub(crate) const DEFAULT_SEARCH_PATH_PACKAGES: [&str; 7] = [
+    "stats",
+    "graphics",
+    "grDevices",
+    "utils",
+    "datasets",
+    "methods",
+    "base",
+];

--- a/crates/oak_db/src/tests/workspace.rs
+++ b/crates/oak_db/src/tests/workspace.rs
@@ -3,11 +3,11 @@ use std::fs;
 use aether_path::FilePath;
 use salsa::Setter;
 
+use crate::all_package_dependencies;
 use crate::tests::test_db::file_path;
 use crate::tests::test_db::library_root;
 use crate::tests::test_db::workspace_root;
 use crate::tests::test_db::TestDb;
-use crate::workspace_dependencies;
 use crate::DbInputs;
 use crate::File;
 use crate::FileRevision;
@@ -52,8 +52,8 @@ fn workspace_with_script(db: &mut TestDb, contents: &str) {
     db.workspace_roots().set_roots(db).to(vec![root]);
 }
 
-fn workspace_dependencies_names(db: &TestDb) -> Vec<String> {
-    workspace_dependencies(db)
+fn all_package_dependencies_names(db: &TestDb) -> Vec<String> {
+    all_package_dependencies(db)
         .iter()
         .map(|&pkg| pkg.name(db).clone())
         .collect()
@@ -67,7 +67,7 @@ fn test_collects_library_and_namespace_accesses() {
 
     // `foo` via `library()`, `bar` via `::`; `unused` is installed but never
     // referenced. Sorted by name.
-    assert_eq!(workspace_dependencies_names(&db), vec!["bar", "foo"]);
+    assert_eq!(all_package_dependencies_names(&db), vec!["bar", "foo"]);
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn test_collects_internal_namespace_access() {
     register_library(&mut db, &["rlang"]);
     workspace_with_script(&mut db, "rlang:::abort()\n");
 
-    assert_eq!(workspace_dependencies_names(&db), vec!["rlang"]);
+    assert_eq!(all_package_dependencies_names(&db), vec!["rlang"]);
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn test_collects_imports_and_depends_from_workspace_package() {
 
     // `cli` via `Depends`, `rlang` via `Imports`. The workspace package
     // `mypkg` itself is not included (it resolves to a workspace root).
-    assert_eq!(workspace_dependencies_names(&db), vec!["cli", "rlang"]);
+    assert_eq!(all_package_dependencies_names(&db), vec!["cli", "rlang"]);
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn test_uninstalled_name_is_dropped() {
     workspace_with_script(&mut db, "library(ghost)\nfoo::thing()\n");
 
     // `ghost` has no installed entity to populate, so only `foo` survives.
-    assert_eq!(workspace_dependencies_names(&db), vec!["foo"]);
+    assert_eq!(all_package_dependencies_names(&db), vec!["foo"]);
 }
 
 #[test]
@@ -150,13 +150,13 @@ fn test_workspace_package_self_reference_is_dropped() {
 
     // `mypkg::helper` resolves to the workspace package, which already has its
     // source, so it's dropped.
-    assert!(workspace_dependencies_names(&db).is_empty());
+    assert!(all_package_dependencies_names(&db).is_empty());
 }
 
 #[test]
 fn test_empty_workspace_uses_nothing() {
     let db = TestDb::new();
-    assert!(workspace_dependencies_names(&db).is_empty());
+    assert!(all_package_dependencies_names(&db).is_empty());
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn test_default_search_path_packages_are_always_available_to_workspace_scripts()
     // Every installed default search path package is implicitly available, even
     // though the script never references them. `unused` isn't on the search
     // path and is never referenced, so it drops out.
-    assert_eq!(workspace_dependencies_names(&db), vec![
+    assert_eq!(all_package_dependencies_names(&db), vec![
         "base",
         "datasets",
         "grDevices",
@@ -221,7 +221,7 @@ fn test_default_search_path_packages_are_always_available_to_workspace_packages(
     // `mypkg` only declares `rlang` in `Imports` and nothing in `Depends`, but
     // the default search path packages `base` and `stats` are always available
     // even though the `DESCRIPTION` never mentions them.
-    assert_eq!(workspace_dependencies_names(&db), vec![
+    assert_eq!(all_package_dependencies_names(&db), vec![
         "base", "rlang", "stats"
     ]);
 }

--- a/crates/oak_db/src/tests/workspace.rs
+++ b/crates/oak_db/src/tests/workspace.rs
@@ -158,3 +158,70 @@ fn test_empty_workspace_uses_nothing() {
     let db = TestDb::new();
     assert!(workspace_dependencies_names(&db).is_empty());
 }
+
+#[test]
+fn test_default_search_path_packages_are_always_available_to_workspace_scripts() {
+    let mut db = TestDb::new();
+    register_library(&mut db, &[
+        "base",
+        "datasets",
+        "grDevices",
+        "graphics",
+        "methods",
+        "stats",
+        "utils",
+        "unused",
+    ]);
+    // A script that attaches nothing and references no package.
+    workspace_with_script(&mut db, "1 + 1\n");
+
+    // Every installed default search path package is implicitly available, even
+    // though the script never references them. `unused` isn't on the search
+    // path and is never referenced, so it drops out.
+    assert_eq!(workspace_dependencies_names(&db), vec![
+        "base",
+        "datasets",
+        "grDevices",
+        "graphics",
+        "methods",
+        "stats",
+        "utils"
+    ]);
+}
+
+#[test]
+fn test_default_search_path_packages_are_always_available_to_workspace_packages() {
+    let mut db = TestDb::new();
+    register_library(&mut db, &["rlang", "base", "stats"]);
+
+    // Build a workspace package that only imports rlang
+    let dir = tempfile::tempdir().unwrap();
+    let description = dir.path().join("DESCRIPTION");
+    fs::write(
+        &description,
+        "Package: mypkg\nVersion: 1.0.0\nImports: rlang\n",
+    )
+    .unwrap();
+
+    let pkg = Package::new(
+        &db,
+        FilePath::from_path_buf(description).unwrap(),
+        "mypkg".to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        vec![],
+        Vec::new(),
+    );
+
+    let root = workspace_root(&db, "proj");
+    root.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    // `mypkg` only declares `rlang` in `Imports` and nothing in `Depends`, but
+    // the default search path packages `base` and `stats` are always available
+    // even though the `DESCRIPTION` never mentions them.
+    assert_eq!(workspace_dependencies_names(&db), vec![
+        "base", "rlang", "stats"
+    ]);
+}

--- a/crates/oak_db/src/tests/workspace.rs
+++ b/crates/oak_db/src/tests/workspace.rs
@@ -210,6 +210,7 @@ fn test_default_search_path_packages_are_always_available_to_workspace_packages(
         FileRevision::zero(),
         FileRevision::zero(),
         None,
+        None,
         vec![],
         Vec::new(),
     );

--- a/crates/oak_db/src/workspace.rs
+++ b/crates/oak_db/src/workspace.rs
@@ -17,10 +17,13 @@ pub fn workspace_dependencies(db: &dyn Db) -> Vec<Package> {
     // shouldn't require re-querying `DESCRIPTION` dependencies)
     let from_files = workspace_file_dependencies(db);
     let from_packages = workspace_package_dependencies(db);
+    let from_search = default_search_package_packages(db);
 
-    let mut packages: Vec<Package> = Vec::with_capacity(from_files.len() + from_packages.len());
+    let mut packages: Vec<Package> =
+        Vec::with_capacity(from_files.len() + from_packages.len() + from_search.len());
     packages.extend(from_files);
     packages.extend(from_packages);
+    packages.extend(from_search);
 
     packages.sort_by_cached_key(|package| package.name(db));
     packages.dedup_by_key(|package| package.name(db));
@@ -75,6 +78,23 @@ fn workspace_package_dependencies(db: &dyn Db) -> Vec<Package> {
     names.dedup();
 
     as_packages(names, db)
+}
+
+/// Packages implicitly used by a workspace via R's default search path
+///
+/// - Workspace scripts always implicitly use these packages, even if they aren't
+///   mentioned via a `library()` / `::` call.
+///
+/// - Workspace package files technically only depend on {base}, but if your package has
+///   any arbitrary scripts in it then we are going need the rest of the base packages
+///   anyways, and returning them all here just ensures that their sources are available,
+///   it doesn't affect package diagnostics, so it's okay to over approximate for
+///   simplicity.
+///
+/// These are effectively static, so we don't need to sort them by name at this point
+#[salsa::tracked(returns(ref))]
+fn default_search_package_packages(db: &dyn Db) -> Vec<Package> {
+    as_packages(crate::search::DEFAULT_SEARCH_PATH_PACKAGES, db)
 }
 
 /// Converts an iterable of `names` into their corresponding `Package`s, throwing out:

--- a/crates/oak_db/src/workspace.rs
+++ b/crates/oak_db/src/workspace.rs
@@ -5,19 +5,19 @@ use crate::Db;
 use crate::Package;
 use crate::RootKind;
 
-/// Packages the workspace depends on
+/// Packages that any workspace root depends on
 ///
 /// Returned sorted on package name and unique, maximizing backdating potential.
 ///
 /// Unknown packages (not installed) are dropped, along with those that resolve to a
 /// workspace package (which is currently being worked on).
 #[salsa::tracked(returns(ref))]
-pub fn workspace_dependencies(db: &dyn Db) -> Vec<Package> {
+pub fn all_package_dependencies(db: &dyn Db) -> Vec<Package> {
     // Split into several queries to maximize backdating (changing a workspace file
     // shouldn't require re-querying `DESCRIPTION` dependencies)
-    let from_files = workspace_file_dependencies(db);
-    let from_packages = workspace_package_dependencies(db);
-    let from_search = default_search_package_packages(db);
+    let from_files = all_workspace_file_dependencies(db);
+    let from_packages = all_workspace_package_dependencies(db);
+    let from_search = default_search_path_packages(db);
 
     let mut packages: Vec<Package> =
         Vec::with_capacity(from_files.len() + from_packages.len() + from_search.len());
@@ -31,13 +31,13 @@ pub fn workspace_dependencies(db: &dyn Db) -> Vec<Package> {
     packages
 }
 
-/// Packages used by files / scripts in the workspace
+/// Packages used by files / scripts in any workspace root
 ///
 /// i.e. `library()` / `require()` / `::` / `:::`
 ///
 /// Returned sorted on package name and unique, maximizing backdating potential.
 #[salsa::tracked(returns(ref))]
-fn workspace_file_dependencies(db: &dyn Db) -> Vec<Package> {
+fn all_workspace_file_dependencies(db: &dyn Db) -> Vec<Package> {
     // It's likely that we will have a lot of duplicated package use across workspace
     // files, so we use a BTreeSet to avoid having to sort and dedup a large vector
     let mut names: BTreeSet<&str> = BTreeSet::new();
@@ -53,14 +53,14 @@ fn workspace_file_dependencies(db: &dyn Db) -> Vec<Package> {
     as_packages(names, db)
 }
 
-/// Packages used by a workspace package's `DESCRIPTION` file
+/// Packages used by any workspace package's `DESCRIPTION` file
 ///
 /// We take `Depends` and `Imports`, but not `Suggests`, as `Suggests` will
 /// instead be referenced by `::` elsewhere as required
 ///
 /// Returned sorted on package name and unique, maximizing backdating potential.
 #[salsa::tracked(returns(ref))]
-fn workspace_package_dependencies(db: &dyn Db) -> Vec<Package> {
+fn all_workspace_package_dependencies(db: &dyn Db) -> Vec<Package> {
     // We aren't expecting there to be many duplicates here (probably none for single
     // package workspaces), so a simple Vec is fine
     let mut names = Vec::new();
@@ -93,7 +93,7 @@ fn workspace_package_dependencies(db: &dyn Db) -> Vec<Package> {
 ///
 /// These are effectively static, so we don't need to sort them by name at this point
 #[salsa::tracked(returns(ref))]
-fn default_search_package_packages(db: &dyn Db) -> Vec<Package> {
+fn default_search_path_packages(db: &dyn Db) -> Vec<Package> {
     as_packages(crate::search::DEFAULT_SEARCH_PATH_PACKAGES, db)
 }
 


### PR DESCRIPTION
I noticed that if you open purrr to https://github.com/tidyverse/purrr/blob/481e829f297fd4315b386518215157f361475ad0/R/adverb-safely.R#L42 and just try to goto definition on `force()`, then nothing happens.

That's because `force()` is a base function, but base isn't listed in Imports or Depends so it doesn't get picked up in `workspace_dependencies()` and we never try and set its package `R/` sources.

Similar story if you open an arbitrary workspace of scripts where you use any package from the default R `search()` path without first calling `library()` or `::` on that package somewhere in the file.

I think the right thing to do is to just ensure that the default `search()` packages are always listed in `workspace_dependencies()`. This is definitely right for workspace scripts. For workspace packages _technically_ an individual package file would only need {base}, but if you add any extra scripts into the package, like `inst/data.R`, then we'd require the rest of the base packages anyways, so I think it is fine to just default to all of the default `search()` packages for workspace packages too. It doesn't affect diagnostics there, just the set of packages we try and download sources for, so over approximation is pretty harmless.