### PR TITLE
Filter same-version rebuilds from `pkg_outdated`

### DIFF
--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -192,8 +192,30 @@
 # cannot guarantee.
 #' @export
 .ps.rpc.pkg_outdated <- function() {
-    outdated <- utils::old.packages()
+    pkg_outdated_result(utils::old.packages())
+}
+
+# Turn an `old.packages()` matrix into the pane's outdated-package list. Split
+# out from the RPC so the filtering and formatting can be tested without
+# querying live repositories.
+#
+# We keep only packages whose repository version is strictly greater than the
+# installed version. old.packages() also flags packages whose repository copy
+# has the *same* version but a newer build or publication date (see the
+# `needs.install` closure inside utils::old.packages). Right after a new R
+# minor is installed, CRAN's freshly rebuilt binaries carry newer Built dates
+# than the user's carried-over packages, so hundreds of same-version packages
+# get flagged even though no newer version exists. The pane's update indicator
+# means "a newer version is available", so a same-version rebuild is not an
+# update we should surface.
+pkg_outdated_result <- function(outdated) {
     if (is.null(outdated) || nrow(outdated) == 0) {
+        return(list())
+    }
+    newer <- package_version(outdated[, "ReposVer"]) >
+        package_version(outdated[, "Installed"])
+    outdated <- outdated[newer, , drop = FALSE]
+    if (nrow(outdated) == 0) {
         return(list())
     }
     unname(Map(

--- a/crates/ark/src/modules/positron/packages_pane.R
+++ b/crates/ark/src/modules/positron/packages_pane.R
@@ -198,20 +198,14 @@
 # Turn an `old.packages()` matrix into the pane's outdated-package list. Split
 # out from the RPC so the filtering and formatting can be tested without
 # querying live repositories.
-#
-# We keep only packages whose repository version is strictly greater than the
-# installed version. old.packages() also flags packages whose repository copy
-# has the *same* version but a newer build or publication date (see the
-# `needs.install` closure inside utils::old.packages). Right after a new R
-# minor is installed, CRAN's freshly rebuilt binaries carry newer Built dates
-# than the user's carried-over packages, so hundreds of same-version packages
-# get flagged even though no newer version exists. The pane's update indicator
-# means "a newer version is available", so a same-version rebuild is not an
-# update we should surface.
 pkg_outdated_result <- function(outdated) {
     if (is.null(outdated) || nrow(outdated) == 0) {
         return(list())
     }
+    # Since R 4.6, `old.packages()` also reports equal-version packages with
+    # newer `Built` or `Published` timestamps, which flags hundreds of packages
+    # right after an R minor upgrade rebuilds CRAN's binaries. The pane promises
+    # a newer package version, so exclude those entries.
     newer <- package_version(outdated[, "ReposVer"]) >
         package_version(outdated[, "Installed"])
     outdated <- outdated[newer, , drop = FALSE]

--- a/crates/ark/tests/integration/main.rs
+++ b/crates/ark/tests/integration/main.rs
@@ -42,6 +42,7 @@ mod kernel_variables;
 mod lsp;
 mod lsp_completions;
 mod options;
+mod packages_pane;
 mod plots;
 mod repos_auto;
 mod repos_conf_file;

--- a/crates/ark/tests/integration/packages_pane.rs
+++ b/crates/ark/tests/integration/packages_pane.rs
@@ -13,17 +13,22 @@ use ark::r_task::r_task;
 // resulting entries formatted as `name@latestVersion`.
 fn pkg_outdated(rows: &str) -> Vec<String> {
     r_task(|| {
+        // Evaluate inside `local()` so the helper bindings land in a fresh
+        // child environment: the positron namespace itself is locked, so
+        // assigning into it directly would error.
         let code = format!(
             r#"
-            row <- function(pkg, installed, repos) {{
-                c(pkg, "lib", installed, "4.4.0", repos, "CRAN")
-            }}
-            m <- rbind({rows})
-            colnames(m) <- c(
-                "Package", "LibPath", "Installed", "Built", "ReposVer", "Repository"
-            )
-            res <- pkg_outdated_result(m)
-            vapply(res, function(x) paste0(x$name, "@", x$latestVersion), character(1))
+            local({{
+                row <- function(pkg, installed, repos) {{
+                    c(pkg, "lib", installed, "4.4.0", repos, "CRAN")
+                }}
+                m <- rbind({rows})
+                colnames(m) <- c(
+                    "Package", "LibPath", "Installed", "Built", "ReposVer", "Repository"
+                )
+                res <- pkg_outdated_result(m)
+                vapply(res, function(x) paste0(x$name, "@", x$latestVersion), character(1))
+            }})
             "#
         );
         harp::parse_eval0(&code, ARK_ENVS.positron_ns)
@@ -87,8 +92,10 @@ fn test_pkg_outdated_handles_null() {
     let outdated: Vec<String> = r_task(|| {
         harp::parse_eval0(
             r#"
-            res <- pkg_outdated_result(NULL)
-            vapply(res, function(x) x$name, character(1))
+            local({
+                res <- pkg_outdated_result(NULL)
+                vapply(res, function(x) x$name, character(1))
+            })
             "#,
             ARK_ENVS.positron_ns,
         )

--- a/crates/ark/tests/integration/packages_pane.rs
+++ b/crates/ark/tests/integration/packages_pane.rs
@@ -1,0 +1,100 @@
+//
+// packages_pane.rs
+//
+// Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+//
+//
+
+use ark::modules::ARK_ENVS;
+use ark::r_task::r_task;
+
+// Build a fake `old.packages()` matrix from `(package, installed, repos)` rows,
+// run it through the pane's `pkg_outdated_result()` helper, and return the
+// resulting entries formatted as `name@latestVersion`.
+fn pkg_outdated(rows: &str) -> Vec<String> {
+    r_task(|| {
+        let code = format!(
+            r#"
+            row <- function(pkg, installed, repos) {{
+                c(pkg, "lib", installed, "4.4.0", repos, "CRAN")
+            }}
+            m <- rbind({rows})
+            colnames(m) <- c(
+                "Package", "LibPath", "Installed", "Built", "ReposVer", "Repository"
+            )
+            res <- pkg_outdated_result(m)
+            vapply(res, function(x) paste0(x$name, "@", x$latestVersion), character(1))
+            "#
+        );
+        harp::parse_eval0(&code, ARK_ENVS.positron_ns)
+            .unwrap()
+            .try_into()
+            .unwrap()
+    })
+}
+
+#[test]
+fn test_pkg_outdated_keeps_newer_repository_version() {
+    let outdated = pkg_outdated(r#"row("pkgA", "1.0.0", "2.0.0")"#);
+    assert_eq!(outdated, vec![String::from("pkgA@2.0.0")]);
+}
+
+#[test]
+fn test_pkg_outdated_drops_same_version_rebuild() {
+    // old.packages() flags this because the repository copy has a newer Built
+    // or publication date, but the version is unchanged so it is not an update.
+    let outdated = pkg_outdated(r#"row("pkgB", "1.5.0", "1.5.0")"#);
+    assert!(outdated.is_empty());
+}
+
+#[test]
+fn test_pkg_outdated_keeps_only_real_upgrades() {
+    let outdated = pkg_outdated(
+        r#"
+        row("pkgA", "1.0.0", "2.0.0"),
+        row("pkgB", "1.5.0", "1.5.0"),
+        row("pkgC", "0.9.0", "0.9.1")
+        "#,
+    );
+    assert_eq!(outdated, vec![
+        String::from("pkgA@2.0.0"),
+        String::from("pkgC@0.9.1"),
+    ]);
+}
+
+#[test]
+fn test_pkg_outdated_compares_versions_numerically() {
+    // Versions must compare as numbers, not strings: "10.0.0" is newer than
+    // "9.0.0" even though it sorts before it as a string. A naive string
+    // comparison would wrongly hide this upgrade.
+    let outdated = pkg_outdated(r#"row("pkgA", "9.0.0", "10.0.0")"#);
+    assert_eq!(outdated, vec![String::from("pkgA@10.0.0")]);
+}
+
+#[test]
+fn test_pkg_outdated_empty_when_all_rebuilds() {
+    let outdated = pkg_outdated(
+        r#"
+        row("pkgA", "1.0.0", "1.0.0"),
+        row("pkgB", "1.5.0", "1.5.0")
+        "#,
+    );
+    assert!(outdated.is_empty());
+}
+
+#[test]
+fn test_pkg_outdated_handles_null() {
+    let outdated: Vec<String> = r_task(|| {
+        harp::parse_eval0(
+            r#"
+            res <- pkg_outdated_result(NULL)
+            vapply(res, function(x) x$name, character(1))
+            "#,
+            ARK_ENVS.positron_ns,
+        )
+        .unwrap()
+        .try_into()
+        .unwrap()
+    });
+    assert!(outdated.is_empty());
+}

--- a/crates/ark/tests/integration/packages_pane.rs
+++ b/crates/ark/tests/integration/packages_pane.rs
@@ -8,100 +8,178 @@
 use ark::modules::ARK_ENVS;
 use ark::r_task::r_task;
 
-// Build a fake `old.packages()` matrix from `(package, installed, repos)` rows,
-// run it through the pane's `pkg_outdated_result()` helper, and return the
-// resulting entries formatted as `name@latestVersion`.
-fn pkg_outdated(rows: &str) -> Vec<String> {
-    r_task(|| {
-        // Evaluate inside `local()` so the helper bindings land in a fresh
-        // child environment: the positron namespace itself is locked, so
-        // assigning into it directly would error.
-        let code = format!(
-            r#"
-            local({{
-                row <- function(pkg, installed, repos) {{
-                    c(pkg, "lib", installed, "4.4.0", repos, "CRAN")
-                }}
-                m <- rbind({rows})
-                colnames(m) <- c(
-                    "Package", "LibPath", "Installed", "Built", "ReposVer", "Repository"
+// R helpers that stand up a fake library and a fake repository so
+// `.ps.rpc.pkg_outdated()` can run against real `old.packages()` output on
+// whichever R version we are testing against.
+//
+// Nothing is installed or compiled: `installed.packages()` only reads
+// `<lib>/<pkg>/Meta/package.rds`, and `available.packages()` only reads a DCF
+// `PACKAGES` file under `<repo>/src/contrib`. `Built` is only a standard field
+// for binary repositories, so we ask for it explicitly through
+// `available_packages_fields` and the fixture stays a portable source repo.
+const FAKE_LIBRARY: &str = r#"
+    pkg <- function(name, version, built) {
+        list(name = name, version = version, built = built)
+    }
+
+    with_fake_library <- function(installed, available, expr) {
+        lib <- tempfile("arklib")
+        contrib <- file.path(tempfile("arkrepo"), "src", "contrib")
+        dir.create(contrib, recursive = TRUE)
+
+        # R >= 4.6 reads the whole `Built` string from the installed
+        # DESCRIPTION, older versions read `Built$R`, so supply both.
+        for (entry in installed) {
+            dir.create(file.path(lib, entry$name, "Meta"), recursive = TRUE)
+            saveRDS(
+                list(
+                    DESCRIPTION = c(
+                        Package = entry$name,
+                        Version = entry$version,
+                        Priority = NA_character_,
+                        Built = entry$built
+                    ),
+                    Built = list(
+                        R = package_version(sub("^R ([0-9.]+).*", "\\1", entry$built))
+                    )
+                ),
+                file.path(lib, entry$name, "Meta", "package.rds")
+            )
+        }
+
+        stanzas <- vapply(
+            available,
+            function(entry) {
+                paste0(
+                    "Package: ", entry$name, "\n",
+                    "Version: ", entry$version, "\n",
+                    "Built: ", entry$built, "\n"
                 )
-                res <- pkg_outdated_result(m)
-                vapply(res, function(x) paste0(x$name, "@", x$latestVersion), character(1))
-            }})
-            "#
-        );
+            },
+            character(1)
+        )
+        writeLines(stanzas, file.path(contrib, "PACKAGES"))
+
+        repo <- dirname(dirname(contrib))
+        old_libs <- .libPaths()
+        old_opts <- options(
+            repos = c(CRAN = paste0("file:///", normalizePath(repo, winslash = "/"))),
+            pkgType = "source",
+            available_packages_fields = "Built"
+        )
+        on.exit({
+            options(old_opts)
+            .libPaths(old_libs)
+        })
+        .libPaths(lib)
+
+        force(expr)
+    }
+
+    # A package built by an older R, and the same package rebuilt more recently.
+    built_old <- "R 4.4.1; ; 2026-01-01 00:00:00 UTC; unix"
+    built_new <- "R 4.6.0; ; 2026-06-01 00:00:00 UTC; unix"
+
+    entries <- function(outdated) {
+        vapply(
+            outdated,
+            function(entry) paste0(entry$name, "@", entry$latestVersion),
+            character(1)
+        )
+    }
+"#;
+
+#[test]
+fn test_pkg_outdated_reports_only_newer_versions() {
+    // `arkfakenumeric` also pins that versions compare as numbers rather than
+    // strings: "10.0.0" is newer than "9.0.0" even though it sorts before it.
+    let result = eval_in_fake_library(
+        r#"
+        with_fake_library(
+            installed = list(
+                pkg("arkfakecurrent", "3.0.0", built_old),
+                pkg("arkfakenumeric", "9.0.0", built_old),
+                pkg("arkfakerebuild", "1.5.0", built_old),
+                pkg("arkfakeupgrade", "1.0.0", built_old)
+            ),
+            available = list(
+                pkg("arkfakecurrent", "3.0.0", built_old),
+                pkg("arkfakenumeric", "10.0.0", built_new),
+                pkg("arkfakerebuild", "1.5.0", built_new),
+                pkg("arkfakeupgrade", "2.0.0", built_new)
+            ),
+            {
+                outdated <- utils::old.packages()
+                c(
+                    paste(entries(.ps.rpc.pkg_outdated()), collapse = ","),
+                    as.character("arkfakerebuild" %in% outdated[, "Package"]),
+                    as.character(getRversion() >= "4.6.0")
+                )
+            }
+        )
+        "#,
+    );
+
+    let [outdated, rebuild_flagged, r_reports_rebuilds] = result.as_slice() else {
+        panic!("Expected three elements, got {result:?}");
+    };
+
+    assert_eq!(outdated, "arkfakenumeric@10.0.0,arkfakeupgrade@2.0.0");
+
+    // `arkfakerebuild` exists to be filtered out, so check that `old.packages()`
+    // really does report it on the R versions that report same-version
+    // rebuilds. Otherwise this test could pass while exercising nothing.
+    assert_eq!(rebuild_flagged, r_reports_rebuilds);
+}
+
+#[test]
+fn test_pkg_outdated_empty_when_no_newer_versions() {
+    let result = eval_in_fake_library(
+        r#"
+        with_fake_library(
+            installed = list(
+                pkg("arkfakecurrent", "3.0.0", built_old),
+                pkg("arkfakerebuild", "1.5.0", built_old)
+            ),
+            available = list(
+                pkg("arkfakecurrent", "3.0.0", built_old),
+                pkg("arkfakerebuild", "1.5.0", built_new)
+            ),
+            {
+                outdated <- utils::old.packages()
+                c(
+                    paste(entries(.ps.rpc.pkg_outdated()), collapse = ","),
+                    as.character(
+                        !is.null(outdated) && "arkfakerebuild" %in% outdated[, "Package"]
+                    ),
+                    as.character(getRversion() >= "4.6.0"),
+                    # `old.packages()` returns `NULL` rather than an empty matrix
+                    # when it finds nothing, which is what R < 4.6 does here.
+                    paste(entries(pkg_outdated_result(NULL)), collapse = ",")
+                )
+            }
+        )
+        "#,
+    );
+
+    let [outdated, rebuild_flagged, r_reports_rebuilds, null_input] = result.as_slice() else {
+        panic!("Expected four elements, got {result:?}");
+    };
+
+    assert_eq!(outdated, "");
+    assert_eq!(rebuild_flagged, r_reports_rebuilds);
+    assert_eq!(null_input, "");
+}
+
+fn eval_in_fake_library(body: &str) -> Vec<String> {
+    // Evaluate inside `local()` so the fixture helpers land in a fresh child
+    // environment: the positron namespace itself is locked, so assigning into
+    // it directly would error.
+    let code = format!("local({{\n{FAKE_LIBRARY}\n{body}\n}})");
+    r_task(|| {
         harp::parse_eval0(&code, ARK_ENVS.positron_ns)
             .unwrap()
             .try_into()
             .unwrap()
     })
-}
-
-#[test]
-fn test_pkg_outdated_keeps_newer_repository_version() {
-    let outdated = pkg_outdated(r#"row("pkgA", "1.0.0", "2.0.0")"#);
-    assert_eq!(outdated, vec![String::from("pkgA@2.0.0")]);
-}
-
-#[test]
-fn test_pkg_outdated_drops_same_version_rebuild() {
-    // old.packages() flags this because the repository copy has a newer Built
-    // or publication date, but the version is unchanged so it is not an update.
-    let outdated = pkg_outdated(r#"row("pkgB", "1.5.0", "1.5.0")"#);
-    assert!(outdated.is_empty());
-}
-
-#[test]
-fn test_pkg_outdated_keeps_only_real_upgrades() {
-    let outdated = pkg_outdated(
-        r#"
-        row("pkgA", "1.0.0", "2.0.0"),
-        row("pkgB", "1.5.0", "1.5.0"),
-        row("pkgC", "0.9.0", "0.9.1")
-        "#,
-    );
-    assert_eq!(outdated, vec![
-        String::from("pkgA@2.0.0"),
-        String::from("pkgC@0.9.1"),
-    ]);
-}
-
-#[test]
-fn test_pkg_outdated_compares_versions_numerically() {
-    // Versions must compare as numbers, not strings: "10.0.0" is newer than
-    // "9.0.0" even though it sorts before it as a string. A naive string
-    // comparison would wrongly hide this upgrade.
-    let outdated = pkg_outdated(r#"row("pkgA", "9.0.0", "10.0.0")"#);
-    assert_eq!(outdated, vec![String::from("pkgA@10.0.0")]);
-}
-
-#[test]
-fn test_pkg_outdated_empty_when_all_rebuilds() {
-    let outdated = pkg_outdated(
-        r#"
-        row("pkgA", "1.0.0", "1.0.0"),
-        row("pkgB", "1.5.0", "1.5.0")
-        "#,
-    );
-    assert!(outdated.is_empty());
-}
-
-#[test]
-fn test_pkg_outdated_handles_null() {
-    let outdated: Vec<String> = r_task(|| {
-        harp::parse_eval0(
-            r#"
-            local({
-                res <- pkg_outdated_result(NULL)
-                vapply(res, function(x) x$name, character(1))
-            })
-            "#,
-            ARK_ENVS.positron_ns,
-        )
-        .unwrap()
-        .try_into()
-        .unwrap()
-    });
-    assert!(outdated.is_empty());
 }


### PR DESCRIPTION
This addresses part of posit-dev/positron#14294, where the packages pane surfaces a large number of packages as having updates available when in fact they don't.

`.ps.rpc.pkg_outdated()` was returning everything from `utils::old.packages()`. That function flags a package as outdated when the repository version is strictly newer *or* when the version is identical but the repository copy has a newer build or publication date (see the `needs.install` closure inside `utils:::old.packages`). Right after a new R minor is installed, CRAN's freshly rebuilt binaries carry newer `Built` dates than the user's carried-over packages, so hundreds of same-version packages get flagged even though no newer version exists.

The pane's update indicator means "a newer version is available," so this filters `old.packages()` down to packages whose repository version is strictly greater than the installed version, dropping same-version rebuilds.

### Changes

- Split the filtering and formatting out of `.ps.rpc.pkg_outdated()` into a pure `pkg_outdated_result()` helper so it can be tested without querying live repositories.
- Keep only packages where `ReposVer > Installed` (compared with `package_version()`, so `10.0.0` correctly beats `9.0.0`).

### Testing

Added integration tests in `crates/ark/tests/integration/packages_pane.rs` driving `pkg_outdated_result()` with fabricated `old.packages()` matrices: a genuine upgrade is kept, a same-version rebuild is dropped, a mixed list keeps only real upgrades in order, versions compare numerically rather than as strings, and `NULL` / all-rebuild inputs return an empty list.

Also verified manually that `old.packages()` really does flag a same-version rebuild (via injected `instPkgs`/`available` matrices with a newer `Built` date) and that the filter drops it while keeping a genuine upgrade.

### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed the packages pane reporting available updates for packages that have only been rebuilt (same version) rather than genuinely updated (posit-dev/positron#14294).
