### PR TITLE
Transition `help_ports` to `Cell`

### DIFF
--- a/crates/ark/src/console.rs
+++ b/crates/ark/src/console.rs
@@ -253,7 +253,7 @@ pub struct Console {
 
     /// Ports for the R help server and our proxy, set once both are running.
     /// `None` until then.
-    help_ports: Option<HelpPorts>,
+    help_ports: Cell<Option<HelpPorts>>,
 
     /// Event channel for notifying the LSP. In principle, could be a Jupyter comm.
     lsp_events_tx: Option<TokioUnboundedSender<Event>>,

--- a/crates/ark/src/console/console_integration.rs
+++ b/crates/ark/src/console/console_integration.rs
@@ -43,12 +43,12 @@ impl Console {
 
 /// Help integration.
 impl Console {
-    pub(crate) fn set_help_ports(&mut self, r_port: u16, proxy_port: u16) {
-        self.help_ports = Some(HelpPorts { r_port, proxy_port });
+    pub(crate) fn set_help_ports(&self, r_port: u16, proxy_port: u16) {
+        self.help_ports.set(Some(HelpPorts { r_port, proxy_port }));
     }
 
     pub(crate) fn send_help_event(&self, event: HelpEvent) -> anyhow::Result<()> {
-        let Some(HelpPorts { r_port, proxy_port }) = self.help_ports else {
+        let Some(HelpPorts { r_port, proxy_port }) = self.help_ports.get() else {
             return Err(anyhow!("No help ports available to handle help event. Is the help comm open? Event {event:?}."));
         };
 
@@ -62,7 +62,7 @@ impl Console {
     }
 
     pub(crate) fn is_help_url(&self, url: &str) -> bool {
-        let Some(HelpPorts { r_port, .. }) = self.help_ports else {
+        let Some(HelpPorts { r_port, .. }) = self.help_ports.get() else {
             log::error!("No help port is available to check if '{url}' is a help url. Is the help comm open?");
             // Fail to recognize this as a help url, allow any fallbacks methods to run instead.
             return false;

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -678,7 +678,7 @@ impl Console {
             ui_comm_id: DebugRefCell::new(None),
             help_comm_id: DebugRefCell::new(None),
             last_error: None,
-            help_ports: None,
+            help_ports: Cell::new(None),
             lsp_events_tx: None,
             lsp_virtual_documents: HashMap::new(),
             debug_dap: dap,

--- a/crates/ark/src/help/r_help.rs
+++ b/crates/ark/src/help/r_help.rs
@@ -243,7 +243,7 @@ impl CommHandler for RHelp {
         };
 
         self.proxy = Some(proxy);
-        Console::get_mut().set_help_ports(r_port, proxy_port);
+        Console::get().set_help_ports(r_port, proxy_port);
     }
 
     fn handle_msg(&mut self, msg: CommMsg, ctx: &CommHandlerContext) {


### PR DESCRIPTION
Part of https://github.com/posit-dev/ark/issues/1145

So `Console::set_help_ports()` can be `&self`

Just low hanging fruit here