### PR TITLE
Detect `Assign` effects

### DIFF
--- a/crates/ark/src/lsp/rename.rs
+++ b/crates/ark/src/lsp/rename.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use aether_lsp_utils::proto::from_proto;
 use aether_lsp_utils::proto::to_proto;
 use anyhow::Context;
+use biome_rowan::TextRange;
 use oak_core::identifier::to_identifier_text;
 use oak_db::Db;
 use tower_lsp_server::ls_types as lsp_types;
@@ -63,29 +64,43 @@ pub(crate) fn rename(
 
     let offset = from_proto::offset_from_position(position, file.line_index(db), encoding)?;
 
-    // Normalize the new name to its canonical R syntax (backtick-wrapped if
-    // needed) before searching, so an invalid name fails fast.
-    let new_text = to_identifier_text(&new_name)?;
+    // Normalize the new name to its canonical R identifier syntax
+    // (backtick-wrapped if needed) up front, so an invalid name fails fast. Use
+    // sites are always bare identifiers, so the name must be a valid identifier
+    // regardless of how any one site is spelled.
+    let identifier_text = to_identifier_text(&new_name)?;
     let ranges = oak_ide::rename(db, file, offset)?;
 
     let mut changes: HashMap<lsp_types::Uri, Vec<TextEdit>> = HashMap::new();
-    for file_range in ranges {
-        let line_index = file_range.file.line_index(db);
-        let path = file_range.file.path(db);
+    for site in ranges {
+        let line_index = site.file.line_index(db);
+        let path = site.file.path(db);
 
         // A rename is all or nothing. Skipping a file here would rename some
         // uses of the symbol and silently leave the rest behind, so we bail
         // instead.
         let target_uri = state
-            .wire_uri(file_range.file)
+            .wire_uri(site.file)
             .with_context(|| format!("Can't rename: no valid URI for `{path}`."))?;
-        let range = to_proto::range(file_range.range, line_index, encoding)
+
+        // A site spelled as a quoted string is a string-form binding
+        // (`assign("x", ..)`, `"x" <- ..`). Rename it in place, keeping the
+        // quotes, rather than unquoting it: dropping the quotes on an
+        // `assign()` argument would turn the name into a variable reference and
+        // change the program.
+        let source = site.file.source_text(db);
+        let new_text = match string_delimiter(source, site.range) {
+            Some(delimiter) => quote_name(&new_name, delimiter),
+            None => identifier_text.clone(),
+        };
+
+        let range = to_proto::range(site.range, line_index, encoding)
             .with_context(|| format!("Can't rename: no valid text range in `{path}`."))?;
 
-        changes.entry(target_uri).or_default().push(TextEdit {
-            range,
-            new_text: new_text.clone(),
-        });
+        changes
+            .entry(target_uri)
+            .or_default()
+            .push(TextEdit { range, new_text });
     }
 
     Ok(Some(WorkspaceEdit {
@@ -93,4 +108,25 @@ pub(crate) fn rename(
         document_changes: None,
         change_annotations: None,
     }))
+}
+
+/// The opening quote of the string literal at `range` in `source`, or `None`
+/// when the site is a bare identifier. A string-form name binding renders its
+/// name as a quoted argument, so its rename edit has to stay quoted.
+fn string_delimiter(source: &str, range: TextRange) -> Option<char> {
+    let slice = &source[usize::from(range.start())..usize::from(range.end())];
+    match slice.chars().next() {
+        Some(delimiter @ ('"' | '\'')) => Some(delimiter),
+        _ => None,
+    }
+}
+
+/// Render `name` as a quoted string literal using `delimiter`. Identifiers
+/// don't contain quotes or backslashes, but we escape defensively so an unusual
+/// name can't break out of the string.
+fn quote_name(name: &str, delimiter: char) -> String {
+    let escaped = name
+        .replace('\\', "\\\\")
+        .replace(delimiter, &format!("\\{delimiter}"));
+    format!("{delimiter}{escaped}{delimiter}")
 }

--- a/crates/ark/src/lsp/rename.rs
+++ b/crates/ark/src/lsp/rename.rs
@@ -84,10 +84,10 @@ pub(crate) fn rename(
             .with_context(|| format!("Can't rename: no valid URI for `{path}`."))?;
 
         // A site spelled as a quoted string is a string-form binding
-        // (`assign("x", ..)`, `"x" <- ..`). Rename it in place, keeping the
-        // quotes, rather than unquoting it: dropping the quotes on an
-        // `assign()` argument would turn the name into a variable reference and
-        // change the program.
+        // (`assign("x", ..)`, `"x" <- ..`). We rename it in place, keeping the
+        // quotes if there are any because they have semantic significance:
+        // dropping the quotes on an `assign("foo", ...)` argument would turn
+        // the name into a variable reference and change the program.
         let source = site.file.source_text(db);
         let new_text = match string_delimiter(source, site.range) {
             Some(delimiter) => quote_name(&new_name, delimiter),
@@ -111,8 +111,7 @@ pub(crate) fn rename(
 }
 
 /// The opening quote of the string literal at `range` in `source`, or `None`
-/// when the site is a bare identifier. A string-form name binding renders its
-/// name as a quoted argument, so its rename edit has to stay quoted.
+/// when the site is a bare identifier.
 fn string_delimiter(source: &str, range: TextRange) -> Option<char> {
     let slice = &source[usize::from(range.start())..usize::from(range.end())];
     match slice.chars().next() {

--- a/crates/ark/src/lsp/rename.rs
+++ b/crates/ark/src/lsp/rename.rs
@@ -3,8 +3,6 @@ use std::collections::HashMap;
 use aether_lsp_utils::proto::from_proto;
 use aether_lsp_utils::proto::to_proto;
 use anyhow::Context;
-use biome_rowan::TextRange;
-use oak_core::identifier::to_identifier_text;
 use oak_db::Db;
 use tower_lsp_server::ls_types as lsp_types;
 use tower_lsp_server::ls_types::PrepareRenameResponse;
@@ -64,43 +62,28 @@ pub(crate) fn rename(
 
     let offset = from_proto::offset_from_position(position, file.line_index(db), encoding)?;
 
-    // Normalize the new name to its canonical R identifier syntax
-    // (backtick-wrapped if needed) up front, so an invalid name fails fast. Use
-    // sites are always bare identifiers, so the name must be a valid identifier
-    // regardless of how any one site is spelled.
-    let identifier_text = to_identifier_text(&new_name)?;
-    let ranges = oak_ide::rename(db, file, offset)?;
+    // oak_ide resolves the sites and renders each edit in its own spelling
+    // (bare identifier, or a quoted string for a string-form binding).
+    let edits = oak_ide::rename(db, file, offset, &new_name)?;
 
     let mut changes: HashMap<lsp_types::Uri, Vec<TextEdit>> = HashMap::new();
-    for site in ranges {
-        let line_index = site.file.line_index(db);
-        let path = site.file.path(db);
+    for edit in edits {
+        let line_index = edit.file.line_index(db);
+        let path = edit.file.path(db);
 
         // A rename is all or nothing. Skipping a file here would rename some
         // uses of the symbol and silently leave the rest behind, so we bail
         // instead.
         let target_uri = state
-            .wire_uri(site.file)
+            .wire_uri(edit.file)
             .with_context(|| format!("Can't rename: no valid URI for `{path}`."))?;
-
-        // A site spelled as a quoted string is a string-form binding
-        // (`assign("x", ..)`, `"x" <- ..`). We rename it in place, keeping the
-        // quotes if there are any because they have semantic significance:
-        // dropping the quotes on an `assign("foo", ...)` argument would turn
-        // the name into a variable reference and change the program.
-        let source = site.file.source_text(db);
-        let new_text = match string_delimiter(source, site.range) {
-            Some(delimiter) => quote_name(&new_name, delimiter),
-            None => identifier_text.clone(),
-        };
-
-        let range = to_proto::range(site.range, line_index, encoding)
+        let range = to_proto::range(edit.range, line_index, encoding)
             .with_context(|| format!("Can't rename: no valid text range in `{path}`."))?;
 
-        changes
-            .entry(target_uri)
-            .or_default()
-            .push(TextEdit { range, new_text });
+        changes.entry(target_uri).or_default().push(TextEdit {
+            range,
+            new_text: edit.new_text,
+        });
     }
 
     Ok(Some(WorkspaceEdit {
@@ -108,24 +91,4 @@ pub(crate) fn rename(
         document_changes: None,
         change_annotations: None,
     }))
-}
-
-/// The opening quote of the string literal at `range` in `source`, or `None`
-/// when the site is a bare identifier.
-fn string_delimiter(source: &str, range: TextRange) -> Option<char> {
-    let slice = &source[usize::from(range.start())..usize::from(range.end())];
-    match slice.chars().next() {
-        Some(delimiter @ ('"' | '\'')) => Some(delimiter),
-        _ => None,
-    }
-}
-
-/// Render `name` as a quoted string literal using `delimiter`. Identifiers
-/// don't contain quotes or backslashes, but we escape defensively so an unusual
-/// name can't break out of the string.
-fn quote_name(name: &str, delimiter: char) -> String {
-    let escaped = name
-        .replace('\\', "\\\\")
-        .replace(delimiter, &format!("\\{delimiter}"));
-    format!("{delimiter}{escaped}{delimiter}")
 }

--- a/crates/ark/src/lsp/tests/rename.rs
+++ b/crates/ark/src/lsp/tests/rename.rs
@@ -252,6 +252,40 @@ fn test_rename_assign_call_keeps_quotes() {
 }
 
 #[test]
+fn test_rename_assign_call_from_definition_site() {
+    // Rename invoked with the cursor ON the `assign()` name literal (not a later
+    // use) works too. This is what the def's own range enables: `definition_at`
+    // hit-tests the name token at the definition site.
+    let code = "assign(\"foo\", 1)\nfoo\n";
+    let uri = test_path("test.R");
+    let state = make_state(&uri, code);
+
+    // Cursor inside the `"foo"` literal.
+    let params = make_rename_params(uri.clone(), 0, 8, "bar");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
+    edits.sort_by_key(|e| e.range.start);
+    let expected: Vec<TextEdit> = vec![
+        TextEdit {
+            range: range((0, 7), (0, 12)),
+            new_text: "\"bar\"".to_string(),
+        },
+        TextEdit {
+            range: range((1, 0), (1, 3)),
+            new_text: "bar".to_string(),
+        },
+    ];
+    assert_eq!(edits, expected);
+
+    // TODO!(nse-resolver): rename of a `%<>%`/`%<~%` binding can't be tested here
+    // yet, from a use or from its definition site. `SalsaImportsResolver` only
+    // resolves `base`, so the operators aren't recognized as assign effects at
+    // this layer until the resolver walks the search path. Operator recognition
+    // and its name range are covered in `oak_semantic`'s builder tests meanwhile.
+}
+
+#[test]
 fn test_rename_assign_call_preserves_single_quote_delimiter() {
     let code = "assign('foo', 1)\nfoo\n";
     let uri = test_path("test.R");

--- a/crates/ark/src/lsp/tests/rename.rs
+++ b/crates/ark/src/lsp/tests/rename.rs
@@ -204,10 +204,9 @@ fn test_rename_string_assignment_keeps_quotes() {
     // `"foo" <- 1` binds `foo` via a string. Renaming keeps it a string rather
     // than unquoting to `bar <- 1`, so the binding form is preserved.
     let code = "\"foo\" <- 1\nfoo\n";
-    let uri = test_path("test.R");
-    let state = make_state(&uri, code);
+    let (state, uri) = make_state(test_path("test.R").as_str(), code);
 
-    let params = make_rename_params(uri.clone(), 1, 0, "bar");
+    let params = make_rename_params(&uri, 1, 0, "bar");
     let edit = rename(params, &state).unwrap().unwrap();
 
     let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
@@ -230,10 +229,9 @@ fn test_rename_assign_call_keeps_quotes() {
     // `assign("foo", 1)` binds `foo` via a string argument. Unquoting it to
     // `assign(bar, 1)` would change the program, so the rename stays quoted.
     let code = "assign(\"foo\", 1)\nfoo\n";
-    let uri = test_path("test.R");
-    let state = make_state(&uri, code);
+    let (state, uri) = make_state(test_path("test.R").as_str(), code);
 
-    let params = make_rename_params(uri.clone(), 1, 0, "bar");
+    let params = make_rename_params(&uri, 1, 0, "bar");
     let edit = rename(params, &state).unwrap().unwrap();
 
     let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
@@ -257,11 +255,10 @@ fn test_rename_assign_call_from_definition_site() {
     // use) works too. This is what the def's own range enables: `definition_at`
     // hit-tests the name token at the definition site.
     let code = "assign(\"foo\", 1)\nfoo\n";
-    let uri = test_path("test.R");
-    let state = make_state(&uri, code);
+    let (state, uri) = make_state(test_path("test.R").as_str(), code);
 
     // Cursor inside the `"foo"` literal.
-    let params = make_rename_params(uri.clone(), 0, 8, "bar");
+    let params = make_rename_params(&uri, 0, 8, "bar");
     let edit = rename(params, &state).unwrap().unwrap();
 
     let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
@@ -288,10 +285,9 @@ fn test_rename_assign_call_from_definition_site() {
 #[test]
 fn test_rename_assign_call_preserves_single_quote_delimiter() {
     let code = "assign('foo', 1)\nfoo\n";
-    let uri = test_path("test.R");
-    let state = make_state(&uri, code);
+    let (state, uri) = make_state(test_path("test.R").as_str(), code);
 
-    let params = make_rename_params(uri.clone(), 1, 0, "bar");
+    let params = make_rename_params(&uri, 1, 0, "bar");
     let edit = rename(params, &state).unwrap().unwrap();
 
     let def_edit = edit
@@ -310,10 +306,9 @@ fn test_rename_string_bound_symbol_to_spaced_name_stays_a_string() {
     // A name needing backticks as an identifier is a plain string in the
     // string-form site: `"foo" <- 1` -> `"new name" <- 1`, use -> `` `new name` ``.
     let code = "\"foo\" <- 1\nfoo\n";
-    let uri = test_path("test.R");
-    let state = make_state(&uri, code);
+    let (state, uri) = make_state(test_path("test.R").as_str(), code);
 
-    let params = make_rename_params(uri.clone(), 1, 0, "new name");
+    let params = make_rename_params(&uri, 1, 0, "new name");
     let edit = rename(params, &state).unwrap().unwrap();
 
     let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
@@ -328,10 +323,9 @@ fn test_rename_assign_call_to_non_syntactic_name_stays_a_string() {
     // `assign("non-syntactic", 1)`, with no backticks (a string holds any name).
     // The bare-identifier use of the same symbol still gets backticks.
     let code = "assign(\"foo\", 1)\nfoo\n";
-    let uri = test_path("test.R");
-    let state = make_state(&uri, code);
+    let (state, uri) = make_state(test_path("test.R").as_str(), code);
 
-    let params = make_rename_params(uri.clone(), 1, 0, "non-syntactic");
+    let params = make_rename_params(&uri, 1, 0, "non-syntactic");
     let edit = rename(params, &state).unwrap().unwrap();
 
     let mut edits = edit.changes.unwrap().remove(&uri).unwrap();

--- a/crates/ark/src/lsp/tests/rename.rs
+++ b/crates/ark/src/lsp/tests/rename.rs
@@ -200,6 +200,113 @@ fn test_rename_cross_file_via_source() {
 }
 
 #[test]
+fn test_rename_string_assignment_keeps_quotes() {
+    // `"foo" <- 1` binds `foo` via a string. Renaming keeps it a string rather
+    // than unquoting to `bar <- 1`, so the binding form is preserved.
+    let code = "\"foo\" <- 1\nfoo\n";
+    let uri = test_path("test.R");
+    let state = make_state(&uri, code);
+
+    let params = make_rename_params(uri.clone(), 1, 0, "bar");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
+    edits.sort_by_key(|e| e.range.start);
+    let expected: Vec<TextEdit> = vec![
+        TextEdit {
+            range: range((0, 0), (0, 5)),
+            new_text: "\"bar\"".to_string(),
+        },
+        TextEdit {
+            range: range((1, 0), (1, 3)),
+            new_text: "bar".to_string(),
+        },
+    ];
+    assert_eq!(edits, expected);
+}
+
+#[test]
+fn test_rename_assign_call_keeps_quotes() {
+    // `assign("foo", 1)` binds `foo` via a string argument. Unquoting it to
+    // `assign(bar, 1)` would change the program, so the rename stays quoted.
+    let code = "assign(\"foo\", 1)\nfoo\n";
+    let uri = test_path("test.R");
+    let state = make_state(&uri, code);
+
+    let params = make_rename_params(uri.clone(), 1, 0, "bar");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
+    edits.sort_by_key(|e| e.range.start);
+    let expected: Vec<TextEdit> = vec![
+        TextEdit {
+            range: range((0, 7), (0, 12)),
+            new_text: "\"bar\"".to_string(),
+        },
+        TextEdit {
+            range: range((1, 0), (1, 3)),
+            new_text: "bar".to_string(),
+        },
+    ];
+    assert_eq!(edits, expected);
+}
+
+#[test]
+fn test_rename_assign_call_preserves_single_quote_delimiter() {
+    let code = "assign('foo', 1)\nfoo\n";
+    let uri = test_path("test.R");
+    let state = make_state(&uri, code);
+
+    let params = make_rename_params(uri.clone(), 1, 0, "bar");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let def_edit = edit
+        .changes
+        .unwrap()
+        .remove(&uri)
+        .unwrap()
+        .into_iter()
+        .find(|e| e.range.start.line == 0)
+        .unwrap();
+    assert_eq!(def_edit.new_text, "'bar'");
+}
+
+#[test]
+fn test_rename_string_bound_symbol_to_spaced_name_stays_a_string() {
+    // A name needing backticks as an identifier is a plain string in the
+    // string-form site: `"foo" <- 1` -> `"new name" <- 1`, use -> `` `new name` ``.
+    let code = "\"foo\" <- 1\nfoo\n";
+    let uri = test_path("test.R");
+    let state = make_state(&uri, code);
+
+    let params = make_rename_params(uri.clone(), 1, 0, "new name");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
+    edits.sort_by_key(|e| e.range.start);
+    assert_eq!(edits[0].new_text, "\"new name\"");
+    assert_eq!(edits[1].new_text, "`new name`");
+}
+
+#[test]
+fn test_rename_assign_call_to_non_syntactic_name_stays_a_string() {
+    // A non-syntactic target lands verbatim inside the quotes,
+    // `assign("non-syntactic", 1)`, with no backticks (a string holds any name).
+    // The bare-identifier use of the same symbol still gets backticks.
+    let code = "assign(\"foo\", 1)\nfoo\n";
+    let uri = test_path("test.R");
+    let state = make_state(&uri, code);
+
+    let params = make_rename_params(uri.clone(), 1, 0, "non-syntactic");
+    let edit = rename(params, &state).unwrap().unwrap();
+
+    let mut edits = edit.changes.unwrap().remove(&uri).unwrap();
+    edits.sort_by_key(|e| e.range.start);
+    assert_eq!(edits[0].new_text, "\"non-syntactic\"");
+    assert_eq!(edits[1].new_text, "`non-syntactic`");
+}
+
+#[test]
 fn test_rename_to_reserved_word_errors() {
     let code = "foo <- 1\n";
     let (state, uri) = make_state(test_path("test.R").as_str(), code);

--- a/crates/oak_core/src/identifier.rs
+++ b/crates/oak_core/src/identifier.rs
@@ -46,6 +46,21 @@ pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
     Ok(format!("`{name}`"))
 }
 
+/// Render `name` as a quoted R string literal using `delimiter` (`"` or `'`).
+///
+/// Counterpart to [`to_identifier_text`] for a site that binds a name in string
+/// form (`assign("x", ..)`, `"x" <- ..`). The rename edit there must stay a
+/// string, or dropping the quotes would turn the name into a variable reference
+/// and change the program. Backslash and the delimiter are escaped so an unusual
+/// name can't break out of the string. Mostly defensive, identifiers never
+/// contain either.
+pub fn quote_name(name: &str, delimiter: char) -> String {
+    let escaped = name
+        .replace('\\', "\\\\")
+        .replace(delimiter, &format!("\\{delimiter}"));
+    format!("{delimiter}{escaped}{delimiter}")
+}
+
 /// Whether `name` is a valid bare R identifier (no backticks needed).
 ///
 /// R's rule: starts with a letter or `.`, then letters, digits, `.`, or
@@ -228,5 +243,21 @@ mod tests {
         assert!(to_identifier_text("``").is_err());
         // Stray backtick inside the pre-wrapped name.
         assert!(to_identifier_text("`foo`bar`").is_err());
+    }
+
+    #[test]
+    fn test_quote_name_wraps_in_delimiter() {
+        assert_eq!(quote_name("bar", '"'), "\"bar\"");
+        assert_eq!(quote_name("bar", '\''), "'bar'");
+    }
+
+    #[test]
+    fn test_quote_name_escapes_delimiter_and_backslash() {
+        // Defensive: a real identifier never contains these, but if a name did,
+        // it stays inside the string rather than breaking out of it.
+        assert_eq!(quote_name("a\"b", '"'), "\"a\\\"b\"");
+        assert_eq!(quote_name("a\\b", '"'), "\"a\\\\b\"");
+        // The other delimiter isn't escaped: a `'` inside a `"`-string is literal.
+        assert_eq!(quote_name("a'b", '"'), "\"a'b\"");
     }
 }

--- a/crates/oak_core/src/identifier.rs
+++ b/crates/oak_core/src/identifier.rs
@@ -6,59 +6,86 @@
 
 use anyhow::anyhow;
 
-/// Convert a semantic name into its canonical R source form.
+/// A validated R name with semantic and source forms.
 ///
-/// A name that parses as a plain R identifier (and isn't a reserved
-/// word) returns as-is. A name already wrapped in backticks (e.g.
-/// `` `foo bar` ``) is accepted as-is too. Anything else gets wrapped
-/// in backticks. Empty names, reserved words, and names with stray
-/// backticks return `Err` (a backtick can't appear inside a
-/// backtick-quoted identifier).
-pub fn to_identifier_text(name: &str) -> anyhow::Result<String> {
-    if name.is_empty() {
-        return Err(anyhow!("Identifier cannot be empty"));
-    }
-    if is_reserved(name) {
-        return Err(anyhow!("`{name}` is a reserved word in R"));
-    }
-    if is_valid_identifier(name) {
-        return Ok(name.to_string());
-    }
-
-    // User pre-wrapped the name in backticks (e.g. `foo bar`)? Normalize:
-    // strip unnecessary backticks when the inside is already a valid bare
-    // identifier; otherwise keep the backticks (they're load-bearing for
-    // names with spaces, leading digits, reserved words, etc.).
-    if let Some(inner) = name.strip_prefix('`').and_then(|s| s.strip_suffix('`')) {
-        if !inner.is_empty() && !inner.contains('`') {
-            if is_valid_identifier(inner) && !is_reserved(inner) {
-                return Ok(inner.to_string());
-            } else {
-                return Ok(name.to_string());
-            }
-        }
-    }
-
-    if name.contains('`') {
-        return Err(anyhow!("Identifier cannot contain a backtick"));
-    }
-
-    Ok(format!("`{name}`"))
+/// Parsing once keeps string-form and identifier sites consistent.
+#[derive(Debug)]
+pub struct RName {
+    semantic: String,
+    identifier: String,
 }
 
-/// Render `name` as a quoted R string literal using `delimiter` (`"` or `'`).
-///
-/// Counterpart to [`to_identifier_text`] for a site that binds a name in string
-/// form (`assign("x", ..)`, `"x" <- ..`). The rename edit there must stay a
-/// string, or dropping the quotes would turn the name into a variable reference
-/// and change the program. Backslash and the delimiter are escaped so an unusual
-/// name can't break out of the string. Mostly defensive, identifiers never
-/// contain either.
-pub fn quote_name(name: &str, delimiter: char) -> String {
-    let escaped = name
-        .replace('\\', "\\\\")
-        .replace(delimiter, &format!("\\{delimiter}"));
-    format!("{delimiter}{escaped}{delimiter}")
+impl RName {
+    /// Parse a bare or backtick-wrapped R name.
+    ///
+    /// Wrapped reserved words are valid. Empty names, bare reserved words, and
+    /// stray backticks return `Err`.
+    pub fn parse(name: &str) -> anyhow::Result<Self> {
+        if name.is_empty() {
+            return Err(anyhow!("Identifier cannot be empty"));
+        }
+
+        if let Some(inner) = name
+            .strip_prefix('`')
+            .and_then(|rest| rest.strip_suffix('`'))
+        {
+            return Self::from_wrapped(inner);
+        }
+        if name.contains('`') {
+            return Err(anyhow!("Identifier cannot contain a backtick"));
+        }
+        if is_reserved(name) {
+            return Err(anyhow!("`{name}` is a reserved word in R"));
+        }
+
+        Ok(Self::from_semantic(name))
+    }
+
+    /// The source spelling for this binding, backtick-wrapped when necessary.
+    pub fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    /// Render the semantic name as an R string literal using `delimiter`.
+    ///
+    /// String-form binding sites store the semantic name, not its backticked
+    /// source spelling.
+    pub fn quoted(&self, delimiter: char) -> String {
+        let escaped = self
+            .semantic
+            .replace('\\', "\\\\")
+            .replace(delimiter, &format!("\\{delimiter}"));
+        format!("{delimiter}{escaped}{delimiter}")
+    }
+
+    fn from_wrapped(inner: &str) -> anyhow::Result<Self> {
+        if inner.is_empty() {
+            return Err(anyhow!("Identifier cannot be empty"));
+        }
+        if inner.contains('`') {
+            return Err(anyhow!("Identifier cannot contain a backtick"));
+        }
+        if is_reserved(inner) {
+            return Ok(Self {
+                semantic: inner.to_string(),
+                identifier: format!("`{inner}`"),
+            });
+        }
+
+        Ok(Self::from_semantic(inner))
+    }
+
+    fn from_semantic(name: &str) -> Self {
+        let identifier = if is_valid_identifier(name) {
+            name.to_string()
+        } else {
+            format!("`{name}`")
+        };
+        Self {
+            semantic: name.to_string(),
+            identifier,
+        }
+    }
 }
 
 /// Whether `name` is a valid bare R identifier (no backticks needed).
@@ -159,9 +186,8 @@ mod tests {
         assert!(is_valid_identifier("foo_μ"));
         assert!(is_valid_identifier("μ2"));
         assert!(is_valid_identifier(".μ"));
-        // `to_identifier_text` should keep these as-is, not wrap them.
-        assert_eq!(to_identifier_text("μ").unwrap(), "μ");
-        assert_eq!(to_identifier_text("αβ").unwrap(), "αβ");
+        assert_eq!(identifier_text("μ"), "μ");
+        assert_eq!(identifier_text("αβ"), "αβ");
     }
 
     #[test]
@@ -192,72 +218,79 @@ mod tests {
         assert!(!is_reserved(".1"));
     }
 
-    #[test]
-    fn test_to_identifier_text_plain() {
-        assert_eq!(to_identifier_text("foo").unwrap(), "foo");
+    fn identifier_text(name: &str) -> String {
+        RName::parse(name).unwrap().identifier().to_string()
     }
 
     #[test]
-    fn test_to_identifier_text_wraps_non_identifier() {
-        assert_eq!(to_identifier_text("foo bar").unwrap(), "`foo bar`");
-        assert_eq!(to_identifier_text("1foo").unwrap(), "`1foo`");
+    fn test_rname_plain() {
+        assert_eq!(identifier_text("foo"), "foo");
     }
 
     #[test]
-    fn test_to_identifier_text_rejects_empty() {
-        assert!(to_identifier_text("").is_err());
+    fn test_rname_wraps_non_identifier() {
+        assert_eq!(identifier_text("foo bar"), "`foo bar`");
+        assert_eq!(identifier_text("1foo"), "`1foo`");
     }
 
     #[test]
-    fn test_to_identifier_text_rejects_reserved() {
-        assert!(to_identifier_text("if").is_err());
+    fn test_rname_rejects_empty() {
+        assert!(RName::parse("").is_err());
     }
 
     #[test]
-    fn test_to_identifier_text_rejects_backtick() {
-        assert!(to_identifier_text("foo`bar").is_err());
+    fn test_rname_rejects_reserved() {
+        assert!(RName::parse("if").is_err());
     }
 
     #[test]
-    fn test_to_identifier_text_keeps_necessary_backticks() {
-        // Names that need backticks stay wrapped as-is.
-        assert_eq!(to_identifier_text("`foo bar`").unwrap(), "`foo bar`");
-        // Reserved-looking word in backticks is fine; the backticks make
-        // it a valid identifier in R.
-        assert_eq!(to_identifier_text("`if`").unwrap(), "`if`");
+    fn test_rname_rejects_backtick() {
+        assert!(RName::parse("foo`bar").is_err());
     }
 
     #[test]
-    fn test_to_identifier_text_strips_unnecessary_backticks() {
-        // Pre-wrapped name whose inside is already a valid bare identifier:
-        // canonicalize by dropping the backticks.
-        assert_eq!(to_identifier_text("`bar`").unwrap(), "bar");
-        assert_eq!(to_identifier_text("`foo.bar`").unwrap(), "foo.bar");
+    fn test_rname_keeps_necessary_backticks() {
+        assert_eq!(identifier_text("`foo bar`"), "`foo bar`");
+        // Backticks make reserved words valid R identifiers.
+        assert_eq!(identifier_text("`if`"), "`if`");
     }
 
     #[test]
-    fn test_to_identifier_text_rejects_pre_wrapped_edge_cases() {
-        // Single backtick.
-        assert!(to_identifier_text("`").is_err());
-        // Empty-inside ``.
-        assert!(to_identifier_text("``").is_err());
-        // Stray backtick inside the pre-wrapped name.
-        assert!(to_identifier_text("`foo`bar`").is_err());
+    fn test_rname_strips_unnecessary_backticks() {
+        assert_eq!(identifier_text("`bar`"), "bar");
+        assert_eq!(identifier_text("`foo.bar`"), "foo.bar");
     }
 
     #[test]
-    fn test_quote_name_wraps_in_delimiter() {
-        assert_eq!(quote_name("bar", '"'), "\"bar\"");
-        assert_eq!(quote_name("bar", '\''), "'bar'");
+    fn test_rname_rejects_pre_wrapped_edge_cases() {
+        assert!(RName::parse("`").is_err());
+        assert!(RName::parse("``").is_err());
+        assert!(RName::parse("`foo`bar`").is_err());
     }
 
     #[test]
-    fn test_quote_name_escapes_delimiter_and_backslash() {
+    fn test_rname_quoted_wraps_in_delimiter() {
+        assert_eq!(RName::parse("bar").unwrap().quoted('"'), "\"bar\"");
+        assert_eq!(RName::parse("bar").unwrap().quoted('\''), "'bar'");
+    }
+
+    #[test]
+    fn test_rname_quoted_drops_backticks() {
+        assert_eq!(RName::parse("`bar`").unwrap().quoted('"'), "\"bar\"");
+        assert_eq!(
+            RName::parse("`foo bar`").unwrap().quoted('"'),
+            "\"foo bar\""
+        );
+        assert_eq!(RName::parse("`if`").unwrap().quoted('"'), "\"if\"");
+    }
+
+    #[test]
+    fn test_rname_quoted_escapes_delimiter_and_backslash() {
         // Defensive: a real identifier never contains these, but if a name did,
         // it stays inside the string rather than breaking out of it.
-        assert_eq!(quote_name("a\"b", '"'), "\"a\\\"b\"");
-        assert_eq!(quote_name("a\\b", '"'), "\"a\\\\b\"");
+        assert_eq!(RName::parse("a\"b").unwrap().quoted('"'), "\"a\\\"b\"");
+        assert_eq!(RName::parse("a\\b").unwrap().quoted('"'), "\"a\\\\b\"");
         // The other delimiter isn't escaped: a `'` inside a `"`-string is literal.
-        assert_eq!(quote_name("a'b", '"'), "\"a'b\"");
+        assert_eq!(RName::parse("a'b").unwrap().quoted('"'), "\"a'b\"");
     }
 }

--- a/crates/oak_core/src/range.rs
+++ b/crates/oak_core/src/range.rs
@@ -1,5 +1,71 @@
+use biome_rowan::AstNode;
+use biome_rowan::AstPtr;
+use biome_rowan::SyntaxNode;
 use biome_rowan::TextRange;
 
 pub trait Ranged {
     fn range(&self) -> TextRange;
+}
+
+/// An [`AstPtr`] that also remembers the trimmed text range of the node it
+/// captured.
+///
+/// A plain `AstPtr` stores only the with-trivia range and can't recover the
+/// trimmed range without re-resolving against the tree. We snapshot the trimmed
+/// range at capture, so a consumer that holds the pointer but not the tree gets
+/// the exact token span for free.
+pub struct RangedAstPtr<N: AstNode> {
+    ptr: AstPtr<N>,
+    range: TextRange,
+}
+
+impl<N: AstNode> RangedAstPtr<N> {
+    pub fn new(node: &N) -> Self {
+        Self {
+            range: node.syntax().text_trimmed_range(),
+            ptr: AstPtr::new(node),
+        }
+    }
+
+    /// The trimmed range which excludes surrounding whitespace and comments,
+    /// snapshotted at creation.
+    pub fn text_trimmed_range(&self) -> TextRange {
+        self.range
+    }
+
+    /// The range including leading and trailing trivia, read back from the
+    /// pointer, which already stores it.
+    pub fn text_range_with_trivia(&self) -> TextRange {
+        self.ptr.syntax_node_ptr().text_range()
+    }
+
+    /// Resolve back to the node against the tree that produced it.
+    pub fn to_node(&self, root: &SyntaxNode<N::Language>) -> N {
+        self.ptr.to_node(root)
+    }
+
+    /// The underlying pointer, for consumers that only need the handle.
+    pub fn as_ptr(&self) -> &AstPtr<N> {
+        &self.ptr
+    }
+}
+
+// Hand-written like `AstPtr`'s own impls, so the bounds don't demand `N: Clone`
+// or `N: Debug`.
+impl<N: AstNode> Clone for RangedAstPtr<N> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr.clone(),
+            range: self.range,
+        }
+    }
+}
+
+impl<N: AstNode> std::fmt::Debug for RangedAstPtr<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RangedAstPtr")
+            .field("ptr", &self.ptr)
+            .field("range", &self.range)
+            .finish()
+    }
 }

--- a/crates/oak_db/src/definition.rs
+++ b/crates/oak_db/src/definition.rs
@@ -78,6 +78,7 @@ impl<'db> Definition<'db> {
                 node.variable().ok()?.into_syntax()
             },
             DefinitionKind::Import { .. } => return None,
+            DefinitionKind::Assign { name, .. } => name.to_node(&root).into_syntax(),
         };
         Some(name_node.text_trimmed_range())
     }

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -300,6 +300,18 @@ fn test_name_range_for_string_as_name() {
 }
 
 #[test]
+fn test_name_range_for_assign_call() {
+    // `assign("x", 1)` binds `x` through the base `assign` effect. Goto lands on
+    // the name literal, so the range covers the quoted `"x"` argument.
+    let mut db = TestDb::new();
+    let source = "assign(\"x\", 1)\n";
+    let files = setup_workspace(&mut db, &[("w/a.R", source)]);
+    let def = resolve_one(&db, files[0], "x");
+    let range = def.name_range(&db).expect("assign() def has a name range");
+    assert_eq!(slice(source, range), "\"x\"");
+}
+
+#[test]
 fn test_name_range_returns_none_for_import_kind() {
     // `File::resolve` chases past every `Import` and only ever returns a
     // `Local`-kinded `Definition`, so the `Import` arm of `name_range` is

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -312,6 +312,24 @@ fn test_name_range_for_assign_call() {
 }
 
 #[test]
+fn test_resolve_from_assign_definition_site() {
+    // Cursor on the `"x"` name of `assign("x", 1)` resolves to its own binding,
+    // so goto/rename can start from the definition site. The def's range is the
+    // name token, not an empty span, which is what `definition_at` hit-tests.
+    use biome_rowan::TextSize;
+    use oak_semantic::semantic_index::DefinitionKind;
+
+    let mut db = TestDb::new();
+    let source = "assign(\"x\", 1)\n";
+    let files = setup_workspace(&mut db, &[("w/a.R", source)]);
+    let offset = source.find("\"x\"").unwrap();
+
+    let defs = files[0].resolve_at(&db, TextSize::from(offset as u32));
+    assert_eq!(defs.len(), 1);
+    assert!(matches!(defs[0].kind(&db), DefinitionKind::Assign { .. }));
+}
+
+#[test]
 fn test_name_range_returns_none_for_import_kind() {
     // `File::resolve` chases past every `Import` and only ever returns a
     // `Local`-kinded `Definition`, so the `Import` arm of `name_range` is

--- a/crates/oak_ide/src/lib.rs
+++ b/crates/oak_ide/src/lib.rs
@@ -16,6 +16,19 @@ pub struct FileRange {
     pub range: TextRange,
 }
 
+/// One edit produced by [`rename`]: a span to replace and the text to write.
+///
+/// The text is already rendered in the site's own spelling, a bare identifier,
+/// or a quoted string when the site binds the name in string form. So the LSP
+/// layer only converts ranges and wires files, it makes no decision about how
+/// the name should appear.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameEdit {
+    pub file: File,
+    pub range: TextRange,
+    pub new_text: String,
+}
+
 /// A location in source code that the editor can navigate to.
 ///
 /// Shared result type for IDE features like goto-definition, hover,

--- a/crates/oak_ide/src/rename.rs
+++ b/crates/oak_ide/src/rename.rs
@@ -1,6 +1,8 @@
 use anyhow::anyhow;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
+use oak_core::identifier::quote_name;
+use oak_core::identifier::to_identifier_text;
 use oak_db::Db;
 use oak_db::Definition;
 use oak_db::File;
@@ -9,6 +11,7 @@ use oak_db::RootKind;
 
 use crate::find_references;
 use crate::FileRange;
+use crate::RenameEdit;
 
 /// Identify the renamable identifier at `offset`, returning its range and
 /// current (unquoted) name.
@@ -26,26 +29,75 @@ pub fn prepare_rename(
     Ok(renamable_at(db, file, offset)?.map(|(range, name)| (range, name.text(db).to_string())))
 }
 
-/// Find every site to rename for the symbol at `offset`. The caller turns
-/// these ranges into edits.
+/// Rename the symbol at `offset` to `new_name`, returning one edit per site
+/// with the replacement text already rendered in that site's spelling.
 ///
-/// Returns `Err` when the cursor isn't on a renamable identifier or it
-/// resolves to an installed package (both via `renamable_at`), or when nothing
-/// in the database binds the cursor's symbol. In that last case a rename would
-/// produce no edits, so we refuse rather than silently succeed.
-pub fn rename(db: &dyn Db, file: File, offset: TextSize) -> anyhow::Result<Vec<FileRange>> {
+/// Each site is rendered here rather than by the caller because how a name
+/// appears is R-language semantics: a use is a bare identifier, but a
+/// string-form binding (e.g. `assign("x", ..)`) must remain a quoted string.
+///
+/// Returns `Err` when the cursor isn't on a renamable identifier, when the
+/// symbol resolves to a definition in an installed package (which we can't
+/// edit), when `new_name` isn't a valid R name, or when nothing in the database
+/// binds the cursor's symbol. In that last case a rename would produce no
+/// edits, so we refuse rather than silently succeed.
+pub fn rename(
+    db: &dyn Db,
+    file: File,
+    offset: TextSize,
+    new_name: &str,
+) -> anyhow::Result<Vec<RenameEdit>> {
     let Some(_) = renamable_at(db, file, offset)? else {
         return Err(anyhow!("Can't rename identifier at cursor."));
     };
 
-    let ranges = find_references(db, file, offset, true);
-    if ranges.is_empty() {
+    // Normalize to canonical R identifier syntax (backtick-wrapped if needed) up
+    // front, so an invalid name fails before we produce any edits, uniformly for
+    // every symbol regardless of how its sites are spelled.
+    let identifier_text = to_identifier_text(new_name)?;
+
+    let sites = find_references(db, file, offset, true);
+    if sites.is_empty() {
         return Err(anyhow!(
             "Can't rename: symbol has no binding in the workspace."
         ));
     }
 
-    Ok(ranges)
+    let edits = sites
+        .into_iter()
+        .map(|site| {
+            let new_text = render_at_site(db, &site, new_name, &identifier_text);
+            RenameEdit {
+                file: site.file,
+                range: site.range,
+                new_text,
+            }
+        })
+        .collect();
+    Ok(edits)
+}
+
+/// Render the replacement text for one site. A site spelled as a quoted string
+/// (`assign("x", ..)`, `"x" <- ..`) stays a string, keeping its delimiter,
+/// because dropping the quotes would turn the name into a variable reference and
+/// change the program. Every other site is a bare identifier, rendered as the
+/// already-validated `identifier_text`.
+fn render_at_site(db: &dyn Db, site: &FileRange, new_name: &str, identifier_text: &str) -> String {
+    let source = site.file.source_text(db);
+    match string_delimiter(&source[..], site.range) {
+        Some(delimiter) => quote_name(new_name, delimiter),
+        None => identifier_text.to_string(),
+    }
+}
+
+/// The opening quote of the string literal at `range` in `source`, or `None`
+/// when the site is a bare identifier.
+fn string_delimiter(source: &str, range: TextRange) -> Option<char> {
+    let slice = &source[usize::from(range.start())..usize::from(range.end())];
+    match slice.chars().next() {
+        Some(delimiter @ ('"' | '\'')) => Some(delimiter),
+        _ => None,
+    }
 }
 
 fn renamable_at<'db>(

--- a/crates/oak_ide/src/rename.rs
+++ b/crates/oak_ide/src/rename.rs
@@ -1,8 +1,7 @@
 use anyhow::anyhow;
 use biome_rowan::TextRange;
 use biome_rowan::TextSize;
-use oak_core::identifier::quote_name;
-use oak_core::identifier::to_identifier_text;
+use oak_core::identifier::RName;
 use oak_db::Db;
 use oak_db::Definition;
 use oak_db::File;
@@ -51,10 +50,7 @@ pub fn rename(
         return Err(anyhow!("Can't rename identifier at cursor."));
     };
 
-    // Normalize to canonical R identifier syntax (backtick-wrapped if needed) up
-    // front, so an invalid name fails before we produce any edits, uniformly for
-    // every symbol regardless of how its sites are spelled.
-    let identifier_text = to_identifier_text(new_name)?;
+    let new_name = RName::parse(new_name)?;
 
     let sites = find_references(db, file, offset, true);
     if sites.is_empty() {
@@ -66,7 +62,7 @@ pub fn rename(
     let edits = sites
         .into_iter()
         .map(|site| {
-            let new_text = render_at_site(db, &site, new_name, &identifier_text);
+            let new_text = render_at_site(db, &site, &new_name);
             RenameEdit {
                 file: site.file,
                 range: site.range,
@@ -77,16 +73,13 @@ pub fn rename(
     Ok(edits)
 }
 
-/// Render the replacement text for one site. A site spelled as a quoted string
-/// (`assign("x", ..)`, `"x" <- ..`) stays a string, keeping its delimiter,
-/// because dropping the quotes would turn the name into a variable reference and
-/// change the program. Every other site is a bare identifier, rendered as the
-/// already-validated `identifier_text`.
-fn render_at_site(db: &dyn Db, site: &FileRange, new_name: &str, identifier_text: &str) -> String {
+/// Preserve quoted sites because removing their quotes changes a binding name
+/// into a variable reference.
+fn render_at_site(db: &dyn Db, site: &FileRange, new_name: &RName) -> String {
     let source = site.file.source_text(db);
     match string_delimiter(&source[..], site.range) {
-        Some(delimiter) => quote_name(new_name, delimiter),
-        None => identifier_text.to_string(),
+        Some(delimiter) => new_name.quoted(delimiter),
+        None => new_name.identifier().to_string(),
     }
 }
 

--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -159,6 +159,26 @@ fn test_super_assignment_targets_outer_scope() {
     ]);
 }
 
+#[test]
+fn test_references_from_assign_definition_site() {
+    // Find-references invoked with the cursor ON the `assign()` name literal (not
+    // a later use) resolves the binding and returns the declaration plus the use.
+    // This is what the definition's own range enables: `definition_at` hit-tests
+    // the name token at the definition site.
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "assign(\"foo\", 1)\nfoo\n");
+
+    // Cursor inside the `"foo"` literal.
+    let refs = find_references(&db, file, offset(8), true);
+    assert_eq!(ranges(&refs), vec![range(7, 12), range(17, 20)]);
+
+    // TODO!(nse-resolver): find-references for a `%<>%`/`%<~%` binding can't be
+    // tested here yet, from a use or from its definition site.
+    // `SalsaImportsResolver` only resolves `base`, so the operators aren't
+    // recognized as assign effects at this layer until the resolver walks the
+    // search path.
+}
+
 // --- Boundary cursor ---
 
 #[test]

--- a/crates/oak_ide/tests/integration/goto_definition.rs
+++ b/crates/oak_ide/tests/integration/goto_definition.rs
@@ -189,3 +189,32 @@ fn test_navigates_to_both_candidates_through_source() {
     assert_eq!(targets[0].focus_range, range(10, 13));
     assert_eq!(targets[1].focus_range, range(24, 27));
 }
+
+#[test]
+fn test_navigates_to_assign_binding() {
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "a.R", "assign(\"x\", 1)\nx\n");
+
+    // Cursor on the use `x` on line 2.
+    let offset = TextSize::from("assign(\"x\", 1)\n".len() as u32);
+    let targets = goto_definition(&db, file, offset);
+    assert_eq!(targets.len(), 1);
+    let target = &targets[0];
+
+    assert_eq!(target.file, file);
+    assert_eq!(target.name, "x");
+    // Lands on the quoted name argument `"x"`.
+    assert_eq!(target.full_range, range(7, 10));
+}
+
+#[test]
+fn test_navigates_to_delayed_assign_binding() {
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "a.R", "delayedAssign(\"x\", expr)\nx\n");
+
+    let offset = TextSize::from("delayedAssign(\"x\", expr)\n".len() as u32);
+    let targets = goto_definition(&db, file, offset);
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].name, "x");
+    assert_eq!(targets[0].full_range, range(14, 17));
+}

--- a/crates/oak_ide/tests/integration/goto_definition.rs
+++ b/crates/oak_ide/tests/integration/goto_definition.rs
@@ -218,3 +218,22 @@ fn test_navigates_to_delayed_assign_binding() {
     assert_eq!(targets[0].name, "x");
     assert_eq!(targets[0].full_range, range(14, 17));
 }
+
+#[test]
+fn test_navigates_from_assign_definition_site() {
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "a.R", "assign(\"x\", 1)\nx\n");
+
+    // Cursor on the `"x"` name literal at the definition site (offset 8, the `x`
+    // inside the quotes), not a later use. Resolving lands on the def itself.
+    let offset = TextSize::from("assign(\"".len() as u32);
+    let targets = goto_definition(&db, file, offset);
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].name, "x");
+    assert_eq!(targets[0].full_range, range(7, 10));
+
+    // TODO!(nse-resolver): goto for a `%<>%`/`%<~%` binding can't be tested here
+    // yet, from a use or from its definition site. `SalsaImportsResolver` only
+    // resolves `base`, so the operators aren't recognized at this layer until
+    // the resolver walks the search path.
+}

--- a/crates/oak_ide/tests/integration/rename.rs
+++ b/crates/oak_ide/tests/integration/rename.rs
@@ -13,12 +13,12 @@ use oak_ide::rename;
 use salsa::Setter;
 use url::Url;
 
+use crate::support::edit_pairs;
+use crate::support::edit_ranges;
 use crate::support::install_library_package;
 use crate::support::install_workspace_package;
 use crate::support::offset;
-use crate::support::pairs;
 use crate::support::range;
-use crate::support::ranges;
 use crate::support::upsert;
 
 // --- prepare_rename ---
@@ -76,8 +76,8 @@ fn test_rename_def_and_use() {
     let mut db = OakDatabase::new();
     let file = upsert(&mut db, "test.R", "foo <- 1\nfoo + foo\n");
 
-    let targets = rename(&db, file, offset(0)).unwrap();
-    assert_eq!(ranges(&targets), vec![
+    let targets = rename(&db, file, offset(0), "bar").unwrap();
+    assert_eq!(edit_ranges(&targets), vec![
         range(0, 3),
         range(9, 12),
         range(15, 18)
@@ -92,8 +92,8 @@ fn test_rename_excludes_shadowed_outer() {
 
     let inner_def = source.find("x <- 2").unwrap() as u32;
     let inner_use = source.rfind('x').unwrap() as u32;
-    let targets = rename(&db, file, offset(inner_def)).unwrap();
-    assert_eq!(ranges(&targets), vec![
+    let targets = rename(&db, file, offset(inner_def), "bar").unwrap();
+    assert_eq!(edit_ranges(&targets), vec![
         range(inner_def, inner_def + 1),
         range(inner_use, inner_use + 1),
     ]);
@@ -106,7 +106,7 @@ fn test_rename_non_renamable_errors() {
     let mut db = OakDatabase::new();
     let file = upsert(&mut db, "test.R", "dplyr::mutate\n");
 
-    let err = rename(&db, file, offset(7)).unwrap_err();
+    let err = rename(&db, file, offset(7), "bar").unwrap_err();
     assert!(err.to_string().contains("Can't rename identifier"));
 }
 
@@ -116,19 +116,86 @@ fn test_rename_unbound_use_errors() {
     let mut db = OakDatabase::new();
     let file = upsert(&mut db, "test.R", "foo\n");
 
-    let err = rename(&db, file, offset(0)).unwrap_err();
+    let err = rename(&db, file, offset(0), "bar").unwrap_err();
     assert!(err.to_string().contains("no binding"));
 }
 
 // --- rename: string definitions ---
 
+/// Project edits to `(range, new_text)`, for asserting how each site renders.
+fn rendered(edits: &[oak_ide::RenameEdit]) -> Vec<(biome_rowan::TextRange, &str)> {
+    edits
+        .iter()
+        .map(|e| (e.range, e.new_text.as_str()))
+        .collect()
+}
+
 #[test]
-fn test_rename_string_def_spans_quoted_range() {
+fn test_rename_string_def_keeps_quotes() {
+    // `"foo" <- 1` binds `foo` via a string. The def site stays a quoted string
+    // (`"bar"`), spanning the quotes; the use is a bare identifier.
     let mut db = OakDatabase::new();
     let file = upsert(&mut db, "test.R", "\"foo\" <- 1\nfoo\n");
 
-    let targets = rename(&db, file, offset(11)).unwrap();
-    assert_eq!(ranges(&targets), vec![range(0, 5), range(11, 14)]);
+    let edits = rename(&db, file, offset(11), "bar").unwrap();
+    assert_eq!(rendered(&edits), vec![
+        (range(0, 5), "\"bar\""),
+        (range(11, 14), "bar"),
+    ]);
+}
+
+#[test]
+fn test_rename_assign_call_keeps_quotes() {
+    // `assign("foo", 1)` binds `foo` via a string argument. Unquoting it would
+    // turn the name into a variable reference, so the def site stays quoted.
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "assign(\"foo\", 1)\nfoo\n");
+
+    let edits = rename(&db, file, offset(17), "bar").unwrap();
+    assert_eq!(rendered(&edits), vec![
+        (range(7, 12), "\"bar\""),
+        (range(17, 20), "bar"),
+    ]);
+}
+
+#[test]
+fn test_rename_string_def_preserves_single_quote_delimiter() {
+    // The rendered string reuses the site's own delimiter.
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "assign('foo', 1)\nfoo\n");
+
+    let edits = rename(&db, file, offset(17), "bar").unwrap();
+    assert_eq!(rendered(&edits), vec![
+        (range(7, 12), "'bar'"),
+        (range(17, 20), "bar"),
+    ]);
+}
+
+#[test]
+fn test_rename_rejects_invalid_name_even_for_string_only_symbol() {
+    // Name validation is uniform: even a symbol only ever spelled as a string
+    // (no bare-identifier site) is rejected for an invalid name up front, rather
+    // than silently producing a string that couldn't be used as an identifier.
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "assign(\"foo\", 1)\n");
+
+    let err = rename(&db, file, offset(8), "if").unwrap_err();
+    assert!(err.to_string().contains("reserved"));
+}
+
+#[test]
+fn test_rename_to_non_syntactic_name_quotes_string_site_backticks_use() {
+    // A non-syntactic target lands verbatim inside the quotes (a string holds
+    // any name, no backticks), while the bare-identifier use gets backticks. The
+    // string site renders the raw name, not the backtick-wrapped identifier form.
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "assign(\"foo\", 1)\nfoo\n");
+
+    let edits = rename(&db, file, offset(17), "non-syntactic").unwrap();
+    assert_eq!(rendered(&edits), vec![
+        (range(7, 12), "\"non-syntactic\""),
+        (range(17, 20), "`non-syntactic`"),
+    ]);
 }
 
 // --- rename: cross-file workspace scripts ---
@@ -143,9 +210,9 @@ fn test_rename_cross_file_workspace_scripts() {
     place_in_workspace_scripts(&mut db, vec![helpers, script]);
 
     let use_start = "source(\"helpers.R\")\n".len() as u32;
-    let targets = rename(&db, script, offset(use_start)).unwrap();
+    let targets = rename(&db, script, offset(use_start), "helper2").unwrap();
     // script.R (cursor's file) first, then helpers.R.
-    assert_eq!(pairs(&targets), vec![
+    assert_eq!(edit_pairs(&targets), vec![
         (script, range(use_start, use_start + 6)),
         (helpers, range(0, 6)),
     ]);
@@ -166,9 +233,9 @@ fn test_rename_cross_file_workspace_package() {
     let (a, b) = (files[0], files[1]);
 
     // Cursor on the def `shared` in a.R at offset 0.
-    let targets = rename(&db, a, offset(0)).unwrap();
+    let targets = rename(&db, a, offset(0), "renamed").unwrap();
     let use_start = "use_shared <- function() ".len() as u32;
-    assert_eq!(pairs(&targets), vec![
+    assert_eq!(edit_pairs(&targets), vec![
         (a, range(0, 6)),
         (b, range(use_start, use_start + 6)),
     ]);
@@ -185,7 +252,7 @@ fn test_rename_refuses_library_package_symbol() {
     let lib_file = build_library_package_file(&mut db, "foo <- function() {}\n");
 
     // Cursor on the def `foo` at offset 0.
-    let err = rename(&db, lib_file, offset(0)).unwrap_err();
+    let err = rename(&db, lib_file, offset(0), "bar").unwrap_err();
     assert_eq!(
         err.to_string(),
         "Can't rename: symbol is defined in an installed package."
@@ -204,7 +271,7 @@ fn test_rename_refuses_package_export_used_via_library() {
     let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
 
     let use_start = "library(mypkg)\n".len() as u32;
-    let err = rename(&db, script, offset(use_start)).unwrap_err();
+    let err = rename(&db, script, offset(use_start), "bar").unwrap_err();
     assert_eq!(
         err.to_string(),
         "Can't rename: symbol is defined in an installed package."
@@ -222,8 +289,8 @@ fn test_rename_succeeds_for_workspace_package_export_via_library() {
     let script = upsert(&mut db, "script.R", "library(mypkg)\nfoo\n");
 
     let use_start = "library(mypkg)\n".len() as u32;
-    let result = rename(&db, script, offset(use_start)).unwrap();
-    assert_eq!(pairs(&result), vec![
+    let result = rename(&db, script, offset(use_start), "bar").unwrap();
+    assert_eq!(edit_pairs(&result), vec![
         (script, range(use_start, use_start + 3)),
         (pkg_file, range(0, 3)),
     ]);

--- a/crates/oak_ide/tests/integration/rename.rs
+++ b/crates/oak_ide/tests/integration/rename.rs
@@ -198,6 +198,30 @@ fn test_rename_to_non_syntactic_name_quotes_string_site_backticks_use() {
     ]);
 }
 
+#[test]
+fn test_rename_to_pre_wrapped_name_agrees_across_sites() {
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "assign(\"foo\", 1)\nfoo\n");
+
+    let edits = rename(&db, file, offset(17), "`bar`").unwrap();
+    assert_eq!(rendered(&edits), vec![
+        (range(7, 12), "\"bar\""),
+        (range(17, 20), "bar"),
+    ]);
+}
+
+#[test]
+fn test_rename_to_pre_wrapped_non_syntactic_name_agrees_across_sites() {
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", "\"foo\" <- 1\nfoo\n");
+
+    let edits = rename(&db, file, offset(11), "`foo bar`").unwrap();
+    assert_eq!(rendered(&edits), vec![
+        (range(0, 5), "\"foo bar\""),
+        (range(11, 14), "`foo bar`"),
+    ]);
+}
+
 // --- rename: cross-file workspace scripts ---
 
 #[test]

--- a/crates/oak_ide/tests/integration/support.rs
+++ b/crates/oak_ide/tests/integration/support.rs
@@ -11,6 +11,7 @@ use oak_db::Package;
 use oak_db::Root;
 use oak_db::RootKind;
 use oak_ide::FileRange;
+use oak_ide::RenameEdit;
 use oak_package_metadata::namespace::Namespace;
 use oak_scan::DbScan;
 use salsa::Setter;
@@ -55,6 +56,16 @@ pub fn ranges(refs: &[FileRange]) -> Vec<TextRange> {
 /// Project results to `(file, range)` pairs (cross-file tests).
 pub fn pairs(refs: &[FileRange]) -> Vec<(File, TextRange)> {
     refs.iter().map(|r| (r.file, r.range)).collect()
+}
+
+/// Project rename edits to in-file ranges (single-file tests).
+pub fn edit_ranges(edits: &[RenameEdit]) -> Vec<TextRange> {
+    edits.iter().map(|e| e.range).collect()
+}
+
+/// Project rename edits to `(file, range)` pairs (cross-file tests).
+pub fn edit_pairs(edits: &[RenameEdit]) -> Vec<(File, TextRange)> {
+    edits.iter().map(|e| (e.file, e.range)).collect()
 }
 
 /// Install `name` as a library package exporting `exports`, with one file at

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -872,10 +872,23 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 if is_assignment(bin) {
                     self.collect_assignment(bin);
                 } else {
-                    // Operands first, as uses: `x %<>% f` is `x <- f(x)`, so `x`
-                    // is both a read and the binding target, and `f` is a use.
-                    if let Ok(lhs) = bin.left() {
-                        self.collect_expression(&lhs);
+                    let range = bin.syntax().text_trimmed_range();
+                    let is_binding_op = self
+                        .call_resolutions
+                        .get(&range)
+                        .is_some_and(|resolution| !resolution.assign.is_empty());
+
+                    // A binding operator (`x := expr`) treats its left operand
+                    // as a definition target, not a read, the same as `<-`. An
+                    // ordinary operator (`a + b`) reads both operands.
+                    //
+                    // TODO(nse): `%<>%` is compound (`x <- f(x)`), so it also
+                    // reads its target. Record that read once the registry
+                    // carries a per-operator "reads target" flag.
+                    if !is_binding_op {
+                        if let Ok(lhs) = bin.left() {
+                            self.collect_expression(&lhs);
+                        }
                     }
                     if let Ok(rhs) = bin.right() {
                         self.collect_expression(&rhs);

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -56,6 +56,7 @@ use oak_index_vec::IndexVec;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use crate::effects::AssignBinding;
 use crate::effects::ResolvedArgumentEffects;
 use crate::resolver::ImportsResolver;
 use crate::resolver::SourceResolution;
@@ -1231,6 +1232,17 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         {
             self.collect_source_call(call);
         }
+
+        // Assign: same recognition path. The scan cached the bound names; here we
+        // emit the definitions so they feed the use-def map, `exports()`, and
+        // goto.
+        if self
+            .call_resolutions
+            .get(&range)
+            .is_some_and(|resolution| !resolution.assign.is_empty())
+        {
+            self.collect_assign_call(call);
+        }
     }
 
     // ## `library()` / `require()` scoping
@@ -1329,6 +1341,42 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
+    // ## `assign()` binding
+    //
+    // `assign("x", value)` binds `x` in the current scope, the same as `x <-
+    // value` would. We record a `DefinitionKind::Assign` def so it feeds the
+    // use-def map, `exports()`, and goto exactly like a syntactic assignment.
+    // The name is not chased to its value, so an `assign("f", local)` def
+    // carries no NSE, just like `f <- local`.
+    fn collect_assign_call(&mut self, call: &aether_syntax::RCall) {
+        let range = call.syntax().text_trimmed_range();
+        let call_offset = range.start();
+
+        // Read back the bindings the scan extracted (their presence is what the
+        // caller checked before dispatching here).
+        let bindings = match self.call_resolutions.get(&range) {
+            Some(resolution) => resolution.assign.clone(),
+            None => return,
+        };
+
+        for binding in bindings {
+            // The precise name-token range is recovered from the stored `name`
+            // handle downstream, so the def's own range is the empty span at the
+            // call offset, mirroring `source()` imports.
+            let name_range = TextRange::empty(call_offset);
+            self.add_definition(
+                &binding.name,
+                SymbolFlags::IS_BOUND,
+                DefinitionKind::Assign {
+                    call: AstPtr::new(call),
+                    name: binding.name_expr,
+                    value: binding.value_expr,
+                },
+                name_range,
+            );
+        }
+    }
+
     fn finish(mut self) -> SemanticIndex {
         self.scopes[ScopeId::from(0)].descendants.end = self.scopes.next_id();
 
@@ -1389,11 +1437,14 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
 ///   `SemanticCall::Attach`.
 /// - `source`: the files a recognized `source()` call brings in, each with its
 ///   resolution.
+/// - `assign`: the bindings a recognized `assign()` call creates in the current
+///   scope. Non-empty is the recognition marker; the walk defines each binding.
 #[derive(Default)]
 struct CallResolution {
     arguments: Option<ResolvedArgumentEffects>,
     attach: Option<String>,
     source: Vec<SourcedFile>,
+    assign: Vec<AssignBinding>,
 }
 
 /// A single file a `source()` call brings in: its statically-extracted path and

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -1244,9 +1244,9 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             self.collect_source_call(call);
         }
 
-        // Assign: same recognition path. The scan cached the bound names; here we
-        // emit the definitions so they feed the use-def map, `exports()`, and
-        // goto.
+        // Assign: same recognition path. The scan cached the bound names and we
+        // emit the corresponding definitions so they feed the use-def map,
+        // `exports()`, and goto.
         if self
             .call_resolutions
             .get(&range)
@@ -1392,7 +1392,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
-    /// Emit the `Assign` definition for a binding operator (`x %<>% f()`) the
+    /// Emit the `Assign` definition for a binding operator (e.g. `x %<>% f()`) the
     /// scan recognized, after its operands were collected as uses.
     fn collect_assign_operator(&mut self, bin: &RBinaryExpression) {
         let range = bin.syntax().text_trimmed_range();
@@ -1464,8 +1464,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
 ///   `SemanticCall::Attach`.
 /// - `source`: the files a recognized `source()` call brings in, each with its
 ///   resolution.
-/// - `assign`: the bindings a recognized `assign()` call creates in the current
-///   scope. Non-empty is the recognition marker; the walk defines each binding.
+/// - `assign`: the bindings `assign()`-like calls create in the current scope.
 #[derive(Default)]
 struct CallResolution {
     arguments: Option<ResolvedArgumentEffects>,

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -637,12 +637,18 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                         }
                     }
                 } else {
+                    // A binding operator (`x %<>% f()`) binds its left operand.
+                    // Scan the operands as uses first, then record the binding,
+                    // so a later callee in this scope sees that name shadowed.
+                    // Mirrors the value-then-target order of the `is_assignment`
+                    // branch.
                     if let Ok(lhs) = bin.left() {
                         self.scan_expression(&lhs);
                     }
                     if let Ok(rhs) = bin.right() {
                         self.scan_expression(&rhs);
                     }
+                    self.scan_operator_assign(bin);
                 }
             },
 
@@ -866,12 +872,17 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 if is_assignment(bin) {
                     self.collect_assignment(bin);
                 } else {
+                    // Operands first, as uses: `x %<>% f` is `x <- f(x)`, so `x`
+                    // is both a read and the binding target, and `f` is a use.
                     if let Ok(lhs) = bin.left() {
                         self.collect_expression(&lhs);
                     }
                     if let Ok(rhs) = bin.right() {
                         self.collect_expression(&rhs);
                     }
+                    // A `%...%` operator the scan recognized as an assign effect
+                    // emits its binding here, after the operand uses.
+                    self.collect_assign_operator(bin);
                 }
             },
 
@@ -1350,7 +1361,6 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     // carries no NSE, just like `f <- local`.
     fn collect_assign_call(&mut self, call: &aether_syntax::RCall) {
         let range = call.syntax().text_trimmed_range();
-        let call_offset = range.start();
 
         // Read back the bindings the scan extracted (their presence is what the
         // caller checked before dispatching here).
@@ -1359,22 +1369,39 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             None => return,
         };
 
+        self.add_assign_definitions(&AnyRExpression::RCall(call.clone()), bindings);
+    }
+
+    fn add_assign_definitions(&mut self, node: &AnyRExpression, bindings: Vec<AssignBinding>) {
         for binding in bindings {
-            // The precise name-token range is recovered from the stored `name`
-            // handle downstream, so the def's own range is the empty span at the
-            // call offset, mirroring `source()` imports.
-            let name_range = TextRange::empty(call_offset);
+            // The def's own range is the name token, captured at scan time, so a
+            // cursor on the name at the definition site hit-tests to it, the same
+            // as a syntactic `<-` binding.
+            let name_range = binding.name_expr.text_trimmed_range();
+            let name = binding.name_expr.as_ptr().clone();
             self.add_definition(
                 &binding.name,
                 SymbolFlags::IS_BOUND,
                 DefinitionKind::Assign {
-                    call: AstPtr::new(call),
-                    name: binding.name_expr,
+                    node: AstPtr::new(node),
+                    name,
                     value: binding.value_expr,
                 },
                 name_range,
             );
         }
+    }
+
+    /// Emit the `Assign` definition for a binding operator (`x %<>% f()`) the
+    /// scan recognized, after its operands were collected as uses.
+    fn collect_assign_operator(&mut self, bin: &RBinaryExpression) {
+        let range = bin.syntax().text_trimmed_range();
+        let bindings = match self.call_resolutions.get(&range) {
+            Some(resolution) if !resolution.assign.is_empty() => resolution.assign.clone(),
+            _ => return,
+        };
+
+        self.add_assign_definitions(&AnyRExpression::RBinaryExpression(bin.clone()), bindings);
     }
 
     fn finish(mut self) -> SemanticIndex {

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -80,8 +80,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
 
         // Record each assigned name as a binding so a later callee in this scope
-        // sees it shadowed (the correctness win: `assign("local", identity)`
-        // masks base `local`), and cache the bindings for the walk to define.
+        // sees it shadowed (e.g. `assign("local", identity)` masks base
+        // `local`).
         if let Some(bindings) = assign {
             let range = call.syntax().text_trimmed_range();
             for binding in bindings {

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -1,9 +1,13 @@
 use aether_syntax::AnyRExpression;
+use aether_syntax::RBinaryExpression;
 use aether_syntax::RCall;
+use aether_syntax::RSyntaxKind;
 use biome_rowan::AstNode;
 use biome_rowan::AstNodeList;
+use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
 use biome_rowan::TextRange;
+use oak_core::range::RangedAstPtr;
 use oak_core::syntax_ext::AnyRSelectorExt;
 use oak_core::syntax_ext::RIdentifierExt;
 
@@ -15,6 +19,7 @@ use super::BoundNames;
 use super::SemanticIndexBuilder;
 use super::SourcedFile;
 use crate::effects::Argument;
+use crate::effects::AssignBinding;
 use crate::effects::CallContext;
 use crate::effects::Effects;
 use crate::effects::EffectsHandlers;
@@ -80,7 +85,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         if let Some(bindings) = assign {
             let range = call.syntax().text_trimmed_range();
             for binding in bindings {
-                self.record_binding(binding.name.clone());
+                self.record_binding(binding.name.clone(), range);
                 self.call_resolutions
                     .entry(range)
                     .or_default()
@@ -163,6 +168,53 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             .entry(call.syntax().text_trimmed_range())
             .or_default()
             .arguments = Some(nse_args);
+    }
+
+    /// Scan a binary operator for an assign effect (e.g. magrittr's `x %<>% f()`)
+    pub(super) fn scan_operator_assign(&mut self, bin: &RBinaryExpression) {
+        let Some(binding) = self.resolve_operator_assign(bin) else {
+            return;
+        };
+        self.record_binding(binding.name.clone(), bin.syntax().text_trimmed_range());
+        self.call_resolutions
+            .entry(bin.syntax().text_trimmed_range())
+            .or_default()
+            .assign
+            .push(binding);
+    }
+
+    /// Recognize a binding operator (`x %<>% f()`, `x %<~% expr`, `x := expr`)
+    /// as an assign effect and build its binding, or `None` for any other binary
+    /// operator.
+    fn resolve_operator_assign(&mut self, bin: &RBinaryExpression) -> Option<AssignBinding> {
+        let op = bin.operator().ok()?;
+
+        // A binding operator is either a `%...%` (`SPECIAL`, e.g. `%<>%`, where
+        // the operator text distinguishes it from `%>%`) or the walrus `:=`
+        // (`WALRUS`). Gate on the token kind before consulting the registry so we
+        // skip the resolver for ordinary operators like `+`.
+        if !matches!(op.kind(), RSyntaxKind::SPECIAL | RSyntaxKind::WALRUS) {
+            return None;
+        }
+        let op_text = op.text_trimmed();
+
+        // Bail early if this operator is not known to have effects annotations
+        if !effects_registry::annotates(op_text) {
+            return None;
+        }
+
+        let handlers = self.resolve_symbol_effects(op_text, bin.syntax().text_trimmed_range())?;
+        let _assign = handlers.assign?;
+
+        let left = bin.left().ok()?;
+        let right = bin.right().ok()?;
+        let (name, _) = assignment_name(&left)?;
+
+        Some(AssignBinding {
+            name,
+            name_expr: RangedAstPtr::new(&left),
+            value_expr: Some(AstPtr::new(&right)),
+        })
     }
 
     /// Copy the names a `Current + Lazy` body defines into the owner's
@@ -264,7 +316,6 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// Resolve a call's effects.
     fn resolve_effects(&mut self, call: &RCall) -> Option<Effects> {
         let handlers = self.resolve_effects_handlers(call)?;
-
         let ctx = CallContext::new();
 
         let arguments = handlers
@@ -313,57 +364,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         match &func {
             AnyRExpression::RIdentifier(ident) => {
                 let name = ident.name_text();
-
-                // First check for a local definition (which in the future may
-                // carry declared effects that we resolve here)
-                //
-                // Looked up from `flow_state` which already carries every
-                // eager binding visible here: the scope's own flow-precise
-                // bindings so far, plus the enclosing eager environment seeded
-                // at `begin_scan()`. Forward and deferred (lazy-routed)
-                // bindings are excluded. A forward one isn't in `flow_state`
-                // yet, and a deferred one (`on_load`, `<<-`) never enters it.
-                if self.flow_state.is_bound(&name) {
-                    return self.resolve_local_effects(&name);
-                }
-
-                // Bail early if it is known that no package annotates this name
-                // with effects. This speeds up the common case of no known annotations.
-                if !effects_registry::annotates(&name) {
-                    return None;
-                }
-
-                // Now check imports since the symbol is locally unbound. The
-                // arena's `current_scope` is the scan unit's scope (the descent
-                // pushes no arena scopes), so its laziness is the "am I in a lazy
-                // context" test the resolver needs. `attached_flow` is the
-                // flow-precise attach prefix during the file scan and the
-                // complete end-of-file set during the walk.
-                let lazy = self.scopes[self.current_scope].kind.is_lazy();
-                let effects = self
-                    .resolver
-                    .resolve_effects(&name, &self.attached_flow, lazy)?;
-
-                // The callee is unbound by any eager binding, so its effect
-                // holds. If a lazy-crossed ancestor binds it whole-scope, that
-                // binding's timing relative to this deferred body is
-                // undetermined, so the decision is a guess. Flag it.
-                //
-                // TODO(diagnostics): a symmetric attach ambiguity is out of
-                // scope here. A callee resolved not-effectful could be flipped
-                // by an attach from a sibling lazy body (`g <- function()
-                // library(shiny); f <- function() reactive({...}`). Detecting it
-                // needs the complete set of lazy-context attaches, a post-pass
-                // rather than this local ancestor check, so it belongs in the
-                // future salsa diagnostics query where this lint should move too.
-                if let Some(overwrite_range) = self.is_lazily_shadowed(&name) {
-                    self.record_lazy_shadow_ambiguity(
-                        name,
-                        call.syntax().text_trimmed_range(),
-                        overwrite_range,
-                    );
-                }
-                Some(effects)
+                self.resolve_symbol_effects(&name, call.syntax().text_trimmed_range())
             },
 
             AnyRExpression::RNamespaceExpression(ns_expr) => {
@@ -381,6 +382,60 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
 
             _ => None,
         }
+    }
+
+    /// Resolve a callee `sym` to its [`EffectsHandlers`].
+    ///
+    /// `range` is the invocation's range, used to anchor a lazy-shadow
+    /// diagnostic.
+    fn resolve_symbol_effects(&mut self, sym: &str, range: TextRange) -> Option<EffectsHandlers> {
+        // First check for a local definition (which in the future may
+        // carry declared effects that we resolve here)
+        //
+        // Looked up from `flow_state` which already carries every
+        // eager binding visible here: the scope's own flow-precise
+        // bindings so far, plus the enclosing eager environment seeded
+        // at `begin_scan()`. Forward and deferred (lazy-routed)
+        // bindings are excluded. A forward one isn't in `flow_state`
+        // yet, and a deferred one (`on_load`, `<<-`) never enters it.
+        if self.flow_state.is_bound(sym) {
+            return self.resolve_local_effects(sym);
+        }
+
+        // Bail early if it is known that no package annotates this name
+        // with effects. This speeds up the common case of no known annotations.
+        if !effects_registry::annotates(sym) {
+            return None;
+        }
+
+        // Now check imports since the symbol is locally unbound. The
+        // arena's `current_scope` is the scan unit's scope (the descent
+        // pushes no arena scopes), so its laziness is the "am I in a lazy
+        // context" test the resolver needs. `attached_flow` is the
+        // flow-precise attach prefix during the file scan and the
+        // complete end-of-file set during the walk.
+        let lazy = self.scopes[self.current_scope].kind.is_lazy();
+        let effects = self
+            .resolver
+            .resolve_effects(sym, &self.attached_flow, lazy)?;
+
+        // The callee is unbound by any eager binding, so its effect
+        // holds. If a lazy-crossed ancestor binds it whole-scope, that
+        // binding's timing relative to this deferred body is
+        // undetermined, so the decision is a guess. Flag it.
+        //
+        // TODO(diagnostics): a symmetric attach ambiguity is out of
+        // scope here. A callee resolved not-effectful could be flipped
+        // by an attach from a sibling lazy body (`g <- function()
+        // library(shiny); f <- function() reactive({...}`). Detecting it
+        // needs the complete set of lazy-context attaches, a post-pass
+        // rather than this local ancestor check, so it belongs in the
+        // future salsa diagnostics query where this lint should move too.
+        if let Some(overwrite_range) = self.is_lazily_shadowed(sym) {
+            self.record_lazy_shadow_ambiguity(sym.to_string(), range, overwrite_range);
+        }
+
+        Some(effects)
     }
 
     /// Local resolver for declared effects, mirroring the imports resolver's

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -27,9 +27,9 @@ use crate::semantic_index::ScopeKind;
 use crate::semantic_index::SemanticDiagnostic;
 
 impl<R: ImportsResolver> SemanticIndexBuilder<R> {
-    /// Scan a call for effects (NSE scopes, attaches, sources) and record its
-    /// decisions for the walk to reuse. The callee is resolved once through
-    /// [`resolve_effects`].
+    /// Scan a call for effects (NSE scopes, attaches, sources, assigns) and
+    /// record its decisions for the walk to reuse. The callee is resolved once
+    /// through [`resolve_effects`].
     ///
     /// `Current + Eager` and `Nested + Eager` arguments are scanned here:
     /// `Current + Eager` transparently, `Nested + Eager` by descending into the
@@ -38,9 +38,14 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// because resolution of effects in these lazy scopes needs the child's own
     /// flow context.
     pub(super) fn scan_call(&mut self, call: &RCall) {
-        let (nse_args, attach, source) = match self.resolve_effects(call) {
-            Some(effects) => (effects.arguments, effects.attach, effects.source),
-            None => (None, None, None),
+        let (nse_args, attach, source, assign) = match self.resolve_effects(call) {
+            Some(effects) => (
+                effects.arguments,
+                effects.attach,
+                effects.source,
+                effects.assign,
+            ),
+            None => (None, None, None, None),
         };
 
         if let Some(package) = attach {
@@ -66,6 +71,21 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     .or_default()
                     .source
                     .push(SourcedFile { path, resolution });
+            }
+        }
+
+        // Record each assigned name as a binding so a later callee in this scope
+        // sees it shadowed (the correctness win: `assign("local", identity)`
+        // masks base `local`), and cache the bindings for the walk to define.
+        if let Some(bindings) = assign {
+            let range = call.syntax().text_trimmed_range();
+            for binding in bindings {
+                self.record_binding(binding.name.clone());
+                self.call_resolutions
+                    .entry(range)
+                    .or_default()
+                    .assign
+                    .push(binding);
             }
         }
 
@@ -256,11 +276,15 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         let source = handlers
             .source
             .and_then(|handler| handler.resolve(call, &ctx));
+        let assign = handlers
+            .assign
+            .and_then(|handler| handler.resolve(call, &ctx));
 
         Some(Effects {
             arguments,
             attach,
             source,
+            assign,
         })
     }
 

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -5,6 +5,9 @@ use aether_syntax::RArgument;
 use aether_syntax::RCall;
 use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
+// Re-exported so consumers building an `AssignBinding` (custom `EffectHandler`s)
+// can name the `name_expr` field's type without depending on oak_core directly.
+pub use oak_core::range::RangedAstPtr;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
 
@@ -28,13 +31,15 @@ pub struct Effects {
 }
 
 /// One name an assign call binds, with the syntax handles its consumers need.
-/// The bound name feeds the symbol table; `name_expr` anchors goto and rename;
-/// `value_expr` is what a type checker infers the binding's type from (`None`
-/// when the call has no value argument).
+/// - The bound name feeds the symbol table.
+/// - `name_expr` anchors the goto target and carries the trimmed range the
+///   cursor hit-tests against, so goto/rename can start from the definition site.
+/// - `value_expr` is what a type checker infers the binding's type from (`None`
+///   with no value argument).
 #[derive(Debug, Clone)]
 pub struct AssignBinding {
     pub name: String,
-    pub name_expr: AstPtr<AnyRExpression>,
+    pub name_expr: RangedAstPtr<AnyRExpression>,
     pub value_expr: Option<AstPtr<AnyRExpression>>,
 }
 
@@ -66,7 +71,9 @@ pub trait EffectHandler: std::fmt::Debug + Sync {
 
 /// Context for effect handlers.
 ///
-/// Allows querying the properties or static values of arguments.
+/// Allows querying the properties or static values of arguments. Stateless
+/// today, an extension point for information a call's syntax doesn't carry (e.g.
+/// resolving a `character.only` variable to its string value) once that lands.
 #[derive(Default)]
 pub struct CallContext;
 
@@ -246,6 +253,10 @@ impl EffectHandler for SourceAnnotation {
         // to a named argument coming first (e.g. `source(echo = TRUE, "x.R")`),
         // which the call-position matching isn't yet. A named `file =` therefore
         // isn't recognized today.
+        //
+        // TODO(nse): once `match_arguments` is signature-aware (see `Formal`),
+        // the leading-named-arg robustness comes for free and this scan could
+        // fold onto it, keeping only the `local =` bail on top.
         let mut path: Option<String> = None;
         let mut positional = 0;
 
@@ -305,8 +316,13 @@ impl EffectHandler for AssignAnnotation {
         // Matched positionally among unnamed arguments, same as `source`, so a
         // leading named argument doesn't shift the count and a named `x =` isn't
         // recognized. The value is the positional right after the name (base
-        // `assign(x, value, ...)`); a named `value =` isn't captured yet.
-        let mut name: Option<(String, AstPtr<AnyRExpression>)> = None;
+        // `assign(x, value, ...)`).
+        //
+        // FIXME: A named `value =` isn't captured yet.
+        // TODO(nse): Fold onto `match_arguments()` once it's signature-aware,
+        // same as `source` (see `SourceAnnotation::resolve`), keeping only the
+        // `envir`/`pos` bail and the value-after-name read on top.
+        let mut name: Option<(String, RangedAstPtr<AnyRExpression>)> = None;
         let mut value_expr: Option<AstPtr<AnyRExpression>> = None;
         let mut positional = 0;
 
@@ -317,9 +333,11 @@ impl EffectHandler for AssignAnnotation {
                 let Ok(AnyRArgumentName::RIdentifier(name_ident)) = name_clause.name() else {
                     continue;
                 };
+
                 // An explicit target environment means the binding lands
                 // somewhere other than the current scope, so it isn't a fact we
-                // can record here.
+                // can record here. In the future, we could statically recognise
+                // some environment selectors like `parent.frame()`.
                 if matches!(name_ident.name_text().as_str(), "envir" | "pos") {
                     return None;
                 }
@@ -329,7 +347,7 @@ impl EffectHandler for AssignAnnotation {
             if positional == self.position {
                 if let Some(value) = arg.value() {
                     if let Some(resolved) = ctx.resolve_static_string(&value) {
-                        name = Some((resolved, AstPtr::new(&value)));
+                        name = Some((resolved, RangedAstPtr::new(&value)));
                     }
                 }
             } else if positional == self.position + 1 {

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -3,6 +3,7 @@ use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRValue;
 use aether_syntax::RArgument;
 use aether_syntax::RCall;
+use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
@@ -20,6 +21,21 @@ pub struct Effects {
     /// Source one or more files. A vector so a collation-style callee can name
     /// several; base `source` resolves to one.
     pub source: Option<Vec<String>>,
+    /// Bind one or more names in the current scope (`assign("x", value)`). A
+    /// vector so a multi-binding callee stays expressible; base `assign` and
+    /// `delayedAssign` resolve to one.
+    pub assign: Option<Vec<AssignBinding>>,
+}
+
+/// One name an assign call binds, with the syntax handles its consumers need.
+/// The bound name feeds the symbol table; `name_expr` anchors goto and rename;
+/// `value_expr` is what a type checker infers the binding's type from (`None`
+/// when the call has no value argument).
+#[derive(Debug, Clone)]
+pub struct AssignBinding {
+    pub name: String,
+    pub name_expr: AstPtr<AnyRExpression>,
+    pub value_expr: Option<AstPtr<AnyRExpression>>,
 }
 
 /// The handlers that compute a function's effects.
@@ -28,6 +44,7 @@ pub struct EffectsHandlers {
     pub arguments: Option<&'static dyn EffectHandler<Output = ResolvedArgumentEffects>>,
     pub attach: Option<&'static dyn EffectHandler<Output = String>>,
     pub source: Option<&'static dyn EffectHandler<Output = Vec<String>>>,
+    pub assign: Option<&'static dyn EffectHandler<Output = Vec<AssignBinding>>>,
 }
 
 /// Resolver for an effect of a call.
@@ -266,6 +283,67 @@ impl EffectHandler for SourceAnnotation {
         }
 
         path.map(|resolved| vec![resolved])
+    }
+}
+
+/// Declares how an assign function (`assign()`, `delayedAssign()`) names the
+/// variable it binds, and serves as the default [`EffectHandler`] for it by
+/// pulling that name out of a call.
+#[derive(Debug, Clone, Copy)]
+pub struct AssignAnnotation {
+    /// Which positional argument holds the bound name, counting only unnamed
+    /// arguments (0 for base `assign`/`delayedAssign`).
+    pub position: usize,
+}
+
+impl EffectHandler for AssignAnnotation {
+    type Output = Vec<AssignBinding>;
+
+    fn resolve(&self, call: &RCall, ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+        let args = call.arguments().ok()?;
+
+        // Matched positionally among unnamed arguments, same as `source`, so a
+        // leading named argument doesn't shift the count and a named `x =` isn't
+        // recognized. The value is the positional right after the name (base
+        // `assign(x, value, ...)`); a named `value =` isn't captured yet.
+        let mut name: Option<(String, AstPtr<AnyRExpression>)> = None;
+        let mut value_expr: Option<AstPtr<AnyRExpression>> = None;
+        let mut positional = 0;
+
+        for item in args.items().iter() {
+            let Ok(arg) = item else { continue };
+
+            if let Some(name_clause) = arg.name_clause() {
+                let Ok(AnyRArgumentName::RIdentifier(name_ident)) = name_clause.name() else {
+                    continue;
+                };
+                // An explicit target environment means the binding lands
+                // somewhere other than the current scope, so it isn't a fact we
+                // can record here.
+                if matches!(name_ident.name_text().as_str(), "envir" | "pos") {
+                    return None;
+                }
+                continue;
+            }
+
+            if positional == self.position {
+                if let Some(value) = arg.value() {
+                    if let Some(resolved) = ctx.resolve_static_string(&value) {
+                        name = Some((resolved, AstPtr::new(&value)));
+                    }
+                }
+            } else if positional == self.position + 1 {
+                value_expr = arg.value().map(|value| AstPtr::new(&value));
+            }
+            positional += 1;
+        }
+
+        let (name, name_expr) = name?;
+        Some(vec![AssignBinding {
+            name,
+            name_expr,
+            value_expr,
+        }])
     }
 }
 

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -32,8 +32,8 @@ pub struct Effects {
 
 /// One name an assign call binds, with the syntax handles its consumers need.
 /// - The bound name feeds the symbol table.
-/// - `name_expr` anchors the goto target and carries the trimmed range the
-///   cursor hit-tests against, so goto/rename can start from the definition site.
+/// - `name_expr` anchors the goto target and carries a trimmed range that can
+///   be matched against a cursor (e.g. for goto/rename).
 /// - `value_expr` is what a type checker infers the binding's type from (`None`
 ///   with no value argument).
 #[derive(Debug, Clone)]

--- a/crates/oak_semantic/src/effects_registry.rs
+++ b/crates/oak_semantic/src/effects_registry.rs
@@ -125,6 +125,10 @@ static REGISTRY: &[Entry] = &[
     // base assign
     assign!("base", "assign", 0),
     assign!("base", "delayedAssign", 0),
+    // magrittr / rlang / S7 binding operators
+    assign!("magrittr", "%<>%", 0),
+    assign!("rlang", "%<~%", 0),
+    assign!("S7", ":=", 0),
     // rlang
     nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
     // shiny

--- a/crates/oak_semantic/src/effects_registry.rs
+++ b/crates/oak_semantic/src/effects_registry.rs
@@ -1,5 +1,6 @@
 use crate::effects::Argument;
 use crate::effects::ArgumentsAnnotation;
+use crate::effects::AssignAnnotation;
 use crate::effects::AttachAnnotation;
 use crate::effects::EffectsHandlers;
 use crate::effects::SourceAnnotation;
@@ -50,6 +51,7 @@ macro_rules! nse {
                 }),
                 attach: None,
                 source: None,
+                assign: None,
             },
         }
     };
@@ -67,6 +69,7 @@ macro_rules! attach {
                     character_only: $character_only,
                 }),
                 source: None,
+                assign: None,
             },
         }
     };
@@ -83,6 +86,24 @@ macro_rules! source {
                 arguments: None,
                 attach: None,
                 source: Some(&SourceAnnotation { position: $pos }),
+                assign: None,
+            },
+        }
+    };
+}
+
+/// An assign entry: `(name-argument position)`. The function binds a name in the
+/// current scope.
+macro_rules! assign {
+    ($pkg:literal, $func:literal, $pos:literal) => {
+        Entry {
+            package: $pkg,
+            function: $func,
+            effects: EffectsHandlers {
+                arguments: None,
+                attach: None,
+                source: None,
+                assign: Some(&AssignAnnotation { position: $pos }),
             },
         }
     };
@@ -101,6 +122,9 @@ static REGISTRY: &[Entry] = &[
     attach!("base", "require", 0, true),
     // base source
     source!("base", "source", 0),
+    // base assign
+    assign!("base", "assign", 0),
+    assign!("base", "delayedAssign", 0),
     // rlang
     nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
     // shiny

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use aether_syntax::AnyRExpression;
 use aether_syntax::RBinaryExpression;
 use aether_syntax::RCall;
 use aether_syntax::RForStatement;
@@ -674,6 +675,15 @@ pub enum DefinitionKind {
         call: AstPtr<RCall>,
         file: Url,
         name: String,
+    },
+    /// A binding created by a call (e.g. `assign("x", value)`) rather than a
+    /// syntactic `<-`. `call` is the whole binding expression (for its range
+    /// and provenance), `name` the name argument (goto, rename), and `value`
+    /// the value argument a type checker infers from (`None` when absent).
+    Assign {
+        call: AstPtr<RCall>,
+        name: AstPtr<AnyRExpression>,
+        value: Option<AstPtr<AnyRExpression>>,
     },
 }
 

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -676,12 +676,13 @@ pub enum DefinitionKind {
         file: Url,
         name: String,
     },
-    /// A binding created by a call (e.g. `assign("x", value)`) rather than a
-    /// syntactic `<-`. `call` is the whole binding expression (for its range
-    /// and provenance), `name` the name argument (goto, rename), and `value`
-    /// the value argument a type checker infers from (`None` when absent).
+    /// A binding created by a call (e.g. `assign("x", value)`) or a binding
+    /// operator (`x %<>% f()`) rather than a syntactic `<-`. `node` is the whole
+    /// binding expression (for its range and provenance), `name` the name
+    /// argument or left operand (goto, rename), and `value` the value a type
+    /// checker infers from (`None` when absent).
     Assign {
-        call: AstPtr<RCall>,
+        node: AstPtr<AnyRExpression>,
         name: AstPtr<AnyRExpression>,
         value: Option<AstPtr<AnyRExpression>>,
     },

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -3,12 +3,12 @@ use aether_parser::RParserOptions;
 use aether_syntax::RCall;
 use aether_syntax::RSyntaxKind;
 use biome_rowan::AstNode;
-use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
 use oak_semantic::build_index;
 use oak_semantic::effects::AssignBinding;
 use oak_semantic::effects::CallContext;
 use oak_semantic::effects::EffectHandler;
+use oak_semantic::effects::RangedAstPtr;
 use oak_semantic::effects::SourceAnnotation;
 use oak_semantic::effects_registry;
 use oak_semantic::semantic_index::DefinitionId;
@@ -1658,6 +1658,161 @@ fn test_assign_without_value_has_no_value_handle() {
     ));
 }
 
+// --- binding operators (`%<>%`, `%<~%`) ---
+
+/// Build with `packages` attached (plus base), for package-contributed effects
+/// like magrittr's `%<>%` operator.
+fn index_with_attached(source: &str, packages: &[&str]) -> SemanticIndex {
+    let parsed = parse(source, RParserOptions::default());
+    if parsed.has_error() {
+        panic!("source has syntax errors: {source}");
+    }
+    build_index(&parsed.tree(), TestImportsResolver::with_attached(packages))
+}
+
+#[test]
+fn test_magrittr_compound_assignment_binds_lhs() {
+    // `x %<>% f()` is sugar for `x <- f(x)`, so it binds `x`, and both `x` and
+    // `f` are reads.
+    let index = index_with_attached("x %<>% f()", &["magrittr"]);
+    let file = ScopeId::from(0);
+
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { .. })
+    ));
+
+    // Operand uses, in collection order: `x` (left), then `f` (right).
+    assert_eq!(index.uses(file).len(), 2);
+    let symbols = index.symbols(file);
+    assert_eq!(
+        symbols
+            .symbol(index.uses(file)[UseId::from(0)].symbol())
+            .name(),
+        "x"
+    );
+    assert_eq!(
+        symbols
+            .symbol(index.uses(file)[UseId::from(1)].symbol())
+            .name(),
+        "f"
+    );
+}
+
+#[test]
+fn test_magrittr_compound_assignment_name_and_value_handles() {
+    // The `name` handle is the left operand (goto, rename), the `value` handle
+    // the right operand.
+    let source = "x %<>% f()";
+    let parsed = parse(source, RParserOptions::default());
+    assert!(!parsed.has_error());
+    let root = parsed.tree().syntax().clone();
+    let index = build_index(
+        &parsed.tree(),
+        TestImportsResolver::with_attached(&["magrittr"]),
+    );
+
+    let Some(DefinitionKind::Assign {
+        name,
+        value: Some(value),
+        ..
+    }) = only_assign_def(&index)
+    else {
+        panic!("expected an assign def with a value handle");
+    };
+    assert_eq!(name.to_node(&root).syntax().text_trimmed().to_string(), "x");
+    assert_eq!(
+        value.to_node(&root).syntax().text_trimmed().to_string(),
+        "f()"
+    );
+}
+
+#[test]
+fn test_rlang_lazy_assignment_binds_lhs() {
+    let index = index_with_attached("x %<~% compute()", &["rlang"]);
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { .. })
+    ));
+}
+
+#[test]
+fn test_s7_walrus_assignment_binds_lhs() {
+    // S7's `:=` binds its left operand, like `%<>%`. It's the `WALRUS` token
+    // kind rather than `SPECIAL`, so it exercises the other arm of the operator
+    // gate.
+    let index = index_with_attached("x := f()", &["S7"]);
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { .. })
+    ));
+}
+
+#[test]
+fn test_plain_operators_do_not_bind() {
+    // A pipe and a plain infix operator are not assign effects, even with
+    // magrittr attached: the match is on the exact operator text.
+    assert!(only_assign_def(&index_with_attached("x %>% f()", &["magrittr"])).is_none());
+    assert!(only_assign_def(&index_with_attached("x %in% y", &["magrittr"])).is_none());
+}
+
+#[test]
+fn test_compound_assignment_shadowed_by_local_binding_not_recognized() {
+    // A user-defined `%<>%` shadows magrittr's, so the operator binds nothing.
+    let index = index_with_attached("`%<>%` <- function(lhs, rhs) {}\nx %<>% f()", &["magrittr"]);
+    assert!(only_assign_def(&index).is_none());
+}
+
+#[test]
+fn test_compound_assignment_complex_lhs_not_recorded() {
+    // A complex target binds no name, matching `<-` on `x$y <- v`.
+    let index = index_with_attached("x$y %<>% f()", &["magrittr"]);
+    assert!(only_assign_def(&index).is_none());
+}
+
+#[test]
+fn test_compound_assignment_not_recognized_without_magrittr() {
+    // Package-aware: without magrittr attached, `%<>%` doesn't resolve, so it
+    // stays a plain operator and binds nothing.
+    let index = index_with_base("x %<>% f()");
+    assert!(only_assign_def(&index).is_none());
+}
+
+#[test]
+fn test_compound_assignment_use_resolves_to_binding() {
+    // A later use resolves to the operator's binding, the same as `assign()`.
+    let index = index_with_attached("y %<>% f()\ny", &["magrittr"]);
+    let file = ScopeId::from(0);
+
+    // Uses in order: `y` (left), `f` (right), then the trailing `y`.
+    let map = index.use_def_map(file);
+    let bindings = map.bindings_at_use(UseId::from(2));
+    assert_eq!(bindings.definitions().len(), 1);
+    let def = &index.definitions(file)[bindings.definitions()[0]];
+    assert!(matches!(def.kind(), DefinitionKind::Assign { .. }));
+}
+
+#[test]
+fn test_compound_assignment_definition_range_is_name() {
+    // The def's range is the left operand, so `definition_at` locates it when the
+    // cursor is on the name at the definition site (not an empty span).
+    let index = index_with_attached("value %<>% f()", &["magrittr"]);
+    let (scope, _id, def) = index
+        .definition_at(biome_rowan::TextSize::from(0))
+        .expect("assign def at the name offset");
+    assert_eq!(scope, ScopeId::from(0));
+    assert!(matches!(def.kind(), DefinitionKind::Assign { .. }));
+}
+
+#[test]
+fn test_compound_assignment_binding_masks_later_callee() {
+    // `local %<>% f()` binds `local`, so the later `local({ ... })` is shadowed
+    // and not treated as NSE (no nested scope pushed). The correctness win,
+    // parallel to `assign("local", identity)` masking base `local`.
+    let index = index_with_attached("local %<>% f()\nlocal({ x <- 1 })", &["magrittr"]);
+    assert_eq!(index.scope_ids().count(), 1);
+}
+
 /// Project each access into a comparable tuple via the public accessors.
 fn accesses(index: &SemanticIndex) -> Vec<(&str, &str, NamespaceAccessKind, u32)> {
     index
@@ -2039,7 +2194,7 @@ impl EffectHandler for MultiAssignHandler {
             .next()?
             .ok()?
             .value()?;
-        let ptr = AstPtr::new(&expr);
+        let ptr = RangedAstPtr::new(&expr);
         Some(vec![
             AssignBinding {
                 name: "a".into(),

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -1672,8 +1672,11 @@ fn index_with_attached(source: &str, packages: &[&str]) -> SemanticIndex {
 
 #[test]
 fn test_magrittr_compound_assignment_binds_lhs() {
-    // `x %<>% f()` is sugar for `x <- f(x)`, so it binds `x`, and both `x` and
-    // `f` are reads.
+    // `x %<>% f()` binds `x`. The left operand is a definition target, not a
+    // read, the same as `<-`, so only `f` (the right operand) is a use.
+    //
+    // `%<>%` is compound (`x <- f(x)`), so `x` is conceptually read too, but we
+    // don't record that read yet. See the `TODO(nse)` in the walk's binary arm.
     let index = index_with_attached("x %<>% f()", &["magrittr"]);
     let file = ScopeId::from(0);
 
@@ -1682,18 +1685,12 @@ fn test_magrittr_compound_assignment_binds_lhs() {
         Some(DefinitionKind::Assign { .. })
     ));
 
-    // Operand uses, in collection order: `x` (left), then `f` (right).
-    assert_eq!(index.uses(file).len(), 2);
+    // Only the right operand `f` is a use; the target `x` is not recorded.
+    assert_eq!(index.uses(file).len(), 1);
     let symbols = index.symbols(file);
     assert_eq!(
         symbols
             .symbol(index.uses(file)[UseId::from(0)].symbol())
-            .name(),
-        "x"
-    );
-    assert_eq!(
-        symbols
-            .symbol(index.uses(file)[UseId::from(1)].symbol())
             .name(),
         "f"
     );
@@ -1749,6 +1746,24 @@ fn test_s7_walrus_assignment_binds_lhs() {
 }
 
 #[test]
+fn test_binding_operator_left_operand_is_not_a_use() {
+    // A pure-binding operator (`:=` is `x <- expr`, not compound) reads only its
+    // right operand. The left operand `x` is the binding target, not a use, so
+    // exactly one use is recorded and it's the value operand.
+    let index = index_with_attached("x := f()", &["S7"]);
+    let file = ScopeId::from(0);
+
+    assert_eq!(index.uses(file).len(), 1);
+    assert_eq!(
+        index
+            .symbols(file)
+            .symbol(index.uses(file)[UseId::from(0)].symbol())
+            .name(),
+        "f"
+    );
+}
+
+#[test]
 fn test_plain_operators_do_not_bind() {
     // A pipe and a plain infix operator are not assign effects, even with
     // magrittr attached: the match is on the exact operator text.
@@ -1784,9 +1799,10 @@ fn test_compound_assignment_use_resolves_to_binding() {
     let index = index_with_attached("y %<>% f()\ny", &["magrittr"]);
     let file = ScopeId::from(0);
 
-    // Uses in order: `y` (left), `f` (right), then the trailing `y`.
+    // Uses in order: `f` (right operand), then the trailing `y`. The left
+    // operand `y` is the binding target, not a use.
     let map = index.use_def_map(file);
-    let bindings = map.bindings_at_use(UseId::from(2));
+    let bindings = map.bindings_at_use(UseId::from(1));
     assert_eq!(bindings.definitions().len(), 1);
     let def = &index.definitions(file)[bindings.definitions()[0]];
     assert!(matches!(def.kind(), DefinitionKind::Assign { .. }));

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -2,7 +2,11 @@ use aether_parser::parse;
 use aether_parser::RParserOptions;
 use aether_syntax::RCall;
 use aether_syntax::RSyntaxKind;
+use biome_rowan::AstNode;
+use biome_rowan::AstPtr;
+use biome_rowan::AstSeparatedList;
 use oak_semantic::build_index;
+use oak_semantic::effects::AssignBinding;
 use oak_semantic::effects::CallContext;
 use oak_semantic::effects::EffectHandler;
 use oak_semantic::effects::SourceAnnotation;
@@ -1545,6 +1549,115 @@ fn test_source_call_recognized_under_base_resolver() {
     assert_eq!(index.semantic_calls().len(), 1);
 }
 
+// --- assign() ---
+
+/// The single `DefinitionKind::Assign` def in a file, or `None`.
+fn only_assign_def(index: &SemanticIndex) -> Option<&DefinitionKind> {
+    let file = ScopeId::from(0);
+    let mut defs = index
+        .definitions(file)
+        .iter()
+        .map(|(_, def)| def.kind())
+        .filter(|kind| matches!(kind, DefinitionKind::Assign { .. }));
+    let first = defs.next();
+    assert!(defs.next().is_none());
+    first
+}
+
+#[test]
+fn test_assign_records_definition() {
+    // `assign("x", 1)` binds `x` in the current scope, and the later use of `x`
+    // resolves to that definition.
+    let index = index_with_base("assign(\"x\", 1)\nx");
+    let file = ScopeId::from(0);
+
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { .. })
+    ));
+
+    // Uses: assign(0), x(1). The `x` use binds to the assign-created def.
+    let map = index.use_def_map(file);
+    let bindings = map.bindings_at_use(UseId::from(1));
+    assert_eq!(bindings.definitions().len(), 1);
+    let def = &index.definitions(file)[bindings.definitions()[0]];
+    assert!(matches!(def.kind(), DefinitionKind::Assign { .. }));
+}
+
+#[test]
+fn test_assign_qualified_base_call_recognized() {
+    // The namespaced form resolves through `resolve_qualified_effects`.
+    let index = index_with_base("base::assign(\"x\", 1)");
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { .. })
+    ));
+}
+
+#[test]
+fn test_delayed_assign_records_definition() {
+    let index = index_with_base("delayedAssign(\"x\", expensive())");
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { .. })
+    ));
+}
+
+#[test]
+fn test_assign_non_literal_name_not_recorded() {
+    // A dynamic name can't be pinned, so the effect is recognized but nothing
+    // is recorded (same spirit as a dynamic `source()` path).
+    let index = index_with_base("assign(nm, 1)");
+    assert!(only_assign_def(&index).is_none());
+}
+
+#[test]
+fn test_assign_explicit_envir_not_recorded() {
+    // An explicit target environment binds outside the current scope, so we
+    // skip it rather than record a def in the wrong place.
+    let index = index_with_base("assign(\"x\", 1, envir = e)");
+    assert!(only_assign_def(&index).is_none());
+}
+
+#[test]
+fn test_assign_shadowed_by_local_binding_not_recognized() {
+    // A user-defined `assign` shadows base `assign`, so the call binds nothing.
+    let index = index_with_base("assign <- function(...) {}\nassign(\"x\", 1)");
+    assert!(only_assign_def(&index).is_none());
+}
+
+#[test]
+fn test_assign_value_handle_points_at_value_expression() {
+    // The stored `value` handle resolves to the value argument, which is what a
+    // type checker infers the binding's type from.
+    let parsed = parse("assign(\"x\", 1 + 2)", RParserOptions::default());
+    assert!(!parsed.has_error());
+    let root = parsed.tree().syntax().clone();
+    let index = build_index(&parsed.tree(), TestImportsResolver::with_base());
+
+    let kind = only_assign_def(&index).expect("assign def");
+    let DefinitionKind::Assign {
+        value: Some(value), ..
+    } = kind
+    else {
+        panic!("expected a value handle");
+    };
+    assert_eq!(
+        value.to_node(&root).syntax().text_trimmed().to_string(),
+        "1 + 2"
+    );
+}
+
+#[test]
+fn test_assign_without_value_has_no_value_handle() {
+    // The name still binds, but there's no value argument to infer from.
+    let index = index_with_base("assign(\"x\")");
+    assert!(matches!(
+        only_assign_def(&index),
+        Some(DefinitionKind::Assign { value: None, .. })
+    ));
+}
+
 /// Project each access into a comparable tuple via the public accessors.
 fn accesses(index: &SemanticIndex) -> Vec<(&str, &str, NamespaceAccessKind, u32)> {
     index
@@ -1874,6 +1987,7 @@ impl ImportsResolver for MultiFileResolver {
                 arguments: None,
                 attach: None,
                 source: Some(&COLLATION_HANDLER),
+                assign: None,
             });
         }
         effects_registry::lookup("base", name).copied()
@@ -1897,6 +2011,64 @@ impl ImportsResolver for PositionResolver {
                 arguments: None,
                 attach: None,
                 source: Some(&SOURCE_AT_POSITION_1),
+                assign: None,
+            });
+        }
+        None
+    }
+}
+
+/// An assign handler that binds a fixed set of names, standing in for a
+/// multi-binding callee. Attached to `assign` by [`MultiAssignResolver`].
+#[derive(Debug)]
+struct MultiAssignHandler;
+
+static MULTI_ASSIGN_HANDLER: MultiAssignHandler = MultiAssignHandler;
+
+impl EffectHandler for MultiAssignHandler {
+    type Output = Vec<AssignBinding>;
+
+    fn resolve(&self, call: &RCall, _ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+        // Point every binding's handles at the first argument. This test only
+        // checks that multiple defs are created and resolve, not their ranges.
+        let expr = call
+            .arguments()
+            .ok()?
+            .items()
+            .iter()
+            .next()?
+            .ok()?
+            .value()?;
+        let ptr = AstPtr::new(&expr);
+        Some(vec![
+            AssignBinding {
+                name: "a".into(),
+                name_expr: ptr.clone(),
+                value_expr: None,
+            },
+            AssignBinding {
+                name: "b".into(),
+                name_expr: ptr,
+                value_expr: None,
+            },
+        ])
+    }
+}
+
+struct MultiAssignResolver;
+
+impl ImportsResolver for MultiAssignResolver {
+    fn resolve_source(&mut self, _path: &str) -> Option<SourceResolution> {
+        None
+    }
+
+    fn resolve_effects(&mut self, name: &str, _: &[String], _: bool) -> Option<EffectsHandlers> {
+        if name == "assign" {
+            return Some(EffectsHandlers {
+                arguments: None,
+                attach: None,
+                source: None,
+                assign: Some(&MULTI_ASSIGN_HANDLER),
             });
         }
         None
@@ -2191,4 +2363,29 @@ fn test_source_call_leading_named_arg_still_finds_path() {
         path: "helpers.R".into(),
         resolved: None,
     }]);
+}
+
+#[test]
+fn test_assign_resolver_multiple_names_each_defined() {
+    // An assign handler can bind several names from one call. Each becomes its
+    // own definition and resolves at its use.
+    let code = "assign(\"unused\")\na\nb\n";
+    let index = build_test_index(code, MultiAssignResolver);
+    let file = ScopeId::from(0);
+
+    let assign_defs = index
+        .definitions(file)
+        .iter()
+        .filter(|(_, def)| matches!(def.kind(), DefinitionKind::Assign { .. }))
+        .count();
+    assert_eq!(assign_defs, 2);
+
+    // Uses: assign(0), a(1), b(2). Both resolve to an assign-created def.
+    let map = index.use_def_map(file);
+    for use_index in [1, 2] {
+        let bindings = map.bindings_at_use(UseId::from(use_index));
+        assert_eq!(bindings.definitions().len(), 1);
+        let def = &index.definitions(file)[bindings.definitions()[0]];
+        assert!(matches!(def.kind(), DefinitionKind::Assign { .. }));
+    }
 }

--- a/crates/oak_semantic/tests/integration/builder_nse.rs
+++ b/crates/oak_semantic/tests/integration/builder_nse.rs
@@ -994,6 +994,54 @@ local({
     );
 }
 
+#[test]
+fn test_nse_assign_shadows_base_callee_eager() {
+    // `assign("local", identity)` binds `local`, so the later `local({...})` is
+    // NOT NSE. The scan records the assign-created binding in flow order, so the
+    // later callee sees the shadow in the same pass.
+    let index = index(
+        "\
+assign(\"local\", identity)
+local({
+    x <- 1
+})
+",
+    );
+    let file = ScopeId::from(0);
+
+    // No NSE scope: `local` is shadowed, so `x` lands at file scope.
+    assert_eq!(index.scope_ids().count(), 1);
+    assert_eq!(
+        index.symbols(file).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
+#[test]
+fn test_nse_assign_shadows_base_callee_in_lazy_body() {
+    // The file-scope `assign("local", ...)` must be visible to the lazy shadow
+    // check when `f`'s deferred body resolves `local`. The file scan completes
+    // before the walk enters `f`, so `bound_names[file]` already carries
+    // `local` and the callee is correctly treated as shadowed (not NSE).
+    let index = index(
+        "\
+assign(\"local\", identity)
+f <- function() local({
+    x <- 1
+})
+",
+    );
+
+    // Scopes: file(0) and f(1) only. A phantom NSE scope inside `f` would be a
+    // third.
+    assert_eq!(index.scope_ids().count(), 2);
+    let f_scope = ScopeId::from(1);
+    assert_eq!(
+        index.symbols(f_scope).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+}
+
 // --- Current + Lazy owner bindings visible before the walk ---
 
 #[test]

--- a/crates/oak_semantic/tests/integration/resolvers.rs
+++ b/crates/oak_semantic/tests/integration/resolvers.rs
@@ -33,8 +33,17 @@ impl TestImportsResolver {
     /// Resolver with base always attached: the minimum for the bare base NSE
     /// functions (`local`, `with`, `within`, `evalq`) to resolve.
     pub fn with_base() -> Self {
+        Self::with_attached(&[])
+    }
+
+    /// Resolver with `packages` always attached, plus base last. For effects
+    /// contributed by a package that would otherwise need a `library()` call to
+    /// enter the flow-precise attach set, e.g. magrittr's `%<>%` operator.
+    pub fn with_attached(packages: &[&str]) -> Self {
+        let mut always_attached: Vec<String> = packages.iter().map(|pkg| pkg.to_string()).collect();
+        always_attached.push(String::from("base"));
         Self {
-            always_attached: vec![String::from("base")],
+            always_attached,
             consultations: Rc::new(Cell::new(0)),
             consultation_log: Rc::new(RefCell::new(Vec::new())),
             sources: HashMap::new(),


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338
Branched from https://github.com/posit-dev/ark/pull/1341

Adds `Assign` as the fourth effect kind, after NSE, attach, and source. A call or operator that binds a name with `Assign` now creates a real definition that feeds the use-def map, `exports()`, goto, and rename exactly like a syntactic `<-`. These Assign effects are shadow-, source-, and attach-aware.

Two forms:

- **Calls** like `assign("x", value)` and `delayedAssign("x", value)`. The name is the string first argument, the value the next positional. Bails when `envir =` or `pos =` is set, since then the binding lands outside the current scope and we can't state it as a fact.
- **Operators** like `x %<>% f()` (magrittr), `x %<~% expr` (rlang), `x := expr` (S7).

Impl notes:

- A new `DefinitionKind::Assign` models this effect in the semantic index.

- A new `RangedAstPtr` wrapper of `AstPtr` allows carrying the trimmed range of the name node. `AstPtr` only carries the full range, and requires the root node to resolve a trimmed range, which is unergonomic.

Goto and rename now work with custom Assign calls. When a name is bound in string form (e.g. `assign("x", ...)`) the rename occurs in place as a string to keep the quotes. To make this easier I've dropped the normalisation of strings during renames (which matches your preference Davis, cf previous discussion).

To support that cleanly, the decision of how a renamed name is spelled moved out of the LSP layer into `oak_ide`. This way the LSP layer only converts ranges and wires files.


### Positron Release Notes

<!--
  These notes are typically filled by the Positron team. If you are an external
  contributor, you may leave the `N/A` bullets in place.
-->

#### New Features

- Code navigation and renaming now understands custom assignment calls and operators like `assign()`, `delayedAssign()`, `%<>%` from magrittr, `:=` from S7, etc.

#### Bug Fixes

- N/A
