### PR TITLE
Use new DigiCert KeyLocker workflow for signing Ark on Windows

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -52,7 +52,7 @@ jobs:
 
     sign_windows:
         name: "Sign Windows Binaries"
-        uses: posit-dev/posit-gh-actions/.github/workflows/sign-windows.yml@main
+        uses: posit-dev/posit-gh-actions/.github/workflows/sign-windows-digicert.yml@main
         needs: [build_windows]
         secrets: inherit
         strategy:


### PR DESCRIPTION
Ark for Windows is currently signed using a certificate that expires in less than a month (August 19). Unfortunately, this certificate can't be replaced as-is because DigiCert has changed their service. 

I've added a new shared action to sign using the new workflow here:

https://github.com/posit-dev/posit-gh-actions/blob/main/.github/workflows/sign-windows-digicert.yml

This change updates Ark to use the new certificate and workflow from the shared action.