### PR TITLE
Add build version info to kernel info reply

### DIFF
--- a/crates/amalthea/src/wire/language_info.rs
+++ b/crates/amalthea/src/wire/language_info.rs
@@ -45,4 +45,13 @@ pub struct LanguageInfoPositron {
 
     /// Initial continuation prompt
     pub continuation_prompt: Option<String>,
+
+    /// The kernel's full build version (e.g. `0.1.252+14.6618e9a`), if known.
+    /// Distinct from the Jupyter `implementation_version` (bare `X.Y.Z`); this
+    /// carries the extra build metadata Positron uses to detect a submodule
+    /// mismatch.
+    pub build_version: Option<String>,
+
+    /// The short git commit hash the kernel was built from, if known.
+    pub commit: Option<String>,
 }

--- a/crates/ark/src/lib.rs
+++ b/crates/ark/src/lib.rs
@@ -56,3 +56,4 @@ pub mod viewer;
 pub(crate) use r_task::r_task;
 
 pub const BUILD_VERSION: &str = env!("BUILD_VERSION");
+pub const BUILD_GIT_HASH: &str = env!("BUILD_GIT_HASH");

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -139,7 +139,7 @@ impl ShellHandler for Shell {
                 input_prompt: kernel_info.input_prompt.clone(),
                 continuation_prompt: kernel_info.continuation_prompt.clone(),
                 build_version: Some(String::from(crate::BUILD_VERSION)),
-                commit: Some(String::from(env!("BUILD_GIT_HASH"))),
+                commit: Some(String::from(crate::BUILD_GIT_HASH)),
             }),
         };
         let mut supported_features = vec![String::from("debugger")];

--- a/crates/ark/src/shell.rs
+++ b/crates/ark/src/shell.rs
@@ -138,6 +138,8 @@ impl ShellHandler for Shell {
             positron: Some(LanguageInfoPositron {
                 input_prompt: kernel_info.input_prompt.clone(),
                 continuation_prompt: kernel_info.continuation_prompt.clone(),
+                build_version: Some(String::from(crate::BUILD_VERSION)),
+                commit: Some(String::from(env!("BUILD_GIT_HASH"))),
             }),
         };
         let mut supported_features = vec![String::from("debugger")];

--- a/crates/ark/src/version.rs
+++ b/crates/ark/src/version.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C-unwind" fn ps_ark_version() -> anyhow::Result<SEXP> {
     info.insert(String::from("version"), String::from(crate::BUILD_VERSION));
 
     // Add the current commit hash and branch; these are set by the build script (build.rs)
-    info.insert(String::from("commit"), String::from(env!("BUILD_GIT_HASH")));
+    info.insert(String::from("commit"), String::from(crate::BUILD_GIT_HASH));
     info.insert(
         String::from("branch"),
         String::from(env!("BUILD_GIT_BRANCH")),


### PR DESCRIPTION
This change adds a couple more Positron-specific fields to the `kernel_info_reply`, with the goal of making it possible for Positron to know exactly what version of ark it's dealing with, without making additional RPCs. 

Needed for https://github.com/posit-dev/positron/issues/14407.