### PR TITLE
Fix within string subset completions on non-syntactic names

### DIFF
--- a/crates/ark/src/lsp/completions/completion_item.rs
+++ b/crates/ark/src/lsp/completions/completion_item.rs
@@ -310,21 +310,37 @@ pub(super) unsafe fn completion_item_from_dataset(name: &str) -> anyhow::Result<
     Ok(item)
 }
 
-pub(super) unsafe fn completion_item_from_data_variable(
+#[derive(Copy, Clone)]
+pub(super) enum QuoteStyle {
+    // Double quote with `"`
+    Double,
+
+    // Backtick with `\`` if the symbol isn't syntactic
+    BacktickIfNotSyntactic,
+
+    // No quoting. Useful if you know you're already inserting into an existing string.
+    None,
+}
+
+pub(super) fn completion_item_from_data_variable(
     name: &str,
     owner: &str,
-    enquote: bool,
+    quote_style: QuoteStyle,
 ) -> anyhow::Result<CompletionItem> {
     let mut item = completion_item(name, CompletionData::DataVariable {
         name: name.to_string(),
         owner: owner.to_string(),
     })?;
 
-    if enquote {
-        item.insert_text = Some(format!("\"{}\"", name));
-    } else if !is_valid_symbol(name) {
-        item.insert_text = Some(sym_quote(name));
-    }
+    match quote_style {
+        QuoteStyle::Double => item.insert_text = Some(format!("\"{name}\"")),
+        QuoteStyle::BacktickIfNotSyntactic => {
+            if !is_valid_symbol(name) {
+                item.insert_text = Some(sym_quote(name));
+            }
+        },
+        QuoteStyle::None => (),
+    };
 
     item.detail = Some(owner.to_string());
     item.kind = Some(CompletionItemKind::VARIABLE);

--- a/crates/ark/src/lsp/completions/sources/composite/pipe.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/pipe.rs
@@ -13,6 +13,7 @@ use tree_sitter::Node;
 
 use crate::console;
 use crate::lsp::completions::completion_context::CompletionContext;
+use crate::lsp::completions::completion_item::QuoteStyle;
 use crate::lsp::completions::sources::utils::completions_from_object_names;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
@@ -56,12 +57,10 @@ fn completions_from_pipe(root: Option<PipeRoot>) -> anyhow::Result<Option<Vec<Co
         return Ok(None);
     };
 
-    const ENQUOTE: bool = false;
-
     Ok(Some(completions_from_object_names(
         object,
         name.as_str(),
-        ENQUOTE,
+        QuoteStyle::BacktickIfNotSyntactic,
     )?))
 }
 

--- a/crates/ark/src/lsp/completions/sources/composite/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/composite/subset.rs
@@ -8,6 +8,7 @@
 use tower_lsp::lsp_types::CompletionItem;
 
 use crate::lsp::completions::completion_context::CompletionContext;
+use crate::lsp::completions::completion_item::QuoteStyle;
 use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
 use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
 use crate::lsp::completions::sources::CompletionSource;
@@ -38,8 +39,6 @@ impl CompletionSource for SubsetSource {
 pub(crate) fn completions_from_subset(
     context: &DocumentContext,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
-    const ENQUOTE: bool = true;
-
     let mut node = context.node;
     let mut needs_completions = false;
 
@@ -82,7 +81,7 @@ pub(crate) fn completions_from_subset(
 
     let text = child.node_as_str(context.contents)?.to_string();
 
-    completions_from_evaluated_object_names(&text, ENQUOTE, node.node_type())
+    completions_from_evaluated_object_names(&text, QuoteStyle::Double, node.node_type())
 }
 
 #[cfg(test)]

--- a/crates/ark/src/lsp/completions/sources/unique/extractor.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/extractor.rs
@@ -19,6 +19,7 @@ use tree_sitter::Node;
 use crate::console;
 use crate::lsp::completions::completion_context::CompletionContext;
 use crate::lsp::completions::completion_item::completion_item_from_data_variable;
+use crate::lsp::completions::completion_item::QuoteStyle;
 use crate::lsp::completions::sources::utils::set_sort_text_by_first_appearance;
 use crate::lsp::completions::sources::CompletionSource;
 use crate::lsp::document_context::DocumentContext;
@@ -137,59 +138,55 @@ fn locate_extractor_node(node: Node, node_type: NodeType) -> Option<Node> {
 fn completions_from_extractor_object(text: &str, fun: &str) -> anyhow::Result<Vec<CompletionItem>> {
     log::trace!("completions_from_extractor_object({text:?}, {fun:?})");
 
-    const ENQUOTE: bool = false;
-
     let mut completions = vec![];
 
-    unsafe {
-        let env_utils = RFunction::new("base", "asNamespace").add("utils").call()?;
-        let sym = r_symbol!(fun);
+    let env_utils = RFunction::new("base", "asNamespace").add("utils").call()?;
+    let sym = r_symbol!(fun);
 
-        if !r_env_has(*env_utils, sym) {
-            // We'd like to generate these completions, but not a new enough version of R
-            return Ok(completions);
-        }
+    if !r_env_has(*env_utils, sym) {
+        // We'd like to generate these completions, but not a new enough version of R
+        return Ok(completions);
+    }
 
-        let options = RParseEvalOptions {
-            forbid_function_calls: true,
-            env: console::selected_env(),
-        };
+    let options = RParseEvalOptions {
+        forbid_function_calls: true,
+        env: console::selected_env(),
+    };
 
-        let object = match harp::parse_eval(text, options) {
-            Ok(object) => object,
-            Err(err) => match err {
-                // LHS of the call was too complex to evaluate. This is fine, we know
-                // we are on the RHS of a `$` or `@`, so we return an empty "unique"
-                // completion list to stop the completions search.
-                Error::UnsafeEvaluationError(_) => return Ok(completions),
-                // LHS of the call evaluated to an error. Totally possible if the
-                // user is writing pseudocode. Don't want to propagate an error here.
-                _ => return Ok(completions),
-            },
-        };
+    let object = match harp::parse_eval(text, options) {
+        Ok(object) => object,
+        Err(err) => match err {
+            // LHS of the call was too complex to evaluate. This is fine, we know
+            // we are on the RHS of a `$` or `@`, so we return an empty "unique"
+            // completion list to stop the completions search.
+            Error::UnsafeEvaluationError(_) => return Ok(completions),
+            // LHS of the call evaluated to an error. Totally possible if the
+            // user is writing pseudocode. Don't want to propagate an error here.
+            _ => return Ok(completions),
+        },
+    };
 
-        // Both `.DollarNames` and `.AtNames` have the same signature. Also, neither
-        // provide a default value for `pattern` in the generic, but do provide a default
-        // value of `pattern = ""` in the default S3 method. We manually pass through
-        // `pattern = ""` in case we hit an S3 method which forgot to provide a default
-        // value for `pattern` (like R6, posit-dev/positron#6699).
-        let names = RFunction::new("utils", fun)
-            .param("x", object)
-            .param("pattern", "")
-            .call()?;
+    // Both `.DollarNames` and `.AtNames` have the same signature. Also, neither
+    // provide a default value for `pattern` in the generic, but do provide a default
+    // value of `pattern = ""` in the default S3 method. We manually pass through
+    // `pattern = ""` in case we hit an S3 method which forgot to provide a default
+    // value for `pattern` (like R6, posit-dev/positron#6699).
+    let names = RFunction::new("utils", fun)
+        .param("x", object)
+        .param("pattern", "")
+        .call()?;
 
-        if r_typeof(*names) != STRSXP {
-            // Could come from a malformed user supplied S3 method
-            return Ok(completions);
-        }
+    if r_typeof(*names) != STRSXP {
+        // Could come from a malformed user supplied S3 method
+        return Ok(completions);
+    }
 
-        let names = names.to::<Vec<String>>()?;
+    let names = names.to::<Vec<String>>()?;
 
-        for name in names {
-            match completion_item_from_data_variable(&name, text, ENQUOTE) {
-                Ok(item) => completions.push(item),
-                Err(err) => log::error!("{err:?}"),
-            }
+    for name in names {
+        match completion_item_from_data_variable(&name, text, QuoteStyle::BacktickIfNotSyntactic) {
+            Ok(item) => completions.push(item),
+            Err(err) => log::error!("{err:?}"),
         }
     }
 

--- a/crates/ark/src/lsp/completions/sources/unique/subset.rs
+++ b/crates/ark/src/lsp/completions/sources/unique/subset.rs
@@ -8,6 +8,7 @@
 use tower_lsp::lsp_types::CompletionItem;
 use tree_sitter::Node;
 
+use crate::lsp::completions::completion_item::QuoteStyle;
 use crate::lsp::completions::sources::common::subset::is_within_subset_delimiters;
 use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
 use crate::lsp::document_context::DocumentContext;
@@ -33,9 +34,6 @@ pub(super) fn completions_from_string_subset(
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_string_subset()");
 
-    // Already inside a string
-    const ENQUOTE: bool = false;
-
     // i.e. find `x` in `x[""]` or `x[c("foo", "")]`
     let Some(node) = node_find_object_for_string_subset(node, context) else {
         return Ok(None);
@@ -49,7 +47,7 @@ pub(super) fn completions_from_string_subset(
     let text = node.node_as_str(context.contents)?;
 
     if let Some(mut candidates) =
-        completions_from_evaluated_object_names(text, ENQUOTE, node.node_type())?
+        completions_from_evaluated_object_names(text, QuoteStyle::None, node.node_type())?
     {
         completions.append(&mut candidates);
     }
@@ -242,6 +240,28 @@ mod tests {
 
             // Clean up
             parse_eval_global("remove(foo)").unwrap();
+        })
+    }
+
+    #[test]
+    fn test_string_subset_completions_with_non_syntactic_names() {
+        r_task(|| {
+            // Set up a list with non syntactic name
+            parse_eval_global("x <- list(`_a` = 1)").unwrap();
+
+            let (text, point) = point_from_cursor(r#"x["@"]"#);
+            let doc = TestDocument::new(&text);
+            let context = doc.context(point);
+            let node = node_find_string(&context.node).unwrap();
+
+            let completions = completions_from_string_subset(&node, &context)
+                .unwrap()
+                .unwrap();
+            assert_eq!(completions.len(), 1);
+
+            // Note how `_a` isn't backticked! We know we are inserting it directly
+            // into existing double quotes (posit-dev/positron#14909).
+            assert_eq!(completions.first().unwrap().label, "_a".to_string());
         })
     }
 }

--- a/crates/ark/src/lsp/completions/sources/utils.rs
+++ b/crates/ark/src/lsp/completions/sources/utils.rs
@@ -18,6 +18,7 @@ use tree_sitter::Point;
 
 use crate::console;
 use crate::lsp::completions::completion_item::completion_item_from_data_variable;
+use crate::lsp::completions::completion_item::QuoteStyle;
 use crate::lsp::document_context::DocumentContext;
 use crate::lsp::traits::node::NodeExt;
 use crate::lsp::traits::point::PointExt;
@@ -189,7 +190,7 @@ fn call_prev_leaf_position_type(node: &Node, allow_ambiguous: bool) -> CallNodeP
 
 pub(super) fn completions_from_evaluated_object_names(
     name: &str,
-    enquote: bool,
+    quote_style: QuoteStyle,
     node_type: NodeType,
 ) -> anyhow::Result<Option<Vec<CompletionItem>>> {
     log::trace!("completions_from_evaluated_object_names({name:?})");
@@ -224,18 +225,18 @@ pub(super) fn completions_from_evaluated_object_names(
 
     let completions = if harp::utils::r_is_matrix(object.sexp) {
         // Special case just for 2D arrays
-        completions_from_object_colnames(object, name, enquote)?
+        completions_from_object_colnames(object, name, quote_style)?
     } else if r_inherits(object.sexp, "data.table") {
-        // The `[` method for data.table uses NSE so we don't enquote the names
+        // The `[` method for data.table uses NSE so we don't double quote the names
         // https://github.com/posit-dev/positron/issues/3140
-        let enquote = match node_type {
-            NodeType::Subset => false,
-            NodeType::Subset2 => true,
-            _ => enquote,
+        let quote_style = if matches!(node_type, NodeType::Subset) {
+            QuoteStyle::BacktickIfNotSyntactic
+        } else {
+            quote_style
         };
-        completions_from_object_names(object, name, enquote)?
+        completions_from_object_names(object, name, quote_style)?
     } else {
-        completions_from_object_names(object, name, enquote)?
+        completions_from_object_names(object, name, quote_style)?
     };
 
     Ok(Some(completions))
@@ -244,40 +245,38 @@ pub(super) fn completions_from_evaluated_object_names(
 pub(super) fn completions_from_object_names(
     object: RObject,
     name: &str,
-    enquote: bool,
+    quote_style: QuoteStyle,
 ) -> anyhow::Result<Vec<CompletionItem>> {
-    completions_from_object_names_impl(object, name, enquote, "names")
+    completions_from_object_names_impl(object, name, quote_style, "names")
 }
 
 pub(super) fn completions_from_object_colnames(
     object: RObject,
     name: &str,
-    enquote: bool,
+    quote_style: QuoteStyle,
 ) -> anyhow::Result<Vec<CompletionItem>> {
-    completions_from_object_names_impl(object, name, enquote, "colnames")
+    completions_from_object_names_impl(object, name, quote_style, "colnames")
 }
 
 fn completions_from_object_names_impl(
     object: RObject,
     name: &str,
-    enquote: bool,
+    quote_style: QuoteStyle,
     function: &str,
 ) -> anyhow::Result<Vec<CompletionItem>> {
     log::trace!("completions_from_object_names_impl({object:?})");
 
     let mut completions = vec![];
 
-    unsafe {
-        let element_names = RFunction::new("base", function)
-            .add(object)
-            .call()?
-            .to::<Vec<String>>()?;
+    let element_names = RFunction::new("base", function)
+        .add(object)
+        .call()?
+        .to::<Vec<String>>()?;
 
-        for element_name in element_names {
-            match completion_item_from_data_variable(&element_name, name, enquote) {
-                Ok(item) => completions.push(item),
-                Err(err) => log::error!("{err:?}"),
-            }
+    for element_name in element_names {
+        match completion_item_from_data_variable(&element_name, name, quote_style) {
+            Ok(item) => completions.push(item),
+            Err(err) => log::error!("{err:?}"),
         }
     }
 
@@ -290,6 +289,7 @@ mod tests {
 
     use crate::fixtures::package_is_installed;
     use crate::fixtures::point_from_cursor;
+    use crate::lsp::completions::completion_item::QuoteStyle;
     use crate::lsp::completions::sources::utils::call_node_position_type;
     use crate::lsp::completions::sources::utils::completions_from_evaluated_object_names;
     use crate::lsp::completions::sources::utils::CallNodePositionType;
@@ -467,9 +467,10 @@ mod tests {
             parse_eval_global("x <- 1:2").unwrap();
             parse_eval_global("names(x) <- c('a', 'b')").unwrap();
 
-            let completions = completions_from_evaluated_object_names("x", false, NodeType::Subset)
-                .unwrap()
-                .unwrap();
+            let completions =
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset)
+                    .unwrap()
+                    .unwrap();
             assert_eq!(completions.len(), 2);
             assert_eq!(completions.first().unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
@@ -479,9 +480,10 @@ mod tests {
             // Data frame
             parse_eval_global("x <- data.frame(a = 1, b = 2, c = 3)").unwrap();
 
-            let completions = completions_from_evaluated_object_names("x", false, NodeType::Subset)
-                .unwrap()
-                .unwrap();
+            let completions =
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset)
+                    .unwrap()
+                    .unwrap();
             assert_eq!(completions.len(), 3);
             assert_eq!(completions.first().unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
@@ -493,9 +495,10 @@ mod tests {
             parse_eval_global("x <- array(1:2)").unwrap();
             parse_eval_global("names(x) <- c('a', 'b')").unwrap();
 
-            let completions = completions_from_evaluated_object_names("x", false, NodeType::Subset)
-                .unwrap()
-                .unwrap();
+            let completions =
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset)
+                    .unwrap()
+                    .unwrap();
             assert_eq!(completions.len(), 2);
             assert_eq!(completions.first().unwrap().label, String::from("a"));
             assert_eq!(completions.get(1).unwrap().label, String::from("b"));
@@ -507,9 +510,10 @@ mod tests {
             parse_eval_global("rownames(x) <- 'a'").unwrap();
             parse_eval_global("colnames(x) <- 'b'").unwrap();
 
-            let completions = completions_from_evaluated_object_names("x", false, NodeType::Subset)
-                .unwrap()
-                .unwrap();
+            let completions =
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset)
+                    .unwrap()
+                    .unwrap();
             assert_eq!(completions.len(), 1);
             assert_eq!(completions.first().unwrap().label, String::from("b"));
 
@@ -523,9 +527,10 @@ mod tests {
             parse_eval_global("rownames(x) <- 'a'").unwrap();
             parse_eval_global("colnames(x) <- 'b'").unwrap();
 
-            let completions = completions_from_evaluated_object_names("x", false, NodeType::Subset)
-                .unwrap()
-                .unwrap();
+            let completions =
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset)
+                    .unwrap()
+                    .unwrap();
             assert!(completions.is_empty());
 
             parse_eval_global("remove(x)").unwrap();
@@ -543,9 +548,13 @@ mod tests {
             parse_eval_global("x <- data.table::as.data.table(mtcars)").unwrap();
 
             // Subset completions
-            let completions = completions_from_evaluated_object_names("x", false, NodeType::Subset)
-                .unwrap()
-                .unwrap();
+            // This is where we have an override for data.table in particular, which
+            // changes our provided `QuoteStyle::Double` to
+            // `QuoteStyle::BacktickIfNotSyntactic` due to data.table's NSE in `[`.
+            let completions =
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset)
+                    .unwrap()
+                    .unwrap();
 
             assert_eq!(completions.len(), 11);
             assert_eq!(completions.first().unwrap().label, String::from("mpg"));
@@ -553,7 +562,7 @@ mod tests {
 
             // Subset2 completions
             let completions =
-                completions_from_evaluated_object_names("x", false, NodeType::Subset2)
+                completions_from_evaluated_object_names("x", QuoteStyle::Double, NodeType::Subset2)
                     .unwrap()
                     .unwrap();
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/14909

Changed from `enquote: bool` to

```rust
pub(super) enum QuoteStyle {
    // Double quote with `"`
    Double,

    // Backtick with `\`` if the symbol isn't syntactic
    BacktickIfNotSyntactic,

    // No quoting. Useful if you know you're already inserting into an existing string.
    None,
}
```

It was a bit weird before, but the previous mapping was:
- `enquote: true` -> `QuoteStyle::Double`
- `enquote: false` -> `QuoteStyle::BacktickIfNotSyntactic`

So we previously had no way to say "please just take this as is, I know what I'm doing", which is the case of `x["<TAB>"]` where we are completing _within an existing string_ and we don't want any quoting whatsoever.

### Positron Release Notes

<!--
  These notes are typically filled by the Positron team. If you are an external
  contributor, you may leave the `N/A` bullets in place.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed usability issue in R completions of string-quoted names in brackets (https://github.com/posit-dev/positron/issues/14909).
