### PR TITLE
Add `attached_packages_anywhere()` for lazy view

### DIFF
--- a/crates/oak_db/src/file.rs
+++ b/crates/oak_db/src/file.rs
@@ -195,15 +195,34 @@ impl File {
         Arc::clone(self.semantic_index(db).use_def_map(scope))
     }
 
-    /// Package names from `library()` / `require()` calls in this file,
-    /// including those propagated transitively through `source()` chains.
-    /// Ordered by call-site position, which preserves R's search-path
-    /// semantics: a later `library(b)` shadows an earlier `library(a)`
-    /// when both export the same name.
+    /// Package names from `library()` / `require()` calls that run at the
+    /// file's own top level, including those propagated transitively through
+    /// `source()` chains. Ordered by call-site position, which preserves R's
+    /// search-path semantics: a later `library(b)` shadows an earlier
+    /// `library(a)` when both export the same name.
+    ///
+    /// A `library()` in a function body does not count here; for every attach
+    /// regardless of context see [`Self::attached_packages_anywhere`].
     #[salsa::tracked(returns(ref))]
     pub fn attached_packages(self, db: &dyn Db) -> Vec<Name<'_>> {
         self.semantic_index(db)
             .attached_packages()
+            .into_iter()
+            .map(|s| Name::new(db, s))
+            .collect()
+    }
+
+    /// Every `library()` / `require()` package in the file, including attaches
+    /// in function bodies and other lazy contexts (see
+    /// [`SemanticIndex::attached_packages_anywhere`]).
+    ///
+    /// Over-approximates the load-time search path. Used for workspace
+    /// dependency discovery, where a package attached only inside a function
+    /// still counts as a dependency.
+    #[salsa::tracked(returns(ref))]
+    pub fn attached_packages_anywhere(self, db: &dyn Db) -> Vec<Name<'_>> {
+        self.semantic_index(db)
+            .attached_packages_anywhere()
             .into_iter()
             .map(|s| Name::new(db, s))
             .collect()
@@ -231,7 +250,9 @@ impl File {
     /// All packages used in this file
     ///
     /// Sources:
-    /// - [Self::attached_packages()], i.e. `library()` or `require()`
+    /// - [Self::attached_packages_anywhere()], i.e. `library()` or `require()`
+    ///   anywhere in the file (a package attached only inside a function is
+    ///   still a dependency)
     /// - [Self::namespace_accessed_packages()], i.e. `::` or `:::`
     ///
     /// Packages are sorted by name and are unique. This maximizes the ability to
@@ -239,7 +260,7 @@ impl File {
     #[salsa::tracked(returns(ref))]
     pub fn used_packages(self, db: &dyn Db) -> Vec<Name<'_>> {
         let mut names: Vec<Name<'_>> = Vec::new();
-        names.extend(self.attached_packages(db));
+        names.extend(self.attached_packages_anywhere(db));
         names.extend(self.namespace_accessed_packages(db));
         names.sort_by_cached_key(|package| package.text(db));
         names.dedup();

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -21,9 +21,9 @@ use crate::RootKind;
 /// - `target.exports(db)` for the names `source()` injects into the
 ///   calling scope.
 ///
-/// - `target.attached_packages(db)` for the target's file-scope `library()`
-///   calls. `source()` runs the target's top-level statements at load time,
-///   so any attach calls take effect in the caller's search path.
+/// - `target.attached_packages(db)` for the target's top-level `library()`
+///   calls, the ones `source()` actually runs. A `library()` buried in a
+///   function body has not run at source time, so it is excluded.
 ///
 /// Both return PartialEq-stable values (a `FileExports` map and a
 /// `Vec<String>` respectively), so body-only edits to the target backdate
@@ -73,6 +73,7 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
             .iter()
             .map(|(name, _)| name.to_string())
             .collect();
+
         let packages: Vec<String> = file
             .attached_packages(self.db)
             .iter()

--- a/crates/oak_db/src/tests/resolver.rs
+++ b/crates/oak_db/src/tests/resolver.rs
@@ -228,6 +228,25 @@ fn test_sourced_file_library_attaches_in_caller() {
 }
 
 #[test]
+fn test_lazy_library_in_sourced_file_does_not_attach_in_caller() {
+    // `b.R` calls `library(shiny)` inside a function body, so it attaches only
+    // if that function runs. Sourcing `b.R` defines the function but never
+    // calls it, so `shiny` must not be forwarded into the caller. `b.R`'s
+    // eager top-level `library(dplyr)` does forward.
+    let mut db = TestDb::new();
+    let (_, scripts) = setup_workspace(&mut db, &[
+        ("a.R", "source(\"b.R\")\n"),
+        ("b.R", "library(dplyr)\nf <- function() library(shiny)\n"),
+    ]);
+    let a = scripts[0];
+
+    let index = a.semantic_index(&db);
+    let attaches = index.attached_packages();
+    assert!(attaches.contains(&"dplyr"));
+    assert!(!attaches.contains(&"shiny"));
+}
+
+#[test]
 fn test_source_to_unregistered_url_resolves_to_none() {
     // `a.R` sources `b.R` but `b.R` isn't registered. The `Source`
     // semantic call is still recorded so diagnostics can flag the

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -174,15 +174,58 @@ impl SemanticIndex {
         exports
     }
 
-    /// Package names from `library()` / `require()` calls in this file.
+    /// Package names from `library()` / `require()` calls that run at the
+    /// file's own top level.
+    ///
+    /// A `library()` reached only by running a lazy body attaches only if that
+    /// body runs, which may be never, so it does not count here. That covers a
+    /// function body, a lazy NSE argument, and an eager `local()` *nested*
+    /// inside one (see [`Self::scope_is_eager`]). This is the load-time
+    /// search-path view: what another file sees after `source()`-ing this one,
+    /// and what an eager callee resolves against. For every `library()`
+    /// regardless of context, see [`Self::attached_packages_anywhere`].
     pub fn attached_packages(&self) -> Vec<&str> {
         self.semantic_calls
             .iter()
-            .filter_map(|c| match &c.kind {
+            .filter(|call| self.scope_is_eager(call.scope))
+            .filter_map(|call| match &call.kind {
                 SemanticCallKind::Attach { package } => Some(package.as_str()),
                 SemanticCallKind::Source { .. } => None,
             })
             .collect()
+    }
+
+    /// Every `library()` / `require()` call in the file, including those in
+    /// function bodies and other lazy contexts.
+    ///
+    /// Over-approximates the load-time search path, since a lazy body may never
+    /// run, so most callers want [`Self::attached_packages`]. Use this only
+    /// where a lazy attach still counts, e.g. "which packages does this file
+    /// depend on" for workspace dependency discovery.
+    pub fn attached_packages_anywhere(&self) -> Vec<&str> {
+        self.semantic_calls
+            .iter()
+            .filter_map(|call| match &call.kind {
+                SemanticCallKind::Attach { package } => Some(package.as_str()),
+                SemanticCallKind::Source { .. } => None,
+            })
+            .collect()
+    }
+
+    /// Whether `scope` runs during the file's own top-level execution, i.e. no
+    /// enclosing scope is lazy.
+    fn scope_is_eager(&self, scope_id: ScopeId) -> bool {
+        let mut ancestor_id = Some(scope_id);
+
+        while let Some(id) = ancestor_id {
+            let ancestor_scope = self.scope(id);
+            if ancestor_scope.kind.is_lazy() {
+                return false;
+            }
+            ancestor_id = ancestor_scope.parent;
+        }
+
+        true
     }
 
     /// Cross-file call sites (`library()`, `source()`, …) recorded

--- a/crates/oak_semantic/tests/integration/builder_nse.rs
+++ b/crates/oak_semantic/tests/integration/builder_nse.rs
@@ -1657,6 +1657,35 @@ reactive({
 }
 
 #[test]
+fn test_nse_attach_eager_body_inside_lazy_body_is_deferred() {
+    // `local` is eager, but it sits inside `f`'s function body, so reaching
+    // its `library(shiny)` waits on `f()` being called. The attach is recorded
+    // (at `local`'s eager scope) but does not run at the file's top level: the
+    // eager `attached_packages()` must exclude it, only `_anywhere()` sees it.
+    // Guards against a one-scope `is_lazy()` check that misses the lazy
+    // ancestor.
+    let index = index(
+        "\
+f <- function() {
+    local({
+        library(shiny)
+    })
+}
+",
+    );
+    let f_scope = ScopeId::from(1);
+    let local_scope = ScopeId::from(2);
+
+    assert!(index.attached_packages().is_empty());
+    assert_eq!(index.attached_packages_anywhere(), vec!["shiny"]);
+    assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
+    assert_eq!(
+        index.scope(local_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+    );
+}
+
+#[test]
 fn test_nse_attach_local_shadow_still_wins() {
     // A local `reactive` def shadows shiny's, so the call is not NSE even with
     // shiny attached.
@@ -1778,8 +1807,11 @@ f <- function() {
     );
     let f_scope = ScopeId::from(1);
 
-    // The attach is recorded (scoped to `f`), but not fed to `reactive`.
-    assert_eq!(index.attached_packages(), vec!["shiny"]);
+    // The attach is recorded (scoped to `f`), but not fed to `reactive`, and
+    // not counted at the file's top level: only `attached_packages_anywhere()`
+    // sees a `library()` buried in a function body.
+    assert_eq!(index.attached_packages_anywhere(), vec!["shiny"]);
+    assert!(index.attached_packages().is_empty());
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
 }


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338
Branched from https://github.com/posit-dev/ark/pull/1342

Splits the file's attach output into two views:

- `attached_packages()` now returns only packages attached at the file's own top level (eager context). A `library()` in a function body, a lazy NSE argument doesn't count, because reaching it depends on that lazy body running. This reflects the EOF view of attached packages, uncontradicted by lazy effects.

- A new variant `attached_packages_anywhere()` returns every `library()`/`require()` regardless of context. `used_packages()` now uses this view.
