### PR TITLE
Extract `arguments` field and generalise NSE with `ArgumentEffect`

### DIFF
--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -1470,8 +1470,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
 /// What the scan resolved a single call to, for the walk to reuse. A call can
 /// carry several of these at once.
 ///
-/// - `arguments`: the NSE effect the call resolved to, filled in flow order. `None`
-///   means "not NSE".
+/// - `arguments`: the per-argument evaluation effects the call resolved to,
+///   filled in flow order. `None` means no annotated arguments (not NSE today).
 /// - `attach`: the package a `library()`/`require()` call attaches, recognized
 ///   shadow-aware on the resolve path. The walk reads it back to emit a scoped
 ///   `SemanticCall::Attach`.

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -19,6 +19,7 @@ use super::BoundNames;
 use super::SemanticIndexBuilder;
 use super::SourcedFile;
 use crate::effects::Argument;
+use crate::effects::ArgumentEffect;
 use crate::effects::AssignBinding;
 use crate::effects::CallContext;
 use crate::effects::Effects;
@@ -43,7 +44,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// because resolution of effects in these lazy scopes needs the child's own
     /// flow context.
     pub(super) fn scan_call(&mut self, call: &RCall) {
-        let (nse_args, attach, source, assign) = match self.resolve_effects(call) {
+        let (arg_effects, attach, source, assign) = match self.resolve_effects(call) {
             Some(effects) => (
                 effects.arguments,
                 effects.attach,
@@ -94,7 +95,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             }
         }
 
-        let Some(nse_args) = nse_args else {
+        let Some(arg_effects) = arg_effects else {
             if let Ok(args) = call.arguments() {
                 for item in args.items().iter() {
                     let Ok(arg) = item else { continue };
@@ -115,9 +116,12 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             let Ok(arg) = item else { continue };
             let Some(value) = arg.value() else { continue };
 
-            match nse_args[i] {
+            match arg_effects[i] {
                 None => self.scan_expression(&value),
-                Some(nse_arg) => match (nse_arg.scope, nse_arg.timing) {
+                Some(Argument {
+                    effect: ArgumentEffect::Nse { scope, timing },
+                    ..
+                }) => match (scope, timing) {
                     // Calls like `evalq()`
                     (NseScope::Current, NseTiming::Eager) => self.scan_expression(&value),
 
@@ -163,11 +167,11 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             }
         }
 
-        // Hand the resolved NSE arguments to the walk (at the end to avoid a clone)
+        // Hand the resolved argument effects to the walk (at the end to avoid a clone)
         self.call_resolutions
             .entry(call.syntax().text_trimmed_range())
             .or_default()
-            .arguments = Some(nse_args);
+            .arguments = Some(arg_effects);
     }
 
     /// Scan a binary operator for an assign effect (e.g. magrittr's `x %<>% f()`)
@@ -492,7 +496,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// Process a call the scan pass decided is NSE, using the resolved argument
     /// scoping the scan cached. Handle each scoped argument, pushing NSE scopes
     /// inline.
-    pub(super) fn collect_nse_call(&mut self, call: &RCall, nse_args: ResolvedArgumentEffects) {
+    pub(super) fn collect_nse_call(&mut self, call: &RCall, arg_effects: ResolvedArgumentEffects) {
         let Ok(args) = call.arguments() else {
             return;
         };
@@ -502,9 +506,9 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             let Ok(arg) = item else { continue };
             let Some(value) = arg.value() else { continue };
 
-            match nse_args[i] {
+            match arg_effects[i] {
                 None => self.collect_expression(&value),
-                Some(nse_arg) => self.collect_nse_argument(nse_arg, &value),
+                Some(argument) => self.collect_nse_argument(argument, &value),
             }
         }
     }
@@ -515,8 +519,9 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// already scanned by the descent, so we install its pending names and only
     /// walk. The remaining lazy bodies are their own scan units that we scan
     /// here on entry.
-    fn collect_nse_argument(&mut self, nse_arg: &Argument, value: &AnyRExpression) {
-        match (nse_arg.scope, nse_arg.timing) {
+    fn collect_nse_argument(&mut self, argument: &Argument, value: &AnyRExpression) {
+        let ArgumentEffect::Nse { scope, timing } = argument.effect;
+        match (scope, timing) {
             // Calls like `evalq()`
             (NseScope::Current, NseTiming::Eager) => {
                 self.collect_expression(value);

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -17,7 +17,9 @@ use crate::semantic_index::NseTiming;
 /// Effects of a call, resolved against the call site.
 #[derive(Debug, Clone, Default)]
 pub struct Effects {
-    /// Evaluate arguments in non-standard fashion
+    /// Per-argument evaluation effects, resolved against the call and aligned
+    /// 1:1 with its arguments. `None` at a slot means a plain (standard-eval)
+    /// argument.
     pub arguments: Option<ResolvedArgumentEffects>,
     /// Attach a package
     pub attach: Option<String>,
@@ -152,24 +154,33 @@ pub struct Formal {
     pub position: usize,
 }
 
-/// A call's resolved NSE arguments: for each argument in call order, the scoped
-/// argument it matched, or `None` for a plain argument.
+/// A call's resolved argument effects: for each argument in call order, the
+/// annotated argument it matched, or `None` for a plain (standard-eval)
+/// argument.
 pub type ResolvedArgumentEffects = Vec<Option<&'static Argument>>;
 
-/// Declares how an NSE function's arguments create scopes, and serves as the
+/// Declares how a function evaluates its annotated arguments, and serves as the
 /// default [`EffectHandler`] for it by matching the declaration to a call.
 #[derive(Debug, Clone, Copy)]
 pub struct ArgumentsAnnotation {
     pub arguments: &'static [Argument],
 }
 
-/// A single argument that creates an NSE scope.
+/// A single annotated argument: its effect, plus where to find it in a call.
 #[derive(Debug)]
 pub struct Argument {
     pub name: &'static str,
     pub position: usize,
-    pub scope: NseScope,
-    pub timing: NseTiming,
+    pub effect: ArgumentEffect,
+}
+
+/// What static operation an argument's evaluation calls for, mirroring R's
+/// evaluation model. Absence (an argument not listed on an annotation) means
+/// standard evaluation of an unquoted expression, the common case.
+#[derive(Debug, Clone, Copy)]
+pub enum ArgumentEffect {
+    /// Quote plus Eval in a controlled scope, fused
+    Nse { scope: NseScope, timing: NseTiming },
 }
 
 impl EffectHandler for ArgumentsAnnotation {

--- a/crates/oak_semantic/src/effects_registry.rs
+++ b/crates/oak_semantic/src/effects_registry.rs
@@ -1,4 +1,5 @@
 use crate::effects::Argument;
+use crate::effects::ArgumentEffect;
 use crate::effects::ArgumentsAnnotation;
 use crate::effects::AssignAnnotation;
 use crate::effects::AttachAnnotation;
@@ -45,8 +46,10 @@ macro_rules! nse {
                     arguments: &[$(Argument {
                         name: $name,
                         position: $pos,
-                        scope: $scope,
-                        timing: $timing,
+                        effect: ArgumentEffect::Nse {
+                            scope: $scope,
+                            timing: $timing,
+                        },
                     }),+],
                 }),
                 attach: None,


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338
Branched from https://github.com/posit-dev/ark/pull/1344

Refactor, no behavior change. Generalizes the per-argument NSE annotations into general per-argument effects. This allows declaring an argument as Quote or Eval in future PRs.
