### PR TITLE
Streamline dispatch of Assign operators

### DIFF
--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -58,6 +58,7 @@ use rustc_hash::FxHashSet;
 
 use crate::effects::AssignBinding;
 use crate::effects::ResolvedArgumentEffects;
+use crate::effects::TargetAccess;
 use crate::resolver::ImportsResolver;
 use crate::resolver::SourceResolution;
 use crate::semantic_index::Definition;
@@ -873,19 +874,21 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     self.collect_assignment(bin);
                 } else {
                     let range = bin.syntax().text_trimmed_range();
-                    let is_binding_op = self
-                        .call_resolutions
-                        .get(&range)
-                        .is_some_and(|resolution| !resolution.assign.is_empty());
 
-                    // A binding operator (`x := expr`) treats its left operand
-                    // as a definition target, not a read, the same as `<-`. An
-                    // ordinary operator (`a + b`) reads both operands.
-                    //
-                    // TODO(nse): `%<>%` is compound (`x <- f(x)`), so it also
-                    // reads its target. Record that read once the registry
-                    // carries a per-operator "reads target" flag.
-                    if !is_binding_op {
+                    let reads_lhs = match self.call_resolutions.get(&range) {
+                        Some(resolution) if !resolution.assign.is_empty() => {
+                            // Pure binding operators such as `x := expr` do not
+                            // read their LHS. `%<>%` is compound and acts like
+                            // `x <- x %>% f()`.
+                            resolution
+                                .assign
+                                .iter()
+                                .any(|binding| binding.target == TargetAccess::ReadWrite)
+                        },
+                        _ => true,
+                    };
+
+                    if reads_lhs {
                         if let Ok(lhs) = bin.left() {
                             self.collect_expression(&lhs);
                         }

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -4,10 +4,8 @@ use aether_syntax::RCall;
 use aether_syntax::RSyntaxKind;
 use biome_rowan::AstNode;
 use biome_rowan::AstNodeList;
-use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
 use biome_rowan::TextRange;
-use oak_core::range::RangedAstPtr;
 use oak_core::syntax_ext::AnyRSelectorExt;
 use oak_core::syntax_ext::RIdentifierExt;
 
@@ -20,6 +18,7 @@ use super::SemanticIndexBuilder;
 use super::SourcedFile;
 use crate::effects::AssignBinding;
 use crate::effects::CallContext;
+use crate::effects::EffectSite;
 use crate::effects::Effects;
 use crate::effects::EffectsHandlers;
 use crate::effects::ResolvedArgumentEffect;
@@ -179,21 +178,24 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
 
     /// Scan a binary operator for an assign effect (e.g. magrittr's `x %<>% f()`)
     pub(super) fn scan_operator_assign(&mut self, bin: &RBinaryExpression) {
-        let Some(binding) = self.resolve_operator_assign(bin) else {
+        let Some(bindings) = self.resolve_operator_assign(bin) else {
             return;
         };
-        self.record_binding(binding.name.clone(), bin.syntax().text_trimmed_range());
-        self.call_resolutions
-            .entry(bin.syntax().text_trimmed_range())
-            .or_default()
-            .assign
-            .push(binding);
+        let range = bin.syntax().text_trimmed_range();
+        for binding in bindings {
+            self.record_binding(binding.name.clone(), range);
+            self.call_resolutions
+                .entry(range)
+                .or_default()
+                .assign
+                .push(binding);
+        }
     }
 
     /// Recognize a binding operator (`x %<>% f()`, `x %<~% expr`, `x := expr`)
-    /// as an assign effect and build its binding, or `None` for any other binary
+    /// as an assign effect and build its bindings, or `None` for any other binary
     /// operator.
-    fn resolve_operator_assign(&mut self, bin: &RBinaryExpression) -> Option<AssignBinding> {
+    fn resolve_operator_assign(&mut self, bin: &RBinaryExpression) -> Option<Vec<AssignBinding>> {
         let op = bin.operator().ok()?;
 
         // A binding operator is either a `%...%` (`SPECIAL`, e.g. `%<>%`, where
@@ -211,17 +213,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
 
         let handlers = self.resolve_symbol_effects(op_text, bin.syntax().text_trimmed_range())?;
-        let _assign = handlers.assign?;
-
-        let left = bin.left().ok()?;
-        let right = bin.right().ok()?;
-        let (name, _) = assignment_name(&left)?;
-
-        Some(AssignBinding {
-            name,
-            name_expr: RangedAstPtr::new(&left),
-            value_expr: Some(AstPtr::new(&right)),
-        })
+        let ctx = CallContext::new();
+        handlers.assign?.resolve(EffectSite::Operator(bin), &ctx)
     }
 
     /// Copy the names a `Current + Lazy` body defines into the owner's
@@ -336,7 +329,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
             .and_then(|handler| handler.resolve(call, &ctx));
         let assign = handlers
             .assign
-            .and_then(|handler| handler.resolve(call, &ctx));
+            .and_then(|handler| handler.resolve(EffectSite::Call(call), &ctx));
 
         Some(Effects {
             arguments,

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -192,9 +192,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
     }
 
-    /// Recognize a binding operator (`x %<>% f()`, `x %<~% expr`, `x := expr`)
-    /// as an assign effect and build its bindings, or `None` for any other binary
-    /// operator.
+    /// Resolve a binding operator's definitions.
     fn resolve_operator_assign(&mut self, bin: &RBinaryExpression) -> Option<Vec<AssignBinding>> {
         let op = bin.operator().ok()?;
 

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -2,12 +2,13 @@ use aether_syntax::AnyRArgumentName;
 use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRValue;
 use aether_syntax::RArgument;
+use aether_syntax::RBinaryExpression;
 use aether_syntax::RCall;
 use biome_rowan::AstNode;
 use biome_rowan::AstPtr;
 use biome_rowan::AstSeparatedList;
 use biome_rowan::WalkEvent;
-// Re-exported so consumers building an `AssignBinding` (custom `EffectHandler`s)
+// Re-exported so consumers building an `AssignBinding` (custom `AssignHandler`s)
 // can name the `name_expr` field's type without depending on oak_core directly.
 pub use oak_core::range::RangedAstPtr;
 use oak_core::syntax_ext::RIdentifierExt;
@@ -53,7 +54,7 @@ pub struct EffectsHandlers {
     pub arguments: Option<&'static dyn EffectHandler<Output = ResolvedArgumentEffects>>,
     pub attach: Option<&'static dyn EffectHandler<Output = String>>,
     pub source: Option<&'static dyn EffectHandler<Output = Vec<String>>>,
-    pub assign: Option<&'static dyn EffectHandler<Output = Vec<AssignBinding>>>,
+    pub assign: Option<&'static dyn AssignHandler>,
 }
 
 /// Resolver for an effect of a call.
@@ -71,6 +72,25 @@ pub trait EffectHandler: std::fmt::Debug + Sync {
     /// `ctx` resolves information the call's own syntax doesn't carry, e.g. what
     /// a `character.only = TRUE` variable is bound to. Unused until that lands.
     fn resolve(&self, call: &RCall, ctx: &CallContext) -> Option<Self::Output>;
+}
+
+/// Where an effect is invoked. Most effects are only ever calls but an Assign
+/// effect can also be a binding operator (`x %<>% f`). [`AssignHandler`] takes
+/// this to disambiguate rather than a bare call.
+pub enum EffectSite<'a> {
+    Call(&'a RCall),
+    Operator(&'a RBinaryExpression),
+}
+
+/// Resolver for an assign-like effect.
+///
+/// Separate from [`EffectHandler`] because an assign has two invocation shapes,
+/// a call (`assign("x", v)`) and a binding operator (`x %<>% f`).
+///
+/// Contributed statically like [`EffectHandler`], so it's `Sync` for the
+/// registry `static`s.
+pub trait AssignHandler: std::fmt::Debug + Sync {
+    fn resolve(&self, site: EffectSite, ctx: &CallContext) -> Option<Vec<AssignBinding>>;
 }
 
 /// Context for effect handlers.
@@ -139,6 +159,15 @@ impl CallContext {
         match value {
             AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
             // Static resolution of expressions is not implemented yet
+            _ => None,
+        }
+    }
+
+    /// Read a quoted name argument. E.g. the LHS of an Assign operator.
+    pub fn resolve_quoted_symbol_or_string(&self, value: &AnyRExpression) -> Option<String> {
+        match value {
+            AnyRExpression::RIdentifier(ident) => Some(ident.name_text()),
+            AnyRExpression::AnyRValue(AnyRValue::RStringValue(s)) => s.string_text(),
             _ => None,
         }
     }
@@ -454,10 +483,11 @@ pub struct AssignAnnotation {
     pub position: usize,
 }
 
-impl EffectHandler for AssignAnnotation {
-    type Output = Vec<AssignBinding>;
-
-    fn resolve(&self, call: &RCall, ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+impl AssignHandler for AssignAnnotation {
+    fn resolve(&self, site: EffectSite, ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+        let EffectSite::Call(call) = site else {
+            return None;
+        };
         let args = call.arguments().ok()?;
 
         // Matched positionally among unnamed arguments, same as `source`, so a
@@ -508,6 +538,30 @@ impl EffectHandler for AssignAnnotation {
             name,
             name_expr,
             value_expr,
+        }])
+    }
+}
+
+/// Handler for a binding operator (`x %<>% f()`, `x %<~% expr`, `x := expr`).
+///
+/// The operator captures its LHS unevaluated.
+#[derive(Debug, Clone, Copy)]
+pub struct BindingOperatorHandler;
+
+impl AssignHandler for BindingOperatorHandler {
+    fn resolve(&self, site: EffectSite, ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+        let EffectSite::Operator(bin) = site else {
+            return None;
+        };
+        let left = bin.left().ok()?;
+        let right = bin.right().ok()?;
+
+        let name = ctx.resolve_quoted_symbol_or_string(&left)?;
+
+        Some(vec![AssignBinding {
+            name,
+            name_expr: RangedAstPtr::new(&left),
+            value_expr: Some(AstPtr::new(&right)),
         }])
     }
 }

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -41,11 +41,13 @@ pub struct Effects {
 ///   be matched against a cursor (e.g. for goto/rename).
 /// - `value_expr` is what a type checker infers the binding's type from (`None`
 ///   with no value argument).
+/// - `target` tells the walk whether the bound name is also read here.
 #[derive(Debug, Clone)]
 pub struct AssignBinding {
     pub name: String,
     pub name_expr: RangedAstPtr<AnyRExpression>,
     pub value_expr: Option<AstPtr<AnyRExpression>>,
+    pub target: TargetAccess,
 }
 
 /// The handlers that compute a function's effects.
@@ -91,6 +93,16 @@ pub enum EffectSite<'a> {
 /// registry `static`s.
 pub trait AssignHandler: std::fmt::Debug + Sync {
     fn resolve(&self, site: EffectSite, ctx: &CallContext) -> Option<Vec<AssignBinding>>;
+}
+
+/// Whether an assign effect reads its target before writing it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetAccess {
+    /// Writes the target without reading it, as in `x <- value`.
+    Write,
+    /// Reads the target before rebinding it. `x %<>% f()` expands to
+    /// `x <- x %>% f()`, so `x` is a use and a definition.
+    ReadWrite,
 }
 
 /// Context for effect handlers.
@@ -538,15 +550,17 @@ impl AssignHandler for AssignAnnotation {
             name,
             name_expr,
             value_expr,
+            target: TargetAccess::Write,
         }])
     }
 }
 
 /// Handler for a binding operator (`x %<>% f()`, `x %<~% expr`, `x := expr`).
-///
-/// The operator captures its LHS unevaluated.
 #[derive(Debug, Clone, Copy)]
-pub struct BindingOperatorHandler;
+pub struct BindingOperatorHandler {
+    /// Whether the target is also read (compound operators like `%<>%`).
+    pub target: TargetAccess,
+}
 
 impl AssignHandler for BindingOperatorHandler {
     fn resolve(&self, site: EffectSite, ctx: &CallContext) -> Option<Vec<AssignBinding>> {
@@ -562,6 +576,7 @@ impl AssignHandler for BindingOperatorHandler {
             name,
             name_expr: RangedAstPtr::new(&left),
             value_expr: Some(AstPtr::new(&right)),
+            target: self.target,
         }])
     }
 }

--- a/crates/oak_semantic/src/effects_registry.rs
+++ b/crates/oak_semantic/src/effects_registry.rs
@@ -3,6 +3,7 @@ use crate::effects::ArgumentEffect;
 use crate::effects::ArgumentsAnnotation;
 use crate::effects::AssignAnnotation;
 use crate::effects::AttachAnnotation;
+use crate::effects::BindingOperatorHandler;
 use crate::effects::BquoteHandler;
 use crate::effects::EffectsHandlers;
 use crate::effects::SourceAnnotation;
@@ -121,7 +122,8 @@ macro_rules! source {
 }
 
 /// An assign entry: `(name-argument position)`. The function binds a name in the
-/// current scope.
+/// current scope, naming it in a positional argument it evaluates (`assign("x",
+/// v)`).
 macro_rules! assign {
     ($pkg:literal, $func:literal, $pos:literal) => {
         Entry {
@@ -132,6 +134,24 @@ macro_rules! assign {
                 attach: None,
                 source: None,
                 assign: Some(&AssignAnnotation { position: $pos }),
+            },
+        }
+    };
+}
+
+/// An assign-operator entry: a binding operator (`x %<>% f`, `x := v`) that binds
+/// a name in the current scope. It captures its LHS unevaluated, so the name
+/// comes from the LHS text rather than a positional argument, hence no position.
+macro_rules! assign_op {
+    ($pkg:literal, $func:literal) => {
+        Entry {
+            package: $pkg,
+            function: $func,
+            effects: EffectsHandlers {
+                arguments: None,
+                attach: None,
+                source: None,
+                assign: Some(&BindingOperatorHandler),
             },
         }
     };
@@ -168,9 +188,9 @@ static REGISTRY: &[Entry] = &[
     assign!("base", "assign", 0),
     assign!("base", "delayedAssign", 0),
     // magrittr / rlang / S7 binding operators
-    assign!("magrittr", "%<>%", 0),
-    assign!("rlang", "%<~%", 0),
-    assign!("S7", ":=", 0),
+    assign_op!("magrittr", "%<>%"),
+    assign_op!("rlang", "%<~%"),
+    assign_op!("S7", ":="),
     // rlang
     nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
     // shiny

--- a/crates/oak_semantic/src/effects_registry.rs
+++ b/crates/oak_semantic/src/effects_registry.rs
@@ -7,6 +7,8 @@ use crate::effects::BindingOperatorHandler;
 use crate::effects::BquoteHandler;
 use crate::effects::EffectsHandlers;
 use crate::effects::SourceAnnotation;
+use crate::effects::TargetAccess::ReadWrite;
+use crate::effects::TargetAccess::Write;
 use crate::semantic_index::NseScope::Current;
 use crate::semantic_index::NseScope::Nested;
 use crate::semantic_index::NseTiming::Eager;
@@ -139,11 +141,10 @@ macro_rules! assign {
     };
 }
 
-/// An assign-operator entry: a binding operator (`x %<>% f`, `x := v`) that binds
-/// a name in the current scope. It captures its LHS unevaluated, so the name
-/// comes from the LHS text rather than a positional argument, hence no position.
+/// Register a binding operator and whether it reads its LHS before rebinding
+/// it. Its unevaluated LHS supplies the bound name.
 macro_rules! assign_op {
-    ($pkg:literal, $func:literal) => {
+    ($pkg:literal, $func:literal, $target:expr) => {
         Entry {
             package: $pkg,
             function: $func,
@@ -151,7 +152,7 @@ macro_rules! assign_op {
                 arguments: None,
                 attach: None,
                 source: None,
-                assign: Some(&BindingOperatorHandler),
+                assign: Some(&BindingOperatorHandler { target: $target }),
             },
         }
     };
@@ -188,9 +189,9 @@ static REGISTRY: &[Entry] = &[
     assign!("base", "assign", 0),
     assign!("base", "delayedAssign", 0),
     // magrittr / rlang / S7 binding operators
-    assign_op!("magrittr", "%<>%"),
-    assign_op!("rlang", "%<~%"),
-    assign_op!("S7", ":="),
+    assign_op!("magrittr", "%<>%", ReadWrite),
+    assign_op!("rlang", "%<~%", Write),
+    assign_op!("S7", ":=", Write),
     // rlang
     nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
     // shiny

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -6,8 +6,10 @@ use biome_rowan::AstNode;
 use biome_rowan::AstSeparatedList;
 use oak_semantic::build_index;
 use oak_semantic::effects::AssignBinding;
+use oak_semantic::effects::AssignHandler;
 use oak_semantic::effects::CallContext;
 use oak_semantic::effects::EffectHandler;
+use oak_semantic::effects::EffectSite;
 use oak_semantic::effects::RangedAstPtr;
 use oak_semantic::effects::SourceAnnotation;
 use oak_semantic::effects_registry;
@@ -2329,10 +2331,11 @@ struct MultiAssignHandler;
 
 static MULTI_ASSIGN_HANDLER: MultiAssignHandler = MultiAssignHandler;
 
-impl EffectHandler for MultiAssignHandler {
-    type Output = Vec<AssignBinding>;
-
-    fn resolve(&self, call: &RCall, _ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+impl AssignHandler for MultiAssignHandler {
+    fn resolve(&self, site: EffectSite, _ctx: &CallContext) -> Option<Vec<AssignBinding>> {
+        let EffectSite::Call(call) = site else {
+            return None;
+        };
         // Point every binding's handles at the first argument. This test only
         // checks that multiple defs are created and resolve, not their ranges.
         let expr = call

--- a/crates/oak_semantic/tests/integration/builder.rs
+++ b/crates/oak_semantic/tests/integration/builder.rs
@@ -12,6 +12,7 @@ use oak_semantic::effects::EffectHandler;
 use oak_semantic::effects::EffectSite;
 use oak_semantic::effects::RangedAstPtr;
 use oak_semantic::effects::SourceAnnotation;
+use oak_semantic::effects::TargetAccess;
 use oak_semantic::effects_registry;
 use oak_semantic::semantic_index::DefinitionId;
 use oak_semantic::semantic_index::DefinitionKind;
@@ -1807,11 +1808,7 @@ fn index_with_attached(source: &str, packages: &[&str]) -> SemanticIndex {
 
 #[test]
 fn test_magrittr_compound_assignment_binds_lhs() {
-    // `x %<>% f()` binds `x`. The left operand is a definition target, not a
-    // read, the same as `<-`, so only `f` (the right operand) is a use.
-    //
-    // `%<>%` is compound (`x <- f(x)`), so `x` is conceptually read too, but we
-    // don't record that read yet. See the `TODO(nse)` in the walk's binary arm.
+    // `%<>%` expands to `x <- x %>% f()`, so it reads and rebinds `x`.
     let index = index_with_attached("x %<>% f()", &["magrittr"]);
     let file = ScopeId::from(0);
 
@@ -1820,15 +1817,33 @@ fn test_magrittr_compound_assignment_binds_lhs() {
         Some(DefinitionKind::Assign { .. })
     ));
 
-    // Only the right operand `f` is a use; the target `x` is not recorded.
-    assert_eq!(index.uses(file).len(), 1);
+    assert_eq!(index.uses(file).len(), 2);
     let symbols = index.symbols(file);
     assert_eq!(
         symbols
             .symbol(index.uses(file)[UseId::from(0)].symbol())
             .name(),
+        "x"
+    );
+    assert_eq!(
+        symbols
+            .symbol(index.uses(file)[UseId::from(1)].symbol())
+            .name(),
         "f"
     );
+}
+
+#[test]
+fn test_magrittr_compound_assignment_target_read_resolves_to_prior_binding() {
+    // `%<>%` reads `x` before rebinding it, so this use reaches `x <- 1`.
+    let index = index_with_attached("x <- 1\nx %<>% f()", &["magrittr"]);
+    let file = ScopeId::from(0);
+
+    let map = index.use_def_map(file);
+    let bindings = map.bindings_at_use(UseId::from(0));
+    assert_eq!(bindings.definitions().len(), 1);
+    let def = &index.definitions(file)[bindings.definitions()[0]];
+    assert_eq!(def.range(), biome_rowan::TextRange::new(0.into(), 1.into()));
 }
 
 #[test]
@@ -1934,10 +1949,9 @@ fn test_compound_assignment_use_resolves_to_binding() {
     let index = index_with_attached("y %<>% f()\ny", &["magrittr"]);
     let file = ScopeId::from(0);
 
-    // Uses in order: `f` (right operand), then the trailing `y`. The left
-    // operand `y` is the binding target, not a use.
+    // The trailing `y` is use 2 because `%<>%` first reads its target and `f`.
     let map = index.use_def_map(file);
-    let bindings = map.bindings_at_use(UseId::from(1));
+    let bindings = map.bindings_at_use(UseId::from(2));
     assert_eq!(bindings.definitions().len(), 1);
     let def = &index.definitions(file)[bindings.definitions()[0]];
     assert!(matches!(def.kind(), DefinitionKind::Assign { .. }));
@@ -2352,11 +2366,13 @@ impl AssignHandler for MultiAssignHandler {
                 name: "a".into(),
                 name_expr: ptr.clone(),
                 value_expr: None,
+                target: TargetAccess::Write,
             },
             AssignBinding {
                 name: "b".into(),
                 name_expr: ptr,
                 value_expr: None,
+                target: TargetAccess::Write,
             },
         ])
     }


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338
Branched from https://github.com/posit-dev/ark/pull/1347

Refactor, no behavior change. Assign effects come in two variants, a call (`assign("x", v)`) and a binding operator (`x %<>% f`), and until now only the call went through a handler. The operator was hand-built in the builder, using the registry only to check a handler was present, and the operator registry entries carried a phantom `position: 0` that was never read.

The refactor moves the operator logic into the handler layer, symmetric with calls. Supporting infra: A new `EffectSite` (`Call` | `Operator`) to disambiguate the variants, and a new `AssignHandler` trait.

