### PR TITLE
Implement cross-file effect resolution

### DIFF
--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use biome_rowan::TextSize;
 use camino::Utf8Path;
 use oak_package_metadata::namespace::Namespace;
-use oak_semantic::semantic_index::SemanticCall;
 use oak_semantic::semantic_index::SemanticCallKind;
 use oak_semantic::ScopeId;
 
@@ -31,6 +30,51 @@ pub enum ImportLayer {
     Package(Package),
 }
 
+/// The cross-file layers a file sees at load time, split at the point where the
+/// file's own `library()` attaches slot in.
+///
+/// `above` outranks the file's own attaches. It holds sibling and predecessor
+/// definitions plus the NAMESPACE imports, the parts R searches before the
+/// attached search path. `below` is the rest of the search path: predecessor
+/// attaches, the test runner's implicit attaches, and `base`.
+///
+/// The file's own attaches are deliberately left out, so building this never
+/// reads the file's own semantic index. That's what lets the resolver call it
+/// while that index is still being built (see [`SalsaImportsResolver`]). Each
+/// caller splices its own attaches between the two bands: [`File::imports`]
+/// reads them from the file's index, the resolver takes them from the builder's
+/// flow-ordered set.
+///
+/// [`SalsaImportsResolver`]: crate::imports::SalsaImportsResolver
+pub(crate) struct CrossFileLayers {
+    pub above: Vec<ImportLayer>,
+    pub below: Vec<ImportLayer>,
+}
+
+impl CrossFileLayers {
+    /// Flatten to a single lookup-ordered layer list, splicing the file's own
+    /// `library()` attaches into the band between the definition/namespace
+    /// layers (which outrank them) and the rest of the search path.
+    pub(crate) fn splice_own_attaches(self, own: Vec<ImportLayer>) -> Vec<ImportLayer> {
+        let CrossFileLayers { mut above, below } = self;
+        above.reserve(own.len() + below.len());
+        above.extend(own);
+        above.extend(below);
+        above
+    }
+}
+
+/// The point in a package's load at which a file views its collation siblings.
+#[derive(Clone, Copy)]
+pub(crate) enum CollationView {
+    /// Deferred (a function body, or end-of-file): the code runs after the
+    /// whole collation has loaded, so every sibling is visible.
+    Lazy,
+    /// In load order (a top-level statement): only siblings sourced before this
+    /// point have loaded, so a name defined later in the collation isn't visible.
+    Eager,
+}
+
 #[salsa::tracked]
 impl File {
     /// The import layers visible to this file at end-of-file, in R's lookup
@@ -49,19 +93,9 @@ impl File {
     /// of imports.
     #[salsa::tracked(returns(ref))]
     pub fn imports(self, db: &dyn Db) -> Vec<ImportLayer> {
-        match self.package(db) {
-            Some(package) if is_testthat_file(self, db) => {
-                testthat_imports(self, db, package, None)
-            },
-            Some(package) if is_package_source(self, db, package) => {
-                package_imports(self, db, package)
-            },
-            // A file with a package back-pointer that isn't a loadable `R/`
-            // file (`data-raw/`, `inst/`, a non-collated `R/` file) lives in
-            // the package but isn't loaded with it. Resolve it as a standalone
-            // script, same as a file with no package at all.
-            _ => script_imports(self, db),
-        }
+        let layers = self.cross_file_layers(db, CollationView::Lazy);
+        let own = self.attach_layers(db, None);
+        layers.splice_own_attaches(own)
     }
 
     /// Import layers visible at an `offset` in a file:
@@ -94,144 +128,127 @@ impl File {
             return self.imports(db).clone();
         }
 
-        // Top-level cursor: sequential narrowing.
+        // Top-level cursor: predecessors only, and own attaches narrowed to the
+        // calls that have run by `offset`.
+        let layers = self.cross_file_layers(db, CollationView::Eager);
+        let own = self.attach_layers(db, Some(offset));
+        layers.splice_own_attaches(own)
+    }
+
+    /// This file's own `library()` / `require()` attaches as `Package` layers,
+    /// in LIFO order (latest-attached first). Reads the file's own semantic
+    /// index. `before` selects which calls to include:
+    ///
+    /// - `None`: every attach. The end-of-file view, used for lazy contexts.
+    /// - `Some(offset)`: only top-level (file-scope) calls that have run by
+    ///   `offset`. Calls nested in a block (e.g. inside `test_that({})`) are
+    ///   dropped, as are calls after the offset.
+    ///
+    /// An attach to a package absent from every root is dropped (no entity).
+    fn attach_layers(self, db: &dyn Db, before: Option<TextSize>) -> Vec<ImportLayer> {
+        let index = self.semantic_index(db);
+        let file_scope = ScopeId::from(0);
+        index
+            .semantic_calls()
+            .iter()
+            .rev()
+            .filter(|call| match before {
+                Some(offset) => call.scope() == file_scope && call.offset() < offset,
+                None => true,
+            })
+            .filter_map(|call| match call.kind() {
+                SemanticCallKind::Attach { package } => {
+                    db.package_by_name(package).map(ImportLayer::Package)
+                },
+                // A `library()` inside the sourced file is forwarded separately
+                // by the semantic index builder as its own `Attach`, scoped to
+                // this `source()`.
+                SemanticCallKind::Source { .. } => None,
+            })
+            .collect()
+    }
+
+    /// The cross-file layers this file sees at load time, excluding its own
+    /// attaches (see [`CrossFileLayers`]). Never reads the file's own semantic
+    /// index, so it's safe to call while that index is being built.
+    pub(crate) fn cross_file_layers(self, db: &dyn Db, view: CollationView) -> CrossFileLayers {
         match self.package(db) {
-            // Helpers, setup, the package, and testthat are all sourced or
-            // attached before a test file's body runs, so they stay visible
-            // at any offset. Only the file's own top-level `library()` calls
-            // narrow.
-            Some(package) if is_testthat_file(self, db) => {
-                testthat_imports(self, db, package, Some(offset))
+            // A `tests/testthat/` file: sees the whole package plus sourced
+            // helpers, with testthat attached.
+            Some(package) if is_testthat_file(self, db) => testthat_load_layers(self, db, package),
+            // A loadable `R/` file: sees collation siblings and the package
+            // NAMESPACE.
+            Some(package) if self.is_package_source(db, package) => {
+                package_load_layers(self, db, package, view)
             },
-            Some(package) if is_package_source(self, db, package) => {
-                narrow_package_top_level(self, db, package)
+            // A standalone script, or a file with a package back-pointer that
+            // isn't a loadable `R/` file (`data-raw/`, `inst/`, a non-collated
+            // `R/` file): lives in the package but isn't loaded with it, so it
+            // sees only its own attaches and the default search path.
+            _ => CrossFileLayers {
+                above: Vec::new(),
+                below: default_search_path_layers(db),
             },
-            // A packaged file that isn't a loadable `R/` file narrows like a
-            // standalone script.
-            _ => narrow_script_top_level(self, db, offset),
         }
     }
-}
 
-/// Whether `file` is one of its package's loadable `R/` files, the ones in
-/// `package.files()`. A file can carry a package back-pointer without being
-/// loadable: `data-raw/`, `inst/`, and `R/` files left out of a `Collate:`
-/// directive all land in `package.scripts()` instead and resolve as
-/// standalone scripts.
-fn is_package_source(file: File, db: &dyn Db, package: Package) -> bool {
-    package.files(db).contains(&file)
-}
-
-fn narrow_script_top_level(file: File, db: &dyn Db, offset: TextSize) -> Vec<ImportLayer> {
-    let mut layers = attach_layers(file, db, Some(offset));
-    extend_with_default_search_path(db, &mut layers);
-    layers
-}
-
-fn narrow_package_top_level(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer> {
-    let files = package.files(db);
-    let Some(file_pos) = files.iter().position(|f| *f == file) else {
-        // File claims membership but isn't in the package's `files`.
-        // Shouldn't happen.
-        log::warn!(
-            "File {file} has package back-pointer to {package} but is not in its files",
-            file = file.path(db),
-            package = package.name(db),
-        );
-        return file.imports(db).clone();
-    };
-
-    let mut layers = Vec::new();
-
-    // Predecessors only, in LIFO order (latest-sourced first).
-    layers.extend(
-        files[..file_pos]
-            .iter()
-            .rev()
-            .copied()
-            .map(ImportLayer::File),
-    );
-
-    let namespace = package.namespace(db);
-    extend_with_namespace_imports(namespace, &mut layers);
-    extend_with_namespace_package_imports(db, namespace, &mut layers);
-
-    extend_with_base(db, &mut layers);
-    layers
-}
-
-/// The file's `library()` / `require()` attaches as `Package` layers, in LIFO
-/// order (latest-attached first). `before` selects which calls to include:
-///
-/// - `None`: every attach. The end-of-file view, used for lazy contexts.
-/// - `Some(offset)`: only top-level (file-scope) calls that have run by
-///   `offset`. Calls nested in a block (e.g. inside `test_that({})`) are
-///   dropped, as are calls after the offset.
-fn attach_layers(file: File, db: &dyn Db, before: Option<TextSize>) -> Vec<ImportLayer> {
-    let index = file.semantic_index(db);
-    let file_scope = ScopeId::from(0);
-    index
-        .semantic_calls()
-        .iter()
-        .rev()
-        .filter(|call| match before {
-            Some(offset) => call.scope() == file_scope && call.offset() < offset,
-            None => true,
-        })
-        .filter_map(|call| attach_layer(db, call))
-        .collect()
-}
-
-fn attach_layer(db: &dyn Db, call: &SemanticCall) -> Option<ImportLayer> {
-    match call.kind() {
-        SemanticCallKind::Attach { package: name } => {
-            db.package_by_name(name).map(ImportLayer::Package)
-        },
-        SemanticCallKind::Source { .. } => {
-            // A `library()` inside the sourced file is forwarded separately by
-            // the semantic index builder as its own `Attach`, scoped to this
-            // `source()`.
-            None
-        },
+    /// Whether this file is one of `package`'s loadable `R/` files, the ones in
+    /// `package.files()`. A file can carry a package back-pointer without being
+    /// loadable: `data-raw/`, `inst/`, and `R/` files left out of a `Collate:`
+    /// directive all land in `package.scripts()` instead and resolve as
+    /// standalone scripts.
+    fn is_package_source(self, db: &dyn Db, package: Package) -> bool {
+        package.files(db).contains(&self)
     }
 }
 
-fn script_imports(file: File, db: &dyn Db) -> Vec<ImportLayer> {
-    let mut layers = attach_layers(file, db, None);
-    extend_with_default_search_path(db, &mut layers);
-    layers
-}
+fn package_load_layers(
+    file: File,
+    db: &dyn Db,
+    package: Package,
+    view: CollationView,
+) -> CrossFileLayers {
+    let files = package.files(db);
 
-fn package_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer> {
-    let mut layers = Vec::new();
+    // The sibling `R/` files visible to this one, in LIFO order (latest-sourced
+    // first): a name defined late in the collation shadows the same name defined
+    // earlier. Self is excluded, its own top-level bindings come from `exports`,
+    // and including it here would cycle in `resolve` for unbound names.
+    let def_files: Vec<File> = match view {
+        CollationView::Lazy => files.iter().rev().copied().filter(|f| *f != file).collect(),
+        CollationView::Eager => match files.iter().position(|f| *f == file) {
+            Some(pos) => files[..pos].iter().rev().copied().collect(),
+            None => {
+                // File claims membership but isn't in the package's `files`.
+                // Shouldn't happen.
+                log::warn!(
+                    "File {file} has package back-pointer to {package} but is not in its files",
+                    file = file.path(db),
+                    package = package.name(db),
+                );
+                files.iter().rev().copied().filter(|f| *f != file).collect()
+            },
+        },
+    };
 
-    // All package files except self, in LIFO order (latest-sourced first).
-    // Self is excluded: a file's own top-level bindings come from `exports`,
-    // and including self here would create a cycle in `resolve` for unbound
-    // names.
-    //
-    // `package.files(db)` is collation-ordered (see `Package::files`), so
-    // reversing it gives R's LIFO precedence: a name defined late in the
-    // collation shadows the same name defined earlier.
-    layers.extend(
-        package
-            .files(db)
-            .iter()
-            .rev()
-            .copied()
-            .filter(|f| *f != file)
-            .map(ImportLayer::File),
-    );
-
+    let mut above: Vec<ImportLayer> = def_files.iter().copied().map(ImportLayer::File).collect();
     let namespace = package.namespace(db);
-    extend_with_namespace_imports(namespace, &mut layers);
-    extend_with_namespace_package_imports(db, namespace, &mut layers);
+    extend_with_namespace_imports(namespace, &mut above);
+    extend_with_namespace_package_imports(db, namespace, &mut above);
 
-    extend_with_base(db, &mut layers);
-    layers
+    // Every def file's attaches go on the search path below the file's own.
+    // For the `Lazy` view that includes successors, whose `library()` calls
+    // actually run after this file's at load time and so outrank the file's own
+    // attaches at runtime. We rank them below instead. Only matters when a
+    // successor re-attaches a package that shadows one of this file's own
+    // attaches, which is rare, and the direction we lose is the safe one.
+    let mut below = predecessor_attach_layers(db, &def_files);
+    below.extend(base_layer(db));
+    CrossFileLayers { above, below }
 }
 
-/// Imports visible to a `tests/testthat/` file, in R's LIFO priority order.
+/// Load-time layers visible to a `tests/testthat/` file, in R's LIFO priority
+/// order.
 ///
 /// A test file runs with the package loaded and `testthat` attached, after
 /// testthat has sourced the package's `helper*.R` and `setup*.R` files into
@@ -240,27 +257,13 @@ fn package_imports(file: File, db: &dyn Db, package: Package) -> Vec<ImportLayer
 /// 1. helper/setup files (sourced into the test env, shadow everything),
 /// 2. the whole package's `R/` code,
 /// 3. the package's NAMESPACE imports,
-/// 4. the file's own top-level `library()` calls,
-/// 5. `testthat` on the search path,
+/// 4. the file's own top-level `library()` calls (spliced in by the caller),
+/// 5. helper/setup and package attaches, then `testthat`, on the search path,
 /// 6. base.
-///
-/// `offset` narrows the components of layer 4. `None` produces the end-of-file
-/// view and uses every `library()` call. `Some(offset)` uses only the calls
-/// that have run by `offset`. The other layers are sourced or attached before
-/// the file body runs, so they never narrow.
-fn testthat_imports(
-    file: File,
-    db: &dyn Db,
-    package: Package,
-    offset: Option<TextSize>,
-) -> Vec<ImportLayer> {
-    let mut layers = Vec::new();
-
-    // testthat sources `helper*.R` / `setup*.R` sorted, so reversing gives
-    // LIFO precedence. Self is dropped when the file being
-    // analysed is itself a helper/setup file: its own bindings come from
-    // `exports`, and keeping it would create a cycle in `resolve()` for
-    // unbound names (same reasoning as self-exclusion in `package_imports()`).
+fn testthat_load_layers(file: File, db: &dyn Db, package: Package) -> CrossFileLayers {
+    // testthat sources `helper*.R` / `setup*.R` sorted, so reversing gives LIFO
+    // precedence. Self is dropped when the file being analysed is itself a
+    // helper/setup file, same self-exclusion reasoning as `package_load_layers`.
     let mut support: Vec<File> = package
         .scripts(db)
         .iter()
@@ -268,34 +271,47 @@ fn testthat_imports(
         .filter(|f| *f != file && is_testthat_support_file(*f, db))
         .collect();
     support.sort_by_cached_key(|f| testthat_support_key(*f, db));
-    layers.extend(support.into_iter().rev().map(ImportLayer::File));
+    support.reverse();
 
-    // The whole package is loaded when tests run, so every `R/` file is
-    // visible. Collation order reversed for LIFO, same as `package_imports()`.
-    layers.extend(
-        package
-            .files(db)
-            .iter()
-            .rev()
-            .copied()
-            .map(ImportLayer::File),
-    );
+    // The whole package is loaded when tests run, so every `R/` file is visible.
+    // Collation order reversed for LIFO, same as `package_load_layers`.
+    let package_files: Vec<File> = package.files(db).iter().rev().copied().collect();
 
+    let mut above: Vec<ImportLayer> = support
+        .iter()
+        .chain(package_files.iter())
+        .copied()
+        .map(ImportLayer::File)
+        .collect();
     let namespace = package.namespace(db);
-    extend_with_namespace_imports(namespace, &mut layers);
-    extend_with_namespace_package_imports(db, namespace, &mut layers);
+    extend_with_namespace_imports(namespace, &mut above);
+    extend_with_namespace_package_imports(db, namespace, &mut above);
 
-    // The test file's own top-level `library()` / `require()` calls attach to
-    // the search path, below the package namespace and its imports but above
-    // `testthat` (they run after the runner attached it).
-    layers.extend(attach_layers(file, db, offset));
+    // Attaches from the sourced helpers and the loaded package, then testthat
+    // (attached first by the runner, so lowest), then base. The test file's own
+    // attaches are spliced above these by the caller.
+    let mut below = predecessor_attach_layers(db, &support);
+    below.extend(predecessor_attach_layers(db, &package_files));
+    below.extend(db.package_by_name("testthat").map(ImportLayer::Package));
+    below.extend(base_layer(db));
 
-    if let Some(testthat) = db.package_by_name("testthat") {
-        layers.push(ImportLayer::Package(testthat));
-    }
+    CrossFileLayers { above, below }
+}
 
-    extend_with_base(db, &mut layers);
-    layers
+/// The search-path attaches contributed by a set of load-order files, latest
+/// file first (the slice is already LIFO), each file's own attaches latest
+/// first. Reads each file's `attached_packages`, never the caller's own index.
+/// An attach to a package absent from every root is dropped (no entity).
+fn predecessor_attach_layers(db: &dyn Db, files: &[File]) -> Vec<ImportLayer> {
+    files
+        .iter()
+        .flat_map(|file| {
+            file.attached_packages(db)
+                .iter()
+                .rev()
+                .filter_map(|name| db.package_by_name(name.text(db)).map(ImportLayer::Package))
+        })
+        .collect()
 }
 
 /// True when `file` sits directly in a `tests/testthat/` directory, the
@@ -370,18 +386,17 @@ fn extend_with_namespace_package_imports(
     }
 }
 
-/// Push the `base` package as a `Package` layer. `base` is always
-/// implicitly available inside a package.
-fn extend_with_base(db: &dyn Db, layers: &mut Vec<ImportLayer>) {
-    if let Some(base) = db.package_by_name("base") {
-        layers.push(ImportLayer::Package(base));
-    }
+/// `base`, always the last thing R searches. `None` when it isn't scanned into
+/// any root (the R system library is normally on `.libPaths()`, so it is).
+fn base_layer(db: &dyn Db) -> Option<ImportLayer> {
+    db.package_by_name("base").map(ImportLayer::Package)
 }
 
-fn extend_with_default_search_path(db: &dyn Db, layers: &mut Vec<ImportLayer>) {
-    for pkg_name in crate::search::DEFAULT_SEARCH_PATH_PACKAGES {
-        if let Some(pkg) = db.package_by_name(pkg_name) {
-            layers.push(ImportLayer::Package(pkg));
-        }
-    }
+/// The default startup search path as `Package` layers, `stats` first through
+/// `base` last. Packages absent from every root drop out.
+fn default_search_path_layers(db: &dyn Db) -> Vec<ImportLayer> {
+    crate::search::DEFAULT_SEARCH_PATH_PACKAGES
+        .iter()
+        .filter_map(|name| db.package_by_name(name).map(ImportLayer::Package))
+        .collect()
 }

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -69,30 +69,9 @@ impl<'db> File {
         // `imports()` directly, as `From` / `Package` layers, so finding
         // them does not require walking through siblings.
         for layer in self.imports(db) {
-            match layer {
-                ImportLayer::File(target) => {
-                    let defs = target.resolve_export(db, name);
-                    if !defs.is_empty() {
-                        return defs;
-                    }
-                },
-                ImportLayer::Package(pkg) => {
-                    let defs = pkg.resolve(db, name, NamespaceVisibility::Exported);
-                    if !defs.is_empty() {
-                        return defs;
-                    }
-                },
-                ImportLayer::From(map) => {
-                    let name_str = name.text(db).as_str();
-                    if let Some(pkg_name) = map.get(name_str) {
-                        if let Some(pkg) = db.package_by_name(pkg_name) {
-                            let defs = pkg.resolve(db, name, NamespaceVisibility::Exported);
-                            if !defs.is_empty() {
-                                return defs;
-                            }
-                        }
-                    }
-                },
+            let defs = resolve_import_layer(db, layer, name);
+            if !defs.is_empty() {
+                return defs;
             }
         }
 
@@ -152,30 +131,9 @@ impl<'db> File {
         // chase, same as `resolve`'s imports walk). Avoids the sibling cycle and
         // matches R's namespace semantics.
         for layer in self.imports_at(db, offset) {
-            match layer {
-                ImportLayer::File(target) => {
-                    let defs = target.resolve_export(db, name);
-                    if !defs.is_empty() {
-                        return defs;
-                    }
-                },
-                ImportLayer::Package(pkg) => {
-                    let defs = pkg.resolve(db, name, NamespaceVisibility::Exported);
-                    if !defs.is_empty() {
-                        return defs;
-                    }
-                },
-                ImportLayer::From(map) => {
-                    let name_str = name.text(db).as_str();
-                    if let Some(pkg_name) = map.get(name_str) {
-                        if let Some(pkg) = db.package_by_name(pkg_name) {
-                            let defs = pkg.resolve(db, name, NamespaceVisibility::Exported);
-                            if !defs.is_empty() {
-                                return defs;
-                            }
-                        }
-                    }
-                },
+            let defs = resolve_import_layer(db, &layer, name);
+            if !defs.is_empty() {
+                return defs;
             }
         }
 
@@ -287,4 +245,36 @@ impl<'db> File {
             }
         }
     }
+}
+
+/// Resolve `name` against a single import layer, returning every definition it
+/// reaches there (empty means the layer doesn't bind it, so the caller falls
+/// through to the next layer). Shared by [`File::resolve`] and
+/// [`File::resolve_at`].
+///
+/// `File` siblings are chased through their exports only, not their full
+/// `resolve`: recursing would walk the sibling's own imports, which include
+/// *this* file, and salsa would cycle on any unbound name. Exports-only is also
+/// what R's namespace semantics asks for, a package's namespace is the merged
+/// exports of its collation files.
+fn resolve_import_layer<'db>(
+    db: &'db dyn Db,
+    layer: &ImportLayer,
+    name: Name<'db>,
+) -> Vec<Definition<'db>> {
+    // Reduce the layer to the package it binds `name` to, then resolve against
+    // that package's exports. A `File` sibling is the exception, resolved
+    // through its own exports chain.
+    let package = match layer {
+        ImportLayer::File(target) => return target.resolve_export(db, name),
+        ImportLayer::Package(package) => *package,
+        ImportLayer::From(map) => match map.get(name.text(db).as_str()) {
+            Some(source) => match db.package_by_name(source) {
+                Some(package) => package,
+                None => return Vec::new(),
+            },
+            None => return Vec::new(),
+        },
+    };
+    package.resolve(db, name, NamespaceVisibility::Exported)
 }

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use aether_path::FilePath;
 use camino::Utf8Component;
 use camino::Utf8Path;
@@ -8,8 +10,11 @@ use oak_semantic::ImportsResolver;
 use oak_semantic::SourceResolution;
 use url::Url;
 
+use crate::file_imports::CollationView;
+use crate::file_imports::ImportLayer;
 use crate::Db;
 use crate::File;
+use crate::Package;
 use crate::RootKind;
 
 /// Salsa-backed [`ImportsResolver`] consumed by the per-file semantic
@@ -38,21 +43,19 @@ use crate::RootKind;
 /// on the narrow queries).
 pub(crate) struct SalsaImportsResolver<'db> {
     db: &'db dyn Db,
-    /// The file currently being indexed. The resolver's whole job is to
-    /// answer import queries on its behalf. Today the only such query
-    /// is `resolve_source()`.
-    calling_file: File,
+    /// The file currently being indexed.
+    file: File,
 }
 
 impl<'db> SalsaImportsResolver<'db> {
-    pub(crate) fn new(db: &'db dyn Db, calling_file: File) -> Self {
-        Self { db, calling_file }
+    pub(crate) fn new(db: &'db dyn Db, file: File) -> Self {
+        Self { db, file }
     }
 }
 
 impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
     fn resolve_source(&mut self, path: &str) -> Option<SourceResolution> {
-        let anchor = anchor_dir(self.db, self.calling_file)?;
+        let anchor = anchor_dir(self.db, self.file)?;
         let target_path = resolve_relative_to(&anchor, path)?;
         // TODO: a `source()` target outside every workspace root never becomes
         // a `File`, so `file_by_path()` misses it and the names it injects stay
@@ -90,15 +93,111 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
     fn resolve_effects(
         &mut self,
         name: &str,
-        _attached: &[String],
+        attached: &[String],
         _lazy: bool,
     ) -> Option<EffectsHandlers> {
-        // Base is the always-attached layer at the bottom of the search path,
-        // resolved through the same registry lookup as any package.
+        // Walk the same load-time layer chain as `File::resolve`, but map each
+        // layer to an NSE effect instead of a definition.
         //
-        // TODO!: walk the rest of the search path too (flow-order attaches,
-        // package siblings via `who_defines`, NAMESPACE imports, re-export chase).
+        // Always the eager (predecessors-only) view, even for a lazy callee. A
+        // top-level callee only sees names loaded before it, so eager is exact
+        // there. A lazy callee (a function body) runs after the whole package
+        // has loaded, so R would resolve it against every sibling, and
+        // `File::resolve` does use the lazy view for that case. We can't here.
+        // This runs while the file's own index is being built, and the lazy
+        // view would read a collation successor's `exports`, whose own build
+        // reads back into this file and cycles (salsa recovers with empty
+        // exports, so the extra shadow detection it would buy is degraded
+        // anyway). A later sibling that shadows a lazy NSE call is missed here,
+        // and is linted later on.
+        let layers = self.file.cross_file_layers(self.db, CollationView::Eager);
+
+        // The file's own attaches slot between the definition/namespace band
+        // and the rest of the search path, exactly as in `File::imports`.
+        // `attached` is the builder's flow-ordered set (latest last), so
+        // eager/lazy flow-sensitivity is already applied; reverse it to LIFO so
+        // a later attach shadows an earlier one.
+        let own: Vec<ImportLayer> = attached
+            .iter()
+            .rev()
+            .filter_map(|package| self.db.package_by_name(package).map(ImportLayer::Package))
+            .collect();
+
+        for layer in layers.splice_own_attaches(own) {
+            if let ControlFlow::Break(effect) = self.layer_effect(&layer, name) {
+                return effect;
+            }
+        }
+
+        // base is the bottom of every R search path and is present in any
+        // session, so its builtins (`library`, `source`, `quote`, `local`, ...)
+        // resolve by name here even when base isn't scanned into a root. A
+        // definition or a higher package on the path shadows it, which the walk
+        // above already handled before falling through.
         effects_registry::lookup("base", name).copied()
+    }
+}
+
+impl<'db> SalsaImportsResolver<'db> {
+    /// Project one import layer to an NSE effect, the effects-side twin of
+    /// `resolve_import_layer` in `file_resolve`. Both reduce the layer to the
+    /// package it binds `name` to and split on the same cases. Only the
+    /// projection differs (definition there, effect here).
+    ///
+    /// `Break` terminates the walk: `Break(Some(effect))` found an effect,
+    /// `Break(None)` hit a definition, which carries no effect today, so the
+    /// bare call is not NSE (the shadow). `Continue` means the layer doesn't
+    /// bind `name`; keep walking.
+    fn layer_effect(
+        &self,
+        layer: &ImportLayer,
+        name: &str,
+    ) -> ControlFlow<Option<EffectsHandlers>> {
+        let package = match layer {
+            // A definition shadows any package effect. Own-file definitions
+            // never reach here, the builder handles them before calling us.
+            ImportLayer::File(file) => {
+                return match file.exports(self.db).get(name).is_some() {
+                    true => ControlFlow::Break(None),
+                    false => ControlFlow::Continue(()),
+                };
+            },
+            ImportLayer::Package(package) => *package,
+            ImportLayer::From(map) => {
+                match map.get(name).and_then(|s| self.db.package_by_name(s)) {
+                    Some(package) => package,
+                    None => return ControlFlow::Continue(()),
+                }
+            },
+        };
+        match self.package_effect(package, name) {
+            Some(effects) => ControlFlow::Break(Some(effects)),
+            None => ControlFlow::Continue(()),
+        }
+    }
+
+    /// The effect `package` gives `name`: a direct registry entry, or a one-hop
+    /// `importFrom` re-export chase, since a re-exported function's annotation
+    /// lives under its original package, not the re-exporter.
+    fn package_effect(&self, package: Package, name: &str) -> Option<EffectsHandlers> {
+        let package_name = package.name(self.db).as_str();
+        if let Some(effects) = effects_registry::lookup(package_name, name) {
+            return Some(*effects);
+        }
+        // Otherwise chase a re-export, but only when the package actually
+        // re-exports `name`. A name it `importFrom`s without re-exporting isn't
+        // visible to a caller that attaches or imports this package (R errors
+        // "could not find function"), so it lends no effect. This is the same
+        // export gate `Package::resolve` applies before its own re-export chase.
+        let namespace = package.namespace(self.db);
+        if package_name != "base" && !namespace.exports.contains_str(name) {
+            return None;
+        }
+        let import = namespace
+            .imports
+            .iter()
+            .find(|import| import.name == name)?;
+        effects_registry::lookup(&import.package, name).copied()
     }
 }
 
@@ -108,16 +207,13 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
 /// resolves `source("foo.R")` against `getwd()`, and IDEs (RStudio, Positron)
 /// `setwd()` to the project root, so workspace-root anchoring typically matches
 /// the runtime behaviour.
-fn anchor_dir(db: &dyn Db, calling_file: File) -> Option<Utf8PathBuf> {
-    if let Some(root) = calling_file
-        .root(db)
-        .filter(|r| r.kind(db) == RootKind::Workspace)
-    {
+fn anchor_dir(db: &dyn Db, file: File) -> Option<Utf8PathBuf> {
+    if let Some(root) = file.root(db).filter(|r| r.kind(db) == RootKind::Workspace) {
         // Workspace roots are file URLs by construction.
         return root.path(db).as_path().map(Utf8Path::to_path_buf);
     }
 
-    let parent = calling_file.path(db).as_path()?.parent()?;
+    let parent = file.path(db).as_path()?.parent()?;
     Some(parent.to_path_buf())
 }
 

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -138,66 +138,98 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
     }
 }
 
+/// What a package layer contributes for `name` as the walk reaches it.
+enum PackageBinding {
+    /// Binds `name` and it carries an effect.
+    Effect(EffectsHandlers),
+    /// Binds `name` (exports it) but with no known effect, e.g. a plain
+    /// exported function. It still shadows any same-named effect deeper on the
+    /// search path, so the walk stops here with no effect.
+    Shadow,
+    /// Doesn't bind `name`, the walk keeps going.
+    Absent,
+}
+
 impl<'db> SalsaImportsResolver<'db> {
     /// Project one import layer to an NSE effect, the effects-side twin of
     /// `resolve_import_layer` in `file_resolve`. Both reduce the layer to the
     /// package it binds `name` to and split on the same cases. Only the
     /// projection differs (definition there, effect here).
     ///
-    /// `Break` terminates the walk: `Break(Some(effect))` found an effect,
-    /// `Break(None)` hit a definition, which carries no effect today, so the
-    /// bare call is not NSE (the shadow). `Continue` means the layer doesn't
+    /// Shadowing is export-driven, matching how the definition side stops at the
+    /// first package that resolves `name`. `Break(Some(effect))` found an
+    /// effect. `Break(None)` hit a binding with no effect (a sibling definition,
+    /// a plain package export, a namespace import), which shadows any deeper
+    /// effect, so the bare call is not NSE. `Continue` means the layer doesn't
     /// bind `name`; keep walking.
     fn layer_effect(
         &self,
         layer: &ImportLayer,
         name: &str,
     ) -> ControlFlow<Option<EffectsHandlers>> {
-        let package = match layer {
-            // A definition shadows any package effect. Own-file definitions
-            // never reach here, the builder handles them before calling us.
-            ImportLayer::File(file) => {
-                return match file.exports(self.db).get(name).is_some() {
-                    true => ControlFlow::Break(None),
-                    false => ControlFlow::Continue(()),
-                };
+        match layer {
+            // A definition shadows any deeper effect. Own-file definitions never
+            // reach here, the builder handles them before calling us.
+            ImportLayer::File(file) => match file.exports(self.db).get(name).is_some() {
+                true => ControlFlow::Break(None),
+                false => ControlFlow::Continue(()),
             },
-            ImportLayer::Package(package) => *package,
-            ImportLayer::From(map) => {
-                match map.get(name).and_then(|s| self.db.package_by_name(s)) {
-                    Some(package) => package,
-                    None => return ControlFlow::Continue(()),
-                }
+            ImportLayer::Package(package) => match self.package_binding(*package, name) {
+                PackageBinding::Effect(effects) => ControlFlow::Break(Some(effects)),
+                PackageBinding::Shadow => ControlFlow::Break(None),
+                PackageBinding::Absent => ControlFlow::Continue(()),
             },
-        };
-        match self.package_effect(package, name) {
-            Some(effects) => ControlFlow::Break(Some(effects)),
-            None => ControlFlow::Continue(()),
+            // A NAMESPACE `importFrom` binds `name` unconditionally (that's what
+            // the directive asserts), so it always shadows the search path
+            // below. Its effect, if any, comes from the source package.
+            ImportLayer::From(map) => match map.get(name) {
+                Some(source) => {
+                    let effect = self.db.package_by_name(source).and_then(|package| {
+                        match self.package_binding(package, name) {
+                            PackageBinding::Effect(effects) => Some(effects),
+                            PackageBinding::Shadow | PackageBinding::Absent => None,
+                        }
+                    });
+                    ControlFlow::Break(effect)
+                },
+                None => ControlFlow::Continue(()),
+            },
         }
     }
 
-    /// The effect `package` gives `name`: a direct registry entry, or a one-hop
-    /// `importFrom` re-export chase, since a re-exported function's annotation
-    /// lives under its original package, not the re-exporter.
-    fn package_effect(&self, package: Package, name: &str) -> Option<EffectsHandlers> {
+    /// How `package` binds `name`: a direct registry effect, a plain export that
+    /// only shadows, or nothing. The re-export chase is one hop through an
+    /// `importFrom`, since a re-exported function's annotation lives under its
+    /// original package, not the re-exporter.
+    fn package_binding(&self, package: Package, name: &str) -> PackageBinding {
         let package_name = package.name(self.db).as_str();
         if let Some(effects) = effects_registry::lookup(package_name, name) {
-            return Some(*effects);
+            return PackageBinding::Effect(*effects);
         }
-        // Otherwise chase a re-export, but only when the package actually
-        // re-exports `name`. A name it `importFrom`s without re-exporting isn't
-        // visible to a caller that attaches or imports this package (R errors
-        // "could not find function"), so it lends no effect. This is the same
-        // export gate `Package::resolve` applies before its own re-export chase.
+        // base is the terminal layer, so it has nothing below to shadow, and we
+        // don't carry its full builtin export list. Treat it as unbound here;
+        // its effects resolve through the registry lookup above (and the base
+        // fallthrough in `resolve_effects`).
+        if package_name == "base" {
+            return PackageBinding::Absent;
+        }
+        // The package binds `name` only when it exports it. This is the same
+        // export gate `Package::resolve` applies. A name it `importFrom`s
+        // without re-exporting isn't visible to a caller that attaches or
+        // imports this package (R errors "could not find function").
         let namespace = package.namespace(self.db);
-        if package_name != "base" && !namespace.exports.contains_str(name) {
-            return None;
+        if !namespace.exports.contains_str(name) {
+            return PackageBinding::Absent;
         }
-        let import = namespace
-            .imports
-            .iter()
-            .find(|import| import.name == name)?;
-        effects_registry::lookup(&import.package, name).copied()
+        // Exports `name`, so it binds. Chase a re-export for the effect; a plain
+        // own definition (no matching `importFrom`) only shadows.
+        match namespace.imports.iter().find(|import| import.name == name) {
+            Some(import) => match effects_registry::lookup(&import.package, name) {
+                Some(effects) => PackageBinding::Effect(*effects),
+                None => PackageBinding::Shadow,
+            },
+            None => PackageBinding::Shadow,
+        }
     }
 }
 

--- a/crates/oak_db/src/tests/file_imports.rs
+++ b/crates/oak_db/src/tests/file_imports.rs
@@ -50,9 +50,15 @@ fn install_packages(db: &mut TestDb, names: &[&str]) -> Vec<Package> {
 #[test]
 fn test_script_with_no_attaches_returns_only_default_search_path() {
     let mut db = TestDb::new();
-    let packages = install_packages(&mut db, &["base", "stats"]);
-    let base = packages[0];
-    let stats = packages[1];
+    install_packages(&mut db, &[
+        "stats",
+        "graphics",
+        "grDevices",
+        "utils",
+        "datasets",
+        "methods",
+        "base",
+    ]);
 
     let file = File::new(
         &db,
@@ -61,26 +67,26 @@ fn test_script_with_no_attaches_returns_only_default_search_path() {
         Some("x <- 1\n".to_string()),
         None,
     );
-    let layers = file.imports(&db);
 
-    // Only `stats` and `base` are registered in this test; the other
-    // default-search-path packages are absent and drop out.
-    let packages: Vec<Package> = layers
-        .iter()
-        .map(|layer| match layer {
-            ImportLayer::Package(p) => *p,
-            other => panic!("unexpected layer: {other:?}"),
-        })
-        .collect();
-    assert_eq!(packages, vec![stats, base]);
+    // The whole default search path shows up as `Package` layers in R's
+    // `search()` order (`stats` first, `base` last).
+    assert_eq!(shape(&db, file.imports(&db)), vec![
+        "Package(stats)".to_string(),
+        "Package(graphics)".to_string(),
+        "Package(grDevices)".to_string(),
+        "Package(utils)".to_string(),
+        "Package(datasets)".to_string(),
+        "Package(methods)".to_string(),
+        "Package(base)".to_string(),
+    ]);
 }
 
 #[test]
 fn test_script_attach_produces_package_exports_layer_in_lifo_order() {
     let mut db = TestDb::new();
-    let packages = install_packages(&mut db, &["dplyr", "ggplot2"]);
-    let dplyr = packages[0];
-    let ggplot2 = packages[1];
+    // Only the attached packages are installed, so the default search path
+    // drops out and the assertion sees just the two `library()` calls.
+    install_packages(&mut db, &["dplyr", "ggplot2"]);
 
     let file = File::new(
         &db,
@@ -89,25 +95,20 @@ fn test_script_attach_produces_package_exports_layer_in_lifo_order() {
         Some("library(dplyr)\nlibrary(ggplot2)\n".to_string()),
         None,
     );
-    let layers = file.imports(&db);
 
-    let attached: Vec<Package> = layers
-        .iter()
-        .filter_map(|layer| match layer {
-            ImportLayer::Package(p) => Some(*p),
-            _ => None,
-        })
-        .collect();
-
-    // LIFO: latest `library()` call comes first (matching R's runtime
-    // search order). Then the default search path (empty in this setup).
-    assert_eq!(attached, vec![ggplot2, dplyr]);
+    // LIFO: latest `library()` call comes first (matching R's runtime search
+    // order).
+    assert_eq!(shape(&db, file.imports(&db)), vec![
+        "Package(ggplot2)".to_string(),
+        "Package(dplyr)".to_string(),
+    ]);
 }
 
 #[test]
 fn test_script_attach_to_unregistered_package_drops_layer() {
     let db = TestDb::new();
-    // No `dplyr` in any library root.
+    // No `dplyr` (or default search path) in any root, so nothing has a
+    // `Package` entity and every layer drops out.
     let file = File::new(
         &db,
         file_path("a.R"),
@@ -116,8 +117,7 @@ fn test_script_attach_to_unregistered_package_drops_layer() {
         None,
     );
 
-    let layers = file.imports(&db);
-    assert!(layers.is_empty());
+    assert!(file.imports(&db).is_empty());
 }
 
 #[test]
@@ -247,9 +247,9 @@ fn test_package_script_resolves_as_standalone_script() {
     db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
 
     let _ = dplyr;
-    // Only its own `library(dplyr)` and `base` from the default search path
-    // (the only other registered package). `R/a.R` and the namespace are
-    // absent because the script isn't part of the package's namespace.
+    // Its own `library(dplyr)` on top of the default search path (only `base`
+    // installed here). `R/a.R` and the namespace are absent because the script
+    // isn't part of the package's namespace.
     assert_eq!(shape(&db, data_raw.imports(&db)), vec![
         "Package(dplyr)".to_string(),
         "Package(base)".to_string(),
@@ -427,6 +427,94 @@ fn test_testthat_file_includes_top_level_library_calls() {
         // above testthat (attached more recently than the runner attached
         // testthat).
         "Package(cli)".to_string(),
+        "Package(testthat)".to_string(),
+        "Package(base)".to_string(),
+    ]);
+}
+
+#[test]
+fn test_package_file_includes_predecessor_attaches() {
+    // A collation predecessor's own `library(dep)` puts dep on the search path
+    // for files loaded after it, so `b.R`'s imports carry it as a `Package`
+    // layer, below the predecessor's `File` layer and above `base`.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["dep", "base"]);
+    let workspace = workspace_root(&db, "w");
+    let pkg = Package::new(
+        &db,
+        file_path("w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        Some(Namespace::default()),
+        Vec::new(),
+        Vec::new(),
+    );
+    let a = File::new(
+        &db,
+        file_path("w/pkg/R/a.R"),
+        FileRevision::zero(),
+        Some("library(dep)\n".to_string()),
+        Some(pkg),
+    );
+    let b = File::new(
+        &db,
+        file_path("w/pkg/R/b.R"),
+        FileRevision::zero(),
+        Some("x <- 1\n".to_string()),
+        Some(pkg),
+    );
+    pkg.set_files(&mut db).to(vec![a, b]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    assert_eq!(shape(&db, b.imports(&db)), vec![
+        "File(a.R)".to_string(),
+        "Package(dep)".to_string(),
+        "Package(base)".to_string(),
+    ]);
+}
+
+#[test]
+fn test_testthat_file_includes_package_namespace_imports() {
+    // A test file runs under the package namespace, so the package's
+    // `importFrom(rlang, abort)` shows up as a `From` layer, ranked above the
+    // implicit testthat/base attaches.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["testthat", "base"]);
+    let workspace = workspace_root(&db, "w");
+    let namespace = Namespace {
+        imports: vec![Import {
+            name: "abort".to_string(),
+            package: "rlang".to_string(),
+        }],
+        ..Default::default()
+    };
+    let pkg = Package::new(
+        &db,
+        file_path("w/pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        Some(namespace),
+        Vec::new(),
+        Vec::new(),
+    );
+    let test_foo = File::new(
+        &db,
+        file_path("w/pkg/tests/testthat/test-foo.R"),
+        FileRevision::zero(),
+        Some("test_that('x', expect_true(TRUE))\n".to_string()),
+        Some(pkg),
+    );
+    pkg.set_scripts(&mut db).to(vec![test_foo]);
+    workspace.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![workspace]);
+
+    assert_eq!(shape(&db, test_foo.imports(&db)), vec![
+        "From([(\"abort\", \"rlang\")])".to_string(),
         "Package(testthat)".to_string(),
         "Package(base)".to_string(),
     ]);

--- a/crates/oak_db/src/tests/file_imports_at.rs
+++ b/crates/oak_db/src/tests/file_imports_at.rs
@@ -1,6 +1,7 @@
 use biome_rowan::TextSize;
 use salsa::Setter;
 
+use crate::search::DEFAULT_SEARCH_PATH_PACKAGES;
 use crate::tests::test_db::file_path;
 use crate::tests::test_db::library_root;
 use crate::tests::test_db::workspace_root;
@@ -77,13 +78,24 @@ fn install_workspace_package(db: &mut TestDb, name: &str) -> Package {
     pkg
 }
 
-fn attached_packages(layers: &[ImportLayer]) -> Vec<Package> {
+/// The package names of all `Package` layers, in layer order.
+fn attach_names(db: &TestDb, layers: &[ImportLayer]) -> Vec<String> {
     layers
         .iter()
         .filter_map(|layer| match layer {
-            ImportLayer::Package(p) => Some(*p),
+            ImportLayer::Package(p) => Some(p.name(db).to_string()),
             _ => None,
         })
+        .collect()
+}
+
+/// User `library()` / `require()` attaches, with the always-present default
+/// search path dropped so a narrowing assertion sees only what the cursor's
+/// position changes.
+fn library_attaches(db: &TestDb, layers: &[ImportLayer]) -> Vec<String> {
+    attach_names(db, layers)
+        .into_iter()
+        .filter(|name| !DEFAULT_SEARCH_PATH_PACKAGES.contains(&name.as_str()))
         .collect()
 }
 
@@ -107,15 +119,13 @@ fn test_script_cursor_before_any_attach_sees_no_attached_packages() {
     let file = make_file(&mut db, "/a.R", source);
 
     let layers = file.imports_at(&db, TextSize::from(0));
-    assert_eq!(attached_packages(&layers), Vec::<Package>::new());
+    assert_eq!(library_attaches(&db, &layers), Vec::<String>::new());
 }
 
 #[test]
 fn test_script_cursor_after_all_attaches_sees_all_in_lifo_order() {
     let mut db = TestDb::new();
-    let packages = install_packages(&mut db, &["dplyr", "ggplot2"]);
-    let dplyr = packages[0];
-    let ggplot2 = packages[1];
+    install_packages(&mut db, &["dplyr", "ggplot2"]);
 
     let source = "library(dplyr)\nlibrary(ggplot2)\nx <- 1\n";
     let file = make_file(&mut db, "/a.R", source);
@@ -123,21 +133,23 @@ fn test_script_cursor_after_all_attaches_sees_all_in_lifo_order() {
     let offset = TextSize::from(source.len() as u32);
     let layers = file.imports_at(&db, offset);
     // LIFO: latest `library()` call comes first.
-    assert_eq!(attached_packages(&layers), vec![ggplot2, dplyr]);
+    assert_eq!(library_attaches(&db, &layers), vec![
+        "ggplot2".to_string(),
+        "dplyr".to_string()
+    ]);
 }
 
 #[test]
 fn test_script_cursor_between_attaches_sees_only_earlier_ones() {
     let mut db = TestDb::new();
-    let packages = install_packages(&mut db, &["dplyr", "ggplot2"]);
-    let dplyr = packages[0];
+    install_packages(&mut db, &["dplyr", "ggplot2"]);
 
     let source = "library(dplyr)\nlibrary(ggplot2)\nx <- 1\n";
     let file = make_file(&mut db, "/a.R", source);
 
     let offset = TextSize::from(source.find("library(ggplot2)").unwrap() as u32);
     let layers = file.imports_at(&db, offset);
-    assert_eq!(attached_packages(&layers), vec![dplyr]);
+    assert_eq!(library_attaches(&db, &layers), vec!["dplyr".to_string()]);
 }
 
 #[test]
@@ -147,15 +159,14 @@ fn test_function_body_sees_file_scope_attaches_even_if_after_function_in_source(
     // order. The offset filter must override its "before cursor" rule for
     // file-scope attaches when the cursor is inside a function body.
     let mut db = TestDb::new();
-    let packages = install_packages(&mut db, &["dplyr"]);
-    let dplyr = packages[0];
+    install_packages(&mut db, &["dplyr"]);
 
     let source = "f <- function() {\n  x\n}\nlibrary(dplyr)\n";
     let file = make_file(&mut db, "/a.R", source);
 
     let offset = TextSize::from(source.find("x\n}").unwrap() as u32);
     let layers = file.imports_at(&db, offset);
-    assert!(attached_packages(&layers).contains(&dplyr));
+    assert!(library_attaches(&db, &layers).contains(&"dplyr".to_string()));
 }
 
 #[test]
@@ -221,15 +232,14 @@ fn test_package_top_level_predecessors_appear_in_lifo_order() {
 #[test]
 fn test_package_namespace_and_base_layers_always_visible() {
     let mut db = TestDb::new();
-    let packages = install_packages(&mut db, &["base"]);
-    let base = packages[0];
+    install_packages(&mut db, &["base"]);
     let pkg = install_workspace_package(&mut db, "pkg");
 
     let file = make_package_file(&mut db, "/w/pkg/R/a.R", "x <- 1\n", pkg);
     pkg.set_files(&mut db).to(vec![file]);
 
     let layers = file.imports_at(&db, TextSize::from(0));
-    assert!(attached_packages(&layers).contains(&base));
+    assert!(attach_names(&db, &layers).contains(&"base".to_string()));
 }
 
 #[test]
@@ -239,7 +249,7 @@ fn test_package_script_top_level_resolves_as_standalone_script() {
     // script and never take the package path, which would log the spurious
     // "back-pointer but not in its files" warning from #1270.
     let mut db = TestDb::new();
-    let dplyr = install_packages(&mut db, &["dplyr"])[0];
+    install_packages(&mut db, &["dplyr"]);
     let pkg = install_workspace_package(&mut db, "pkg");
 
     let r_file = make_package_file(&mut db, "/workspace/pkg/R/a.R", "internal <- 1\n", pkg);
@@ -251,12 +261,12 @@ fn test_package_script_top_level_resolves_as_standalone_script() {
     // Before the `library()` call: nothing attached, and no `R/` `File`
     // layers (the script isn't part of the package's namespace).
     let before = data_raw.imports_at(&db, TextSize::from(0));
-    assert_eq!(attached_packages(&before), Vec::<Package>::new());
+    assert_eq!(library_attaches(&db, &before), Vec::<String>::new());
     assert_eq!(package_files(&before), Vec::<File>::new());
 
     // After the call: dplyr attached, still no `R/` `File` layers.
     let after = data_raw.imports_at(&db, TextSize::from(source.len() as u32));
-    assert_eq!(attached_packages(&after), vec![dplyr]);
+    assert_eq!(library_attaches(&db, &after), vec!["dplyr".to_string()]);
     assert_eq!(package_files(&after), Vec::<File>::new());
 }
 
@@ -266,7 +276,7 @@ fn test_testthat_top_level_library_narrows_by_offset() {
     // invisible before the call, visible after. Helpers, the package, and
     // testthat (omitted here) stay visible at any offset.
     let mut db = TestDb::new();
-    let cli = install_packages(&mut db, &["cli", "testthat", "base"])[0];
+    install_packages(&mut db, &["cli"]);
     let pkg = install_workspace_package(&mut db, "pkg");
 
     let source = "library(cli)\ntest_that('x', expect_true(TRUE))\n";
@@ -279,20 +289,20 @@ fn test_testthat_top_level_library_narrows_by_offset() {
     pkg.set_scripts(&mut db).to(vec![test_file]);
 
     let before = test_file.imports_at(&db, TextSize::from(0));
-    assert!(!attached_packages(&before).contains(&cli));
+    assert!(!library_attaches(&db, &before).contains(&"cli".to_string()));
 
     let after = test_file.imports_at(&db, TextSize::from(source.len() as u32));
-    assert!(attached_packages(&after).contains(&cli));
+    assert!(library_attaches(&db, &after).contains(&"cli".to_string()));
 }
 
 #[test]
 fn test_library_in_function_scoped_source_is_visible_only_in_that_function() {
     // A `library()` inside a file that's `source()`d from a function body is
     // forwarded by the builder as an `Attach` scoped to that `source()` call,
-    // so its `Package` layer is visible inside the function (the lazy / EOF
-    // view) but not at file scope before or after it.
+    // so its attach layer is visible inside the function (the lazy / EOF view)
+    // but not at file scope before or after it.
     let mut db = TestDb::new();
-    let dplyr = install_packages(&mut db, &["dplyr"])[0];
+    install_packages(&mut db, &["dplyr"]);
 
     let helpers = make_file(&mut db, "w/helpers.R", "library(dplyr)\n");
     let script_src = "before\nf <- function() {\n  source(\"helpers.R\")\n}\nafter\n";
@@ -304,10 +314,10 @@ fn test_library_in_function_scoped_source_is_visible_only_in_that_function() {
 
     let at = |needle: &str| {
         let offset = TextSize::from(script_src.find(needle).unwrap() as u32);
-        attached_packages(&script.imports_at(&db, offset))
+        library_attaches(&db, &script.imports_at(&db, offset))
     };
 
-    assert!(!at("before").contains(&dplyr));
-    assert!(at("source").contains(&dplyr));
-    assert!(!at("after").contains(&dplyr));
+    assert!(!at("before").contains(&"dplyr".to_string()));
+    assert!(at("source").contains(&"dplyr".to_string()));
+    assert!(!at("after").contains(&"dplyr".to_string()));
 }

--- a/crates/oak_db/src/tests/file_resolve.rs
+++ b/crates/oak_db/src/tests/file_resolve.rs
@@ -1,6 +1,10 @@
+use oak_package_metadata::namespace::Import;
+use oak_package_metadata::namespace::Namespace;
 use salsa::Setter;
+use stdext::SortedVec;
 
 use crate::tests::test_db::file_path;
+use crate::tests::test_db::make_package;
 use crate::tests::test_db::workspace_root;
 use crate::tests::test_db::TestDb;
 use crate::DbInputs;
@@ -757,4 +761,73 @@ fn test_resolve_collated_sequential_redef_resolves_to_last() {
         ),
         12
     );
+}
+
+#[test]
+fn test_resolve_finds_definition_through_sibling_library_attach() {
+    // `a.R` does `library(dep)`; by the time the rest of the package loads, dep
+    // is on the search path, so `b.R`'s unbound `dep_fn` resolves to dep's
+    // exported binding. This is the predecessor-attach layer `imports()` now
+    // carries (previously `resolve` never saw a sibling's `library()`).
+    let mut db = TestDb::new();
+    let root = workspace_root(&db, "ws");
+    let (pkg, files) = make_package(&mut db, "pkg", Namespace::default(), &[
+        ("ws/pkg/R/a.R", "library(dep)\n"),
+        ("ws/pkg/R/b.R", "use <- function() dep_fn\n"),
+    ]);
+    let dep_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["dep_fn".to_string()]),
+        ..Default::default()
+    };
+    let (dep, dep_files) = make_package(&mut db, "dep", dep_ns, &[(
+        "ws/dep/R/z.R",
+        "dep_fn <- function() 1\n",
+    )]);
+    root.set_packages(&mut db).to(vec![pkg, dep]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let def = resolve_one(&db, files[1], "dep_fn");
+    assert_eq!(def.file(&db), dep_files[0]);
+    assert_eq!(def.name(&db).text(&db).as_str(), "dep_fn");
+}
+
+#[test]
+fn test_resolve_namespace_import_beats_attached_package() {
+    // The package imports `foo` from `depA` via NAMESPACE, and `a.R` also
+    // attaches `depB`, which exports `foo` too. R searches the namespace before
+    // the attached search path, so `foo` resolves to depA's binding, not depB's.
+    let mut db = TestDb::new();
+    let root = workspace_root(&db, "ws");
+    let namespace = Namespace {
+        imports: vec![Import {
+            name: "foo".to_string(),
+            package: "depA".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (pkg, files) = make_package(&mut db, "pkg", namespace, &[(
+        "ws/pkg/R/a.R",
+        "library(depB)\nuse <- function() foo\n",
+    )]);
+    let dep_a_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["foo".to_string()]),
+        ..Default::default()
+    };
+    let (dep_a, dep_a_files) = make_package(&mut db, "depA", dep_a_ns, &[(
+        "ws/depA/R/z.R",
+        "foo <- function() 1\n",
+    )]);
+    let dep_b_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["foo".to_string()]),
+        ..Default::default()
+    };
+    let (dep_b, _) = make_package(&mut db, "depB", dep_b_ns, &[(
+        "ws/depB/R/z.R",
+        "foo <- function() 2\n",
+    )]);
+    root.set_packages(&mut db).to(vec![pkg, dep_a, dep_b]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let def = resolve_one(&db, files[0], "foo");
+    assert_eq!(def.file(&db), dep_a_files[0]);
 }

--- a/crates/oak_db/src/tests/resolver.rs
+++ b/crates/oak_db/src/tests/resolver.rs
@@ -1,16 +1,25 @@
 use std::collections::HashSet;
 
+use oak_package_metadata::namespace::Import;
+use oak_package_metadata::namespace::Namespace;
 use oak_semantic::semantic_index::DefinitionKind;
+use oak_semantic::semantic_index::NseScope;
+use oak_semantic::semantic_index::NseTiming;
 use oak_semantic::semantic_index::ScopeId;
+use oak_semantic::semantic_index::ScopeKind;
 use oak_semantic::semantic_index::SemanticCallKind;
 use salsa::Setter;
+use stdext::SortedVec;
 
 use crate::tests::test_db::file_path;
+use crate::tests::test_db::library_root;
+use crate::tests::test_db::make_package;
 use crate::tests::test_db::workspace_root;
 use crate::tests::test_db::TestDb;
 use crate::DbInputs;
 use crate::File;
 use crate::FileRevision;
+use crate::Package;
 use crate::Root;
 
 fn make_script(db: &mut TestDb, name: &str, contents: &str) -> File {
@@ -34,6 +43,410 @@ fn setup_workspace(db: &mut TestDb, scripts: &[(&str, &str)]) -> (Root, Vec<File
     root.set_scripts(db).to(scripts.clone());
     db.workspace_roots().set_roots(db).to(vec![root]);
     (root, scripts)
+}
+
+/// Build a `pkg`-named workspace package with `files` as its collation-ordered
+/// `R/` sources and an empty NAMESPACE. Returns the files in collation order.
+fn setup_package(db: &mut TestDb, files: &[(&str, &str)]) -> Vec<File> {
+    let root = workspace_root(db, "pkg");
+    let pkg = Package::new(
+        db,
+        file_path("pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        Some(Namespace::default()),
+        Vec::new(),
+        Vec::new(),
+    );
+    let entities: Vec<File> = files
+        .iter()
+        .map(|(path, contents)| {
+            File::new(
+                db,
+                file_path(path),
+                FileRevision::zero(),
+                Some(contents.to_string()),
+                Some(pkg),
+            )
+        })
+        .collect();
+    pkg.set_files(db).to(entities.clone());
+    root.set_packages(db).to(vec![pkg]);
+    db.workspace_roots().set_roots(db).to(vec![root]);
+    entities
+}
+
+/// Build a `pkg` package whose `tests/testthat/` files are `scripts` (so they
+/// resolve as test files, not `R/` sources). Returns the script files in the
+/// given order.
+fn setup_testthat(db: &mut TestDb, scripts: &[(&str, &str)]) -> Vec<File> {
+    let root = workspace_root(db, "pkg");
+    let pkg = Package::new(
+        db,
+        file_path("pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        Some(Namespace::default()),
+        Vec::new(),
+        Vec::new(),
+    );
+    let entities: Vec<File> = scripts
+        .iter()
+        .map(|(path, contents)| {
+            File::new(
+                db,
+                file_path(path),
+                FileRevision::zero(),
+                Some(contents.to_string()),
+                Some(pkg),
+            )
+        })
+        .collect();
+    pkg.set_scripts(db).to(entities.clone());
+    root.set_packages(db).to(vec![pkg]);
+    db.workspace_roots().set_roots(db).to(vec![root]);
+    entities
+}
+
+/// Register bare installed packages (empty namespace) on `LibraryRoots`, one
+/// root each, so `package_by_name` finds them. Their NSE effects come from the
+/// static registry keyed on the name, so no namespace is needed here.
+fn install_packages(db: &mut TestDb, names: &[&str]) {
+    let roots: Vec<Root> = names
+        .iter()
+        .map(|&name| {
+            let root = library_root(db, &format!("libs/{name}"));
+            let pkg = Package::new(
+                db,
+                file_path(&format!("libs/{name}/DESCRIPTION")),
+                name.to_string(),
+                FileRevision::zero(),
+                FileRevision::zero(),
+                None,
+                None,
+                Vec::new(),
+                Vec::new(),
+            );
+            root.set_packages(db).to(vec![pkg]);
+            root
+        })
+        .collect();
+    db.library_roots().set_roots(db).to(roots);
+}
+
+#[test]
+fn test_testthat_test_that_is_nse_without_library() {
+    // The runner attaches testthat before a test file's body runs, so a bare
+    // `test_that` resolves to its NSE annotation with no `library(testthat)`.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["testthat"]);
+    let files = setup_testthat(&mut db, &[(
+        "pkg/tests/testthat/test-a.R",
+        "test_that(\"x\", {\n    y <- 1\n})\n",
+    )]);
+
+    let index = files[0].semantic_index(&db);
+    let test_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(test_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+    );
+}
+
+#[test]
+fn test_testthat_helper_attach_enables_nse() {
+    // A `helper*.R` file is sourced into the test env before the body runs, so
+    // its `library(shiny)` puts shiny on the search path and the test's bare
+    // `reactive` is NSE.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let files = setup_testthat(&mut db, &[
+        ("pkg/tests/testthat/helper-x.R", "library(shiny)\n"),
+        (
+            "pkg/tests/testthat/test-a.R",
+            "reactive({\n    x <- 1\n})\n",
+        ),
+    ]);
+
+    let index = files[1].semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_testthat_helper_definition_shadows() {
+    // A `helper*.R` file defines `local`, so the test's bare `local` resolves
+    // to that helper definition rather than base's NSE `local`. No NSE scope.
+    let mut db = TestDb::new();
+    let files = setup_testthat(&mut db, &[
+        ("pkg/tests/testthat/helper-x.R", "local <- function(x) x\n"),
+        ("pkg/tests/testthat/test-a.R", "local({\n    y <- 1\n})\n"),
+    ]);
+
+    let index = files[1].semantic_index(&db);
+    assert_eq!(index.scope_ids().count(), 1);
+}
+
+#[test]
+fn test_namespace_import_from_enables_nse() {
+    // `importFrom(shiny, reactive)` brings `reactive` into the package
+    // namespace, so a bare `reactive` call resolves to shiny's NSE annotation
+    // with no `library()`.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let root = workspace_root(&db, "ws");
+    let namespace = Namespace {
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "shiny".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (pkg, files) = make_package(&mut db, "pkg", namespace, &[(
+        "ws/pkg/R/a.R",
+        "reactive({\n    x <- 1\n})\n",
+    )]);
+    root.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = files[0].semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_namespace_bulk_import_enables_nse() {
+    // `import(shiny)` makes all of shiny's exports visible. shiny exports
+    // `reactive`, so the bare call is NSE. The registry supplies the effect.
+    let mut db = TestDb::new();
+    let root = workspace_root(&db, "ws");
+
+    let caller_ns = Namespace {
+        package_imports: vec!["shiny".to_string()],
+        ..Default::default()
+    };
+    let (caller, files) = make_package(&mut db, "caller", caller_ns, &[(
+        "ws/caller/R/a.R",
+        "reactive({\n    x <- 1\n})\n",
+    )]);
+
+    let shiny_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["reactive".to_string()]),
+        ..Default::default()
+    };
+    let (shiny, _) = make_package(&mut db, "shiny", shiny_ns, &[]);
+
+    root.set_packages(&mut db).to(vec![caller, shiny]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = files[0].semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_namespace_reexport_chases_to_source_package() {
+    // `caller` imports `reactive` from `mypkg`, which re-exports it from shiny
+    // (`importFrom(shiny, reactive)`). The NSE annotation lives under shiny, so
+    // resolution follows one hop through `mypkg`'s import to `shiny`.
+    let mut db = TestDb::new();
+    let root = workspace_root(&db, "ws");
+
+    let caller_ns = Namespace {
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "mypkg".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (caller, files) = make_package(&mut db, "caller", caller_ns, &[(
+        "ws/caller/R/a.R",
+        "reactive({\n    x <- 1\n})\n",
+    )]);
+
+    let mypkg_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["reactive".to_string()]),
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "shiny".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (mypkg, _) = make_package(&mut db, "mypkg", mypkg_ns, &[]);
+
+    root.set_packages(&mut db).to(vec![caller, mypkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = files[0].semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_namespace_reexport_requires_export() {
+    // `caller` importFroms `reactive` from `mypkg`, but `mypkg` only importFroms
+    // it from shiny without re-exporting it. mypkg doesn't hand `reactive` to
+    // its importers (R errors "could not find function"), so the bare call is
+    // not NSE. The re-export chase is gated on mypkg's own exports, same as
+    // `Package::resolve`.
+    let mut db = TestDb::new();
+    let root = workspace_root(&db, "ws");
+
+    let caller_ns = Namespace {
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "mypkg".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (caller, files) = make_package(&mut db, "caller", caller_ns, &[(
+        "ws/caller/R/a.R",
+        "reactive({\n    x <- 1\n})\n",
+    )]);
+
+    // mypkg imports reactive from shiny but does NOT export it.
+    let mypkg_ns = Namespace {
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "shiny".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (mypkg, _) = make_package(&mut db, "mypkg", mypkg_ns, &[]);
+
+    root.set_packages(&mut db).to(vec![caller, mypkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = files[0].semantic_index(&db);
+    assert_eq!(index.scope_ids().count(), 1);
+}
+
+#[test]
+fn test_testthat_namespace_import_enables_nse() {
+    // A test file runs in a child of the package's namespace, so the package's
+    // `importFrom(shiny, reactive)` is visible to the test body: a bare
+    // `reactive` is NSE without any `library()`.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let root = workspace_root(&db, "pkg");
+    let namespace = Namespace {
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "shiny".to_string(),
+        }],
+        ..Default::default()
+    };
+    let pkg = Package::new(
+        &db,
+        file_path("pkg/DESCRIPTION"),
+        "pkg".to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        Some(namespace),
+        Vec::new(),
+        Vec::new(),
+    );
+    let test = File::new(
+        &db,
+        file_path("pkg/tests/testthat/test-a.R"),
+        FileRevision::zero(),
+        Some("reactive({\n    x <- 1\n})\n".to_string()),
+        Some(pkg),
+    );
+    pkg.set_scripts(&mut db).to(vec![test]);
+    root.set_packages(&mut db).to(vec![pkg]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = test.semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_sibling_definition_shadows_attached_nse() {
+    // `a.R` defines `reactive`, so in the later `b.R` the bare `reactive` call
+    // resolves to that sibling definition, not shiny's NSE function, even
+    // though `b.R` attaches shiny. A collation predecessor's binding beats the
+    // attached search path, so no NSE scope is pushed.
+    let mut db = TestDb::new();
+    let files = setup_package(&mut db, &[
+        ("pkg/R/a.R", "reactive <- function(x) x\n"),
+        ("pkg/R/b.R", "library(shiny)\nreactive({\n    x <- 1\n})\n"),
+    ]);
+    let b = files[1];
+
+    let index = b.semantic_index(&db);
+    assert_eq!(index.scope_ids().count(), 1);
+}
+
+#[test]
+fn test_later_sibling_does_not_shadow() {
+    // `b.R` defines `reactive`, but it's a collation successor of `a.R`, so it
+    // hasn't loaded when `a.R` runs. `a.R`'s bare `reactive` still resolves to
+    // shiny (attached in `a.R`) and stays NSE. The predecessors-only rule.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let files = setup_package(&mut db, &[
+        ("pkg/R/a.R", "library(shiny)\nreactive({\n    x <- 1\n})\n"),
+        ("pkg/R/b.R", "reactive <- function(x) x\n"),
+    ]);
+    let a = files[0];
+
+    let index = a.semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_predecessor_sibling_attach_enables_nse() {
+    // `a.R` attaches shiny at top level. By the time `b.R` loads shiny is on
+    // the search path, so `b.R`'s bare `reactive` is NSE without a `library()`
+    // of its own.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let files = setup_package(&mut db, &[
+        ("pkg/R/a.R", "library(shiny)\n"),
+        ("pkg/R/b.R", "reactive({\n    x <- 1\n})\n"),
+    ]);
+    let b = files[1];
+
+    let index = b.semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
 }
 
 #[test]
@@ -225,6 +638,47 @@ fn test_sourced_file_library_attaches_in_caller() {
 
     let index = a.semantic_index(&db);
     assert!(index.attached_packages().contains(&"foo"));
+}
+
+#[test]
+fn test_attached_package_enables_nse_scope() {
+    // `library(shiny)` attaches shiny, so the eager `reactive` resolves through
+    // `SalsaImportsResolver::resolve_effects` walking the `attached` set to
+    // shiny's NSE annotation and pushes a lazy nested scope. Base-only
+    // resolution would miss it.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let (_, scripts) = setup_workspace(&mut db, &[(
+        "app.R",
+        "library(shiny)\nreactive({\n    x <- 1\n})\n",
+    )]);
+    let app = scripts[0];
+
+    let index = app.semantic_index(&db);
+    let reactive_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(reactive_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+    );
+}
+
+#[test]
+fn test_base_nse_resolves_with_no_attaches() {
+    // No attaches, so the search-path walk falls straight through to base:
+    // `local` is a base NSE function and still pushes its nested scope. Guards
+    // the base fallback through the new attached-walk code path.
+    let mut db = TestDb::new();
+    let (_, scripts) = setup_workspace(&mut db, &[("s.R", "local({\n    x <- 1\n})\n")]);
+    let s = scripts[0];
+
+    let index = s.semantic_index(&db);
+    let local_scope = ScopeId::from(1);
+    assert_eq!(index.scope_ids().count(), 2);
+    assert_eq!(
+        index.scope(local_scope).kind(),
+        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+    );
 }
 
 #[test]

--- a/crates/oak_db/src/tests/resolver.rs
+++ b/crates/oak_db/src/tests/resolver.rs
@@ -406,6 +406,71 @@ fn test_sibling_definition_shadows_attached_nse() {
 }
 
 #[test]
+fn test_namespace_import_shadows_attached_nse() {
+    // The package importFroms `reactive` from `dep`, which exports it as a plain
+    // function, and `a.R` also attaches shiny, whose `reactive` is NSE. R
+    // searches the namespace before the attached search path, so the plain
+    // `dep::reactive` binds the name and shadows shiny's NSE one. Export-driven
+    // shadowing: the namespace import stops the walk even though it has no
+    // effect, so the bare call is not NSE.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let root = workspace_root(&db, "ws");
+    let namespace = Namespace {
+        imports: vec![Import {
+            name: "reactive".to_string(),
+            package: "dep".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (pkg, files) = make_package(&mut db, "pkg", namespace, &[(
+        "ws/pkg/R/a.R",
+        "library(shiny)\nreactive({\n    x <- 1\n})\n",
+    )]);
+    let dep_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["reactive".to_string()]),
+        ..Default::default()
+    };
+    let (dep, _) = make_package(&mut db, "dep", dep_ns, &[(
+        "ws/dep/R/z.R",
+        "reactive <- function(x) x\n",
+    )]);
+    root.set_packages(&mut db).to(vec![pkg, dep]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = files[0].semantic_index(&db);
+    assert_eq!(index.scope_ids().count(), 1);
+}
+
+#[test]
+fn test_higher_attach_plain_export_shadows_lower_nse() {
+    // `a.R` attaches shiny (NSE `reactive`) then `dep`, which exports `reactive`
+    // as a plain function. `dep` is attached last, so it's highest on the search
+    // path and its plain `reactive` binds the name, shadowing shiny's NSE one.
+    // The bare call is not NSE.
+    let mut db = TestDb::new();
+    install_packages(&mut db, &["shiny"]);
+    let root = workspace_root(&db, "ws");
+    let dep_ns = Namespace {
+        exports: SortedVec::from_vec(vec!["reactive".to_string()]),
+        ..Default::default()
+    };
+    let (dep, _) = make_package(&mut db, "dep", dep_ns, &[(
+        "ws/dep/R/z.R",
+        "reactive <- function(x) x\n",
+    )]);
+    let (pkg, files) = make_package(&mut db, "pkg", Namespace::default(), &[(
+        "ws/pkg/R/a.R",
+        "library(shiny)\nlibrary(dep)\nreactive({\n    x <- 1\n})\n",
+    )]);
+    root.set_packages(&mut db).to(vec![pkg, dep]);
+    db.workspace_roots().set_roots(&mut db).to(vec![root]);
+
+    let index = files[0].semantic_index(&db);
+    assert_eq!(index.scope_ids().count(), 1);
+}
+
+#[test]
 fn test_later_sibling_does_not_shadow() {
     // `b.R` defines `reactive`, but it's a collation successor of `a.R`, so it
     // hasn't loaded when `a.R` runs. `a.R`'s bare `reactive` still resolves to

--- a/crates/oak_db/src/tests/test_db.rs
+++ b/crates/oak_db/src/tests/test_db.rs
@@ -10,12 +10,17 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use aether_path::FilePath;
+use oak_package_metadata::namespace::Namespace;
+use salsa::Setter;
 use url::Url;
 
 use crate::Db;
 use crate::DbInputs;
+use crate::File;
+use crate::FileRevision;
 use crate::LibraryRoots;
 use crate::OrphanRoot;
+use crate::Package;
 use crate::Root;
 use crate::RootKind;
 use crate::StaleRoot;
@@ -138,4 +143,41 @@ pub(super) fn workspace_root(db: &impl Db, path: &str) -> Root {
 /// Build a fresh empty `RootKind::Library` `Root` at `path`.
 pub(super) fn library_root(db: &impl Db, path: &str) -> Root {
     Root::new(db, file_path(path), RootKind::Library, vec![], vec![])
+}
+
+/// Build a package `pkg_name` with the given namespace and `R/` files (each
+/// back-pointing to it), rooted under `ws/{pkg_name}`. Not registered on any
+/// root, so callers can assemble several packages into one workspace. Returns
+/// the package and its files in the given order.
+pub(super) fn make_package(
+    db: &mut TestDb,
+    pkg_name: &str,
+    namespace: Namespace,
+    files: &[(&str, &str)],
+) -> (Package, Vec<File>) {
+    let pkg = Package::new(
+        db,
+        file_path(&format!("ws/{pkg_name}/DESCRIPTION")),
+        pkg_name.to_string(),
+        FileRevision::zero(),
+        FileRevision::zero(),
+        None,
+        Some(namespace),
+        Vec::new(),
+        Vec::new(),
+    );
+    let entities: Vec<File> = files
+        .iter()
+        .map(|(path, contents)| {
+            File::new(
+                db,
+                file_path(path),
+                FileRevision::zero(),
+                Some(contents.to_string()),
+                Some(pkg),
+            )
+        })
+        .collect();
+    pkg.set_files(db).to(entities.clone());
+    (pkg, entities)
 }


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338
Branched from https://github.com/posit-dev/ark/pull/1343

This PR ties effects support together. `SalsaImportsResolver::resolve_effects()` now resolves the effects of a function call in exactly the way the definition side resolves a name, with import-layer chains.

Shadowing is export-driven: a layer that binds the name but carries no effect (a plain export, a sibling definition, a namespace import) still shadows any deeper effect. If a `library(evil)` overwrites `source()`, `library()`, or `assign()`, the effects (or absence thereof) from evil exports win.

To avoid Salsa cycles, effect resolution always uses the eager (predecessors-only) collation view, even for a lazy callee. If a later sibling shadows effects in a lazy call, we'll emit a diagnostic instead (NYI).

To share the search-path model, the import layer chain is extracted into `CrossFileLayers` / `CollationView` / `cross_file_layers()`, which support both the definition and effect sides.
