### PR TITLE
Detect `Attach` effects during semantic scan

### DIFF
--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -3,7 +3,7 @@ use camino::Utf8Component;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use oak_semantic::effects_registry;
-use oak_semantic::Effects;
+use oak_semantic::EffectsHandlers;
 use oak_semantic::ImportsResolver;
 use oak_semantic::SourceResolution;
 use url::Url;
@@ -91,15 +91,13 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
         name: &str,
         _attached: &[String],
         _lazy: bool,
-    ) -> Option<Effects> {
+    ) -> Option<EffectsHandlers> {
         // Base is the always-attached layer at the bottom of the search path,
         // resolved through the same registry lookup as any package.
         //
         // TODO!: walk the rest of the search path too (flow-order attaches,
         // package siblings via `who_defines`, NAMESPACE imports, re-export chase).
-        effects_registry::lookup("base", name)
-            .copied()
-            .map(Effects::nse)
+        effects_registry::lookup("base", name).copied()
     }
 }
 

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -57,7 +57,7 @@ use oak_index_vec::IndexVec;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
-use crate::effects::ArgumentsAnnotation;
+use crate::effects::ResolvedArgumentEffects;
 use crate::resolver::ImportsResolver;
 use crate::resolver::SourceResolution;
 use crate::semantic_index::Definition;
@@ -136,6 +136,14 @@ struct SemanticIndexBuilder<R: ImportsResolver> {
     // by the scope's range. Captured from `flow_state`, and read by
     // `begin_scan()` to seed the scope's own scan.
     enclosing_flow: FxHashMap<TextRange, FlowState>,
+    // Packages attached in eager flow order (file level and eager NSE descents),
+    // appended only when `!is_lazy()`. Append-only, never restored across a
+    // descent or branch: attaches hit the global search path, they aren't scoped
+    // like `flow_state`. An eager callee reads the flow-precise prefix during
+    // the file scan. A lazy callee reads the complete set during the walk (which
+    // runs after the file scan finishes), so this doubles as the end-of-file
+    // attach view.
+    attached_flow: Vec<String>,
     // Bound names of Eager + Nested bodies like `local()` are discovered inline
     // by the scanner. See `EagerNestedDescent`.
     eager_descent: EagerNestedDescent,
@@ -184,6 +192,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             call_resolutions: FxHashMap::default(),
             flow_state: FlowState::default(),
             enclosing_flow: FxHashMap::default(),
+            attached_flow: Vec::new(),
             eager_descent: EagerNestedDescent::default(),
             diagnostics: Vec::new(),
             resolver,
@@ -746,8 +755,10 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     ///
     /// Only `source()` needs handling here. Its injected bindings shadow NSE
     /// callees, and the walk injects them too late for a later call in the same
-    /// scope to see. `library()`/`require()` attaches don't affect the scan
-    /// decisions yet, so they stay with the walk.
+    /// scope to see. `library()`/`require()` attaches are recognized on the
+    /// resolve path in [`scan_call`], not here.
+    ///
+    /// [`scan_call`]: Self::scan_call
     ///
     /// [`collect_semantic_call`]: Self::collect_semantic_call
     fn scan_semantic_call(&mut self, call: &aether_syntax::RCall) {
@@ -778,6 +789,15 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         let range = call.syntax().text_trimmed_range();
         for name in &resolution.names {
             self.record_binding(name.clone(), range);
+        }
+
+        // A `source()`-forwarded `library()` attaches at this call's flow
+        // position, the same as an attach written here directly. Only in eager
+        // context, matching `scan_attach_call`'s `!is_lazy()` gate.
+        if !self.scopes[self.current_scope].kind.is_lazy() {
+            for pkg in &resolution.packages {
+                self.attached_flow.push(pkg.clone());
+            }
         }
 
         self.call_resolutions.entry(range).or_default().source = Some(resolution);
@@ -818,10 +838,10 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
-    fn nse_effect(&self, call: &RCall) -> Option<ArgumentsAnnotation> {
+    fn nse_effect(&self, call: &RCall) -> Option<ResolvedArgumentEffects> {
         self.call_resolutions
             .get(&call.syntax().text_trimmed_range())
-            .and_then(|resolution| resolution.nse)
+            .and_then(|resolution| resolution.arguments.clone())
     }
 
     // --- Recursive descent ---
@@ -884,8 +904,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     self.collect_expression(&func);
                 }
 
-                if let Some(annotation) = self.nse_effect(call) {
-                    self.collect_nse_call(call, annotation)
+                if let Some(scoping) = self.nse_effect(call) {
+                    self.collect_nse_call(call, scoping)
                 } else if let Ok(args) = call.arguments() {
                     self.collect_arguments(&args.items());
                 }
@@ -1208,15 +1228,25 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     }
 
     fn collect_semantic_call(&mut self, call: &aether_syntax::RCall) {
-        let Ok(AnyRExpression::RIdentifier(ident)) = call.function() else {
-            return;
-        };
+        // Attach: the scan recognized it (shadow- and mask-aware) and recorded
+        // the package by range. We emit the `SemanticCall::Attach` here so it
+        // carries the walk-time scope, e.g. the pushed NSE scope for a
+        // `library()` inside `local({...})`.
+        let range = call.syntax().text_trimmed_range();
+        if let Some(package) = self
+            .call_resolutions
+            .get(&range)
+            .and_then(|resolution| resolution.attach.clone())
+        {
+            self.record_attach(call, package);
+        }
 
-        let fn_name = ident.name_text();
-        if fn_name == "library" || fn_name == "require" {
-            self.collect_attach_call(call);
-        } else if fn_name == "source" {
-            self.collect_source_call(call);
+        // Source is still recognized by callee name here, reading the resolution
+        // the scan cached.
+        if let Ok(AnyRExpression::RIdentifier(ident)) = call.function() {
+            if ident.name_text() == "source" {
+                self.collect_source_call(call);
+            }
         }
     }
 
@@ -1228,37 +1258,10 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     // execution is guaranteed), but inside a function it's only visible
     // within that function and its children, since the function might never
     // be called. Same reasoning as `source()` calls.
-    fn collect_attach_call(&mut self, call: &aether_syntax::RCall) {
-        let Ok(args) = call.arguments() else {
-            return;
-        };
-        let mut items = args.items().iter();
-
-        // For now, only recognise exactly one unnamed argument. We'll do
-        // argument matching later (`character.only` unquoting is another
-        // complication).
-        let Some(Ok(first_arg)) = items.next() else {
-            return;
-        };
-        if first_arg.name_clause().is_some() || items.next().is_some() {
-            return;
-        }
-        let Some(value) = first_arg.value() else {
-            return;
-        };
-
-        let pkg_name = match &value {
-            AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
-            AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
-            _ => None,
-        };
-        let Some(pkg_name) = pkg_name else {
-            return;
-        };
-
+    fn record_attach(&mut self, call: &RCall, package: String) {
         let call_offset = call.syntax().text_trimmed_range().start();
         self.semantic_calls.push(SemanticCall {
-            kind: SemanticCallKind::Attach { package: pkg_name },
+            kind: SemanticCallKind::Attach { package },
             offset: call_offset,
             scope: self.current_scope,
         });
@@ -1403,9 +1406,9 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     call_range,
                     overwrite_range,
                 } => log::warn!(
-                    "NSE lazy-shadow ambiguity: callee `{name}` at {call_range:?} is recognized \
-                     as NSE, but a lazy-crossed ancestor binds it at {overwrite_range:?} with \
-                     undetermined timing"
+                    "Lazy-shadow ambiguity: callee `{name}` at {call_range:?} is recognized \
+                     as effectful, but a lazy-crossed ancestor binds it at {overwrite_range:?} \
+                     with undetermined timing"
                 ),
             }
         }
@@ -1443,17 +1446,21 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
 }
 
 /// What the scan resolved a single call to, for the walk to reuse. A call can
-/// carry both facts at once.
+/// carry several of these at once.
 ///
-/// - `nse`: the NSE effect the call resolved to, filled in flow order. `None`
+/// - `arguments`: the NSE effect the call resolved to, filled in flow order. `None`
 ///   means "not NSE".
 /// - `source`: the resolution of a `source()` call. The scan fills it once
 ///   (consulting `resolve_source`), the walk reads it back, so the resolver is
 ///   queried exactly once per `source()` call site.
+/// - `attach`: the package a `library()`/`require()` call attaches, recognized
+///   shadow-aware on the resolve path. The walk reads it back to emit a scoped
+///   `SemanticCall::Attach`.
 #[derive(Default)]
 struct CallResolution {
-    nse: Option<ArgumentsAnnotation>,
+    arguments: Option<ResolvedArgumentEffects>,
     source: Option<SourceResolution>,
+    attach: Option<String>,
 }
 
 /// The scan's flow-precise binding state: which names are bound at the current

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -227,10 +227,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     fn resolve_effects(&mut self, call: &RCall) -> Option<Effects> {
         let handlers = self.resolve_effects_handlers(call)?;
 
-        // The closure carries `&self` access into the handlers without exposing
-        // the builder's resolver generic. Bound to a local so it outlives `ctx`.
-        let resolve_string = |name: &str| self.resolve_string(name);
-        let ctx = CallContext::new(&resolve_string);
+        let ctx = CallContext::new();
 
         let arguments = handlers
             .arguments
@@ -240,13 +237,6 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             .and_then(|handler| handler.resolve(call, &ctx));
 
         Some(Effects { arguments, attach })
-    }
-
-    /// Resolve an identifier to a statically known string value, for a handler's
-    /// `character.only`-style needs. Always `None` until variable resolution lands.
-    fn resolve_string(&self, name: &str) -> Option<String> {
-        let _ = name;
-        None
     }
 
     /// Resolve a call's callee to its [`EffectsHandlers`] (NSE, attach, ...).

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -1,6 +1,4 @@
-use aether_syntax::AnyRArgumentName;
 use aether_syntax::AnyRExpression;
-use aether_syntax::RArgumentList;
 use aether_syntax::RCall;
 use biome_rowan::AstNode;
 use biome_rowan::AstNodeList;
@@ -8,7 +6,6 @@ use biome_rowan::AstSeparatedList;
 use biome_rowan::TextRange;
 use oak_core::syntax_ext::AnyRSelectorExt;
 use oak_core::syntax_ext::RIdentifierExt;
-use oak_core::syntax_ext::RStringValueExt;
 
 use super::assignment_name;
 use super::is_assignment;
@@ -17,8 +14,10 @@ use super::is_super_assignment;
 use super::BoundNames;
 use super::SemanticIndexBuilder;
 use crate::effects::Argument;
-use crate::effects::ArgumentsAnnotation;
+use crate::effects::CallContext;
 use crate::effects::Effects;
+use crate::effects::EffectsHandlers;
+use crate::effects::ResolvedArgumentEffects;
 use crate::effects_registry;
 use crate::resolver::ImportsResolver;
 use crate::semantic_index::NseScope;
@@ -27,13 +26,8 @@ use crate::semantic_index::ScopeKind;
 use crate::semantic_index::SemanticDiagnostic;
 
 impl<R: ImportsResolver> SemanticIndexBuilder<R> {
-    /// Scan a call for effects (e.g. NSE scopes) and record its decision for
-    /// the walk to reuse.
-    ///
-    /// If the callee resolves to an NSE annotation, the annotation is recorded
-    /// in `call_resolutions` under the call's range (as the entry's `nse`).
-    /// Arguments evaluated in nested calls are scanned accordingly. Otherwise
-    /// all arguments are scanned in the current scope.
+    /// Scan a call for effects (NSE scopes, attaches) and record its decisions
+    /// for the walk to reuse. The callee is resolved once through [`resolve_effects`].
     ///
     /// `Current + Eager` and `Nested + Eager` arguments are scanned here:
     /// `Current + Eager` transparently, `Nested + Eager` by descending into the
@@ -42,7 +36,22 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// because resolution of effects in these lazy scopes needs the child's own
     /// flow context.
     pub(super) fn scan_call(&mut self, call: &RCall) {
-        let Some(annotation) = self.resolve_nse(call) else {
+        let (nse_args, attach) = match self.resolve_effects(call) {
+            Some(effects) => (effects.arguments, effects.attach),
+            None => (None, None),
+        };
+
+        if let Some(package) = attach {
+            self.call_resolutions
+                .entry(call.syntax().text_trimmed_range())
+                .or_default()
+                .attach = Some(package.clone());
+            if !self.scopes[self.current_scope].kind.is_lazy() {
+                self.attached_flow.push(package);
+            }
+        }
+
+        let Some(nse_args) = nse_args else {
             if let Ok(args) = call.arguments() {
                 for item in args.items().iter() {
                     let Ok(arg) = item else { continue };
@@ -54,16 +63,10 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             return;
         };
 
-        self.call_resolutions
-            .entry(call.syntax().text_trimmed_range())
-            .or_default()
-            .nse = Some(annotation);
-
         let Ok(args) = call.arguments() else {
             return;
         };
         let items = args.items();
-        let nse_args = self.match_nse_arguments(&items, annotation);
 
         for (i, item) in items.iter().enumerate() {
             let Ok(arg) = item else { continue };
@@ -116,6 +119,12 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 },
             }
         }
+
+        // Hand the resolved NSE arguments to the walk (at the end to avoid a clone)
+        self.call_resolutions
+            .entry(call.syntax().text_trimmed_range())
+            .or_default()
+            .arguments = Some(nse_args);
     }
 
     /// Copy the names a `Current + Lazy` body defines into the owner's
@@ -214,13 +223,40 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
-    /// Resolve a call's callee to an NSE annotation.
+    /// Resolve a call's effects.
+    fn resolve_effects(&mut self, call: &RCall) -> Option<Effects> {
+        let handlers = self.resolve_effects_handlers(call)?;
+
+        // The closure carries `&self` access into the handlers without exposing
+        // the builder's resolver generic. Bound to a local so it outlives `ctx`.
+        let resolve_string = |name: &str| self.resolve_string(name);
+        let ctx = CallContext::new(&resolve_string);
+
+        let arguments = handlers
+            .arguments
+            .and_then(|handler| handler.resolve(call, &ctx));
+        let attach = handlers
+            .attach
+            .and_then(|handler| handler.resolve(call, &ctx));
+
+        Some(Effects { arguments, attach })
+    }
+
+    /// Resolve an identifier to a statically known string value, for a handler's
+    /// `character.only`-style needs. Always `None` until variable resolution lands.
+    fn resolve_string(&self, name: &str) -> Option<String> {
+        let _ = name;
+        None
+    }
+
+    /// Resolve a call's callee to its [`EffectsHandlers`] (NSE, attach, ...).
     ///
-    /// Two cases resolve here:
+    /// The shared core for both NSE recognition ([`scan_call`] reads `.arguments`) and
+    /// attach recognition ([`scan_call`] reads `.attach`). Two cases resolve:
     /// - A bare identifier. If bound locally it goes through the local
     ///   [`resolve_local_effects`](Self::resolve_local_effects). Otherwise the
     ///   cross-file `ImportsResolver::resolve_effects()` resolves it across the
-    ///   search path.
+    ///   search path, against the attach set in `attached_flow`.
     /// - A `pkg::fn` namespace expression, resolved through
     ///   `ImportsResolver::resolve_qualified_effects()`. `::` names the package,
     ///   so there's no search-path disambiguation; the resolver answers from
@@ -229,7 +265,10 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     ///
     /// The bound check reads the scan pass's flow-precise binding state
     /// for the current scope, so this must run during the scan, not the walk.
-    fn resolve_nse(&mut self, call: &RCall) -> Option<ArgumentsAnnotation> {
+    ///
+    /// [`EffectsHandlers`]: crate::effects::EffectsHandlers
+    /// [`scan_call`]: Self::scan_call
+    fn resolve_effects_handlers(&mut self, call: &RCall) -> Option<EffectsHandlers> {
         let func = call.function().ok()?;
 
         match &func {
@@ -237,7 +276,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 let name = ident.name_text();
 
                 // First check for a local definition (which in the future may
-                // contain NSE annotations that we resolve here)
+                // carry declared effects that we resolve here)
                 //
                 // Looked up from `flow_state` which already carries every
                 // eager binding visible here: the scope's own flow-precise
@@ -246,9 +285,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 // bindings are excluded. A forward one isn't in `flow_state`
                 // yet, and a deferred one (`on_load`, `<<-`) never enters it.
                 if self.flow_state.is_bound(&name) {
-                    return self
-                        .resolve_local_effects(&name)
-                        .and_then(|effects| effects.nse);
+                    return self.resolve_local_effects(&name);
                 }
 
                 // Bail early if it is known that no package annotates this name
@@ -260,17 +297,26 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 // Now check imports since the symbol is locally unbound. The
                 // arena's `current_scope` is the scan unit's scope (the descent
                 // pushes no arena scopes), so its laziness is the "am I in a lazy
-                // context" test the resolver needs.
+                // context" test the resolver needs. `attached_flow` is the
+                // flow-precise attach prefix during the file scan and the
+                // complete end-of-file set during the walk.
                 let lazy = self.scopes[self.current_scope].kind.is_lazy();
-                let nse = self
+                let effects = self
                     .resolver
-                    .resolve_effects(&name, &[], lazy)
-                    .and_then(|effects| effects.nse)?;
+                    .resolve_effects(&name, &self.attached_flow, lazy)?;
 
-                // The callee is unbound by any eager binding, so it is NSE.
-                // If a lazy-crossed ancestor binds it whole-scope, that binding's
-                // timing relative to this deferred body is undetermined, so the
-                // decision is a guess. Flag it.
+                // The callee is unbound by any eager binding, so its effect
+                // holds. If a lazy-crossed ancestor binds it whole-scope, that
+                // binding's timing relative to this deferred body is
+                // undetermined, so the decision is a guess. Flag it.
+                //
+                // TODO(diagnostics): a symmetric attach ambiguity is out of
+                // scope here. A callee resolved not-effectful could be flipped
+                // by an attach from a sibling lazy body (`g <- function()
+                // library(shiny); f <- function() reactive({...}`). Detecting it
+                // needs the complete set of lazy-context attaches, a post-pass
+                // rather than this local ancestor check, so it belongs in the
+                // future salsa diagnostics query where this lint should move too.
                 if let Some(overwrite_range) = self.is_lazily_shadowed(&name) {
                     self.record_lazy_shadow_ambiguity(
                         name,
@@ -278,7 +324,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                         overwrite_range,
                     );
                 }
-                Some(nse)
+                Some(effects)
             },
 
             AnyRExpression::RNamespaceExpression(ns_expr) => {
@@ -291,9 +337,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     return None;
                 }
 
-                self.resolver
-                    .resolve_qualified_effects(&pkg, &func_name)
-                    .and_then(|effects| effects.nse)
+                self.resolver.resolve_qualified_effects(&pkg, &func_name)
             },
 
             _ => None,
@@ -303,18 +347,18 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// Local resolver for declared effects, mirroring the imports resolver's
     /// `resolve_effects()` method on the cross-file side.
     /// TODO(nse, annotations): always `None` until `declare()` parsing lands.
-    fn resolve_local_effects(&self, _name: &str) -> Option<Effects> {
+    fn resolve_local_effects(&self, _name: &str) -> Option<EffectsHandlers> {
         None
     }
 
     /// Detect ambiguities caused by laziness.
     ///
-    /// We've decided `name` is NSE because it was locally unbound at the
-    /// current flow cursor, and eager-flow resolution found an NSE effect. If
-    /// we're in a lazy context, that decision could be wrong: an enclosing
-    /// scope may bind `name` with a timing we can't pin down, either a later
-    /// assignment, or one from another deferred body that could run before or
-    /// after us We detect this ambiguity here so it can be linted.
+    /// We've recognized an effect for `name` (NSE scope or attach) because it
+    /// was locally unbound at the current flow cursor and eager-flow resolution
+    /// found one. If we're in a lazy context, that decision could be wrong: an
+    /// enclosing scope may bind `name` with a timing we can't pin down, either a
+    /// later assignment, or one from another deferred body that could run before
+    /// or after us. We detect this ambiguity here so it can be linted.
     ///
     /// Returns the site of the shadowing binding.
     fn is_lazily_shadowed(&self, name: &str) -> Option<TextRange> {
@@ -351,15 +395,14 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             });
     }
 
-    /// Process a call the scan pass decided is NSE. Match its arguments
-    /// against the annotation, then handle each scoped argument, pushing NSE
-    /// scopes inline.
-    pub(super) fn collect_nse_call(&mut self, call: &RCall, annotation: ArgumentsAnnotation) {
+    /// Process a call the scan pass decided is NSE, using the resolved argument
+    /// scoping the scan cached. Handle each scoped argument, pushing NSE scopes
+    /// inline.
+    pub(super) fn collect_nse_call(&mut self, call: &RCall, nse_args: ResolvedArgumentEffects) {
         let Ok(args) = call.arguments() else {
             return;
         };
         let items = args.items();
-        let nse_args = self.match_nse_arguments(&items, annotation);
 
         for (i, item) in items.iter().enumerate() {
             let Ok(arg) = item else { continue };
@@ -370,53 +413,6 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 Some(nse_arg) => self.collect_nse_argument(nse_arg, &value),
             }
         }
-    }
-
-    /// Match a call's arguments against an NSE annotation. Returns, per argument
-    /// in call order, the scoped argument it matched (if any). Named arguments
-    /// match first, then unmatched positions fill by call-site position.
-    ///
-    /// FIXME: This is a stopgap helper. In the future, `Effects` will be
-    /// returned from the resolvers with the function signature, and we'll
-    /// implement a proper argument matching routine.
-    fn match_nse_arguments(
-        &self,
-        items: &RArgumentList,
-        annotation: ArgumentsAnnotation,
-    ) -> Vec<Option<&'static Argument>> {
-        let arg_count = items.iter().count();
-        let mut nse_args: Vec<Option<&'static Argument>> = vec![None; arg_count];
-        let mut consumed = vec![false; annotation.arguments.len()];
-
-        // Named pass
-        for (i, item) in items.iter().enumerate() {
-            let Ok(arg) = item else { continue };
-            if let Some(nse_idx) = match_named_arg(&arg, &annotation, &consumed) {
-                consumed[nse_idx] = true;
-                nse_args[i] = Some(&annotation.arguments[nse_idx]);
-            }
-        }
-
-        // Positional pass. Only unnamed args reach the match, and none of them
-        // were set by the named pass, so no need to re-check `nse_args[i]`.
-        let mut position = 0usize;
-        for (i, item) in items.iter().enumerate() {
-            let Ok(arg) = item else {
-                position += 1;
-                continue;
-            };
-            if arg.name_clause().is_some() {
-                position += 1;
-                continue;
-            }
-            if let Some(scoped_idx) = match_positional_arg(&annotation, position, &consumed) {
-                consumed[scoped_idx] = true;
-                nse_args[i] = Some(&annotation.arguments[scoped_idx]);
-            }
-            position += 1;
-        }
-
-        nse_args
     }
 
     /// Walk a single NSE argument body, pushing a scope when appropriate.
@@ -478,51 +474,4 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             },
         }
     }
-}
-
-/// Match a named argument against the annotation's arguments. Returns the
-/// index into `annotation.arguments` if matched.
-///
-/// Should we do partial argument matching? Or rely on partial matching being linted?
-fn match_named_arg(
-    arg: &aether_syntax::RArgument,
-    annotation: &ArgumentsAnnotation,
-    consumed: &[bool],
-) -> Option<usize> {
-    let clause = arg.name_clause()?;
-    let name = clause.name().ok()?;
-    let name_text = match &name {
-        AnyRArgumentName::RIdentifier(ident) => ident.name_text(),
-        AnyRArgumentName::RStringValue(s) => s.string_text()?,
-        _ => return None,
-    };
-    annotation
-        .arguments
-        .iter()
-        .enumerate()
-        .find(|(i, nse_arg)| !consumed[*i] && nse_arg.name == name_text.as_str())
-        .map(|(i, _)| i)
-}
-
-/// Match an unnamed argument at `position` against the annotation's arguments.
-/// Returns the index into `annotation.arguments` if matched.
-///
-/// FIXME: This matches positionally on call-site position only: an unnamed
-/// argument at position N matches an annotation argument declared at position
-/// N. It doesn't replicate R's full matching, where named arguments are pulled
-/// out first and the rest fill the remaining formals in order. So `test_that({
-/// ... }, desc = "d")`, with the block at position 0 but the `code` formal at
-/// position 1, won't match. Good enough without the callee's formal list;
-/// revisit if it misses real cases.
-fn match_positional_arg(
-    annotation: &ArgumentsAnnotation,
-    position: usize,
-    consumed: &[bool],
-) -> Option<usize> {
-    annotation
-        .arguments
-        .iter()
-        .enumerate()
-        .find(|(i, scoped)| !consumed[*i] && scoped.position == position)
-        .map(|(i, _)| i)
 }

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -45,19 +45,12 @@ pub trait EffectHandler: std::fmt::Debug + Sync {
 /// Context for effect handlers.
 ///
 /// Allows querying the properties or static values of arguments.
-pub struct CallContext<'a> {
-    /// Resolve an identifier to a statically known string value, e.g. a
-    /// `character.only` package name for `library()`.
-    ///
-    /// TODO: This method is currently illustrative. It shows why the methods
-    /// are type-erased (so they give access to `self` which can do static
-    /// resolution).
-    resolve_string: &'a dyn Fn(&str) -> Option<String>,
-}
+#[derive(Default)]
+pub struct CallContext;
 
-impl<'a> CallContext<'a> {
-    pub fn new(resolve_string: &'a dyn Fn(&str) -> Option<String>) -> Self {
-        Self { resolve_string }
+impl CallContext {
+    pub fn new() -> Self {
+        Self
     }
 
     /// Match `call`'s arguments to `formals`, returning for each call argument
@@ -105,12 +98,6 @@ impl<'a> CallContext<'a> {
         }
 
         matched
-    }
-
-    /// Resolve an argument `name` to a statically known string value, or `None`.
-    /// E.g. could be used to implement `character.only` in the `library()` handler.
-    pub fn resolve_string(&self, name: &str) -> Option<String> {
-        (self.resolve_string)(name)
     }
 }
 

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -1,23 +1,137 @@
+use aether_syntax::AnyRArgumentName;
+use aether_syntax::AnyRExpression;
+use aether_syntax::AnyRValue;
+use aether_syntax::RArgument;
+use aether_syntax::RCall;
+use biome_rowan::AstSeparatedList;
+use oak_core::syntax_ext::RIdentifierExt;
+use oak_core::syntax_ext::RStringValueExt;
+
 use crate::semantic_index::NseScope;
 use crate::semantic_index::NseTiming;
 
-/// Effects of a resolved function.
-///
-/// Currently only records NSE effects. In the future this will include other
-/// effects such as `attach` (for e.g. `library()`) and `assign` (for the
-/// eponymous function).
-#[derive(Debug, Clone, Copy, Default)]
+/// Effects of a call, resolved against the call site.
+#[derive(Debug, Clone, Default)]
 pub struct Effects {
-    pub nse: Option<ArgumentsAnnotation>,
+    pub arguments: Option<ResolvedArgumentEffects>,
+    pub attach: Option<String>,
 }
 
-impl Effects {
-    pub fn nse(nse: ArgumentsAnnotation) -> Self {
-        Self { nse: Some(nse) }
+/// The handlers that compute a function's effects.
+#[derive(Debug, Clone, Copy)]
+pub struct EffectsHandlers {
+    pub arguments: Option<&'static dyn EffectHandler<Output = ResolvedArgumentEffects>>,
+    pub attach: Option<&'static dyn EffectHandler<Output = String>>,
+}
+
+/// Resolver for an effect of a call.
+///
+/// The single interface behind every effect kind (NSE, attach, and `source`
+/// later).
+///
+/// Handlers are contributed statically for now (a `&'static dyn` in the
+/// registry), so the trait is `Sync`, which every registry `static` needs.
+pub trait EffectHandler: std::fmt::Debug + Sync {
+    type Output;
+
+    /// Resolve this effect for `call`, or `None` when the call isn't in a shape
+    /// this handler recognizes.
+    ///
+    /// `ctx` resolves information the call's own syntax doesn't carry, e.g. what
+    /// a `character.only = TRUE` variable is bound to. Unused until that lands.
+    fn resolve(&self, call: &RCall, ctx: &CallContext) -> Option<Self::Output>;
+}
+
+/// Context for effect handlers.
+///
+/// Allows querying the properties or static values of arguments.
+pub struct CallContext<'a> {
+    /// Resolve an identifier to a statically known string value, e.g. a
+    /// `character.only` package name for `library()`.
+    ///
+    /// TODO: This method is currently illustrative. It shows why the methods
+    /// are type-erased (so they give access to `self` which can do static
+    /// resolution).
+    resolve_string: &'a dyn Fn(&str) -> Option<String>,
+}
+
+impl<'a> CallContext<'a> {
+    pub fn new(resolve_string: &'a dyn Fn(&str) -> Option<String>) -> Self {
+        Self { resolve_string }
+    }
+
+    /// Match `call`'s arguments to `formals`, returning for each call argument
+    /// in order the index into `formals` it bound to. Named arguments match
+    /// first, then the rest fill by position.
+    ///
+    /// A stopgap: without the callee's full formal list, a positional argument
+    /// only binds a formal declared at that exact position.
+    pub fn match_arguments(&self, call: &RCall, formals: &[Formal]) -> Vec<Option<usize>> {
+        let Ok(args) = call.arguments() else {
+            return Vec::new();
+        };
+        let items = args.items();
+
+        let arg_count = items.iter().count();
+        let mut matched: Vec<Option<usize>> = vec![None; arg_count];
+        let mut consumed = vec![false; formals.len()];
+
+        // Named pass
+        for (i, item) in items.iter().enumerate() {
+            let Ok(arg) = item else { continue };
+            if let Some(formal_idx) = match_named(&arg, formals, &consumed) {
+                consumed[formal_idx] = true;
+                matched[i] = Some(formal_idx);
+            }
+        }
+
+        // Positional pass. Only unnamed args reach the match, and none of them
+        // were set by the named pass, so no need to re-check `matched[i]`.
+        let mut position = 0usize;
+        for (i, item) in items.iter().enumerate() {
+            let Ok(arg) = item else {
+                position += 1;
+                continue;
+            };
+            if arg.name_clause().is_some() {
+                position += 1;
+                continue;
+            }
+            if let Some(formal_idx) = match_positional(formals, position, &consumed) {
+                consumed[formal_idx] = true;
+                matched[i] = Some(formal_idx);
+            }
+            position += 1;
+        }
+
+        matched
+    }
+
+    /// Resolve an argument `name` to a statically known string value, or `None`.
+    /// E.g. could be used to implement `character.only` in the `library()` handler.
+    pub fn resolve_string(&self, name: &str) -> Option<String> {
+        (self.resolve_string)(name)
     }
 }
 
-/// Annotation describing how an NSE function's arguments create scopes.
+/// A formal a handler wants to locate in a call, by name and by its position in
+/// the callee's signature.
+///
+/// TODO(nse): `position` is a stopgap that stems from our annotation registry
+/// listing only its scoped formals. Once `match_arguments` is signature-aware
+/// it gets the callee's full ordered formals, and this collapses to a list of
+/// names where the index is the position.
+pub struct Formal {
+    pub name: &'static str,
+    pub position: usize,
+}
+
+/// A call's resolved NSE arguments: for each argument in call order, the scoped
+/// argument it matched, or `None` for a plain argument.
+pub type ResolvedArgumentEffects = Vec<Option<&'static Argument>>;
+
+/// Declares how an NSE function's arguments create scopes, and serves as the
+/// default [`EffectHandler`] for it by matching the declaration to a call.
 #[derive(Debug, Clone, Copy)]
 pub struct ArgumentsAnnotation {
     pub arguments: &'static [Argument],
@@ -30,4 +144,98 @@ pub struct Argument {
     pub position: usize,
     pub scope: NseScope,
     pub timing: NseTiming,
+}
+
+impl EffectHandler for ArgumentsAnnotation {
+    type Output = ResolvedArgumentEffects;
+
+    fn resolve(&self, call: &RCall, ctx: &CallContext) -> Option<ResolvedArgumentEffects> {
+        let arguments = self.arguments;
+        let formals: Vec<Formal> = arguments
+            .iter()
+            .map(|arg| Formal {
+                name: arg.name,
+                position: arg.position,
+            })
+            .collect();
+
+        // The match yields a formal index per call argument
+        let matched = ctx.match_arguments(call, &formals);
+        Some(
+            matched
+                .into_iter()
+                .map(|formal| formal.map(|i| &arguments[i]))
+                .collect(),
+        )
+    }
+}
+
+/// Declares how an attach function (`library()`, `require()`) names its package,
+/// and serves as the default [`EffectHandler`] for it by extracting that package
+/// from a call.
+#[derive(Debug, Clone, Copy)]
+pub struct AttachAnnotation {
+    /// Whether the callee has a `character.only`-style flag. Unread today.
+    pub character_only: bool,
+}
+
+impl EffectHandler for AttachAnnotation {
+    type Output = String;
+
+    fn resolve(&self, call: &RCall, ctx: &CallContext) -> Option<String> {
+        // `library()`/`require()` name their package in the `package` formal,
+        // the first positional argument.
+        let formals = [Formal {
+            name: "package",
+            position: 0,
+        }];
+        let matched = ctx.match_arguments(call, &formals);
+
+        let arg_index = matched.iter().position(|formal| *formal == Some(0))?;
+        let arg = call.arguments().ok()?.items().iter().nth(arg_index)?.ok()?;
+        let value = arg.value()?;
+
+        match &value {
+            AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
+            AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
+            _ => None,
+        }
+    }
+}
+
+/// Match a named argument against `formals`. Returns the index of the matched
+/// formal.
+///
+/// Should we do partial argument matching? Or rely on partial matching being linted?
+fn match_named(arg: &RArgument, formals: &[Formal], consumed: &[bool]) -> Option<usize> {
+    let clause = arg.name_clause()?;
+    let name = clause.name().ok()?;
+    let name_text = match &name {
+        AnyRArgumentName::RIdentifier(ident) => ident.name_text(),
+        AnyRArgumentName::RStringValue(s) => s.string_text()?,
+        _ => return None,
+    };
+    formals
+        .iter()
+        .enumerate()
+        .find(|(i, formal)| !consumed[*i] && formal.name == name_text.as_str())
+        .map(|(i, _)| i)
+}
+
+/// Match an unnamed argument at `position` against `formals`. Returns the index
+/// of the matched formal.
+///
+/// FIXME: This matches positionally on call-site position only: an unnamed
+/// argument at position N matches a formal declared at position N. It doesn't
+/// replicate R's full matching, where named arguments are pulled out first and
+/// the rest fill the remaining formals in order. So `test_that({ ... }, desc =
+/// "d")`, with the block at position 0 but the `code` formal at position 1,
+/// won't match. Good enough without the callee's formal list; revisit if it
+/// misses real cases.
+fn match_positional(formals: &[Formal], position: usize, consumed: &[bool]) -> Option<usize> {
+    formals
+        .iter()
+        .enumerate()
+        .find(|(i, formal)| !consumed[*i] && formal.position == position)
+        .map(|(i, _)| i)
 }

--- a/crates/oak_semantic/src/effects_registry.rs
+++ b/crates/oak_semantic/src/effects_registry.rs
@@ -1,5 +1,7 @@
 use crate::effects::Argument;
 use crate::effects::ArgumentsAnnotation;
+use crate::effects::AttachAnnotation;
+use crate::effects::EffectsHandlers;
 use crate::semantic_index::NseScope::Current;
 use crate::semantic_index::NseScope::Nested;
 use crate::semantic_index::NseTiming::Eager;
@@ -8,15 +10,15 @@ use crate::semantic_index::NseTiming::Lazy;
 struct Entry {
     package: &'static str,
     function: &'static str,
-    annotation: ArgumentsAnnotation,
+    effects: EffectsHandlers,
 }
 
-/// Look up the NSE annotation for a `(package, function)` pair.
-pub fn lookup(package: &str, function: &str) -> Option<&'static ArgumentsAnnotation> {
+/// Look up the effect handlers of a `(package, function)` pair.
+pub fn lookup(package: &str, function: &str) -> Option<&'static EffectsHandlers> {
     REGISTRY
         .iter()
         .find(|e| e.package == package && e.function == function)
-        .map(|e| &e.annotation)
+        .map(|e| &e.effects)
 }
 
 /// Whether any registry entry annotates `name`. This is the bare-callee front
@@ -29,43 +31,65 @@ pub fn annotates(name: &str) -> bool {
     REGISTRY.iter().any(|e| e.function == name)
 }
 
-/// One registry entry. Each `(name, position, scope, laziness)` tuple is a
-/// scoped argument; list more than one for a function that scopes several.
-macro_rules! entry {
+/// An NSE entry. Each `(name, position, scope, laziness)` tuple is a scoped
+/// argument; list more than one for a function that scopes several.
+macro_rules! nse {
     ($pkg:literal, $func:literal, $(($name:literal, $pos:literal, $scope:expr, $timing:expr)),+ $(,)?) => {
         Entry {
             package: $pkg,
             function: $func,
-            annotation: ArgumentsAnnotation {
-                arguments: &[$(Argument {
-                    name: $name,
-                    position: $pos,
-                    scope: $scope,
-                    timing: $timing,
-                }),+],
+            effects: EffectsHandlers {
+                arguments: Some(&ArgumentsAnnotation {
+                    arguments: &[$(Argument {
+                        name: $name,
+                        position: $pos,
+                        scope: $scope,
+                        timing: $timing,
+                    }),+],
+                }),
+                attach: None,
+            },
+        }
+    };
+}
+
+/// An attach entry: `(package-argument position, has-`character.only`-flag)`.
+macro_rules! attach {
+    ($pkg:literal, $func:literal, $pos:literal, $character_only:literal) => {
+        Entry {
+            package: $pkg,
+            function: $func,
+            effects: EffectsHandlers {
+                arguments: None,
+                attach: Some(&AttachAnnotation {
+                    character_only: $character_only,
+                }),
             },
         }
     };
 }
 
 static REGISTRY: &[Entry] = &[
-    // base
-    entry!("base", "evalq", ("expr", 0, Current, Eager)),
-    entry!("base", "local", ("expr", 0, Nested, Eager)),
-    entry!("base", "with", ("expr", 1, Nested, Eager)),
-    entry!("base", "with.default", ("expr", 1, Nested, Eager)),
-    entry!("base", "within", ("expr", 1, Nested, Eager)),
-    entry!("base", "within.data.frame", ("expr", 1, Nested, Eager)),
+    // base NSE
+    nse!("base", "evalq", ("expr", 0, Current, Eager)),
+    nse!("base", "local", ("expr", 0, Nested, Eager)),
+    nse!("base", "with", ("expr", 1, Nested, Eager)),
+    nse!("base", "with.default", ("expr", 1, Nested, Eager)),
+    nse!("base", "within", ("expr", 1, Nested, Eager)),
+    nse!("base", "within.data.frame", ("expr", 1, Nested, Eager)),
+    // base attach
+    attach!("base", "library", 0, true),
+    attach!("base", "require", 0, true),
     // rlang
-    entry!("rlang", "on_load", ("expr", 0, Current, Lazy)),
+    nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
     // shiny
-    entry!("shiny", "observe", ("x", 0, Nested, Lazy)),
-    entry!("shiny", "reactive", ("x", 0, Nested, Lazy)),
-    entry!("shiny", "renderPlot", ("expr", 0, Nested, Lazy)),
-    entry!("shiny", "renderPrint", ("expr", 0, Nested, Lazy)),
-    entry!("shiny", "renderTable", ("expr", 0, Nested, Lazy)),
-    entry!("shiny", "renderText", ("expr", 0, Nested, Lazy)),
-    entry!("shiny", "renderUI", ("expr", 0, Nested, Lazy)),
+    nse!("shiny", "observe", ("x", 0, Nested, Lazy)),
+    nse!("shiny", "reactive", ("x", 0, Nested, Lazy)),
+    nse!("shiny", "renderPlot", ("expr", 0, Nested, Lazy)),
+    nse!("shiny", "renderPrint", ("expr", 0, Nested, Lazy)),
+    nse!("shiny", "renderTable", ("expr", 0, Nested, Lazy)),
+    nse!("shiny", "renderText", ("expr", 0, Nested, Lazy)),
+    nse!("shiny", "renderUI", ("expr", 0, Nested, Lazy)),
     // testthat
-    entry!("testthat", "test_that", ("code", 1, Nested, Eager)),
+    nse!("testthat", "test_that", ("code", 1, Nested, Eager)),
 ];

--- a/crates/oak_semantic/src/lib.rs
+++ b/crates/oak_semantic/src/lib.rs
@@ -7,6 +7,8 @@ pub mod use_def_map;
 
 pub use builder::build_index;
 pub use effects::Effects;
+pub use effects::EffectsHandlers;
+pub use effects::ResolvedArgumentEffects;
 pub use resolver::ImportsResolver;
 pub use resolver::NoopImportsResolver;
 pub use resolver::SourceResolution;

--- a/crates/oak_semantic/src/resolver.rs
+++ b/crates/oak_semantic/src/resolver.rs
@@ -1,6 +1,6 @@
 use url::Url;
 
-use crate::effects::Effects;
+use crate::effects::EffectsHandlers;
 use crate::effects_registry;
 
 /// The result of resolving a `source()` call. Returned by
@@ -54,17 +54,20 @@ pub trait ImportsResolver {
     ///
     /// - `attached`: packages attached at this point, in flow order.
     /// - `lazy`: whether the callee sits in a lazy context like a function.
-    fn resolve_effects(&mut self, name: &str, attached: &[String], lazy: bool) -> Option<Effects> {
+    fn resolve_effects(
+        &mut self,
+        name: &str,
+        attached: &[String],
+        lazy: bool,
+    ) -> Option<EffectsHandlers> {
         let _ = (name, attached, lazy);
         None
     }
 
     /// Resolve a namespace-qualified callee `pkg::fn` (or equivalently with
     /// `:::`) to its effects.
-    fn resolve_qualified_effects(&mut self, package: &str, name: &str) -> Option<Effects> {
-        effects_registry::lookup(package, name)
-            .copied()
-            .map(Effects::nse)
+    fn resolve_qualified_effects(&mut self, package: &str, name: &str) -> Option<EffectsHandlers> {
+        effects_registry::lookup(package, name).copied()
     }
 }
 

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -817,11 +817,12 @@ pub enum NamespaceAccessKind {
 /// consumers to turn into user-facing diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SemanticDiagnostic {
-    /// An NSE call recognized in a lazy context whose callee is also bound by a
-    /// lazy-crossed ancestor with undetermined timing, so the NSE decision is a
-    /// guess. `call_range` points at the NSE call we recognized, `overwrite_range`
-    /// at the ancestor binding that could invalidate it (a later assignment in
-    /// parent code, or one from another lazy context).
+    /// An effectful call (NSE scope or attach) recognized in a lazy context
+    /// whose callee is also bound by a lazy-crossed ancestor with undetermined
+    /// timing, so the decision is a guess. `call_range` points at the call we
+    /// recognized, `overwrite_range` at the ancestor binding that could
+    /// invalidate it (a later assignment in parent code, or one from another
+    /// lazy context).
     LazyShadowAmbiguity {
         name: String,
         call_range: TextRange,

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -16,6 +16,8 @@ use oak_semantic::NoopImportsResolver;
 use oak_semantic::SourceResolution;
 use url::Url;
 
+use crate::resolvers::TestImportsResolver;
+
 fn index(source: &str) -> SemanticIndex {
     let parsed = parse(source, RParserOptions::default());
 
@@ -24,6 +26,19 @@ fn index(source: &str) -> SemanticIndex {
     }
 
     build_index(&parsed.tree(), NoopImportsResolver)
+}
+
+/// Build with base attached. Attach recognition (`library()`/`require()`) runs
+/// on the resolve path now, so it needs a resolver that resolves base, unlike
+/// the resolver-independent `source()` recognition the `index()` helper covers.
+fn index_with_base(source: &str) -> SemanticIndex {
+    let parsed = parse(source, RParserOptions::default());
+
+    if parsed.has_error() {
+        panic!("source has syntax errors: {source}");
+    }
+
+    build_index(&parsed.tree(), TestImportsResolver::with_base())
 }
 
 fn semantic_call_kinds(index: &SemanticIndex) -> Vec<&SemanticCallKind> {
@@ -1312,7 +1327,7 @@ fn test_file_exports_sequential_redef_keeps_last() {
 
 #[test]
 fn test_directive_library_identifier() {
-    let index = index("library(dplyr)");
+    let index = index_with_base("library(dplyr)");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
         package: "dplyr".into()
     }]);
@@ -1320,7 +1335,7 @@ fn test_directive_library_identifier() {
 
 #[test]
 fn test_directive_library_string() {
-    let index = index("library(\"tidyr\")");
+    let index = index_with_base("library(\"tidyr\")");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
         package: "tidyr".into()
     }]);
@@ -1328,7 +1343,7 @@ fn test_directive_library_string() {
 
 #[test]
 fn test_directive_library_single_quoted_string() {
-    let index = index("library('ggplot2')");
+    let index = index_with_base("library('ggplot2')");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
         package: "ggplot2".into()
     }]);
@@ -1336,7 +1351,7 @@ fn test_directive_library_single_quoted_string() {
 
 #[test]
 fn test_directive_require() {
-    let index = index("require(data.table)");
+    let index = index_with_base("require(data.table)");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
         package: "data.table".into()
     }]);
@@ -1344,7 +1359,7 @@ fn test_directive_require() {
 
 #[test]
 fn test_directive_multiple_libraries() {
-    let index = index("library(dplyr)\nlibrary(tidyr)\nrequire(ggplot2)");
+    let index = index_with_base("library(dplyr)\nlibrary(tidyr)\nrequire(ggplot2)");
     assert_eq!(semantic_call_kinds(&index), [
         &SemanticCallKind::Attach {
             package: "dplyr".into()
@@ -1359,27 +1374,34 @@ fn test_directive_multiple_libraries() {
 }
 
 #[test]
-fn test_directive_named_argument_ignored() {
-    let index = index("library(package = dplyr)");
-    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
+fn test_directive_named_argument() {
+    // The package binds the `package` formal by name.
+    let index = index_with_base("library(package = dplyr)");
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "dplyr".into()
+    }]);
 }
 
 #[test]
-fn test_directive_multiple_arguments_ignored() {
-    let index = index("library(dplyr, warn.conflicts = FALSE)");
-    assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
+fn test_directive_multiple_arguments() {
+    // The package binds `package` positionally; the extra named argument binds
+    // no formal we track.
+    let index = index_with_base("library(dplyr, warn.conflicts = FALSE)");
+    assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
+        package: "dplyr".into()
+    }]);
 }
 
 #[test]
 fn test_directive_no_arguments_ignored() {
-    let index = index("library()");
+    let index = index_with_base("library()");
     assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_library_in_function_scope() {
     // library() in a function body now records a scoped directive
-    let index = index("f <- function() { library(dplyr) }");
+    let index = index_with_base("f <- function() { library(dplyr) }");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
         package: "dplyr".into()
     }]);
@@ -1389,13 +1411,13 @@ fn test_directive_library_in_function_scope() {
 
 #[test]
 fn test_directive_non_static_argument_ignored() {
-    let index = index("library(get_pkg())");
+    let index = index_with_base("library(get_pkg())");
     assert_eq!(semantic_call_kinds(&index), Vec::<&SemanticCallKind>::new());
 }
 
 #[test]
 fn test_directive_preserves_offset() {
-    let index = index("x <- 1\nlibrary(dplyr)");
+    let index = index_with_base("x <- 1\nlibrary(dplyr)");
     let semantic_calls = index.semantic_calls();
     assert_eq!(semantic_calls.len(), 1);
     assert_eq!(semantic_calls[0].offset(), biome_rowan::TextSize::from(7));
@@ -1480,7 +1502,7 @@ fn test_source_call_local_true_recorded() {
 
 #[test]
 fn test_source_and_library_calls_coexist() {
-    let index = index("library(dplyr)\nsource(\"helpers.R\")\nrequire(tidyr)");
+    let index = index_with_base("library(dplyr)\nsource(\"helpers.R\")\nrequire(tidyr)");
     assert_eq!(semantic_call_kinds(&index), [
         &SemanticCallKind::Attach {
             package: "dplyr".into()
@@ -1679,7 +1701,7 @@ fn test_fixme_directive_declare_library_transparent() {
     // `declare()` is transparent: the inner `library(dplyr)` is still
     // picked up as a directive.
     // FIXME: We should declare `declare()` as a quoting function.
-    let index = index("declare(library(dplyr))");
+    let index = index_with_base("declare(library(dplyr))");
     assert_eq!(semantic_call_kinds(&index), [&SemanticCallKind::Attach {
         package: "dplyr".into()
     }]);
@@ -1707,7 +1729,8 @@ fn test_directive_tilde_declare_not_at_file_scope() {
 
 #[test]
 fn test_directive_declare_mixed_with_bare() {
-    let index = index("library(dplyr)\ndeclare(source(\"helpers.R\"))\nsource(\"utils.R\")");
+    let index =
+        index_with_base("library(dplyr)\ndeclare(source(\"helpers.R\"))\nsource(\"utils.R\")");
     assert_eq!(semantic_call_kinds(&index), [
         &SemanticCallKind::Attach {
             package: "dplyr".into()

--- a/crates/oak_semantic/tests/integration/builder_nse.rs
+++ b/crates/oak_semantic/tests/integration/builder_nse.rs
@@ -1477,3 +1477,261 @@ f <- function() {
         .collect();
     assert_eq!(local_lazy, vec![true, true]);
 }
+
+// --- Attach tracking ---
+
+#[test]
+fn test_nse_attach_enables_lazy_scope() {
+    // `library(shiny)` attaches shiny in eager flow, so the later `reactive`
+    // resolves to shiny's NSE annotation and pushes a lazy nested scope.
+    let index = index(
+        "\
+library(shiny)
+reactive({
+    x <- 1
+})
+",
+    );
+    let file = ScopeId::from(0);
+    let reactive_scope = ScopeId::from(1);
+
+    assert_eq!(index.attached_packages(), vec!["shiny"]);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+    assert_eq!(index.scope(reactive_scope).parent(), Some(file));
+    assert!(index.symbols(file).get("x").is_none());
+    assert_eq!(
+        index.symbols(reactive_scope).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_attach_absent_leaves_callee_flat() {
+    // Without the attach, shiny is unattached, so `reactive` doesn't resolve to
+    // an NSE annotation and `x` stays at file scope.
+    let index = index(
+        "\
+reactive({
+    x <- 1
+})
+",
+    );
+    let file = ScopeId::from(0);
+
+    assert!(index.attached_packages().is_empty());
+    assert_eq!(index.scope_ids().count(), 1);
+    assert_eq!(
+        index.symbols(file).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_attach_after_eager_callee_is_too_late() {
+    // Flow order: at the eager `reactive` position shiny isn't attached yet, so
+    // it is not NSE even though `library(shiny)` runs afterwards.
+    let index = index(
+        "\
+reactive({
+    x <- 1
+})
+library(shiny)
+",
+    );
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.attached_packages(), vec!["shiny"]);
+    assert_eq!(index.scope_ids().count(), 1);
+    assert_eq!(
+        index.symbols(file).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_attach_after_lazy_callee_is_visible() {
+    // A callee inside a function runs at an unknown later time, so it sees the
+    // end-of-file attach set. `reactive` inside `f` is resolved during the walk,
+    // after the file scan attached shiny, so it is NSE even though `library`
+    // comes after `f` textually.
+    let index = index(
+        "\
+f <- function() {
+    reactive({
+        x <- 1
+    })
+}
+library(shiny)
+",
+    );
+    let f_scope = ScopeId::from(1);
+    let reactive_scope = ScopeId::from(2);
+
+    assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+    assert_eq!(index.scope(reactive_scope).parent(), Some(f_scope));
+}
+
+#[test]
+fn test_nse_attach_inside_eager_body_counts() {
+    // The attach happens inside an eager `local` body, which the file scan
+    // descends into, so shiny is attached in flow before the later top-level
+    // `reactive`. This is where flow tracking beats a file-scope offset filter.
+    let index = index(
+        "\
+local({
+    library(shiny)
+})
+reactive({
+    x <- 1
+})
+",
+    );
+    let local_scope = ScopeId::from(1);
+    let reactive_scope = ScopeId::from(2);
+
+    assert_eq!(index.attached_packages(), vec!["shiny"]);
+    assert_eq!(
+        index.scope(local_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+    );
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_nse_attach_local_shadow_still_wins() {
+    // A local `reactive` def shadows shiny's, so the call is not NSE even with
+    // shiny attached.
+    let index = index(
+        "\
+reactive <- function(x) x
+library(shiny)
+reactive({
+    y <- 1
+})
+",
+    );
+    let file = ScopeId::from(0);
+    let fn_scope = ScopeId::from(1);
+
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(index.scope(fn_scope).kind(), ScopeKind::Function);
+    assert_eq!(
+        index.symbols(file).get("y").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_attach_recognition_respects_shadowing() {
+    // `library` is rebound before the attach call, so `library(shiny)` isn't an
+    // attach: shiny never attaches and the later `reactive` is not NSE. The bug
+    // this fixes: a syntactic `fn_name == "library"` match recorded a bogus
+    // attach here.
+    let index = index(
+        "\
+library <- quote
+library(shiny)
+reactive({
+    y <- 1
+})
+",
+    );
+    let file = ScopeId::from(0);
+
+    assert!(index.attached_packages().is_empty());
+    assert_eq!(index.scope_ids().count(), 1);
+    assert_eq!(
+        index.symbols(file).get("y").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_attach_shadow_confined_to_nse_scope() {
+    // The `library` rebind is confined to `local`'s scope, so the top-level
+    // `library(shiny)` sees the unshadowed `library` and attaches. The descent
+    // keeps the rebind from leaking, so `reactive` is NSE.
+    let index = index(
+        "\
+local({
+    library <- quote
+})
+library(shiny)
+reactive({
+    y <- 1
+})
+",
+    );
+    let reactive_scope = ScopeId::from(2);
+
+    assert_eq!(index.attached_packages(), vec!["shiny"]);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_nse_attach_in_body_verb_shadow_determined() {
+    // Inside `local`, `library` is rebound before `library(shiny)`, so the
+    // descent resolves the rebind first and the attach call is not an attach.
+    // shiny never attaches and `reactive` is not NSE. Neither the rebind nor a
+    // (non-)attach leaks out of `local`.
+    let index = index(
+        "\
+local({
+    library <- quote
+    library(shiny)
+})
+reactive({
+    y <- 1
+})
+",
+    );
+    let file = ScopeId::from(0);
+
+    assert!(index.attached_packages().is_empty());
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.symbols(file).get("y").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_attach_within_lazy_body_not_yet_supported() {
+    // Sequential-within-one-lazy-body: when `f` runs, `library(shiny)` runs
+    // before `reactive`, so `reactive` is determinately NSE. We don't promote it
+    // today: `attached_flow` only grows in eager context, so the attach inside
+    // `f` (a lazy body) isn't visible to `reactive` in the same body. The attach
+    // is still recorded as a `SemanticCall::Attach`. This could be supported by
+    // tracking a per-unit attach set seeded from the EOF view, parallel to
+    // `bound_so_far`; deferred for now.
+    let index = index(
+        "\
+f <- function() {
+    library(shiny)
+    reactive({
+        x <- 1
+    })
+}
+",
+    );
+    let f_scope = ScopeId::from(1);
+
+    // The attach is recorded (scoped to `f`), but not fed to `reactive`.
+    assert_eq!(index.attached_packages(), vec!["shiny"]);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
+}

--- a/crates/oak_semantic/tests/integration/resolvers.rs
+++ b/crates/oak_semantic/tests/integration/resolvers.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use oak_semantic::effects_registry;
-use oak_semantic::Effects;
+use oak_semantic::EffectsHandlers;
 use oak_semantic::ImportsResolver;
 use oak_semantic::SourceResolution;
 use url::Url;
@@ -71,7 +71,12 @@ impl ImportsResolver for TestImportsResolver {
         self.sources.get(path).cloned()
     }
 
-    fn resolve_effects(&mut self, name: &str, attached: &[String], lazy: bool) -> Option<Effects> {
+    fn resolve_effects(
+        &mut self,
+        name: &str,
+        attached: &[String],
+        lazy: bool,
+    ) -> Option<EffectsHandlers> {
         self.consultations.set(self.consultations.get() + 1);
         self.consultation_log
             .borrow_mut()
@@ -81,6 +86,5 @@ impl ImportsResolver for TestImportsResolver {
             .rev()
             .chain(self.always_attached.iter())
             .find_map(|pkg| effects_registry::lookup(pkg, name).copied())
-            .map(Effects::nse)
     }
 }


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338
Branched from https://github.com/posit-dev/ark/pull/1339

This PR does two related things:

- Recognise `library()` / `require()` Attach effects during the linear scan
- Feed those attaches into imported effects resolution

This allows the following pattern to be correctly recognised:

```r
library(shiny)
reactive(...)
```

It's all flow dependent and recognises locally bound and imported symbols as you'd expect:

```r
local(library <- identity)
library(dplyr) # Attaches

library <- identity
library(dplyr) # Symbol not found
```

A new `attached_flow` state powers this feature. During the linear scan, it contains the eager flow prefix so that eager code sees eager effects. During the walk, it contains the EOF state which serves as an over-approximation for lazy contexts (similarly to how they see the union of all bindings via enclosing snapshots).

The PR also starts the work of abstracting "effects". I'm planning for all these to be effects that alter the construction of the semantic index:

- NSE evaluation of arguments
- Attaching a package to the global search path: `library()`, `require()`
- Sourcing another file: `source()`, `pkgload::load_code()`
- Quoting an argument: `quote()`, `bquote()`
- Evaluating a quoted argument: `eval()`
- Capturing an environment: `new.env()`, `parent.frame()`

I'm working towards two ways of declaring effects:

- `declare()` annotations for simple patterns.
- Custom handlers in a `contrib/` folder in Oak that will have access to Oak's resolution machinery.

Simple patterns can still be somewhat complex with the language I'm toying with, e.g.:

```r
library <- function(pkg, character.only = FALSE) {
  declare(
    Attach(if (.(character.only)) .(pkg) else .(substitute(pkg)))
  )
}
```

The `.()` means "whatever this statically resolves to" and should allow expressing a lot of patterns, in combination with if/else interpretation. However trying to express everything R functions do in the wild is a lost cause, so custom handlers will often be the pragmatic choice.

This PR introduces a new `EffectHandler` trait. The effect resolver in `ImportsResolver` now return these handlers and the builder runs them against a `CallContext` to get a resolved set of effects. The `CallContext` object allows the handlers to match arguments and resolve them to statically known values (it's still rudimentary).

`LazyShadowAmbiguity` now covers Attach as well as NSE so we can lint ambiguous code:

```r
f <- function() library(shiny)
library <- identity
```


### Positron Release Notes

#### New Features

- Smarter handling of `library()` and `require()` calls.

#### Bug Fixes

- N/A
