### PR TITLE
Fix blank Data Explorer grid for matrices with row names

### DIFF
--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -1142,10 +1142,21 @@ impl RDataExplorer {
         selection: ArraySelection,
         format_options: &FormatOptions,
     ) -> anyhow::Result<Vec<String>> {
+        let indices = self.get_row_selection_indices(selection);
+
+        // An empty selection has no labels to resolve. Positron sends an empty
+        // selection during its first cache update before the viewport rows are
+        // laid out. We must short-circuit here: subsetting a matrix to zero rows
+        // drops its rownames to `NULL`, which the strict match below would
+        // otherwise reject.
+        if indices.is_empty() {
+            return Ok(vec![]);
+        }
+
         let tbl = tbl_subset_with_view_indices(
             self.table.get().sexp,
             &self.view_indices,
-            Some(self.get_row_selection_indices(selection)),
+            Some(indices),
             Some(vec![]), // Use empty vec, because we only need the row names.
         )?;
 
@@ -1158,6 +1169,9 @@ impl RDataExplorer {
                 let labels = format_string(row_names.sexp, format_options);
                 Ok(labels)
             },
+            // Defense in depth: `row.names()` returns `NULL` for a table with no
+            // row names, so treat that as "no labels" rather than an error.
+            NILSXP => Ok(vec![]),
             _ => Err(anyhow!(
                 "`row.names` should be strings, got {:?}",
                 row_names.kind()

--- a/crates/ark/src/data_explorer/r_data_explorer.rs
+++ b/crates/ark/src/data_explorer/r_data_explorer.rs
@@ -1169,9 +1169,6 @@ impl RDataExplorer {
                 let labels = format_string(row_names.sexp, format_options);
                 Ok(labels)
             },
-            // Defense in depth: `row.names()` returns `NULL` for a table with no
-            // row names, so treat that as "no labels" rather than an error.
-            NILSXP => Ok(vec![]),
             _ => Err(anyhow!(
                 "`row.names` should be strings, got {:?}",
                 row_names.kind()

--- a/crates/ark/tests/integration/data_explorer.rs
+++ b/crates/ark/tests/integration/data_explorer.rs
@@ -2039,6 +2039,39 @@ fn test_row_names_matrix() {
     );
 }
 
+// Regression test for posit-dev/positron#12547: a matrix with row names used to
+// produce a blank Data Explorer grid. Positron's first cache update sends
+// `get_row_labels` with an empty selection, and subsetting a matrix to zero rows
+// drops its row names to `NULL`, which used to error rather than return no labels.
+#[test]
+fn test_row_names_matrix_empty_selection() {
+    let setup = open_data_explorer_from_expression(
+        "matrix(1:4, nrow = 2, dimnames = list(c(\"A\", \"B\"), NULL))",
+        Some("m"),
+    )
+    .unwrap();
+
+    // The matrix has row names, so state reports them.
+    TestAssertions::assert_state(&setup, |state| {
+        assert!(state.has_row_labels);
+    });
+
+    // An empty selection returns empty labels rather than erroring.
+    TestAssertions::assert_row_labels(&setup, SelectionBuilder::indices(vec![]), |labels| {
+        assert_eq!(labels[0].len(), 0);
+    });
+
+    // A range selection still returns the actual row names.
+    let range = ArraySelection::SelectRange(DataSelectionRange {
+        first_index: 0,
+        last_index: 1,
+    });
+    TestAssertions::assert_row_labels(&setup, range, |labels| {
+        assert_eq!(labels[0][0], "A");
+        assert_eq!(labels[0][1], "B");
+    });
+}
+
 #[test]
 fn test_schema_identification() {
     let setup = open_data_explorer_from_expression(


### PR DESCRIPTION
### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed a blank Data Explorer grid when viewing an R matrix that has row names (posit-dev/positron#12547).

---

### Description

`View()` on an R matrix with row names opened the Data Explorer but showed a blank grid. Data frames were fine, and matrices without row names were fine.

The root cause is in `get_row_labels`. When the Data Explorer opens, Positron's first cache update runs before the viewport rows are laid out, so it sends `get_row_labels` with an empty row selection. Ark implemented that request by subsetting the table to the selected rows and calling `row.names()` on the result. A zero-row subset of a matrix drops its row names to `NULL` (unlike a data.frame, which returns `character(0)`), and the strict match on the result then errored with "`row.names` should be strings, got 0". That single failed RPC was enough to leave the grid blank.

This PR fixes the Ark side:

- `get_row_labels` now early-returns an empty result when the resolved row selection is empty, skipping the R subset call entirely.
- As defense in depth, a `NILSXP` result from `row.names()` is treated as "no labels" rather than an error. The error is kept for other unexpected kinds.

### Manual verification

Build a dev Ark (`cargo build`), point Positron at it with the `positron.r.kernel.path` setting (`target/debug/ark`), run _Developer: Reload Window_, and start a fresh R session.

1. Minimal repro renders with row labels `A` and `B`, no `row.names` error in the console:

   ```r
   m <- matrix(1:4, nrow = 2)
   rownames(m) <- c("A", "B")
   View(m)
   ```

2. Scrolling after open still repaints correctly with the right row labels:

   ```r
   big <- matrix(1:2000, ncol = 2)
   rownames(big) <- paste0("r", 1:1000)
   View(big)
   ```

3. The `as.matrix(data.frame)` variant from the issue renders with its row names:

   ```r
   View(as.matrix(mtcars[1:10, 1:8]))
   ```

<img width="1684" height="1145" alt="Screenshot 2026-07-21 at 6 05 11 PM" src="https://github.com/user-attachments/assets/837610a6-9203-47ea-a49c-b3a2aa2554ae" />


4. Regressions are unaffected: `View(matrix(1:4, nrow = 2))` (no row names), `View(mtcars)`, and `View(iris)` all render normally.

Automated: `cargo test` covers the new `test_row_names_matrix_empty_selection` integration test alongside the existing matrix row-label tests.

### A follow-up as well

This Ark fix removes the failing RPC, which is enough to unblank the viewer on its own. I'm going to do a separate Positron PR to harden `TableDataCache.update()` so that any future failing backend request degrades a single paint rather than permanently wedging the viewer. We'll wrap the update body in try/finally so `_updating` is always cleared and the pending-descriptor drain still runs, and skip the row-labels RPC entirely when the row selection is empty. That change is independent of this one and will ship with its own vitest coverage.
