### PR TITLE
Add source fetching settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "tokio",
+ "tower",
  "tower-lsp-server",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ syn = { version = "2.0.117", features = ["full"] }
 tar = "0.4.45"
 tempfile = "3.27.0"
 tokio = { version = "1.52.1", features = ["full"] }
+tower = { version = "0.5.3", default-features = false }
 tower-lsp-server = "0.23.0"
 tracing = "0.1.44"
 tracing-appender = "0.2.5"

--- a/crates/ark/Cargo.toml
+++ b/crates/ark/Cargo.toml
@@ -97,6 +97,7 @@ oak_semantic = { workspace = true, features = ["testing"] }
 oak_package_metadata = { workspace = true, features = ["testing"] }
 stdext = { workspace = true, features = ["testing"] }
 tempfile.workspace = true
+tower.workspace = true
 
 [build-dependencies]
 cc.workspace = true

--- a/crates/ark/src/lsp/capabilities.rs
+++ b/crates/ark/src/lsp/capabilities.rs
@@ -14,6 +14,7 @@ use tower_lsp_server::ls_types::WorkDoneProgressOptions;
 /// Capabilities negotiated with [lsp_types::ClientCapabilities]
 #[derive(Debug, Default)]
 pub(crate) struct Capabilities {
+    workspace_configuration: bool,
     dynamic_registration_for_did_change_configuration: bool,
     code_action_literal_support: bool,
     workspace_edit_document_changes: bool,
@@ -21,6 +22,12 @@ pub(crate) struct Capabilities {
 
 impl Capabilities {
     pub(crate) fn new(client_capabilities: lsp_types::ClientCapabilities) -> Self {
+        let workspace_configuration = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.configuration)
+            .unwrap_or(false);
+
         let dynamic_registration_for_did_change_configuration = client_capabilities
             .workspace
             .as_ref()
@@ -47,10 +54,16 @@ impl Capabilities {
             .is_some_and(|document_changes| document_changes);
 
         Self {
+            workspace_configuration,
             dynamic_registration_for_did_change_configuration,
             code_action_literal_support,
             workspace_edit_document_changes,
         }
+    }
+
+    /// Whether the client answers `workspace/configuration` requests.
+    pub(crate) fn workspace_configuration(&self) -> bool {
+        self.workspace_configuration
     }
 
     pub(crate) fn dynamic_registration_for_did_change_configuration(&self) -> bool {

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -37,11 +37,11 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
         },
     },
     Setting {
-        key: "oak.enableSourceFetching",
+        key: "oak.sourceFetching.enabled",
         set: |cfg, v| {
-            cfg.oak.enable_source_fetching = v
+            cfg.oak.source_fetching_enabled = v
                 .as_bool()
-                .unwrap_or_else(|| OakConfig::default().enable_source_fetching)
+                .unwrap_or_else(|| OakConfig::default().source_fetching_enabled)
         },
     },
     Setting {
@@ -64,7 +64,7 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
 
 /// Source fetching is enabled by default except on CI.
 /// This env-var opts a CI job back into source fetching.
-pub(crate) const OAK_ENABLE_SOURCE_FETCHING_ENV_VAR: &str = "OAK_ENABLE_SOURCE_FETCHING";
+pub(crate) const OAK_SOURCE_FETCHING_ENABLED_ENV_VAR: &str = "OAK_SOURCE_FETCHING_ENABLED";
 
 pub struct EnvOverride<T> {
     pub name: &'static str,
@@ -74,8 +74,8 @@ pub struct EnvOverride<T> {
 /// Environment variables that override an LSP setting. Only listed here if
 /// there is a corresponding client setting that needs resolution.
 pub static ENV_OVERRIDES: &[EnvOverride<LspConfig>] = &[EnvOverride {
-    name: OAK_ENABLE_SOURCE_FETCHING_ENV_VAR,
-    set: |cfg, on| cfg.oak.enable_source_fetching = on,
+    name: OAK_SOURCE_FETCHING_ENABLED_ENV_VAR,
+    set: |cfg, on| cfg.oak.source_fetching_enabled = on,
 }];
 
 /// Resolve [`ENV_OVERRIDES`] into `config`.
@@ -159,13 +159,13 @@ pub struct OakConfig {
     /// Whether to recover R sources for package dependencies. Sources are
     /// needed for full analysis, but the LSP degrades gracefully if it doesn't
     /// have them.
-    pub enable_source_fetching: bool,
+    pub source_fetching_enabled: bool,
 }
 
 impl Default for OakConfig {
     fn default() -> Self {
         Self {
-            enable_source_fetching: true,
+            source_fetching_enabled: true,
         }
     }
 }

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -62,6 +62,27 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
     },
 ];
 
+/// Resolve global settings from the client's `initializationOptions`.
+///
+/// Keys are the dotted paths from [`GLOBAL_SETTINGS`], looked up through nested
+/// objects, so `oak.sourceFetching.enabled` reads `{oak: {sourceFetching:
+/// {enabled: ...}}}`.
+pub(crate) fn apply_initialization_options(config: &mut LspConfig, options: &Value) {
+    for setting in GLOBAL_SETTINGS {
+        if let Some(value) = nested_setting(options, setting.key) {
+            (setting.set)(config, value.clone());
+        }
+    }
+}
+
+fn nested_setting<'options>(options: &'options Value, key: &str) -> Option<&'options Value> {
+    let mut value = options;
+    for segment in key.split('.') {
+        value = value.get(segment)?;
+    }
+    Some(value)
+}
+
 /// Source fetching is enabled by default except on CI.
 /// This env-var opts a CI job back into source fetching.
 pub(crate) const OAK_SOURCE_FETCHING_ENABLED_ENV_VAR: &str = "OAK_SOURCE_FETCHING_ENABLED";

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -37,7 +37,7 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
         },
     },
     Setting {
-        key: "oak.sourceFetching.enabled",
+        key: OAK_SOURCE_FETCHING_ENABLED_SETTING,
         set: |cfg, v| {
             cfg.oak.source_fetching_enabled = v
                 .as_bool()
@@ -62,8 +62,10 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
     },
 ];
 
-/// Overrides `oak.sourceFetching.enabled` when set to `1`, `true`, `0`, or `false`.
-/// Set to `1` or `true` to allow source fetching on CI.
+pub(crate) const OAK_SOURCE_FETCHING_ENABLED_SETTING: &str = "oak.sourceFetching.enabled";
+
+/// Overrides [`OAK_SOURCE_FETCHING_ENABLED_SETTING`] when set to `1`, `true`,
+/// `0`, or `false`. Set to `1` or `true` to enable source fetching on CI.
 pub(crate) const OAK_SOURCE_FETCHING_ENABLED_ENV_VAR: &str = "OAK_SOURCE_FETCHING_ENABLED";
 
 pub struct EnvOverride<T> {

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -3,6 +3,7 @@ use biome_line_index::WideEncoding;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
+use stdext::env_flag_opt;
 
 use crate::lsp::diagnostics::DiagnosticsConfig;
 
@@ -36,6 +37,14 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
         },
     },
     Setting {
+        key: "oak.enableSourceFetching",
+        set: |cfg, v| {
+            cfg.oak.enable_source_fetching = v
+                .as_bool()
+                .unwrap_or_else(|| OakConfig::default().enable_source_fetching)
+        },
+    },
+    Setting {
         key: "positron.r.symbols.includeAssignmentsInBlocks",
         set: |cfg, v| {
             cfg.symbols.include_assignments_in_blocks = v
@@ -52,6 +61,35 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
         },
     },
 ];
+
+/// Source fetching is enabled by default except on CI.
+/// This env-var opts a CI job back into source fetching.
+pub(crate) const OAK_ENABLE_SOURCE_FETCHING_ENV_VAR: &str = "OAK_ENABLE_SOURCE_FETCHING";
+
+pub struct EnvOverride<T> {
+    pub name: &'static str,
+    pub set: fn(&mut T, bool),
+}
+
+/// Environment variables that override an LSP setting. Only listed here if
+/// there is a corresponding client setting that needs resolution.
+pub static ENV_OVERRIDES: &[EnvOverride<LspConfig>] = &[EnvOverride {
+    name: OAK_ENABLE_SOURCE_FETCHING_ENV_VAR,
+    set: |cfg, on| cfg.oak.enable_source_fetching = on,
+}];
+
+/// Resolve [`ENV_OVERRIDES`] into `config`.
+///
+/// Runs after the client's settings have been applied, because an environment
+/// variable outranks them. An unset or unrecognised variable leaves the setting
+/// alone. See the precedence section of `doc/configuration-oak.md`.
+pub(crate) fn apply_env_overrides(config: &mut LspConfig) {
+    for env_override in ENV_OVERRIDES {
+        if let Some(on) = env_flag_opt(env_override.name) {
+            (env_override.set)(config, on);
+        }
+    }
+}
 
 /// These document settings are updated on a URI basis. Each document has its
 /// own value of the setting.
@@ -94,6 +132,7 @@ pub static DOCUMENT_SETTINGS: &[Setting<DocumentConfig>] = &[
 #[derive(Clone, Debug)]
 pub(crate) struct LspConfig {
     pub(crate) diagnostics: DiagnosticsConfig,
+    pub(crate) oak: OakConfig,
     pub(crate) symbols: SymbolsConfig,
     pub(crate) workspace_symbols: WorkspaceSymbolsConfig,
 
@@ -107,9 +146,26 @@ impl Default for LspConfig {
     fn default() -> Self {
         Self {
             diagnostics: DiagnosticsConfig::default(),
+            oak: OakConfig::default(),
             symbols: SymbolsConfig::default(),
             workspace_symbols: WorkspaceSymbolsConfig::default(),
             position_encoding: PositionEncoding::Wide(WideEncoding::Utf16),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct OakConfig {
+    /// Whether to recover R sources for package dependencies. Sources are
+    /// needed for full analysis, but the LSP degrades gracefully if it doesn't
+    /// have them.
+    pub enable_source_fetching: bool,
+}
+
+impl Default for OakConfig {
+    fn default() -> Self {
+        Self {
+            enable_source_fetching: true,
         }
     }
 }

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -12,56 +12,86 @@ pub struct Setting<T> {
     pub set: fn(&mut T, Value),
 }
 
-/// List of LSP settings for which clients can send `didChangeConfiguration`
-/// notifications. We register our interest in watching over these settings in
-/// our `initialized` handler. The `set` methods convert from a json `Value` to
-/// the expected type, using a default value if the conversion fails.
-///
-/// This array is for global settings. If the setting should only affect a given
-/// document URI, add it to `DOCUMENT_SETTINGS` instead.
-pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
-    Setting {
-        key: "positron.r.diagnostics.enable",
-        set: |cfg, v| {
-            cfg.diagnostics.enable = v
-                .as_bool()
-                .unwrap_or_else(|| DiagnosticsConfig::default().enable)
-        },
-    },
-    Setting {
-        key: "oak.diagnostics.experimental.enabled",
-        set: |cfg, v| {
-            cfg.diagnostics.experimental = v
-                .as_bool()
-                .unwrap_or_else(|| DiagnosticsConfig::default().experimental)
-        },
-    },
-    Setting {
-        key: OAK_SOURCE_FETCHING_ENABLED_SETTING,
-        set: |cfg, v| {
-            cfg.oak.source_fetching_enabled = v
-                .as_bool()
-                .unwrap_or_else(|| OakConfig::default().source_fetching_enabled)
-        },
-    },
-    Setting {
-        key: "positron.r.symbols.includeAssignmentsInBlocks",
-        set: |cfg, v| {
-            cfg.symbols.include_assignments_in_blocks = v
-                .as_bool()
-                .unwrap_or_else(|| SymbolsConfig::default().include_assignments_in_blocks)
-        },
-    },
-    Setting {
-        key: "positron.r.workspaceSymbols.includeCommentSections",
-        set: |cfg, v| {
-            cfg.workspace_symbols.include_comment_sections = v
-                .as_bool()
-                .unwrap_or_else(|| WorkspaceSymbolsConfig::default().include_comment_sections)
-        },
-    },
-];
+/// Declare global settings with their [`LspSettings`] and [`LspConfig`] fields.
+/// Keeping the mapping here synchronizes the request, layering, and resolution
+/// code. All global settings are (currently) booleans.
+macro_rules! global_settings {
+    ($($key:expr => $field:ident : $($config:ident).+),+ $(,)?) => {
+        /// A partial settings layer. `None` lets a lower-priority layer or a
+        /// default supply the setting.
+        #[derive(Clone, Debug, Default, Eq, PartialEq)]
+        pub(crate) struct LspSettings {
+            $(pub(crate) $field: Option<bool>,)+
+        }
 
+        impl LspSettings {
+            /// Overlay `self` on `base`, preferring every value set in `self`.
+            #[must_use]
+            pub(crate) fn or(self, base: Self) -> Self {
+                Self {
+                    $($field: self.$field.or(base.$field),)+
+                }
+            }
+
+            /// Apply this layer to `config`. Missing settings use defaults, and
+            /// unrelated fields such as the position encoding remain unchanged.
+            pub(crate) fn resolve_into(&self, config: &mut LspConfig) {
+                $(
+                    config.$($config).+ = self
+                        .$field
+                        .unwrap_or_else(|| LspConfig::default().$($config).+);
+                )+
+            }
+        }
+
+        /// Global settings requested through `workspace/configuration` and
+        /// registered for `didChangeConfiguration` notifications.
+        pub static GLOBAL_SETTINGS: &[Setting<LspSettings>] = &[
+            $(Setting {
+                key: $key,
+                set: |settings, value| settings.$field = value.as_bool(),
+            },)+
+        ];
+    };
+}
+
+// Each row is `key => field: config.path`. It maps an LSP setting key to the
+// corresponding fields in [`LspSettings`] and [`LspConfig`].
+global_settings! {
+    OAK_DIAGNOSTICS_EXPERIMENTAL_ENABLED_SETTING
+        => diagnostics_experimental: diagnostics.experimental,
+    OAK_SOURCE_FETCHING_ENABLED_SETTING => source_fetching_enabled: oak.source_fetching_enabled,
+    "positron.r.diagnostics.enable" => diagnostics_enable: diagnostics.enable,
+    "positron.r.symbols.includeAssignmentsInBlocks"
+        => include_assignments_in_blocks: symbols.include_assignments_in_blocks,
+    "positron.r.workspaceSymbols.includeCommentSections"
+        => include_comment_sections: workspace_symbols.include_comment_sections,
+}
+
+/// Read global settings from the client's `initializationOptions`.
+///
+/// Dotted keys from [`GLOBAL_SETTINGS`] follow nested objects. For example,
+/// `oak.sourceFetching.enabled` reads `{oak: {sourceFetching: {enabled: ...}}}`.
+pub(crate) fn initialization_options(options: &Value) -> LspSettings {
+    let mut layer = LspSettings::default();
+    for setting in GLOBAL_SETTINGS {
+        if let Some(value) = nested_setting(options, setting.key) {
+            (setting.set)(&mut layer, value.clone());
+        }
+    }
+    layer
+}
+
+fn nested_setting<'options>(options: &'options Value, key: &str) -> Option<&'options Value> {
+    let mut value = options;
+    for segment in key.split('.') {
+        value = value.get(segment)?;
+    }
+    Some(value)
+}
+
+pub(crate) const OAK_DIAGNOSTICS_EXPERIMENTAL_ENABLED_SETTING: &str =
+    "oak.diagnostics.experimental.enabled";
 pub(crate) const OAK_SOURCE_FETCHING_ENABLED_SETTING: &str = "oak.sourceFetching.enabled";
 
 /// Overrides [`OAK_SOURCE_FETCHING_ENABLED_SETTING`] when set to `1`, `true`,
@@ -74,19 +104,21 @@ pub struct EnvOverride<T> {
 }
 
 /// Environment overrides for LSP settings.
-pub static ENV_OVERRIDES: &[EnvOverride<LspConfig>] = &[EnvOverride {
+pub static ENV_OVERRIDES: &[EnvOverride<LspSettings>] = &[EnvOverride {
     name: OAK_SOURCE_FETCHING_ENABLED_ENV_VAR,
-    set: |cfg, on| cfg.oak.source_fetching_enabled = on,
+    set: |settings, on| settings.source_fetching_enabled = Some(on),
 }];
 
-/// Apply recognized environment overrides after client settings.
-/// Unset or unrecognized values preserve the client setting.
-pub(crate) fn apply_env_overrides(config: &mut LspConfig) {
+/// Read recognized environment values into a settings layer. Unset or invalid
+/// values leave their setting available to lower-priority layers.
+pub(crate) fn env_settings() -> LspSettings {
+    let mut layer = LspSettings::default();
     for env_override in ENV_OVERRIDES {
         if let Some(on) = env_flag_opt(env_override.name) {
-            (env_override.set)(config, on);
+            (env_override.set)(&mut layer, on);
         }
     }
+    layer
 }
 
 /// These document settings are updated on a URI basis. Each document has its

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -62,27 +62,6 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
     },
 ];
 
-/// Resolve global settings from the client's `initializationOptions`.
-///
-/// Keys are the dotted paths from [`GLOBAL_SETTINGS`], looked up through nested
-/// objects, so `oak.sourceFetching.enabled` reads `{oak: {sourceFetching:
-/// {enabled: ...}}}`.
-pub(crate) fn apply_initialization_options(config: &mut LspConfig, options: &Value) {
-    for setting in GLOBAL_SETTINGS {
-        if let Some(value) = nested_setting(options, setting.key) {
-            (setting.set)(config, value.clone());
-        }
-    }
-}
-
-fn nested_setting<'options>(options: &'options Value, key: &str) -> Option<&'options Value> {
-    let mut value = options;
-    for segment in key.split('.') {
-        value = value.get(segment)?;
-    }
-    Some(value)
-}
-
 /// Source fetching is enabled by default except on CI.
 /// This env-var opts a CI job back into source fetching.
 pub(crate) const OAK_SOURCE_FETCHING_ENABLED_ENV_VAR: &str = "OAK_SOURCE_FETCHING_ENABLED";

--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -62,8 +62,8 @@ pub static GLOBAL_SETTINGS: &[Setting<LspConfig>] = &[
     },
 ];
 
-/// Source fetching is enabled by default except on CI.
-/// This env-var opts a CI job back into source fetching.
+/// Overrides `oak.sourceFetching.enabled` when set to `1`, `true`, `0`, or `false`.
+/// Set to `1` or `true` to allow source fetching on CI.
 pub(crate) const OAK_SOURCE_FETCHING_ENABLED_ENV_VAR: &str = "OAK_SOURCE_FETCHING_ENABLED";
 
 pub struct EnvOverride<T> {
@@ -71,18 +71,14 @@ pub struct EnvOverride<T> {
     pub set: fn(&mut T, bool),
 }
 
-/// Environment variables that override an LSP setting. Only listed here if
-/// there is a corresponding client setting that needs resolution.
+/// Environment overrides for LSP settings.
 pub static ENV_OVERRIDES: &[EnvOverride<LspConfig>] = &[EnvOverride {
     name: OAK_SOURCE_FETCHING_ENABLED_ENV_VAR,
     set: |cfg, on| cfg.oak.source_fetching_enabled = on,
 }];
 
-/// Resolve [`ENV_OVERRIDES`] into `config`.
-///
-/// Runs after the client's settings have been applied, because an environment
-/// variable outranks them. An unset or unrecognised variable leaves the setting
-/// alone. See the precedence section of `doc/configuration-oak.md`.
+/// Apply recognized environment overrides after client settings.
+/// Unset or unrecognized values preserve the client setting.
 pub(crate) fn apply_env_overrides(config: &mut LspConfig) {
     for env_override in ENV_OVERRIDES {
         if let Some(on) = env_flag_opt(env_override.name) {
@@ -156,9 +152,7 @@ impl Default for LspConfig {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct OakConfig {
-    /// Whether to recover R sources for package dependencies. Sources are
-    /// needed for full analysis, but the LSP degrades gracefully if it doesn't
-    /// have them.
+    /// Recover package sources so Oak can analyze dependencies.
     pub source_fetching_enabled: bool,
 }
 

--- a/crates/ark/src/lsp/handlers.rs
+++ b/crates/ark/src/lsp/handlers.rs
@@ -14,14 +14,11 @@ use tower_lsp_server::ls_types::CodeActionResponse;
 use tower_lsp_server::ls_types::CompletionItem;
 use tower_lsp_server::ls_types::CompletionParams;
 use tower_lsp_server::ls_types::CompletionResponse;
-use tower_lsp_server::ls_types::DidChangeWatchedFilesRegistrationOptions;
 use tower_lsp_server::ls_types::DocumentOnTypeFormattingParams;
 use tower_lsp_server::ls_types::DocumentSymbolParams;
 use tower_lsp_server::ls_types::DocumentSymbolResponse;
-use tower_lsp_server::ls_types::FileSystemWatcher;
 use tower_lsp_server::ls_types::FoldingRange;
 use tower_lsp_server::ls_types::FoldingRangeParams;
-use tower_lsp_server::ls_types::GlobPattern;
 use tower_lsp_server::ls_types::GotoDefinitionParams;
 use tower_lsp_server::ls_types::GotoDefinitionResponse;
 use tower_lsp_server::ls_types::Hover;
@@ -31,7 +28,6 @@ use tower_lsp_server::ls_types::Location;
 use tower_lsp_server::ls_types::MessageType;
 use tower_lsp_server::ls_types::PrepareRenameResponse;
 use tower_lsp_server::ls_types::ReferenceParams;
-use tower_lsp_server::ls_types::Registration;
 use tower_lsp_server::ls_types::RenameParams;
 use tower_lsp_server::ls_types::SelectionRange;
 use tower_lsp_server::ls_types::SelectionRangeParams;
@@ -43,7 +39,6 @@ use tower_lsp_server::ls_types::TextEdit;
 use tower_lsp_server::ls_types::WorkspaceEdit;
 use tower_lsp_server::ls_types::WorkspaceSymbolParams;
 use tower_lsp_server::Client;
-use tracing::Instrument;
 
 use crate::analysis::input_boundaries::input_boundaries;
 use crate::lsp;
@@ -92,70 +87,6 @@ pub(crate) type VirtualDocumentResponse = String;
 
 // Handlers that do not mutate the world state. They take a sharing reference or
 // a clone of the state.
-
-pub(crate) async fn handle_initialized(
-    client: &Client,
-    lsp_state: &LspState,
-) -> anyhow::Result<()> {
-    let span = tracing::info_span!("handle_initialized").entered();
-
-    // Register capabilities to the client
-    let mut regs: Vec<Registration> = vec![];
-
-    // Watch R files and DESCRIPTION. We get notified on any disk change;
-    // the handler skips editor-owned URLs since those are tracked via
-    // `textDocument/did*` instead.
-    let watchers = vec![
-        FileSystemWatcher {
-            glob_pattern: GlobPattern::String("**/*.{R,r}".to_string()),
-            kind: None,
-        },
-        FileSystemWatcher {
-            glob_pattern: GlobPattern::String("**/DESCRIPTION".to_string()),
-            kind: None,
-        },
-    ];
-    regs.push(Registration {
-        id: uuid::Uuid::new_v4().to_string(),
-        method: String::from("workspace/didChangeWatchedFiles"),
-        register_options: Some(
-            serde_json::to_value(DidChangeWatchedFilesRegistrationOptions { watchers }).unwrap(),
-        ),
-    });
-
-    if lsp_state
-        .capabilities
-        .dynamic_registration_for_did_change_configuration()
-    {
-        // The `didChangeConfiguration` request instructs the client to send
-        // a notification when the tracked settings have changed.
-        //
-        // Note that some settings, such as editor indentation properties, may be
-        // changed by extensions or by the user without changing the actual
-        // underlying setting. Unfortunately we don't receive updates in that case.
-
-        for setting in crate::lsp::config::GLOBAL_SETTINGS {
-            regs.push(Registration {
-                id: uuid::Uuid::new_v4().to_string(),
-                method: String::from("workspace/didChangeConfiguration"),
-                register_options: Some(serde_json::json!({ "section": setting.key })),
-            });
-        }
-        for setting in crate::lsp::config::DOCUMENT_SETTINGS {
-            regs.push(Registration {
-                id: uuid::Uuid::new_v4().to_string(),
-                method: String::from("workspace/didChangeConfiguration"),
-                register_options: Some(serde_json::json!({ "section": setting.key })),
-            });
-        }
-    }
-
-    client
-        .register_capability(regs)
-        .instrument(span.exit())
-        .await?;
-    Ok(())
-}
 
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) fn handle_symbol(

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -50,6 +50,7 @@ use crate::lsp::backend::LspRequest;
 use crate::lsp::backend::LspResponse;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
+use crate::lsp::config::OAK_ENABLE_SOURCE_FETCHING_ENV_VAR;
 use crate::lsp::handlers;
 use crate::lsp::io_pool::IoPool;
 use crate::lsp::sources::OakSourceHandler;
@@ -82,10 +83,6 @@ pub(crate) type TokioUnboundedReceiver<T> = tokio::sync::mpsc::UnboundedReceiver
 static AUXILIARY_EVENT_TX: RwLock<Option<TokioUnboundedSender<AuxiliaryEvent>>> = RwLock::new(None);
 
 pub static LSP_HAS_CRASHED: AtomicBool = AtomicBool::new(false);
-
-/// Source fetching is enabled by default except on CI.
-/// This env-var opts a CI job back into source fetching.
-const OAK_SOURCE_FETCHING_ENV_VAR: &str = "OAK_ENABLE_SOURCE_FETCHING";
 
 #[derive(Debug)]
 #[expect(clippy::large_enum_variant)]
@@ -633,6 +630,7 @@ impl GlobalState {
             );
             self.lsp_state.source_scheduler.schedule(
                 &self.world.db,
+                &self.world.config.oak,
                 &self.lsp_state.source_pool,
                 &self.events_tx,
             );
@@ -645,9 +643,9 @@ impl GlobalState {
 /// Build the LSP's [`SourceHandler`], or `None` to disable source fetching
 fn source_handler(r_home: &Path) -> Option<Arc<dyn SourceHandler>> {
     // Avoid unnecessary traffic on CI
-    if is_ci() && !env_flag(OAK_SOURCE_FETCHING_ENV_VAR) {
+    if is_ci() && !env_flag(OAK_ENABLE_SOURCE_FETCHING_ENV_VAR) {
         log::info!(
-            "Source fetching is disabled on CI. Set {OAK_SOURCE_FETCHING_ENV_VAR}=1 to enable it."
+            "Source fetching is disabled on CI. Set {OAK_ENABLE_SOURCE_FETCHING_ENV_VAR}=1 to enable it."
         );
         return None;
     }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -722,14 +722,6 @@ impl GlobalState {
     pub(crate) fn world(&self) -> &WorldState {
         &self.world
     }
-
-    /// Reach into the config the way a `didChangeConfiguration` would. The
-    /// dummy test client can't answer `workspace/configuration`, so a test that
-    /// needs a setting to change mid-session writes it here instead of driving
-    /// the notification.
-    pub(crate) fn world_mut(&mut self) -> &mut WorldState {
-        &mut self.world
-    }
 }
 
 /// Run each [`ScanRequest`] on `pool`. Each job runs the pure-I/O

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -17,6 +17,7 @@ use std::sync::RwLock;
 use aether_path::FilePath;
 use anyhow::anyhow;
 use oak_db::OakDatabase;
+use oak_db::Package;
 use oak_scan::DbScan;
 use oak_scan::ScanCompleted;
 use oak_scan::ScanRequest;
@@ -55,6 +56,7 @@ use crate::lsp::sources::source_fetching_disabled_by_ci;
 use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceCompleted;
 use crate::lsp::sources::SourceHandler;
+use crate::lsp::sources::SourceOrigin;
 use crate::lsp::sources::SourceResponse;
 use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
@@ -589,18 +591,19 @@ impl GlobalState {
             },
 
             Event::SourceCompleted(SourceCompleted { package, response }) => {
-                let outcome = match &response {
-                    SourceResponse::Success(_) => "completed",
-                    SourceResponse::Failure => "failed",
-                    SourceResponse::Skipped => "skipped, source fetching was turned off",
-                };
-                lsp::log_info!(
-                    "Source fetch for package {name} {outcome}",
-                    name = package.name(&self.world.db)
-                );
+                self.log_source_completed(package, &response);
+
+                let skipped = matches!(response, SourceResponse::Skipped);
 
                 if let Some(directory) = self.lsp_state.source_scheduler.finish(package, response) {
                     self.world.db.set_package_sources(package, &directory);
+                }
+
+                // Schedule a skipped package immediately. `finish()` removes it
+                // without advancing the revision, so tick-end scheduling cannot
+                // retry it after fetching is re-enabled.
+                if skipped {
+                    self.schedule_sources();
                 }
             },
 
@@ -635,15 +638,45 @@ impl GlobalState {
                 &self.lsp_state.analysis_pool,
                 &self.events_tx,
             );
-            self.lsp_state.source_scheduler.schedule(
-                &self.world.db,
-                &self.world.config.oak,
-                &self.lsp_state.source_pool,
-                &self.events_tx,
-            );
+            self.schedule_sources();
         }
 
         Ok(())
+    }
+
+    fn schedule_sources(&mut self) {
+        self.lsp_state.source_scheduler.schedule(
+            &self.world.db,
+            &self.world.config.oak,
+            &self.lsp_state.source_pool,
+            &self.events_tx,
+        );
+    }
+
+    fn log_source_completed(&self, package: Package, response: &SourceResponse) {
+        let name = package.name(&self.world.db);
+
+        match response {
+            SourceResponse::Success {
+                origin: SourceOrigin::Cached,
+                ..
+            } => {
+                // Cache hits use trace logging because they do not make a network request.
+                tracing::trace!("Sources for package {name} came from the cache")
+            },
+            SourceResponse::Success {
+                origin: SourceOrigin::Fetched,
+                ..
+            } => {
+                lsp::log_info!("Fetched sources for package {name}")
+            },
+            SourceResponse::Failure => {
+                lsp::log_info!("Found no sources for package {name}")
+            },
+            SourceResponse::Skipped => {
+                lsp::log_info!("Skipped sources for package {name}, source fetching was turned off")
+            },
+        }
     }
 }
 
@@ -715,6 +748,19 @@ impl GlobalState {
     pub(crate) async fn pump_sources_to_quiescence(&mut self) {
         while self.lsp_state.source_scheduler.has_pending() {
             let event = self.next_event().await;
+            self.handle_event(event).await.unwrap();
+        }
+    }
+
+    /// Pump events until one satisfies `wanted`, handling the others, and hand
+    /// that one back unhandled. Lets a test slip its own events in front of a
+    /// response that is already in flight.
+    pub(crate) async fn take_event(&mut self, wanted: impl Fn(&Event) -> bool) -> Event {
+        loop {
+            let event = self.next_event().await;
+            if wanted(&event) {
+                return event;
+            }
             self.handle_event(event).await.unwrap();
         }
     }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -642,7 +642,6 @@ impl GlobalState {
 
 /// Build the LSP's [`SourceHandler`], or `None` to disable source fetching
 fn source_handler(r_home: &Path) -> Option<Arc<dyn SourceHandler>> {
-    // Avoid unnecessary traffic on CI
     if is_ci() && !env_flag(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR) {
         log::info!(
             "Source fetching is disabled on CI. Set {OAK_SOURCE_FETCHING_ENABLED_ENV_VAR}=1 to enable it."

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -21,6 +21,8 @@ use oak_scan::DbScan;
 use oak_scan::ScanCompleted;
 use oak_scan::ScanRequest;
 use oak_scan::ScanScheduler;
+use stdext::env_flag;
+use stdext::is_ci;
 use stdext::panic_message;
 use stdext::result::ResultExt;
 use stdext::spawn;
@@ -80,6 +82,10 @@ pub(crate) type TokioUnboundedReceiver<T> = tokio::sync::mpsc::UnboundedReceiver
 static AUXILIARY_EVENT_TX: RwLock<Option<TokioUnboundedSender<AuxiliaryEvent>>> = RwLock::new(None);
 
 pub static LSP_HAS_CRASHED: AtomicBool = AtomicBool::new(false);
+
+/// Source fetching is enabled by default except on CI.
+/// This env-var opts a CI job back into source fetching.
+const OAK_SOURCE_FETCHING_ENV_VAR: &str = "OAK_ENABLE_SOURCE_FETCHING";
 
 #[derive(Debug)]
 #[expect(clippy::large_enum_variant)]
@@ -638,6 +644,14 @@ impl GlobalState {
 
 /// Build the LSP's [`SourceHandler`], or `None` to disable source fetching
 fn source_handler(r_home: &Path) -> Option<Arc<dyn SourceHandler>> {
+    // Avoid unnecessary traffic on CI
+    if is_ci() && !env_flag(OAK_SOURCE_FETCHING_ENV_VAR) {
+        log::info!(
+            "Source fetching is disabled on CI. Set {OAK_SOURCE_FETCHING_ENV_VAR}=1 to enable it."
+        );
+        return None;
+    }
+
     let Some(r) = harp::command::r_executable(r_home) else {
         log::warn!(
             "Can't locate an R executable under '{}', source fetching is disabled",

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -167,6 +167,10 @@ pub(crate) struct LoopHandles {
     _aux_loop: tokio::task::JoinSet<()>,
 }
 
+/// Workers on [`LspState::source_pool`]. We never have more than this many
+/// package downloads in flight.
+pub(crate) const SOURCE_POOL_THREADS: usize = 2;
+
 /// Non-cloneable, per-session state mutated only by exclusive handlers.
 /// Sits alongside [`WorldState`], which the main loop owns. State that can't
 /// travel with a snapshot lives here instead.
@@ -224,10 +228,13 @@ impl LspState {
             // `ignore::Walk` and `WalkDir`, both iterative, and parses
             // DESCRIPTION line by line.
             scan_pool: IoPool::new("oak-scan", 1, stdext::SMALL_STACK_SIZE),
-            // Two threads, so we never have more than two package downloads in flight.
             // Full stack because a fetch runs a rustls handshake, zstd and tar
             // decoding, and an R subprocess.
-            source_pool: IoPool::new("oak-source", 2, stdext::DEFAULT_STACK_SIZE),
+            source_pool: IoPool::new(
+                "oak-source",
+                SOURCE_POOL_THREADS,
+                stdext::DEFAULT_STACK_SIZE,
+            ),
             watchdog: Watchdog::new(),
         }
     }
@@ -585,6 +592,7 @@ impl GlobalState {
                 let outcome = match &response {
                     SourceResponse::Success(_) => "completed",
                     SourceResponse::Failure => "failed",
+                    SourceResponse::Skipped => "skipped, source fetching was turned off",
                 };
                 lsp::log_info!(
                     "Source fetch for package {name} {outcome}",
@@ -698,6 +706,14 @@ impl GlobalState {
     /// requests.
     pub(crate) async fn pump_scans_to_quiescence(&mut self) {
         while self.lsp_state.oak_scheduler.has_pending_scans() {
+            let event = self.next_event().await;
+            self.handle_event(event).await.unwrap();
+        }
+    }
+
+    /// Pump events until no source request is pending, ignoring pending scans.
+    pub(crate) async fn pump_sources_to_quiescence(&mut self) {
+        while self.lsp_state.source_scheduler.has_pending() {
             let event = self.next_event().await;
             self.handle_event(event).await.unwrap();
         }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -706,6 +706,14 @@ impl GlobalState {
     pub(crate) fn world(&self) -> &WorldState {
         &self.world
     }
+
+    /// Reach into the config the way a `didChangeConfiguration` would. The
+    /// dummy test client can't answer `workspace/configuration`, so a test that
+    /// needs a setting to change mid-session writes it here instead of driving
+    /// the notification.
+    pub(crate) fn world_mut(&mut self) -> &mut WorldState {
+        &mut self.world
+    }
 }
 
 /// Run each [`ScanRequest`] on `pool`. Each job runs the pure-I/O

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -50,7 +50,7 @@ use crate::lsp::backend::LspRequest;
 use crate::lsp::backend::LspResponse;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
-use crate::lsp::config::OAK_ENABLE_SOURCE_FETCHING_ENV_VAR;
+use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::handlers;
 use crate::lsp::io_pool::IoPool;
 use crate::lsp::sources::OakSourceHandler;
@@ -643,9 +643,9 @@ impl GlobalState {
 /// Build the LSP's [`SourceHandler`], or `None` to disable source fetching
 fn source_handler(r_home: &Path) -> Option<Arc<dyn SourceHandler>> {
     // Avoid unnecessary traffic on CI
-    if is_ci() && !env_flag(OAK_ENABLE_SOURCE_FETCHING_ENV_VAR) {
+    if is_ci() && !env_flag(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR) {
         log::info!(
-            "Source fetching is disabled on CI. Set {OAK_ENABLE_SOURCE_FETCHING_ENV_VAR}=1 to enable it."
+            "Source fetching is disabled on CI. Set {OAK_SOURCE_FETCHING_ENABLED_ENV_VAR}=1 to enable it."
         );
         return None;
     }

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -21,8 +21,6 @@ use oak_scan::DbScan;
 use oak_scan::ScanCompleted;
 use oak_scan::ScanRequest;
 use oak_scan::ScanScheduler;
-use stdext::env_flag;
-use stdext::is_ci;
 use stdext::panic_message;
 use stdext::result::ResultExt;
 use stdext::spawn;
@@ -53,6 +51,7 @@ use crate::lsp::capabilities::Capabilities;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::handlers;
 use crate::lsp::io_pool::IoPool;
+use crate::lsp::sources::source_fetching_disabled_by_ci;
 use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceCompleted;
 use crate::lsp::sources::SourceHandler;
@@ -642,7 +641,8 @@ impl GlobalState {
 
 /// Build the LSP's [`SourceHandler`], or `None` to disable source fetching
 fn source_handler(r_home: &Path) -> Option<Arc<dyn SourceHandler>> {
-    if is_ci() && !env_flag(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR) {
+    // Also reported to the LSP output channel from `handle_initialized()`.
+    if source_fetching_disabled_by_ci() {
         log::info!(
             "Source fetching is disabled on CI. Set {OAK_SOURCE_FETCHING_ENABLED_ENV_VAR}=1 to enable it."
         );

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -419,7 +419,7 @@ impl GlobalState {
 
                     match notif {
                         LspNotification::Initialized(_params) => {
-                            handlers::handle_initialized(&self.client, &self.lsp_state).await?;
+                            state_handlers::handle_initialized(&self.client, &mut self.lsp_state, &mut self.world, &self.events_tx).await;
                         },
                         LspNotification::DidChangeWorkspaceFolders(params) => {
                             state_handlers::did_change_workspace_folders(params, &mut self.world, &mut self.lsp_state, &self.events_tx)?;

--- a/crates/ark/src/lsp/main_loop.rs
+++ b/crates/ark/src/lsp/main_loop.rs
@@ -424,7 +424,7 @@ impl GlobalState {
                             state_handlers::did_change_workspace_folders(params, &mut self.world, &mut self.lsp_state, &self.events_tx)?;
                         },
                         LspNotification::DidChangeConfiguration(params) => {
-                            state_handlers::did_change_configuration(params, &self.client, &mut self.world).await?;
+                            state_handlers::did_change_configuration(params, &self.client, &self.lsp_state.capabilities, &mut self.world).await?;
                         },
                         LspNotification::DidChangeWatchedFiles(params) => {
                             state_handlers::did_change_watched_files(params, &mut self.world, &mut self.lsp_state, &self.events_tx)?;

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -173,7 +173,7 @@ impl SourceScheduler {
         // flip this mid-session. Turning it back on picks up every package
         // we've seen so far. Already resolved against the environment by
         // `apply_env_overrides()`.
-        if !config.enable_source_fetching {
+        if !config.source_fetching_enabled {
             return;
         }
 

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -146,8 +146,7 @@ pub(crate) struct SourceScheduler {
     handler: Option<Arc<dyn SourceHandler>>,
     state: HashMap<Package, SourceState>,
 
-    /// Whether we're still waiting on the client's settings. Set until
-    /// [`Self::config_arrived`].
+    /// Blocks initial fetches until client configuration is resolved.
     awaiting_config: bool,
 }
 
@@ -160,10 +159,9 @@ impl SourceScheduler {
         }
     }
 
-    /// Let fetches start, the client's settings having landed.
-    ///
-    /// Until this runs, [`Self::schedule`] records nothing, so the packages it
-    /// declined are all still unseen and the next call picks them up.
+    /// Release fetches after attempting to load client configuration. While
+    /// blocked, [`Self::schedule()`] leaves packages unrecorded so it can queue
+    /// them later.
     pub(crate) fn config_arrived(&mut self) {
         self.awaiting_config = false;
     }
@@ -182,19 +180,14 @@ impl SourceScheduler {
         pool: &IoPool,
         events_tx: &TokioUnboundedSender<Event>,
     ) {
-        // The workspace scan runs during `initialize`, so it can hand us
-        // packages before the client has told us whether to fetch at all. Wait
-        // for its settings rather than fetching against the defaults, which
-        // would download base R sources a `sourceFetching.enabled` of `false`
-        // was meant to prevent.
+        // Wait for client configuration so `oak.sourceFetching.enabled = false`
+        // may prevent startup fetches.
         if self.awaiting_config {
             return;
         }
 
-        // Checked per call rather than at construction, because the client can
-        // flip this mid-session. Turning it back on picks up every package
-        // we've seen so far. Already resolved against the environment by
-        // `apply_env_overrides()`.
+        // Check every time so re-enabling source fetching queues packages left
+        // unhandled while disabled.
         if !config.source_fetching_enabled {
             return;
         }

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -14,7 +14,6 @@ use stdext::is_ci;
 use stdext::result::ResultExt;
 use tokio::sync::watch;
 
-use crate::lsp;
 use crate::lsp::config::OakConfig;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::io_pool::IoPool;
@@ -69,20 +68,21 @@ impl SourceHandler for OakSourceHandler {
         // Base packages are served from a downloaded base R source archive, keyed by R
         // version
         if matches!(request.priority(), Some(Priority::Base)) {
-            return self
-                .source
-                .get_r(version)
-                .or_else(|| self.source.insert_r(version))
-                .map(|root| SourceResponse::Success(r_dir_for_base(&root, name)))
-                .unwrap_or(SourceResponse::Failure);
+            if let Some(root) = self.source.get_r(version) {
+                return SourceResponse::cached(r_dir_for_base(&root, name));
+            }
+            if let Some(root) = self.source.insert_r(version) {
+                return SourceResponse::fetched(r_dir_for_base(&root, name));
+            }
+            return SourceResponse::Failure;
         }
 
         // Try to "get" from all sources before doing an expensive "insert"
         if let Some(dir) = self.srcref.get(name, version, request.built()) {
-            return SourceResponse::Success(dir);
+            return SourceResponse::cached(dir);
         }
         if let Some(root) = self.source.get_cran(name, version) {
-            return SourceResponse::Success(r_dir_for_cran(&root));
+            return SourceResponse::cached(r_dir_for_cran(&root));
         }
 
         // Prefer `srcref` to CRAN download since it doesn't require internet and would
@@ -91,10 +91,10 @@ impl SourceHandler for OakSourceHandler {
             self.srcref
                 .insert(name, version, request.built(), request.library_path())
         {
-            return SourceResponse::Success(dir);
+            return SourceResponse::fetched(dir);
         }
         if let Some(root) = self.source.insert_cran(name, version) {
-            return SourceResponse::Success(r_dir_for_cran(&root));
+            return SourceResponse::fetched(r_dir_for_cran(&root));
         }
 
         SourceResponse::Failure
@@ -127,12 +127,41 @@ pub(crate) struct SourceRequest {
 
 #[derive(Debug)]
 pub(crate) enum SourceResponse {
-    Success(PathBuf),
+    Success {
+        directory: PathBuf,
+        origin: SourceOrigin,
+    },
     Failure,
 
     /// Fetching was turned off while the job waited in the pool's queue, so no
     /// handler ran. Never returned by a [`SourceHandler`].
     Skipped,
+}
+
+/// Whether a successful response used cached sources or recovered them.
+#[derive(Debug)]
+pub(crate) enum SourceOrigin {
+    /// An existing source-cache entry, with no network request.
+    Cached,
+
+    /// Recovered from a local `srcref` or downloaded source archive.
+    Fetched,
+}
+
+impl SourceResponse {
+    pub(crate) fn cached(directory: PathBuf) -> Self {
+        Self::Success {
+            directory,
+            origin: SourceOrigin::Cached,
+        }
+    }
+
+    pub(crate) fn fetched(directory: PathBuf) -> Self {
+        Self::Success {
+            directory,
+            origin: SourceOrigin::Fetched,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -162,8 +191,7 @@ pub(crate) struct SourceScheduler {
     /// Blocks initial fetches until client configuration is resolved.
     awaiting_config: bool,
 
-    /// Shares the latest [`OakConfig::source_fetching_enabled`] with queued
-    /// jobs. Read this value before starting the job.
+    /// Read by queued jobs to check for skip updates before starting.
     enabled_tx: watch::Sender<bool>,
 }
 
@@ -204,8 +232,7 @@ impl SourceScheduler {
         pool: &IoPool,
         events_tx: &TokioUnboundedSender<Event>,
     ) {
-        // Send the current setting before returning so queued jobs observe a
-        // newly disabled fetch.
+        // Publish before returning to inform queued jobs of new setting value.
         self.enabled_tx.send_replace(config.source_fetching_enabled);
 
         // Wait for client configuration so `oak.sourceFetching.enabled = false`
@@ -248,12 +275,6 @@ impl SourceScheduler {
             // Mark as `Pending` just before launching the job
             self.state.insert(package, SourceState::Pending);
 
-            lsp::log_info!(
-                "Fetching sources for package {name}, {n} pending",
-                name = request.name(),
-                n = self.pending_count(),
-            );
-
             pool.submit(move || {
                 // Copy the value before fetching so the `borrow()` guard does
                 // not span `handle()`.
@@ -277,7 +298,7 @@ impl SourceScheduler {
     #[must_use]
     pub(crate) fn finish(&mut self, package: Package, response: SourceResponse) -> Option<PathBuf> {
         match response {
-            SourceResponse::Success(directory) => {
+            SourceResponse::Success { directory, .. } => {
                 self.state.insert(package, SourceState::Finished);
                 Some(directory)
             },
@@ -291,14 +312,6 @@ impl SourceScheduler {
                 None
             },
         }
-    }
-
-    /// How many source requests are in flight
-    fn pending_count(&self) -> usize {
-        self.state
-            .values()
-            .filter(|state| matches!(state, SourceState::Pending))
-            .count()
     }
 
     /// Whether any source request is in flight. Allows tests to deterministically "wait"

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -12,6 +12,7 @@ use oak_srcref::SrcrefCache;
 use stdext::result::ResultExt;
 
 use crate::lsp;
+use crate::lsp::config::OakConfig;
 use crate::lsp::io_pool::IoPool;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::TokioUnboundedSender;
@@ -164,9 +165,18 @@ impl SourceScheduler {
     pub(crate) fn schedule(
         &mut self,
         db: &dyn Db,
+        config: &OakConfig,
         pool: &IoPool,
         events_tx: &TokioUnboundedSender<Event>,
     ) {
+        // Checked per call rather than at construction, because the client can
+        // flip this mid-session. Turning it back on picks up every package
+        // we've seen so far. Already resolved against the environment by
+        // `apply_env_overrides()`.
+        if !config.enable_source_fetching {
+            return;
+        }
+
         let Some(handler) = &self.handler else {
             return;
         };

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -12,6 +12,7 @@ use oak_srcref::SrcrefCache;
 use stdext::env_flag;
 use stdext::is_ci;
 use stdext::result::ResultExt;
+use tokio::sync::watch;
 
 use crate::lsp;
 use crate::lsp::config::OakConfig;
@@ -128,6 +129,10 @@ pub(crate) struct SourceRequest {
 pub(crate) enum SourceResponse {
     Success(PathBuf),
     Failure,
+
+    /// Fetching was turned off while the job waited in the pool's queue, so no
+    /// handler ran. Never returned by a [`SourceHandler`].
+    Skipped,
 }
 
 #[derive(Debug)]
@@ -156,6 +161,10 @@ pub(crate) struct SourceScheduler {
 
     /// Blocks initial fetches until client configuration is resolved.
     awaiting_config: bool,
+
+    /// Shares the latest [`OakConfig::source_fetching_enabled`] with queued
+    /// jobs. Read this value before starting the job.
+    enabled_tx: watch::Sender<bool>,
 }
 
 impl SourceScheduler {
@@ -164,6 +173,7 @@ impl SourceScheduler {
             handler,
             state: HashMap::new(),
             awaiting_config: true,
+            enabled_tx: watch::Sender::new(OakConfig::default().source_fetching_enabled),
         }
     }
 
@@ -194,6 +204,10 @@ impl SourceScheduler {
         pool: &IoPool,
         events_tx: &TokioUnboundedSender<Event>,
     ) {
+        // Send the current setting before returning so queued jobs observe a
+        // newly disabled fetch.
+        self.enabled_tx.send_replace(config.source_fetching_enabled);
+
         // Wait for client configuration so `oak.sourceFetching.enabled = false`
         // may prevent startup fetches.
         if self.awaiting_config {
@@ -228,6 +242,7 @@ impl SourceScheduler {
             };
 
             let handler = Arc::clone(handler);
+            let enabled_rx = self.enabled_tx.subscribe();
             let tx = events_tx.clone();
 
             // Mark as `Pending` just before launching the job
@@ -240,7 +255,15 @@ impl SourceScheduler {
             );
 
             pool.submit(move || {
-                let response = handler.handle(&request);
+                // Copy the value before fetching so the `borrow()` guard does
+                // not span `handle()`.
+                let enabled = *enabled_rx.borrow();
+
+                let response = if enabled {
+                    handler.handle(&request)
+                } else {
+                    SourceResponse::Skipped
+                };
 
                 tx.send(Event::SourceCompleted(SourceCompleted {
                     package,
@@ -253,10 +276,20 @@ impl SourceScheduler {
 
     #[must_use]
     pub(crate) fn finish(&mut self, package: Package, response: SourceResponse) -> Option<PathBuf> {
-        self.state.insert(package, SourceState::Finished);
         match response {
-            SourceResponse::Success(directory) => Some(directory),
-            SourceResponse::Failure => None,
+            SourceResponse::Success(directory) => {
+                self.state.insert(package, SourceState::Finished);
+                Some(directory)
+            },
+            SourceResponse::Failure => {
+                self.state.insert(package, SourceState::Finished);
+                None
+            },
+            SourceResponse::Skipped => {
+                // Forget the package, so turning fetching back on queues it again.
+                self.state.remove(&package);
+                None
+            },
         }
     }
 

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -145,6 +145,10 @@ enum SourceState {
 pub(crate) struct SourceScheduler {
     handler: Option<Arc<dyn SourceHandler>>,
     state: HashMap<Package, SourceState>,
+
+    /// Whether we're still waiting on the client's settings. Set until
+    /// [`Self::config_arrived`].
+    awaiting_config: bool,
 }
 
 impl SourceScheduler {
@@ -152,7 +156,16 @@ impl SourceScheduler {
         Self {
             handler,
             state: HashMap::new(),
+            awaiting_config: true,
         }
+    }
+
+    /// Let fetches start, the client's settings having landed.
+    ///
+    /// Until this runs, [`Self::schedule`] records nothing, so the packages it
+    /// declined are all still unseen and the next call picks them up.
+    pub(crate) fn config_arrived(&mut self) {
+        self.awaiting_config = false;
     }
 
     /// Run a fetch for each package we haven't seen before on `pool`, shipping
@@ -169,6 +182,15 @@ impl SourceScheduler {
         pool: &IoPool,
         events_tx: &TokioUnboundedSender<Event>,
     ) {
+        // The workspace scan runs during `initialize`, so it can hand us
+        // packages before the client has told us whether to fetch at all. Wait
+        // for its settings rather than fetching against the defaults, which
+        // would download base R sources a `sourceFetching.enabled` of `false`
+        // was meant to prevent.
+        if self.awaiting_config {
+            return;
+        }
+
         // Checked per call rather than at construction, because the client can
         // flip this mid-session. Turning it back on picks up every package
         // we've seen so far. Already resolved against the environment by

--- a/crates/ark/src/lsp/sources.rs
+++ b/crates/ark/src/lsp/sources.rs
@@ -9,10 +9,13 @@ use oak_db::Package;
 use oak_db::Priority;
 use oak_source::SourceCache;
 use oak_srcref::SrcrefCache;
+use stdext::env_flag;
+use stdext::is_ci;
 use stdext::result::ResultExt;
 
 use crate::lsp;
 use crate::lsp::config::OakConfig;
+use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::io_pool::IoPool;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::TokioUnboundedSender;
@@ -97,6 +100,11 @@ impl SourceHandler for OakSourceHandler {
     }
 }
 
+/// Whether source fetching is disabled due to to CI env.
+pub(crate) fn source_fetching_disabled_by_ci() -> bool {
+    is_ci() && !env_flag(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR)
+}
+
 /// Find `R/` from a CRAN package tarball
 fn r_dir_for_cran(root: &Path) -> PathBuf {
     root.join("R")
@@ -164,6 +172,12 @@ impl SourceScheduler {
     /// them later.
     pub(crate) fn config_arrived(&mut self) {
         self.awaiting_config = false;
+    }
+
+    /// Whether a handler was built at all. `false` means fetching is off for a
+    /// reason that predates any setting, such as running on CI or a missing R.
+    pub(crate) fn has_handler(&self) -> bool {
+        self.handler.is_some()
     }
 
     /// Run a fetch for each package we haven't seen before on `pool`, shipping

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -79,8 +79,7 @@ impl WorldState {
             db,
             ..Default::default()
         };
-        // Resolved here as well as in `initialize()` and `update_config()`, so
-        // an override holds at all times.
+        // Apply environment overrides before the LSP receives client configuration.
         crate::lsp::config::apply_env_overrides(&mut state.config);
         state
     }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -79,9 +79,8 @@ impl WorldState {
             db,
             ..Default::default()
         };
-        // Resolved here too, not just in `update_config()`. This way an
-        // override holds over the window before the client's first
-        // `didChangeConfiguration`.
+        // Resolved here as well as in `initialize()` and `update_config()`, so
+        // an override holds at all times.
         crate::lsp::config::apply_env_overrides(&mut state.config);
         state
     }

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -75,10 +75,15 @@ pub(crate) struct Workspace {
 
 impl WorldState {
     pub(crate) fn new(db: OakDatabase) -> Self {
-        Self {
+        let mut state = Self {
             db,
             ..Default::default()
-        }
+        };
+        // Resolved here too, not just in `update_config()`. This way an
+        // override holds over the window before the client's first
+        // `didChangeConfiguration`.
+        crate::lsp::config::apply_env_overrides(&mut state.config);
+        state
     }
 
     /// Advance the oak revision without changing any oak input.

--- a/crates/ark/src/lsp/state.rs
+++ b/crates/ark/src/lsp/state.rs
@@ -8,7 +8,9 @@ use oak_db::OakDatabase;
 use salsa::Database;
 use tower_lsp_server::ls_types::Uri;
 
+use crate::lsp::config::env_settings;
 use crate::lsp::config::LspConfig;
+use crate::lsp::config::LspSettings;
 use crate::lsp::open_file::OpenFile;
 use crate::lsp::traits::url::UrlExt;
 
@@ -66,6 +68,10 @@ pub(crate) struct WorldState {
     pub(crate) installed_packages: Vec<String>,
 
     pub(crate) config: LspConfig,
+
+    /// Persist `initializationOptions` so omitted settings in later pulls can
+    /// fall through to it.
+    pub(crate) initialization_options: LspSettings,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -79,9 +85,19 @@ impl WorldState {
             db,
             ..Default::default()
         };
-        // Apply environment overrides before the LSP receives client configuration.
-        crate::lsp::config::apply_env_overrides(&mut state.config);
+
+        state.resolve_config(LspSettings::default());
         state
+    }
+
+    /// Resolve [`Self::config`] from environment, pulled client, and
+    /// initialization options. Earlier layers override later ones, and missing
+    /// values use defaults.
+    pub(crate) fn resolve_config(&mut self, client_settings: LspSettings) {
+        env_settings()
+            .or(client_settings)
+            .or(self.initialization_options.clone())
+            .resolve_into(&mut self.config);
     }
 
     /// Advance the oak revision without changing any oak input.

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -258,9 +258,14 @@ pub(crate) async fn handle_initialized(
         .await
         .log_err();
 
-    update_config(open_file_wire_uris(state), client, state)
-        .await
-        .log_err();
+    update_config(
+        open_file_wire_uris(state),
+        client,
+        &lsp_state.capabilities,
+        state,
+    )
+    .await
+    .log_err();
 
     // Release the startup gate after attempting to load client configuration.
     // Packages seen so far will be queued now if the scheduler is activated.
@@ -488,6 +493,7 @@ fn to_std_paths(paths: &[AbsPathBuf]) -> Vec<PathBuf> {
 pub(crate) async fn did_change_configuration(
     _params: DidChangeConfigurationParams,
     client: &tower_lsp_server::Client,
+    capabilities: &Capabilities,
     state: &mut WorldState,
 ) -> anyhow::Result<()> {
     // The notification params sometimes contain data but it seems in practice
@@ -497,7 +503,7 @@ pub(crate) async fn did_change_configuration(
     // Note that the client sends notifications for settings for which we have
     // declared interest in. This registration is done in `handle_initialized()`.
 
-    update_config(open_file_wire_uris(state), client, state)
+    update_config(open_file_wire_uris(state), client, capabilities, state)
         .instrument(tracing::info_span!("did_change_configuration"))
         .await
 }
@@ -536,12 +542,51 @@ pub(crate) fn did_change_formatting_options(
 async fn update_config(
     open_files: Vec<(FilePath, Uri)>,
     client: &tower_lsp_server::Client,
+    capabilities: &Capabilities,
     state: &mut WorldState,
 ) -> anyhow::Result<()> {
     // Keep track of existing config to detect whether it was changed
     let diagnostics_config = state.config.diagnostics.clone();
     let oak_config = state.config.oak.clone();
 
+    let pulled = if capabilities.workspace_configuration() {
+        pull_config(open_files, client, state).await
+    } else {
+        lsp::log_info!("Client can't answer `workspace/configuration`, using default settings");
+        Ok(())
+    };
+
+    // Overrides apply even when the pull failed, so that an unresponsive client
+    // doesn't strand us on the defaults.
+    apply_env_overrides(&mut state.config);
+
+    if state.config.oak.source_fetching_enabled != oak_config.source_fetching_enabled {
+        let state_name = if state.config.oak.source_fetching_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        lsp::log_info!("Source fetching {state_name} by `oak.sourceFetching.enabled`");
+    }
+
+    // `config` is not an Oak input, so we manually bump the revision to refresh
+    // diagnostics and rerun source scheduling. This queues already discovered
+    // packages when source fetching is re-enabled.
+    if state.config.diagnostics != diagnostics_config || state.config.oak != oak_config {
+        tracing::info!("Bumping salsa revision after configuration changed");
+        state.bump_revision();
+    }
+
+    pulled
+}
+
+/// Pull the global and document settings from the client with a
+/// `workspace/configuration` request, then store them in `state`.
+async fn pull_config(
+    open_files: Vec<(FilePath, Uri)>,
+    client: &tower_lsp_server::Client,
+    state: &mut WorldState,
+) -> anyhow::Result<()> {
     // Build the configuration request for global and document settings
     let mut items: Vec<_> = vec![];
 
@@ -606,25 +651,6 @@ async fn update_config(
                 (mapping.set)(doc.config_mut(), value);
             }
         }
-    }
-
-    apply_env_overrides(&mut state.config);
-
-    if state.config.oak.source_fetching_enabled != oak_config.source_fetching_enabled {
-        let state_name = if state.config.oak.source_fetching_enabled {
-            "enabled"
-        } else {
-            "disabled"
-        };
-        lsp::log_info!("Source fetching {state_name} by `oak.sourceFetching.enabled`");
-    }
-
-    // `config` is not an Oak input, so we manually bump the revision to refresh
-    // diagnostics and rerun source scheduling. This queues already discovered
-    // packages when source fetching is re-enabled.
-    if state.config.diagnostics != diagnostics_config || state.config.oak != oak_config {
-        tracing::info!("Bumping salsa revision after configuration changed");
-        state.bump_revision();
     }
 
     Ok(())

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -503,9 +503,23 @@ pub(crate) async fn did_change_configuration(
     // Note that the client sends notifications for settings for which we have
     // declared interest in. This registration is done in `handle_initialized()`.
 
-    update_config(open_file_wire_uris(state), client, capabilities, state)
+    let was_enabled = state.config.oak.source_fetching_enabled;
+
+    let result = update_config(open_file_wire_uris(state), client, capabilities, state)
         .instrument(tracing::info_span!("did_change_configuration"))
-        .await
+        .await;
+
+    // Report only changes after startup. `handle_initialized()` reports the initial state.
+    if state.config.oak.source_fetching_enabled != was_enabled {
+        let state_name = if state.config.oak.source_fetching_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        lsp::log_info!("Source fetching {state_name} by `oak.sourceFetching.enabled`");
+    }
+
+    result
 }
 
 #[tracing::instrument(level = "info", skip_all)]
@@ -559,15 +573,6 @@ async fn update_config(
     // Overrides apply even when the pull failed, so that an unresponsive client
     // doesn't strand us on the defaults.
     apply_env_overrides(&mut state.config);
-
-    if state.config.oak.source_fetching_enabled != oak_config.source_fetching_enabled {
-        let state_name = if state.config.oak.source_fetching_enabled {
-            "enabled"
-        } else {
-            "disabled"
-        };
-        lsp::log_info!("Source fetching {state_name} by `oak.sourceFetching.enabled`");
-    }
 
     // `config` is not an Oak input, so we manually bump the revision to refresh
     // diagnostics and rerun source scheduling. This queues already discovered

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -52,6 +52,7 @@ use crate::lsp;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
 use crate::lsp::config::apply_env_overrides;
+use crate::lsp::config::apply_initialization_options;
 use crate::lsp::config::indent_style_from_lsp;
 use crate::lsp::config::DOCUMENT_SETTINGS;
 use crate::lsp::config::GLOBAL_SETTINGS;
@@ -95,6 +96,11 @@ pub(crate) fn initialize(
 ) -> LspResult<InitializeResult> {
     let workspace_paths = effective_workspace_paths(&params);
     lsp_state.capabilities = Capabilities::new(params.capabilities);
+
+    if let Some(options) = &params.initialization_options {
+        apply_initialization_options(&mut state.config, options);
+    }
+    apply_env_overrides(&mut state.config);
 
     state.workspace.folders = workspace_paths;
 

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -51,6 +51,7 @@ use crate::console::ConsoleNotification;
 use crate::lsp;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
+use crate::lsp::config::apply_env_overrides;
 use crate::lsp::config::indent_style_from_lsp;
 use crate::lsp::config::DOCUMENT_SETTINGS;
 use crate::lsp::config::GLOBAL_SETTINGS;
@@ -436,6 +437,7 @@ async fn update_config(
 ) -> anyhow::Result<()> {
     // Keep track of existing config to detect whether it was changed
     let diagnostics_config = state.config.diagnostics.clone();
+    let oak_config = state.config.oak.clone();
 
     // Build the configuration request for global and document settings
     let mut items: Vec<_> = vec![];
@@ -503,10 +505,14 @@ async fn update_config(
         }
     }
 
-    // Refresh diagnostics if the configuration changed. The config lives
-    // outside Oak so we bump the revision manually, causing diagnostics
-    // to refresh on the next tick.
-    if state.config.diagnostics != diagnostics_config {
+    // Last, so an environment variable outranks client settings.
+    apply_env_overrides(&mut state.config);
+
+    // The config lives outside Oak, so we bump the revision manually to make the
+    // next tick act on it. That refreshes diagnostics and reruns source
+    // scheduling, which is how turning `enableSourceFetching` back on starts
+    // fetching the packages we've already seen.
+    if state.config.diagnostics != diagnostics_config || state.config.oak != oak_config {
         tracing::info!("Bumping salsa revision after configuration changed");
         state.bump_revision();
     }

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -102,9 +102,6 @@ pub(crate) fn initialize(
 
     state.workspace.folders = workspace_paths;
 
-    // Kick off the initial workspace scan. Fetching sources for whatever it
-    // finds waits on `handle_initialized()`, which is the first point we could
-    // have the client's settings; see `SourceScheduler::config_arrived()`.
     dispatch_workspace_scan(state, lsp_state, events_tx);
 
     let result = InitializeResult {
@@ -253,9 +250,6 @@ pub(crate) async fn handle_initialized(
         }
     }
 
-    // Neither this nor the config pull below propagate. Fetching is released
-    // at the end either way, so a client that can't answer falls back to the
-    // defaults rather than never fetching at all.
     client
         .register_capability(regs)
         .instrument(span.exit())
@@ -266,9 +260,8 @@ pub(crate) async fn handle_initialized(
         .await
         .log_err();
 
-    // Now that settings are in hand, release the packages the workspace scan
-    // has turned up so far. Later arrivals ride the tick's usual
-    // revision-advance check.
+    // Release the startup gate after attempting to load client configuration.
+    // Packages seen so far will be queued now if the scheduler is activated.
     lsp_state.source_scheduler.config_arrived();
     lsp_state.source_scheduler.schedule(
         &state.db,
@@ -447,11 +440,8 @@ pub(crate) fn did_change_workspace_folders(
     Ok(())
 }
 
-/// Scan `state.workspace.folders`, dispatching a request for whatever
-/// `oak_scheduler.set_workspace_paths()` finds newly in or out of scope.
-///
-/// Called both after `initialized` (the first scan) and whenever the client
-/// reports workspace folders changing afterwards.
+/// Update scan roots from `state.workspace.folders`. Dispatch scans for files
+/// entering or leaving workspace scope.
 fn dispatch_workspace_scan(
     state: &mut WorldState,
     lsp_state: &mut LspState,
@@ -602,13 +592,11 @@ async fn update_config(
         }
     }
 
-    // Last, so an environment variable outranks client settings.
     apply_env_overrides(&mut state.config);
 
-    // The config lives outside Oak, so we bump the revision manually to make the
-    // next tick act on it. That refreshes diagnostics and reruns source
-    // scheduling, which is how turning `sourceFetching.enabled` back on starts
-    // fetching the packages we've already seen.
+    // `config` is not an Oak input, so we manually bump the revision to refresh
+    // diagnostics and rerun source scheduling. This queues already discovered
+    // packages when source fetching is re-enabled.
     if state.config.diagnostics != diagnostics_config || state.config.oak != oak_config {
         tracing::info!("Bumping salsa revision after configuration changed");
         state.bump_revision();

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -510,7 +510,7 @@ async fn update_config(
 
     // The config lives outside Oak, so we bump the revision manually to make the
     // next tick act on it. That refreshes diagnostics and reruns source
-    // scheduling, which is how turning `enableSourceFetching` back on starts
+    // scheduling, which is how turning `sourceFetching.enabled` back on starts
     // fetching the packages we've already seen.
     if state.config.diagnostics != diagnostics_config || state.config.oak != oak_config {
         tracing::info!("Bumping salsa revision after configuration changed");

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -59,6 +59,7 @@ use crate::lsp::config::apply_env_overrides;
 use crate::lsp::config::indent_style_from_lsp;
 use crate::lsp::config::DOCUMENT_SETTINGS;
 use crate::lsp::config::GLOBAL_SETTINGS;
+use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::content_changes::apply_content_changes;
 use crate::lsp::main_loop::dispatch_scan_requests;
 use crate::lsp::main_loop::DiagnosticsPublication;
@@ -67,6 +68,7 @@ use crate::lsp::main_loop::DidOpenVirtualDocumentParams;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::main_loop::TokioUnboundedSender;
+use crate::lsp::sources::source_fetching_disabled_by_ci;
 use crate::lsp::state::open_file_wire_uris;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::url::UriExt;
@@ -263,6 +265,20 @@ pub(crate) async fn handle_initialized(
     // Release the startup gate after attempting to load client configuration.
     // Packages seen so far will be queued now if the scheduler is activated.
     lsp_state.source_scheduler.config_arrived();
+
+    // Say once why nothing will be fetched, if that's the case.
+    if !state.config.oak.source_fetching_enabled {
+        lsp::log_info!("Source fetching is disabled by `oak.sourceFetching.enabled`");
+    } else if source_fetching_disabled_by_ci() {
+        lsp::log_info!(
+            "Source fetching is disabled on CI. Set {OAK_SOURCE_FETCHING_ENABLED_ENV_VAR}=1 to enable it."
+        );
+    } else if !lsp_state.source_scheduler.has_handler() {
+        // The specific reason (no R executable, or a handler that failed to
+        // build) was logged to the kernel log.
+        lsp::log_info!("Source fetching is unavailable, no source handler was built");
+    }
+
     lsp_state.source_scheduler.schedule(
         &state.db,
         &state.config.oak,
@@ -593,6 +609,15 @@ async fn update_config(
     }
 
     apply_env_overrides(&mut state.config);
+
+    if state.config.oak.source_fetching_enabled != oak_config.source_fetching_enabled {
+        let state_name = if state.config.oak.source_fetching_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        lsp::log_info!("Source fetching {state_name} by `oak.sourceFetching.enabled`");
+    }
 
     // `config` is not an Oak input, so we manually bump the revision to refresh
     // diagnostics and rerun source scheduling. This queues already discovered

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -21,19 +21,23 @@ use tower_lsp_server::ls_types::CompletionOptionsCompletionItem;
 use tower_lsp_server::ls_types::DidChangeConfigurationParams;
 use tower_lsp_server::ls_types::DidChangeTextDocumentParams;
 use tower_lsp_server::ls_types::DidChangeWatchedFilesParams;
+use tower_lsp_server::ls_types::DidChangeWatchedFilesRegistrationOptions;
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp_server::ls_types::DidCloseTextDocumentParams;
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
 use tower_lsp_server::ls_types::DocumentOnTypeFormattingOptions;
 use tower_lsp_server::ls_types::ExecuteCommandOptions;
 use tower_lsp_server::ls_types::FileChangeType;
+use tower_lsp_server::ls_types::FileSystemWatcher;
 use tower_lsp_server::ls_types::FoldingRangeProviderCapability;
 use tower_lsp_server::ls_types::FormattingOptions;
+use tower_lsp_server::ls_types::GlobPattern;
 use tower_lsp_server::ls_types::HoverProviderCapability;
 use tower_lsp_server::ls_types::ImplementationProviderCapability;
 use tower_lsp_server::ls_types::InitializeParams;
 use tower_lsp_server::ls_types::InitializeResult;
 use tower_lsp_server::ls_types::OneOf;
+use tower_lsp_server::ls_types::Registration;
 use tower_lsp_server::ls_types::RenameOptions;
 use tower_lsp_server::ls_types::SelectionRangeProviderCapability;
 use tower_lsp_server::ls_types::ServerCapabilities;
@@ -52,7 +56,6 @@ use crate::lsp;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
 use crate::lsp::config::apply_env_overrides;
-use crate::lsp::config::apply_initialization_options;
 use crate::lsp::config::indent_style_from_lsp;
 use crate::lsp::config::DOCUMENT_SETTINGS;
 use crate::lsp::config::GLOBAL_SETTINGS;
@@ -97,21 +100,12 @@ pub(crate) fn initialize(
     let workspace_paths = effective_workspace_paths(&params);
     lsp_state.capabilities = Capabilities::new(params.capabilities);
 
-    if let Some(options) = &params.initialization_options {
-        apply_initialization_options(&mut state.config, options);
-    }
-    apply_env_overrides(&mut state.config);
-
     state.workspace.folders = workspace_paths;
 
-    // Kick off the initial workspace scan
-    let editor_owned: HashSet<FilePath> = state.open_files.keys().cloned().collect();
-    let requests = lsp_state.oak_scheduler.set_workspace_paths(
-        &mut state.db,
-        &to_std_paths(&state.workspace.folders),
-        &editor_owned,
-    );
-    dispatch_scan_requests(&lsp_state.scan_pool, events_tx, requests);
+    // Kick off the initial workspace scan. Fetching sources for whatever it
+    // finds waits on `handle_initialized()`, which is the first point we could
+    // have the client's settings; see `SourceScheduler::config_arrived()`.
+    dispatch_workspace_scan(state, lsp_state, events_tx);
 
     let result = InitializeResult {
         server_info: Some(ServerInfo {
@@ -198,6 +192,90 @@ pub(super) fn effective_workspace_paths(params: &InitializeParams) -> Vec<AbsPat
         .filter_map(|folder| folder.uri.to_url().log_err())
         .filter_map(|url| AbsPathBuf::from_url(&url))
         .collect()
+}
+
+pub(crate) async fn handle_initialized(
+    client: &tower_lsp_server::Client,
+    lsp_state: &mut LspState,
+    state: &mut WorldState,
+    events_tx: &TokioUnboundedSender<Event>,
+) {
+    let span = tracing::info_span!("handle_initialized").entered();
+
+    // Register capabilities to the client
+    let mut regs: Vec<Registration> = vec![];
+
+    // Watch R files and DESCRIPTION. We get notified on any disk change;
+    // the handler skips editor-owned URLs since those are tracked via
+    // `textDocument/did*` instead.
+    let watchers = vec![
+        FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/*.{R,r}".to_string()),
+            kind: None,
+        },
+        FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/DESCRIPTION".to_string()),
+            kind: None,
+        },
+    ];
+    regs.push(Registration {
+        id: uuid::Uuid::new_v4().to_string(),
+        method: String::from("workspace/didChangeWatchedFiles"),
+        register_options: Some(
+            serde_json::to_value(DidChangeWatchedFilesRegistrationOptions { watchers }).unwrap(),
+        ),
+    });
+
+    if lsp_state
+        .capabilities
+        .dynamic_registration_for_did_change_configuration()
+    {
+        // The `didChangeConfiguration` request instructs the client to send
+        // a notification when the tracked settings have changed.
+        //
+        // Note that some settings, such as editor indentation properties, may be
+        // changed by extensions or by the user without changing the actual
+        // underlying setting. Unfortunately we don't receive updates in that case.
+
+        for setting in GLOBAL_SETTINGS {
+            regs.push(Registration {
+                id: uuid::Uuid::new_v4().to_string(),
+                method: String::from("workspace/didChangeConfiguration"),
+                register_options: Some(serde_json::json!({ "section": setting.key })),
+            });
+        }
+        for setting in DOCUMENT_SETTINGS {
+            regs.push(Registration {
+                id: uuid::Uuid::new_v4().to_string(),
+                method: String::from("workspace/didChangeConfiguration"),
+                register_options: Some(serde_json::json!({ "section": setting.key })),
+            });
+        }
+    }
+
+    // Neither this nor the config pull below propagate. Fetching is released
+    // at the end either way, so a client that can't answer falls back to the
+    // defaults rather than never fetching at all.
+    client
+        .register_capability(regs)
+        .instrument(span.exit())
+        .await
+        .log_err();
+
+    update_config(open_file_wire_uris(state), client, state)
+        .await
+        .log_err();
+
+    // Now that settings are in hand, release the packages the workspace scan
+    // has turned up so far. Later arrivals ride the tick's usual
+    // revision-advance check.
+    lsp_state.source_scheduler.config_arrived();
+    lsp_state.source_scheduler.schedule(
+        &state.db,
+        &state.config.oak,
+        &lsp_state.source_pool,
+        events_tx,
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]
@@ -365,6 +443,20 @@ pub(crate) fn did_change_workspace_folders(
         }
     }
 
+    dispatch_workspace_scan(state, lsp_state, events_tx);
+    Ok(())
+}
+
+/// Scan `state.workspace.folders`, dispatching a request for whatever
+/// `oak_scheduler.set_workspace_paths()` finds newly in or out of scope.
+///
+/// Called both after `initialized` (the first scan) and whenever the client
+/// reports workspace folders changing afterwards.
+fn dispatch_workspace_scan(
+    state: &mut WorldState,
+    lsp_state: &mut LspState,
+    events_tx: &TokioUnboundedSender<Event>,
+) {
     // Editor-owned URLs survive eviction in `OrphanRoot` so the user's
     // open buffers keep getting analysed even when their workspace
     // folder goes away.
@@ -376,7 +468,6 @@ pub(crate) fn did_change_workspace_folders(
         &editor_owned,
     );
     dispatch_scan_requests(&lsp_state.scan_pool, events_tx, requests);
-    Ok(())
 }
 
 /// Convert workspace folders to the `std::path::PathBuf`s the scan scheduler

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -55,8 +55,9 @@ use crate::console::ConsoleNotification;
 use crate::lsp;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
-use crate::lsp::config::apply_env_overrides;
 use crate::lsp::config::indent_style_from_lsp;
+use crate::lsp::config::initialization_options;
+use crate::lsp::config::LspSettings;
 use crate::lsp::config::DOCUMENT_SETTINGS;
 use crate::lsp::config::GLOBAL_SETTINGS;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
@@ -101,6 +102,13 @@ pub(crate) fn initialize(
 ) -> LspResult<InitializeResult> {
     let workspace_paths = effective_workspace_paths(&params);
     lsp_state.capabilities = Capabilities::new(params.capabilities);
+
+    // Retain `initializationOptions` so a missing setting in a later pull falls
+    // through to it.
+    if let Some(options) = &params.initialization_options {
+        state.initialization_options = initialization_options(options);
+        state.resolve_config(LspSettings::default());
+    }
 
     state.workspace.folders = workspace_paths;
 
@@ -566,13 +574,19 @@ async fn update_config(
     let pulled = if capabilities.workspace_configuration() {
         pull_config(open_files, client, state).await
     } else {
-        lsp::log_info!("Client can't answer `workspace/configuration`, using default settings");
-        Ok(())
+        lsp::log_info!(
+            "Client can't answer `workspace/configuration`, keeping the settings from `initializationOptions`"
+        );
+        Ok(LspSettings::default())
     };
 
-    // Overrides apply even when the pull failed, so that an unresponsive client
-    // doesn't strand us on the defaults.
-    apply_env_overrides(&mut state.config);
+    // A failed pull supplies no values, but must not discard environment or
+    // initialization options.
+    let (client_settings, pull_result) = match pulled {
+        Ok(options) => (options, Ok(())),
+        Err(err) => (LspSettings::default(), Err(err)),
+    };
+    state.resolve_config(client_settings);
 
     // `config` is not an Oak input, so we manually bump the revision to refresh
     // diagnostics and rerun source scheduling. This queues already discovered
@@ -582,16 +596,17 @@ async fn update_config(
         state.bump_revision();
     }
 
-    pulled
+    pull_result
 }
 
-/// Pull the global and document settings from the client with a
-/// `workspace/configuration` request, then store them in `state`.
+/// Pull global and document settings with `workspace/configuration`. Document
+/// settings update their documents, while global settings form a layer to
+/// resolve.
 async fn pull_config(
     open_files: Vec<(FilePath, Uri)>,
     client: &tower_lsp_server::Client,
     state: &mut WorldState,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<LspSettings> {
     // Build the configuration request for global and document settings
     let mut items: Vec<_> = vec![];
 
@@ -639,8 +654,9 @@ async fn pull_config(
     let document_configs = configs.split_off(GLOBAL_SETTINGS.len());
     let global_configs = configs;
 
+    let mut global_options = LspSettings::default();
     for (mapping, value) in GLOBAL_SETTINGS.iter().zip(global_configs) {
-        (mapping.set)(&mut state.config, value);
+        (mapping.set)(&mut global_options, value);
     }
 
     let mut remaining = document_configs;
@@ -658,7 +674,7 @@ async fn pull_config(
         }
     }
 
-    Ok(())
+    Ok(global_options)
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -18,6 +18,7 @@ use super::utils::did_change_workspace_folders;
 use super::utils::insert_file;
 use super::utils::make_state;
 use super::utils::range;
+use super::utils::source_scheduler_for_test;
 use super::utils::test_client;
 use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
@@ -27,7 +28,6 @@ use crate::lsp::goto_definition::goto_definition;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
-use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::url::UrlExt;
 use crate::lsp::util::test_path;
@@ -285,7 +285,7 @@ async fn test_goto_definition_resolves_unqualified_import_into_package() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler)),
+            source_scheduler_for_test(handler),
         ),
     );
 
@@ -351,7 +351,7 @@ async fn test_goto_definition_resolves_unqualified_import_from_into_package() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler)),
+            source_scheduler_for_test(handler),
         ),
     );
 
@@ -421,7 +421,7 @@ async fn test_goto_definition_resolves_namespace_accesses() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler)),
+            source_scheduler_for_test(handler),
         ),
     );
 

--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -282,7 +282,7 @@ async fn test_goto_definition_resolves_unqualified_import_into_package() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),
@@ -348,7 +348,7 @@ async fn test_goto_definition_resolves_unqualified_import_from_into_package() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),
@@ -418,7 +418,7 @@ async fn test_goto_definition_resolves_namespace_accesses() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),

--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -19,6 +19,7 @@ use super::utils::insert_file;
 use super::utils::make_state;
 use super::utils::range;
 use super::utils::test_client;
+use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use super::utils::NamespaceWriter;
@@ -281,7 +282,7 @@ async fn test_goto_definition_resolves_unqualified_import_into_package() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler)),
@@ -347,7 +348,7 @@ async fn test_goto_definition_resolves_unqualified_import_from_into_package() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler)),
@@ -417,7 +418,7 @@ async fn test_goto_definition_resolves_namespace_accesses() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler)),

--- a/crates/ark/src/lsp/tests/goto_definition.rs
+++ b/crates/ark/src/lsp/tests/goto_definition.rs
@@ -282,7 +282,7 @@ async fn test_goto_definition_resolves_unqualified_import_into_package() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),
@@ -348,7 +348,7 @@ async fn test_goto_definition_resolves_unqualified_import_from_into_package() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),
@@ -418,7 +418,7 @@ async fn test_goto_definition_resolves_namespace_accesses() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -124,7 +124,7 @@ async fn test_main_loop_write_survives_saturated_source_pool() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -124,7 +124,7 @@ async fn test_main_loop_write_survives_saturated_source_pool() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -24,6 +24,7 @@ use super::source_handler::TestSourceHandler;
 use super::utils::did_change;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
+use super::utils::source_scheduler_for_test;
 use super::utils::test_client;
 use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
@@ -126,7 +127,7 @@ async fn test_main_loop_write_survives_saturated_source_pool() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler)),
+            source_scheduler_for_test(handler),
         ),
     );
 

--- a/crates/ark/src/lsp/tests/main_loop.rs
+++ b/crates/ark/src/lsp/tests/main_loop.rs
@@ -25,6 +25,7 @@ use super::utils::did_change;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
 use super::utils::test_client;
+use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use crate::lsp::backend::LspMessage;
@@ -122,7 +123,7 @@ async fn test_main_loop_write_survives_saturated_source_pool() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler)),

--- a/crates/ark/src/lsp/tests/source_handler.rs
+++ b/crates/ark/src/lsp/tests/source_handler.rs
@@ -90,7 +90,7 @@ impl SourceHandler for TestSourceHandler {
             Some(TestBehavior::Success(files)) => {
                 let dir = self.sources.path().join(request.name());
                 write_sources(&dir, files);
-                SourceResponse::Success(dir)
+                SourceResponse::fetched(dir)
             },
             Some(TestBehavior::Failure) => SourceResponse::Failure,
             Some(TestBehavior::Gated(gate)) => {

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -12,6 +12,7 @@ use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use tokio::sync::mpsc::UnboundedReceiver;
 
+use super::source_handler::gate;
 use super::source_handler::TestBehavior;
 use super::source_handler::TestSourceHandler;
 use super::utils::did_change_workspace_folders;
@@ -32,6 +33,7 @@ use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
+use crate::lsp::main_loop::SOURCE_POOL_THREADS;
 use crate::lsp::sources::source_fetching_disabled_by_ci;
 use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceHandler;
@@ -317,6 +319,99 @@ async fn test_disabling_stops_fetching_new_packages() {
     let db = &state.world().db;
     assert!(db.package_by_name("donor2").unwrap().files(db).is_empty());
     assert_eq!(db.package_by_name("donor1").unwrap().files(db).len(), 1);
+}
+
+/// Turning the setting off also stops the fetches still sitting in the pool's
+/// queue. A fetch already inside the handler can't be interrupted, so what we
+/// assert is that the queued one never reaches it, and that it stays on offer
+/// for when fetching comes back on.
+#[tokio::test]
+async fn test_disabling_skips_queued_fetches() {
+    let _aux = init_aux_for_test();
+
+    // One gated package per source worker, plus the one that has to wait in the
+    // queue. They share an "entered" sender because which of them a worker picks
+    // up is unpredictable.
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+    let donors: Vec<String> = (0..SOURCE_POOL_THREADS + 1)
+        .map(|i| format!("donor{i}"))
+        .collect();
+
+    let mut behavior = HashMap::new();
+    let mut releases = Vec::new();
+    for name in &donors {
+        let (gate, release) = gate(entered_tx.clone());
+        behavior.insert(name.clone(), TestBehavior::Gated(gate));
+        releases.push(release);
+    }
+    let handler = Arc::new(TestSourceHandler::new(behavior));
+
+    let lib = tempfile::tempdir().unwrap();
+    for name in &donors {
+        DescriptionWriter::new()
+            .package(name)
+            .version("0.0.0")
+            .built("dummy")
+            .write(&lib.path().join(name));
+    }
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        world_with_source_fetching(db, true),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            source_scheduler_for_test(handler.clone()),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    let uses: String = donors
+        .iter()
+        .map(|name| format!("{name}::foo()\n"))
+        .collect();
+    write_sources(&myproj.join("R"), &[("use.R", &uses)]);
+
+    state
+        .handle_event_once(did_change_workspace_folders(workspace.path()))
+        .await;
+    state.pump_scans_to_quiescence().await;
+
+    // Every worker is now parked in `handle()`. A parked worker can't pick up
+    // another job, so the last fetch is stuck in the queue until we release
+    // them, which is what makes the rest of this test deterministic.
+    for _ in 0..SOURCE_POOL_THREADS {
+        entered_rx.recv().unwrap();
+    }
+
+    // The new setting reaches the queued job through the `schedule()` call that
+    // ends this tick.
+    state.world_mut().config.oak.source_fetching_enabled = false;
+    state
+        .handle_event_once(did_open(&workspace.path().join("script.R"), "x <- 1\n"))
+        .await;
+
+    // Let the parked fetches through and collect every response.
+    drop(releases);
+    state.pump_sources_to_quiescence().await;
+    assert_eq!(handler.calls().lock().unwrap().len(), SOURCE_POOL_THREADS);
+
+    state.world_mut().config.oak.source_fetching_enabled = true;
+    state
+        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "x <- 2\n"))
+        .await;
+
+    // The skipped package was left on offer, so it gets fetched now. The ones
+    // that ran while fetching was on aren't asked for twice.
+    let mut names = dispatched_names(handler.calls());
+    names.sort();
+    assert_eq!(names, donors);
 }
 
 /// Do not fetch packages found during `initialize()` before attempting client configuration.

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -121,6 +121,61 @@ async fn test_source_pipeline_ingests_package_sources() {
     assert!(files[0].source_text(db).contains("foo <- function()"));
 }
 
+/// With `positron.r.oak.enableSourceFetching` off, the same workspace that
+/// dispatches a request in `test_source_pipeline_ingests_package_sources`
+/// dispatches nothing. The scan still runs and still finds the dependency, so
+/// this pins that the gate is on the fetch and not on the analysis around it.
+#[tokio::test]
+async fn test_disabled_source_fetching_dispatches_nothing() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut world = WorldState::new(db);
+    world.config.oak.enable_source_fetching = false;
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        world,
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+
+    assert!(handler.calls().lock().unwrap().is_empty());
+
+    // The dependency was still discovered, so re-enabling would have something
+    // to fetch. Only the fetch is gated.
+    let db = &state.world().db;
+    let donor = db.package_by_name("donor").unwrap();
+    assert!(donor.files(db).is_empty());
+}
+
 /// A `Failure` fetch is terminal! Here, a later edit advances the revision, but the
 /// package is not dispatched again.
 #[tokio::test]

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -2,6 +2,7 @@
 //! event loop.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -9,22 +10,26 @@ use std::sync::Mutex;
 use oak_db::Db;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use super::source_handler::TestBehavior;
 use super::source_handler::TestSourceHandler;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
 use super::utils::initialize;
+use super::utils::initialize_without_configuration;
 use super::utils::initialized;
 use super::utils::source_scheduler_for_test;
 use super::utils::test_client;
 use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
+use crate::lsp::backend::RequestResponse;
 use crate::lsp::config::apply_env_overrides;
 use crate::lsp::config::LspConfig;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::main_loop::init_aux_for_test;
+use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
 use crate::lsp::sources::source_fetching_disabled_by_ci;
@@ -318,6 +323,19 @@ async fn test_disabling_stops_fetching_new_packages() {
 /// Release the startup gate after a failed configuration request.
 #[tokio::test]
 async fn test_fetching_waits_for_initialized() {
+    check_fetching_waits_for_initialized(initialize).await;
+}
+
+/// A client that doesn't support `workspace/configuration` is never asked for
+/// settings, so the gate releases on the defaults instead of waiting forever.
+#[tokio::test]
+async fn test_fetching_waits_for_initialized_without_configuration() {
+    check_fetching_waits_for_initialized(initialize_without_configuration).await;
+}
+
+async fn check_fetching_waits_for_initialized(
+    initialize: fn(&Path) -> (Event, UnboundedReceiver<RequestResponse>),
+) {
     let _aux = init_aux_for_test();
 
     let handler = Arc::new(TestSourceHandler::new(HashMap::from([(

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -13,6 +13,7 @@ use oak_db::Db;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use serde_json::json;
+use serde_json::Value;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use super::source_handler::gate;
@@ -22,6 +23,7 @@ use super::utils::did_change_configuration;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
 use super::utils::initialize;
+use super::utils::initialize_with_options;
 use super::utils::initialize_without_configuration;
 use super::utils::initialized;
 use super::utils::source_scheduler_for_test;
@@ -31,8 +33,8 @@ use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use super::utils::TestClient;
 use crate::lsp::backend::RequestResponse;
-use crate::lsp::config::apply_env_overrides;
-use crate::lsp::config::LspConfig;
+use crate::lsp::config::initialization_options;
+use crate::lsp::config::LspSettings;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_SETTING;
 use crate::lsp::main_loop::init_aux_for_test;
@@ -47,6 +49,7 @@ use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceRequest;
 use crate::lsp::sources::SourceResponse;
 use crate::lsp::sources::SourceScheduler;
+use crate::lsp::state::WorldState;
 
 /// The package names passed to the handler, in call order.
 fn dispatched_names(calls: &Mutex<Vec<SourceRequest>>) -> Vec<String> {
@@ -238,7 +241,7 @@ async fn test_configuration_not_pulled_without_capability() {
         .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
 
-    let (event, _response_rx) = initialize_without_configuration(workspace.path());
+    let (event, _response_rx) = initialize_without_configuration(workspace.path(), None);
     state.handle_event_to_quiescence(event).await;
     state.handle_event_to_quiescence(initialized()).await;
 
@@ -247,6 +250,179 @@ async fn test_configuration_not_pulled_without_capability() {
     ]);
     assert!(state.world().config.oak.source_fetching_enabled);
     assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
+}
+
+/// Without `workspace/configuration`, `initializationOptions = false` disables
+/// source fetching before the startup gate opens.
+#[tokio::test]
+async fn test_initialization_options_disable_startup_fetching() {
+    let options = json!({ "oak": { "sourceFetching": { "enabled": false } } });
+    let handler = check_initialization_options(Some(options)).await;
+
+    assert!(handler.calls().lock().unwrap().is_empty());
+}
+
+/// Without `initializationOptions`, the default keeps source fetching enabled.
+#[tokio::test]
+async fn test_initialize_without_options_fetches() {
+    let handler = check_initialization_options(None).await;
+
+    assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
+}
+
+async fn check_initialization_options(options: Option<Value>) -> Arc<TestSourceHandler> {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        world_with_source_fetching(db),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    let (event, _response_rx) = initialize_without_configuration(workspace.path(), options);
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
+
+    handler
+}
+
+/// An absent pulled value does not override `initializationOptions`.
+#[tokio::test]
+async fn test_initialization_options_survive_a_silent_pull() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let client = TestClient::new(&[]).await;
+
+    let mut state = GlobalState::from_parts(
+        client.client(),
+        world_with_source_fetching(db),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    let options = json!({ "oak": { "sourceFetching": { "enabled": false } } });
+    let (event, _response_rx) = initialize_with_options(workspace.path(), options);
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
+
+    assert_eq!(client.answered_requests(), vec![
+        "client/registerCapability",
+        "workspace/configuration"
+    ]);
+    assert!(!state.world().config.oak.source_fetching_enabled);
+    assert!(handler.calls().lock().unwrap().is_empty());
+}
+
+/// The environment setting overrides `initializationOptions`.
+#[test]
+fn test_env_var_beats_initialization_options() {
+    let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
+    let options = json!({ "oak": { "sourceFetching": { "enabled": false } } });
+
+    let resolve =
+        || resolved_source_fetching(initialization_options(&options), LspSettings::default());
+
+    unsafe { std::env::remove_var(name) };
+    assert!(!resolve());
+
+    unsafe { std::env::set_var(name, "1") };
+    assert!(resolve());
+
+    unsafe { std::env::remove_var(name) };
+}
+
+/// A pulled value overrides `initializationOptions` for the same setting.
+#[test]
+fn test_pulled_setting_beats_initialization_options() {
+    unsafe { std::env::remove_var(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR) };
+
+    let options = initialization_options(&json!({
+        "oak": { "sourceFetching": { "enabled": false } }
+    }));
+
+    let pulled = LspSettings {
+        source_fetching_enabled: Some(true),
+        ..Default::default()
+    };
+    assert!(resolved_source_fetching(options.clone(), pulled));
+
+    // An absent pulled value preserves the initialization option.
+    assert!(!resolved_source_fetching(options, LspSettings::default()));
+}
+
+fn resolved_source_fetching(options: LspSettings, client_settings: LspSettings) -> bool {
+    let mut state = WorldState {
+        initialization_options: options,
+        ..Default::default()
+    };
+    state.resolve_config(client_settings);
+    state.config.oak.source_fetching_enabled
+}
+
+/// Dotted setting names must be nested objects, not flat `initializationOptions` keys.
+#[test]
+fn test_initialization_options_read_nested_objects_only() {
+    for options in [
+        json!({}),
+        json!({ "oak": {} }),
+        json!({ "oak": { "sourceFetching": {} } }),
+        json!({ "oak.sourceFetching.enabled": true }),
+        json!({ "oak": { "sourceFetching": "not-an-object" } }),
+    ] {
+        assert_eq!(
+            initialization_options(&options).source_fetching_enabled,
+            None
+        );
+    }
 }
 
 /// Turning the setting back on fetches the packages Oak saw while it was off,
@@ -584,7 +760,7 @@ async fn test_fetching_waits_for_initialized() {
 /// settings, so the gate releases on the defaults instead of waiting forever.
 #[tokio::test]
 async fn test_fetching_waits_for_initialized_without_configuration() {
-    check_fetching_waits_for_initialized(initialize_without_configuration).await;
+    check_fetching_waits_for_initialized(|path| initialize_without_configuration(path, None)).await;
 }
 
 async fn check_fetching_waits_for_initialized(
@@ -670,10 +846,11 @@ fn test_env_var_overrides_the_setting() {
     let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 
     let resolve = |client_says: bool| {
-        let mut config = LspConfig::default();
-        config.oak.source_fetching_enabled = client_says;
-        apply_env_overrides(&mut config);
-        config.oak.source_fetching_enabled
+        let client_settings = LspSettings {
+            source_fetching_enabled: Some(client_says),
+            ..Default::default()
+        };
+        resolved_source_fetching(LspSettings::default(), client_settings)
     };
 
     unsafe { std::env::remove_var(name) };

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -15,12 +15,13 @@ use super::source_handler::TestSourceHandler;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
 use super::utils::initialize;
+use super::utils::initialized;
+use super::utils::source_scheduler_for_test;
 use super::utils::test_client;
 use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use crate::lsp::config::apply_env_overrides;
-use crate::lsp::config::apply_initialization_options;
 use crate::lsp::config::LspConfig;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::main_loop::init_aux_for_test;
@@ -91,7 +92,7 @@ async fn test_source_pipeline_ingests_package_sources() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler.clone())),
+            source_scheduler_for_test(handler.clone()),
         ),
     );
 
@@ -157,7 +158,7 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
         world,
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler.clone())),
+            source_scheduler_for_test(handler.clone()),
         ),
     );
 
@@ -182,59 +183,21 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     assert!(donor.files(db).is_empty());
 }
 
-/// `initializationOptions` reaches the config early enough to stop the very
-/// first dispatch. `initialize()` advances the revision itself, so the tick it
-/// runs in already schedules fetches: a setting that only arrived over
-/// `workspace/configuration` would land after the packages were on their way.
+/// The workspace scan runs during `initialize`, but fetching what it turns up
+/// waits for `initialized`. That's the first point `handle_initialized()` could
+/// have pulled the client's settings, and the `initialize` request handler
+/// can't await that round trip before answering. Without the wait, a workspace
+/// opened with `sourceFetching.enabled` off would still fetch at startup.
+///
+/// Only the fetch waits: the scan and the analysis around it run on the
+/// original schedule, so intellisense doesn't pay for the round trip.
+///
+/// The dummy `test_client()` can't actually answer `workspace/configuration`
+/// (its sends go nowhere), so this also pins that a failed pull still releases
+/// fetching. `handle_initialized()` has to log and move on rather than
+/// propagate, or the dispatch below would never happen either.
 #[tokio::test]
-async fn test_initialization_options_gate_the_first_dispatch() {
-    let _aux = init_aux_for_test();
-
-    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
-        String::from("donor"),
-        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
-    )])));
-
-    let lib = tempfile::tempdir().unwrap();
-    DescriptionWriter::new()
-        .package("donor")
-        .version("0.0.0")
-        .built("dummy")
-        .write(&lib.path().join("donor"));
-    let mut db = OakDatabase::new();
-    db.set_library_paths(&[lib.path().to_path_buf()]);
-
-    let mut state = GlobalState::from_parts(
-        test_client(),
-        WorldState::new(db),
-        LspState::new(
-            tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler.clone())),
-        ),
-    );
-
-    let workspace = tempfile::tempdir().unwrap();
-    let myproj = workspace.path().join("myproj");
-    DescriptionWriter::new()
-        .package("myproj")
-        .version("0.0.0")
-        .write(&myproj);
-    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
-
-    let options = serde_json::json!({
-        "oak": { "sourceFetching": { "enabled": false } }
-    });
-    let (event, _response_rx) = initialize(workspace.path(), Some(options));
-    state.handle_event_to_quiescence(event).await;
-
-    assert!(handler.calls().lock().unwrap().is_empty());
-}
-
-/// The same `initialize` without `initializationOptions` fetches, so the test
-/// above pins the setting rather than some other reason the dispatch was
-/// skipped.
-#[tokio::test]
-async fn test_initialize_without_options_fetches() {
+async fn test_fetching_waits_for_initialized() {
     let _aux = init_aux_for_test();
 
     let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
@@ -268,51 +231,18 @@ async fn test_initialize_without_options_fetches() {
         .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
 
-    let (event, _response_rx) = initialize(workspace.path(), None);
+    let (event, _response_rx) = initialize(workspace.path());
     state.handle_event_to_quiescence(event).await;
 
+    // The scan ran to completion and found the dependency, yet nothing was
+    // fetched for it.
+    assert!(handler.calls().lock().unwrap().is_empty());
+    let db = &state.world().db;
+    let donor = db.package_by_name("donor").unwrap();
+    assert!(donor.files(db).is_empty());
+
+    state.handle_event_to_quiescence(initialized()).await;
     assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
-}
-
-/// The env var outranks `initializationOptions` too, in the same order
-/// `initialize()` resolves them.
-#[test]
-fn test_env_var_beats_initialization_options() {
-    let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
-    let options = serde_json::json!({ "oak": { "sourceFetching": { "enabled": false } } });
-
-    let resolve = || {
-        let mut config = LspConfig::default();
-        apply_initialization_options(&mut config, &options);
-        apply_env_overrides(&mut config);
-        config.oak.source_fetching_enabled
-    };
-
-    unsafe { std::env::remove_var(name) };
-    assert!(!resolve());
-
-    unsafe { std::env::set_var(name, "1") };
-    assert!(resolve());
-
-    unsafe { std::env::remove_var(name) };
-}
-
-/// Only nested objects are read. A key the client omits, or spells as a flat
-/// dotted string, leaves the setting where it was instead of resetting it.
-#[test]
-fn test_initialization_options_read_nested_objects_only() {
-    for options in [
-        serde_json::json!({}),
-        serde_json::json!({ "oak": {} }),
-        serde_json::json!({ "oak": { "sourceFetching": {} } }),
-        serde_json::json!({ "oak.sourceFetching.enabled": true }),
-        serde_json::json!({ "oak": { "sourceFetching": "not-an-object" } }),
-    ] {
-        let mut config = LspConfig::default();
-        config.oak.source_fetching_enabled = false;
-        apply_initialization_options(&mut config, &options);
-        assert!(!config.oak.source_fetching_enabled);
-    }
 }
 
 /// `OAK_SOURCE_FETCHING_ENABLED` beats the LSP setting in both directions,
@@ -375,7 +305,7 @@ async fn test_failed_source_is_not_retried() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler.clone())),
+            source_scheduler_for_test(handler.clone()),
         ),
     );
 
@@ -450,7 +380,7 @@ async fn test_source_pipeline_ingests_real_srcref_sources() {
         world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            SourceScheduler::new(Some(handler)),
+            source_scheduler_for_test(handler),
         ),
     );
 

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -10,11 +10,13 @@ use std::sync::Mutex;
 use oak_db::Db;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
+use serde_json::json;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use super::source_handler::gate;
 use super::source_handler::TestBehavior;
 use super::source_handler::TestSourceHandler;
+use super::utils::did_change_configuration;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
 use super::utils::initialize;
@@ -25,10 +27,12 @@ use super::utils::test_client;
 use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
+use super::utils::TestClient;
 use crate::lsp::backend::RequestResponse;
 use crate::lsp::config::apply_env_overrides;
 use crate::lsp::config::LspConfig;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
+use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_SETTING;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::Event;
 use crate::lsp::main_loop::GlobalState;
@@ -96,7 +100,7 @@ async fn test_source_pipeline_ingests_package_sources() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -135,8 +139,8 @@ async fn test_source_pipeline_ingests_package_sources() {
     assert!(files[0].source_text(db).contains("foo <- function()"));
 }
 
-/// Disabling `oak.sourceFetching.enabled` leaves dependency discovery intact
-/// but dispatches no source request.
+/// A `false` startup `workspace/configuration` response leaves dependency
+/// discovery intact but dispatches no source request.
 #[tokio::test]
 async fn test_disabled_source_fetching_dispatches_nothing() {
     let _aux = init_aux_for_test();
@@ -155,12 +159,14 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
+    let client = TestClient::new(&[(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(false))]).await;
+
     let mut state = GlobalState::from_parts(
-        test_client(),
-        world_with_source_fetching(db, false),
+        client.client(),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            source_scheduler_for_test(handler.clone()),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 
@@ -172,10 +178,14 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
         .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
 
-    state
-        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
-        .await;
+    let (event, _response_rx) = initialize(workspace.path());
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
 
+    assert_eq!(client.answered_requests(), vec![
+        "client/registerCapability",
+        "workspace/configuration"
+    ]);
     assert!(handler.calls().lock().unwrap().is_empty());
 
     // The dependency is indexed even though its sources were not fetched.
@@ -184,15 +194,65 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     assert!(donor.files(db).is_empty());
 }
 
+/// Without `workspace/configuration` support, source fetching uses its default
+/// because the client is never queried.
+#[tokio::test]
+async fn test_configuration_not_pulled_without_capability() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    // Configuring `false` proves that the client is never queried.
+    let client = TestClient::new(&[(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(false))]).await;
+
+    let mut state = GlobalState::from_parts(
+        client.client(),
+        world_with_source_fetching(db),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    let (event, _response_rx) = initialize_without_configuration(workspace.path());
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
+
+    assert_eq!(client.answered_requests(), vec![
+        "client/registerCapability"
+    ]);
+    assert!(state.world().config.oak.source_fetching_enabled);
+    assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
+}
+
 /// Turning the setting back on fetches the packages Oak saw while it was off,
 /// which is what `doc/configuration-oak.md` promises. This works because both
 /// early returns in `schedule()` come before the loop that records a package,
 /// so a declined package stays unseen rather than being marked `Finished`.
 ///
-/// In production `update_config()` bumps the revision itself, so the fetch
-/// starts on the config change alone. The `did_open()` here stands in for that
-/// bump, which a test can't reach without a client that answers
-/// `workspace/configuration`.
+/// The client returns `false` at startup and `true` after
+/// `didChangeConfiguration`. The configuration update advances the revision,
+/// so re-enabling starts the fetch without another workspace event.
 #[tokio::test]
 async fn test_reenabling_fetches_packages_seen_while_off() {
     let _aux = init_aux_for_test();
@@ -211,12 +271,14 @@ async fn test_reenabling_fetches_packages_seen_while_off() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
+    let client = TestClient::new(&[(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(false))]).await;
+
     let mut state = GlobalState::from_parts(
-        test_client(),
-        world_with_source_fetching(db, false),
+        client.client(),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            source_scheduler_for_test(handler.clone()),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 
@@ -228,14 +290,17 @@ async fn test_reenabling_fetches_packages_seen_while_off() {
         .write(&myproj);
     write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
 
-    state
-        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
-        .await;
+    let (event, _response_rx) = initialize(workspace.path());
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
+
+    // The startup response overrides `WorldState`'s default before source requests are released.
+    assert!(!state.world().config.oak.source_fetching_enabled);
     assert!(handler.calls().lock().unwrap().is_empty());
 
-    state.world_mut().config.oak.source_fetching_enabled = true;
+    client.set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true));
     state
-        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "1 + 1\n"))
+        .handle_event_to_quiescence(did_change_configuration())
         .await;
 
     // `donor` was declined while off, so it is still on offer and gets fetched
@@ -246,6 +311,13 @@ async fn test_reenabling_fetches_packages_seen_while_off() {
     let files = donor.files(db).clone();
     assert_eq!(files.len(), 1);
     assert!(files[0].source_text(db).contains("foo <- function()"));
+
+    // Each configuration pull consumes one client response.
+    assert_eq!(client.answered_requests(), vec![
+        "client/registerCapability",
+        "workspace/configuration",
+        "workspace/configuration"
+    ]);
 }
 
 /// Turning the setting off mid-session stops fetching for a dependency that
@@ -276,12 +348,14 @@ async fn test_disabling_stops_fetching_new_packages() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
+    let client = TestClient::new(&[(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true))]).await;
+
     let mut state = GlobalState::from_parts(
-        test_client(),
-        world_with_source_fetching(db, true),
+        client.client(),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            source_scheduler_for_test(handler.clone()),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 
@@ -303,12 +377,15 @@ async fn test_disabling_stops_fetching_new_packages() {
         .write(&proj2);
     write_sources(&proj2.join("R"), &[("use.R", "donor2::bar()\n")]);
 
-    state
-        .handle_event_to_quiescence(did_change_workspace_folders(first.path()))
-        .await;
+    let (event, _response_rx) = initialize(first.path());
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
     assert_eq!(dispatched_names(handler.calls()), vec!["donor1"]);
 
-    state.world_mut().config.oak.source_fetching_enabled = false;
+    client.set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(false));
+    state
+        .handle_event_to_quiescence(did_change_configuration())
+        .await;
     state
         .handle_event_to_quiescence(did_change_workspace_folders(second.path()))
         .await;
@@ -357,12 +434,14 @@ async fn test_disabling_skips_queued_fetches() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
+    let client = TestClient::new(&[(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true))]).await;
+
     let mut state = GlobalState::from_parts(
-        test_client(),
-        world_with_source_fetching(db, true),
+        client.client(),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
-            source_scheduler_for_test(handler.clone()),
+            SourceScheduler::new(Some(handler.clone())),
         ),
     );
 
@@ -378,44 +457,39 @@ async fn test_disabling_skips_queued_fetches() {
         .collect();
     write_sources(&myproj.join("R"), &[("use.R", &uses)]);
 
-    state
-        .handle_event_once(did_change_workspace_folders(workspace.path()))
-        .await;
+    // Gated fetches never finish until `releases` drops, so waiting for quiescence would hang.
+    let (event, _response_rx) = initialize(workspace.path());
+    state.handle_event_once(event).await;
     state.pump_scans_to_quiescence().await;
+    state.handle_event_once(initialized()).await;
 
-    // Every worker is now parked in `handle()`. A parked worker can't pick up
-    // another job, so the last fetch is stuck in the queue until we release
-    // them, which is what makes the rest of this test deterministic.
+    // Every worker is blocked in `handle()`, leaving the final fetch queued until `releases` drops.
     for _ in 0..SOURCE_POOL_THREADS {
         entered_rx.recv().unwrap();
     }
 
-    // The new setting reaches the queued job through the `schedule()` call that
-    // ends this tick.
-    state.world_mut().config.oak.source_fetching_enabled = false;
-    state
-        .handle_event_once(did_open(&workspace.path().join("script.R"), "x <- 1\n"))
-        .await;
+    // The configuration pull publishes `false` before the queued job starts.
+    client.set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(false));
+    state.handle_event_once(did_change_configuration()).await;
 
     // Let the parked fetches through and collect every response.
     drop(releases);
     state.pump_sources_to_quiescence().await;
     assert_eq!(handler.calls().lock().unwrap().len(), SOURCE_POOL_THREADS);
 
-    state.world_mut().config.oak.source_fetching_enabled = true;
+    client.set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true));
     state
-        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "x <- 2\n"))
+        .handle_event_to_quiescence(did_change_configuration())
         .await;
 
-    // The skipped package was left on offer, so it gets fetched now. The ones
-    // that ran while fetching was on aren't asked for twice.
+    // The skipped package remains unrecorded and is queued after re-enabling. Completed jobs stay `Finished`.
     let mut names = dispatched_names(handler.calls());
     names.sort();
     assert_eq!(names, donors);
 }
 
-/// Do not fetch packages found during `initialize()` before attempting client configuration.
-/// Release the startup gate after a failed configuration request.
+/// Source fetching waits for configuration resolution, but a failed request
+/// releases the startup gate. `test_client()` simulates the failed request.
 #[tokio::test]
 async fn test_fetching_waits_for_initialized() {
     check_fetching_waits_for_initialized(initialize).await;
@@ -449,7 +523,7 @@ async fn check_fetching_waits_for_initialized(
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler.clone())),
@@ -558,7 +632,7 @@ async fn test_failed_source_is_not_retried() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -633,7 +707,7 @@ async fn test_source_pipeline_ingests_real_srcref_sources() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db, true),
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -1,9 +1,5 @@
 //! Tests that drive the source request pipeline through the real [`GlobalState`]
 //! event loop.
-//!
-//! Each test pins `source_fetching_enabled` rather than taking the default,
-//! since `WorldState::new()` reads `OAK_SOURCE_FETCHING_ENABLED` and an exported
-//! value would otherwise decide what these tests exercise.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -19,6 +15,7 @@ use super::source_handler::TestSourceHandler;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
 use super::utils::test_client;
+use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use crate::lsp::config::apply_env_overrides;
@@ -87,12 +84,9 @@ async fn test_source_pipeline_ingests_package_sources() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
-    let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = true;
-
     let mut state = GlobalState::from_parts(
         test_client(),
-        world,
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler.clone())),
@@ -241,12 +235,9 @@ async fn test_failed_source_is_not_retried() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
-    let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = true;
-
     let mut state = GlobalState::from_parts(
         test_client(),
-        world,
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler.clone())),
@@ -319,12 +310,9 @@ async fn test_source_pipeline_ingests_real_srcref_sources() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[library.path().to_path_buf()]);
 
-    let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = true;
-
     let mut state = GlobalState::from_parts(
         test_client(),
-        world,
+        world_with_source_fetching(db),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler)),

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -17,6 +17,9 @@ use super::utils::did_open;
 use super::utils::test_client;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
+use crate::lsp::config::apply_env_overrides;
+use crate::lsp::config::LspConfig;
+use crate::lsp::config::OAK_ENABLE_SOURCE_FETCHING_ENV_VAR;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
@@ -121,7 +124,7 @@ async fn test_source_pipeline_ingests_package_sources() {
     assert!(files[0].source_text(db).contains("foo <- function()"));
 }
 
-/// With `positron.r.oak.enableSourceFetching` off, the same workspace that
+/// With `oak.enableSourceFetching` off, the same workspace that
 /// dispatches a request in `test_source_pipeline_ingests_package_sources`
 /// dispatches nothing. The scan still runs and still finds the dependency, so
 /// this pins that the gate is on the fetch and not on the analysis around it.
@@ -174,6 +177,41 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     let db = &state.world().db;
     let donor = db.package_by_name("donor").unwrap();
     assert!(donor.files(db).is_empty());
+}
+
+/// `OAK_ENABLE_SOURCE_FETCHING` beats the LSP setting in both directions,
+/// following ty and ruff: a value given at the invocation wins over one from a
+/// settings file. Unset falls through to the setting.
+#[test]
+fn test_env_var_overrides_the_setting() {
+    let name = OAK_ENABLE_SOURCE_FETCHING_ENV_VAR;
+
+    // Whether fetching is on after resolving `client_says` against the env var.
+    let resolve = |client_says: bool| {
+        let mut config = LspConfig::default();
+        config.oak.enable_source_fetching = client_says;
+        apply_env_overrides(&mut config);
+        config.oak.enable_source_fetching
+    };
+
+    unsafe { std::env::remove_var(name) };
+    assert!(resolve(true));
+    assert!(!resolve(false));
+
+    unsafe { std::env::set_var(name, "1") };
+    assert!(resolve(true));
+    assert!(resolve(false));
+
+    unsafe { std::env::set_var(name, "0") };
+    assert!(!resolve(true));
+    assert!(!resolve(false));
+
+    // Unrecognised falls through to the setting rather than forcing a value.
+    unsafe { std::env::set_var(name, "yes") };
+    assert!(resolve(true));
+    assert!(!resolve(false));
+
+    unsafe { std::env::remove_var(name) };
 }
 
 /// A `Failure` fetch is terminal! Here, a later edit advances the revision, but the

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -1,5 +1,9 @@
 //! Tests that drive the source request pipeline through the real [`GlobalState`]
 //! event loop.
+//!
+//! Each test pins `source_fetching_enabled` rather than taking the default,
+//! since `WorldState::new()` reads `OAK_SOURCE_FETCHING_ENABLED` and an exported
+//! value would otherwise decide what these tests exercise.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -83,9 +87,12 @@ async fn test_source_pipeline_ingests_package_sources() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
+    let mut world = WorldState::new(db);
+    world.config.oak.source_fetching_enabled = true;
+
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world,
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler.clone())),
@@ -234,9 +241,12 @@ async fn test_failed_source_is_not_retried() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
+    let mut world = WorldState::new(db);
+    world.config.oak.source_fetching_enabled = true;
+
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world,
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler.clone())),
@@ -309,9 +319,12 @@ async fn test_source_pipeline_ingests_real_srcref_sources() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[library.path().to_path_buf()]);
 
+    let mut world = WorldState::new(db);
+    world.config.oak.source_fetching_enabled = true;
+
     let mut state = GlobalState::from_parts(
         test_client(),
-        WorldState::new(db),
+        world,
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler)),

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -40,8 +42,10 @@ use crate::lsp::main_loop::LspState;
 use crate::lsp::main_loop::SOURCE_POOL_THREADS;
 use crate::lsp::sources::source_fetching_disabled_by_ci;
 use crate::lsp::sources::OakSourceHandler;
+use crate::lsp::sources::SourceCompleted;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceRequest;
+use crate::lsp::sources::SourceResponse;
 use crate::lsp::sources::SourceScheduler;
 
 /// The package names passed to the handler, in call order.
@@ -405,7 +409,91 @@ async fn test_disabling_stops_fetching_new_packages() {
 #[tokio::test]
 async fn test_disabling_skips_queued_fetches() {
     let _aux = init_aux_for_test();
+    let mut session = queued_fetch_session().await;
 
+    // Let the parked fetches through and collect every response.
+    drop(session.releases);
+    session.state.pump_sources_to_quiescence().await;
+    assert_eq!(
+        session.handler.calls().lock().unwrap().len(),
+        SOURCE_POOL_THREADS
+    );
+
+    session
+        .client
+        .set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true));
+    session
+        .state
+        .handle_event_to_quiescence(did_change_configuration())
+        .await;
+
+    // The skipped package remains unrecorded and is queued after re-enabling. Completed jobs stay `Finished`.
+    let mut names = dispatched_names(session.handler.calls());
+    names.sort();
+    assert_eq!(names, session.donors);
+}
+
+/// Re-enabling while a `Skipped` response is still in flight must not strand the
+/// package. The scheduling pass on the re-enable can't pick it up, since the
+/// package still looks `Pending` until its response lands, so handling the
+/// response has to be what starts the fetch.
+#[tokio::test]
+async fn test_reenabling_before_a_skip_lands_still_fetches() {
+    let _aux = init_aux_for_test();
+    let mut session = queued_fetch_session().await;
+
+    // The queued job now starts, reads the `false`, and answers `Skipped`. Hold
+    // that response back so the re-enable lands in front of it.
+    drop(session.releases);
+    let skipped = session
+        .state
+        .take_event(|event| {
+            matches!(
+                event,
+                Event::SourceCompleted(SourceCompleted {
+                    response: SourceResponse::Skipped,
+                    ..
+                })
+            )
+        })
+        .await;
+
+    session
+        .client
+        .set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true));
+    session
+        .state
+        .handle_event_once(did_change_configuration())
+        .await;
+
+    session.state.handle_event_to_quiescence(skipped).await;
+
+    let mut names = dispatched_names(session.handler.calls());
+    names.sort();
+    assert_eq!(names, session.donors);
+}
+
+/// A session with every source worker parked in a gated fetch, one more fetch
+/// queued behind them, and fetching turned off through the client while that
+/// last one waits. Dropping [`Self::releases`] lets the parked fetches return,
+/// which is when the queued job starts and reads the setting.
+struct QueuedFetchSession {
+    state: GlobalState,
+    client: TestClient,
+    handler: Arc<TestSourceHandler>,
+    donors: Vec<String>,
+    releases: Vec<Sender<()>>,
+
+    /// Held for the duration of the test. The sources live under the temporary
+    /// directories, and dropping the response receiver early makes `respond()`
+    /// fail.
+    _lib: tempfile::TempDir,
+    _workspace: tempfile::TempDir,
+    _response_rx: UnboundedReceiver<RequestResponse>,
+    _entered_rx: Receiver<()>,
+}
+
+async fn queued_fetch_session() -> QueuedFetchSession {
     // One gated package per source worker, plus the one that has to wait in the
     // queue. They share an "entered" sender because which of them a worker picks
     // up is unpredictable.
@@ -472,20 +560,17 @@ async fn test_disabling_skips_queued_fetches() {
     client.set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(false));
     state.handle_event_once(did_change_configuration()).await;
 
-    // Let the parked fetches through and collect every response.
-    drop(releases);
-    state.pump_sources_to_quiescence().await;
-    assert_eq!(handler.calls().lock().unwrap().len(), SOURCE_POOL_THREADS);
-
-    client.set_setting(OAK_SOURCE_FETCHING_ENABLED_SETTING, json!(true));
-    state
-        .handle_event_to_quiescence(did_change_configuration())
-        .await;
-
-    // The skipped package remains unrecorded and is queued after re-enabling. Completed jobs stay `Finished`.
-    let mut names = dispatched_names(handler.calls());
-    names.sort();
-    assert_eq!(names, donors);
+    QueuedFetchSession {
+        state,
+        client,
+        handler,
+        donors,
+        releases,
+        _lib: lib,
+        _workspace: workspace,
+        _response_rx,
+        _entered_rx: entered_rx,
+    }
 }
 
 /// Source fetching waits for configuration resolution, but a failed request

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -128,10 +128,8 @@ async fn test_source_pipeline_ingests_package_sources() {
     assert!(files[0].source_text(db).contains("foo <- function()"));
 }
 
-/// With `oak.sourceFetching.enabled` off, the same workspace that
-/// dispatches a request in `test_source_pipeline_ingests_package_sources`
-/// dispatches nothing. The scan still runs and still finds the dependency, so
-/// this pins that the gate is on the fetch and not on the analysis around it.
+/// Disabling `oak.sourceFetching.enabled` leaves dependency discovery intact
+/// but dispatches no source request.
 #[tokio::test]
 async fn test_disabled_source_fetching_dispatches_nothing() {
     let _aux = init_aux_for_test();
@@ -176,26 +174,14 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
 
     assert!(handler.calls().lock().unwrap().is_empty());
 
-    // The dependency was still discovered, so re-enabling would have something
-    // to fetch. Only the fetch is gated.
+    // The dependency is indexed even though its sources were not fetched.
     let db = &state.world().db;
     let donor = db.package_by_name("donor").unwrap();
     assert!(donor.files(db).is_empty());
 }
 
-/// The workspace scan runs during `initialize`, but fetching what it turns up
-/// waits for `initialized`. That's the first point `handle_initialized()` could
-/// have pulled the client's settings, and the `initialize` request handler
-/// can't await that round trip before answering. Without the wait, a workspace
-/// opened with `sourceFetching.enabled` off would still fetch at startup.
-///
-/// Only the fetch waits: the scan and the analysis around it run on the
-/// original schedule, so intellisense doesn't pay for the round trip.
-///
-/// The dummy `test_client()` can't actually answer `workspace/configuration`
-/// (its sends go nowhere), so this also pins that a failed pull still releases
-/// fetching. `handle_initialized()` has to log and move on rather than
-/// propagate, or the dispatch below would never happen either.
+/// Do not fetch packages found during `initialize()` before attempting client configuration.
+/// Release the startup gate after a failed configuration request.
 #[tokio::test]
 async fn test_fetching_waits_for_initialized() {
     let _aux = init_aux_for_test();
@@ -234,8 +220,7 @@ async fn test_fetching_waits_for_initialized() {
     let (event, _response_rx) = initialize(workspace.path());
     state.handle_event_to_quiescence(event).await;
 
-    // The scan ran to completion and found the dependency, yet nothing was
-    // fetched for it.
+    // The initial scan discovered the dependency without fetching its sources.
     assert!(handler.calls().lock().unwrap().is_empty());
     let db = &state.world().db;
     let donor = db.package_by_name("donor").unwrap();
@@ -245,14 +230,12 @@ async fn test_fetching_waits_for_initialized() {
     assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
 }
 
-/// `OAK_SOURCE_FETCHING_ENABLED` beats the LSP setting in both directions,
-/// following ty and ruff: a value given at the invocation wins over one from a
-/// settings file. Unset falls through to the setting.
+/// A recognized `OAK_SOURCE_FETCHING_ENABLED` value overrides `oak.sourceFetching.enabled`.
+/// Unset or unrecognized values preserve the LSP setting.
 #[test]
 fn test_env_var_overrides_the_setting() {
     let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 
-    // Whether fetching is on after resolving `client_says` against the env var.
     let resolve = |client_says: bool| {
         let mut config = LspConfig::default();
         config.oak.source_fetching_enabled = client_says;
@@ -272,7 +255,6 @@ fn test_env_var_overrides_the_setting() {
     assert!(!resolve(true));
     assert!(!resolve(false));
 
-    // Unrecognised falls through to the setting rather than forcing a value.
     unsafe { std::env::set_var(name, "yes") };
     assert!(resolve(true));
     assert!(!resolve(false));

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -19,7 +19,7 @@ use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use crate::lsp::config::apply_env_overrides;
 use crate::lsp::config::LspConfig;
-use crate::lsp::config::OAK_ENABLE_SOURCE_FETCHING_ENV_VAR;
+use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
@@ -124,7 +124,7 @@ async fn test_source_pipeline_ingests_package_sources() {
     assert!(files[0].source_text(db).contains("foo <- function()"));
 }
 
-/// With `oak.enableSourceFetching` off, the same workspace that
+/// With `oak.sourceFetching.enabled` off, the same workspace that
 /// dispatches a request in `test_source_pipeline_ingests_package_sources`
 /// dispatches nothing. The scan still runs and still finds the dependency, so
 /// this pins that the gate is on the fetch and not on the analysis around it.
@@ -147,7 +147,7 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
     let mut world = WorldState::new(db);
-    world.config.oak.enable_source_fetching = false;
+    world.config.oak.source_fetching_enabled = false;
 
     let mut state = GlobalState::from_parts(
         test_client(),
@@ -179,19 +179,19 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     assert!(donor.files(db).is_empty());
 }
 
-/// `OAK_ENABLE_SOURCE_FETCHING` beats the LSP setting in both directions,
+/// `OAK_SOURCE_FETCHING_ENABLED` beats the LSP setting in both directions,
 /// following ty and ruff: a value given at the invocation wins over one from a
 /// settings file. Unset falls through to the setting.
 #[test]
 fn test_env_var_overrides_the_setting() {
-    let name = OAK_ENABLE_SOURCE_FETCHING_ENV_VAR;
+    let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 
     // Whether fetching is on after resolving `client_says` against the env var.
     let resolve = |client_says: bool| {
         let mut config = LspConfig::default();
-        config.oak.enable_source_fetching = client_says;
+        config.oak.source_fetching_enabled = client_says;
         apply_env_overrides(&mut config);
-        config.oak.enable_source_fetching
+        config.oak.source_fetching_enabled
     };
 
     unsafe { std::env::remove_var(name) };

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -180,6 +180,146 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     assert!(donor.files(db).is_empty());
 }
 
+/// Turning the setting back on fetches the packages Oak saw while it was off,
+/// which is what `doc/configuration-oak.md` promises. This works because both
+/// early returns in `schedule()` come before the loop that records a package,
+/// so a declined package stays unseen rather than being marked `Finished`.
+///
+/// In production `update_config()` bumps the revision itself, so the fetch
+/// starts on the config change alone. The `did_open()` here stands in for that
+/// bump, which a test can't reach without a client that answers
+/// `workspace/configuration`.
+#[tokio::test]
+async fn test_reenabling_fetches_packages_seen_while_off() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut world = WorldState::new(db);
+    world.config.oak.source_fetching_enabled = false;
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        world,
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            source_scheduler_for_test(handler.clone()),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(workspace.path()))
+        .await;
+    assert!(handler.calls().lock().unwrap().is_empty());
+
+    state.world_mut().config.oak.source_fetching_enabled = true;
+    state
+        .handle_event_to_quiescence(did_open(&workspace.path().join("other.R"), "1 + 1\n"))
+        .await;
+
+    // `donor` was declined while off, so it is still on offer and gets fetched
+    // now, sources and all.
+    assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
+    let db = &state.world().db;
+    let donor = db.package_by_name("donor").unwrap();
+    let files = donor.files(db).clone();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].source_text(db).contains("foo <- function()"));
+}
+
+/// Turning the setting off mid-session stops fetching for a dependency that
+/// turns up afterwards, without disturbing the one already fetched.
+#[tokio::test]
+async fn test_disabling_stops_fetching_new_packages() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([
+        (
+            String::from("donor1"),
+            TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+        ),
+        (
+            String::from("donor2"),
+            TestBehavior::Success(vec![("bar.R", "bar <- function() 2\n")]),
+        ),
+    ])));
+
+    let lib = tempfile::tempdir().unwrap();
+    for name in ["donor1", "donor2"] {
+        DescriptionWriter::new()
+            .package(name)
+            .version("0.0.0")
+            .built("dummy")
+            .write(&lib.path().join(name));
+    }
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        world_with_source_fetching(db),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            source_scheduler_for_test(handler.clone()),
+        ),
+    );
+
+    // Two workspace folders, each depending on a different library package, so
+    // the second dependency only appears once the second folder is added.
+    let first = tempfile::tempdir().unwrap();
+    let proj1 = first.path().join("proj1");
+    DescriptionWriter::new()
+        .package("proj1")
+        .version("0.0.0")
+        .write(&proj1);
+    write_sources(&proj1.join("R"), &[("use.R", "donor1::foo()\n")]);
+
+    let second = tempfile::tempdir().unwrap();
+    let proj2 = second.path().join("proj2");
+    DescriptionWriter::new()
+        .package("proj2")
+        .version("0.0.0")
+        .write(&proj2);
+    write_sources(&proj2.join("R"), &[("use.R", "donor2::bar()\n")]);
+
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(first.path()))
+        .await;
+    assert_eq!(dispatched_names(handler.calls()), vec!["donor1"]);
+
+    state.world_mut().config.oak.source_fetching_enabled = false;
+    state
+        .handle_event_to_quiescence(did_change_workspace_folders(second.path()))
+        .await;
+
+    // `donor2` was discovered by the second scan but never dispatched, and
+    // `donor1` keeps the sources it already has.
+    assert_eq!(dispatched_names(handler.calls()), vec!["donor1"]);
+    let db = &state.world().db;
+    assert!(db.package_by_name("donor2").unwrap().files(db).is_empty());
+    assert_eq!(db.package_by_name("donor1").unwrap().files(db).len(), 1);
+}
+
 /// Do not fetch packages found during `initialize()` before attempting client configuration.
 /// Release the startup gate after a failed configuration request.
 #[tokio::test]

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -14,11 +14,13 @@ use super::source_handler::TestBehavior;
 use super::source_handler::TestSourceHandler;
 use super::utils::did_change_workspace_folders;
 use super::utils::did_open;
+use super::utils::initialize;
 use super::utils::test_client;
 use super::utils::world_with_source_fetching;
 use super::utils::write_sources;
 use super::utils::DescriptionWriter;
 use crate::lsp::config::apply_env_overrides;
+use crate::lsp::config::apply_initialization_options;
 use crate::lsp::config::LspConfig;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::main_loop::init_aux_for_test;
@@ -178,6 +180,139 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     let db = &state.world().db;
     let donor = db.package_by_name("donor").unwrap();
     assert!(donor.files(db).is_empty());
+}
+
+/// `initializationOptions` reaches the config early enough to stop the very
+/// first dispatch. `initialize()` advances the revision itself, so the tick it
+/// runs in already schedules fetches: a setting that only arrived over
+/// `workspace/configuration` would land after the packages were on their way.
+#[tokio::test]
+async fn test_initialization_options_gate_the_first_dispatch() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        WorldState::new(db),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    let options = serde_json::json!({
+        "oak": { "sourceFetching": { "enabled": false } }
+    });
+    let (event, _response_rx) = initialize(workspace.path(), Some(options));
+    state.handle_event_to_quiescence(event).await;
+
+    assert!(handler.calls().lock().unwrap().is_empty());
+}
+
+/// The same `initialize` without `initializationOptions` fetches, so the test
+/// above pins the setting rather than some other reason the dispatch was
+/// skipped.
+#[tokio::test]
+async fn test_initialize_without_options_fetches() {
+    let _aux = init_aux_for_test();
+
+    let handler = Arc::new(TestSourceHandler::new(HashMap::from([(
+        String::from("donor"),
+        TestBehavior::Success(vec![("foo.R", "foo <- function() 1\n")]),
+    )])));
+
+    let lib = tempfile::tempdir().unwrap();
+    DescriptionWriter::new()
+        .package("donor")
+        .version("0.0.0")
+        .built("dummy")
+        .write(&lib.path().join("donor"));
+    let mut db = OakDatabase::new();
+    db.set_library_paths(&[lib.path().to_path_buf()]);
+
+    let mut state = GlobalState::from_parts(
+        test_client(),
+        world_with_source_fetching(db),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(Some(handler.clone())),
+        ),
+    );
+
+    let workspace = tempfile::tempdir().unwrap();
+    let myproj = workspace.path().join("myproj");
+    DescriptionWriter::new()
+        .package("myproj")
+        .version("0.0.0")
+        .write(&myproj);
+    write_sources(&myproj.join("R"), &[("use.R", "donor::foo()\n")]);
+
+    let (event, _response_rx) = initialize(workspace.path(), None);
+    state.handle_event_to_quiescence(event).await;
+
+    assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
+}
+
+/// The env var outranks `initializationOptions` too, in the same order
+/// `initialize()` resolves them.
+#[test]
+fn test_env_var_beats_initialization_options() {
+    let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
+    let options = serde_json::json!({ "oak": { "sourceFetching": { "enabled": false } } });
+
+    let resolve = || {
+        let mut config = LspConfig::default();
+        apply_initialization_options(&mut config, &options);
+        apply_env_overrides(&mut config);
+        config.oak.source_fetching_enabled
+    };
+
+    unsafe { std::env::remove_var(name) };
+    assert!(!resolve());
+
+    unsafe { std::env::set_var(name, "1") };
+    assert!(resolve());
+
+    unsafe { std::env::remove_var(name) };
+}
+
+/// Only nested objects are read. A key the client omits, or spells as a flat
+/// dotted string, leaves the setting where it was instead of resetting it.
+#[test]
+fn test_initialization_options_read_nested_objects_only() {
+    for options in [
+        serde_json::json!({}),
+        serde_json::json!({ "oak": {} }),
+        serde_json::json!({ "oak": { "sourceFetching": {} } }),
+        serde_json::json!({ "oak.sourceFetching.enabled": true }),
+        serde_json::json!({ "oak": { "sourceFetching": "not-an-object" } }),
+    ] {
+        let mut config = LspConfig::default();
+        config.oak.source_fetching_enabled = false;
+        apply_initialization_options(&mut config, &options);
+        assert!(!config.oak.source_fetching_enabled);
+    }
 }
 
 /// `OAK_SOURCE_FETCHING_ENABLED` beats the LSP setting in both directions,

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -32,7 +32,6 @@ use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceRequest;
 use crate::lsp::sources::SourceScheduler;
-use crate::lsp::state::WorldState;
 
 /// The package names passed to the handler, in call order.
 fn dispatched_names(calls: &Mutex<Vec<SourceRequest>>) -> Vec<String> {
@@ -90,7 +89,7 @@ async fn test_source_pipeline_ingests_package_sources() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -149,12 +148,9 @@ async fn test_disabled_source_fetching_dispatches_nothing() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
-    let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = false;
-
     let mut state = GlobalState::from_parts(
         test_client(),
-        world,
+        world_with_source_fetching(db, false),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -208,12 +204,9 @@ async fn test_reenabling_fetches_packages_seen_while_off() {
     let mut db = OakDatabase::new();
     db.set_library_paths(&[lib.path().to_path_buf()]);
 
-    let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = false;
-
     let mut state = GlobalState::from_parts(
         test_client(),
-        world,
+        world_with_source_fetching(db, false),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -278,7 +271,7 @@ async fn test_disabling_stops_fetching_new_packages() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -343,7 +336,7 @@ async fn test_fetching_waits_for_initialized() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             SourceScheduler::new(Some(handler.clone())),
@@ -452,7 +445,7 @@ async fn test_failed_source_is_not_retried() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler.clone()),
@@ -527,7 +520,7 @@ async fn test_source_pipeline_ingests_real_srcref_sources() {
 
     let mut state = GlobalState::from_parts(
         test_client(),
-        world_with_source_fetching(db),
+        world_with_source_fetching(db, true),
         LspState::new(
             tokio::sync::mpsc::unbounded_channel().0,
             source_scheduler_for_test(handler),

--- a/crates/ark/src/lsp/tests/sources.rs
+++ b/crates/ark/src/lsp/tests/sources.rs
@@ -27,6 +27,7 @@ use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::main_loop::init_aux_for_test;
 use crate::lsp::main_loop::GlobalState;
 use crate::lsp::main_loop::LspState;
+use crate::lsp::sources::source_fetching_disabled_by_ci;
 use crate::lsp::sources::OakSourceHandler;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceRequest;
@@ -368,6 +369,33 @@ async fn test_fetching_waits_for_initialized() {
 
     state.handle_event_to_quiescence(initialized()).await;
     assert_eq!(dispatched_names(handler.calls()), vec!["donor"]);
+}
+
+/// CI holds fetching back unless the env var opts a job back in. Both
+/// `source_handler()` and the output-channel report in `handle_initialized()`
+/// read this, so they always agree on whether CI is the reason.
+#[test]
+fn test_ci_holds_source_fetching_back_unless_opted_in() {
+    let name = OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
+
+    unsafe { std::env::set_var("CI", "true") };
+
+    unsafe { std::env::remove_var(name) };
+    assert!(source_fetching_disabled_by_ci());
+
+    unsafe { std::env::set_var(name, "1") };
+    assert!(!source_fetching_disabled_by_ci());
+
+    // An explicit `0` leaves CI's own suppression in place rather than fighting
+    // it, since both point the same way.
+    unsafe { std::env::set_var(name, "0") };
+    assert!(source_fetching_disabled_by_ci());
+
+    // Off CI the gate never applies, whatever the variable says.
+    unsafe { std::env::remove_var("CI") };
+    assert!(!source_fetching_disabled_by_ci());
+    unsafe { std::env::remove_var(name) };
+    assert!(!source_fetching_disabled_by_ci());
 }
 
 /// A recognized `OAK_SOURCE_FETCHING_ENABLED` value overrides `oak.sourceFetching.enabled`.

--- a/crates/ark/src/lsp/tests/utils/client.rs
+++ b/crates/ark/src/lsp/tests/utils/client.rs
@@ -1,0 +1,197 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use futures::SinkExt;
+use futures::StreamExt;
+use serde_json::json;
+use serde_json::Value;
+use tokio::task::JoinSet;
+use tower::Service;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types as lsp_types;
+use tower_lsp_server::Client;
+use tower_lsp_server::ClientSocket;
+use tower_lsp_server::LanguageServer;
+use tower_lsp_server::LspService;
+
+/// Get a real `Client` without a live connection. `LspService::new` hands a
+/// `Client` to its init closure; we capture it and drop the service. The
+/// client's sends go nowhere, which is fine since the event paths under test
+/// never use it. Use [`TestClient`] when a handler needs an answer.
+pub(crate) fn test_client() -> Client {
+    let (_service, _socket, client) = service();
+    client
+}
+
+/// A live [`Client`] paired with a peer that answers the requests the server
+/// sends it, so tests can drive the real `workspace/configuration` path.
+///
+/// The peer answers each requested configuration item from `settings`, keyed by
+/// section. A section it doesn't hold answers `null`, which selects that
+/// setting's default. Tests change a value with [`Self::set_setting()`] and then
+/// drive a `didChangeConfiguration` notification, the way an editor does.
+pub(crate) struct TestClient {
+    client: Client,
+    settings: Arc<Mutex<HashMap<String, Value>>>,
+    requests: Arc<Mutex<Vec<String>>>,
+
+    /// Aborts the peer on drop.
+    _peer: JoinSet<()>,
+}
+
+impl TestClient {
+    /// Build a client whose peer answers `settings`, given as `(section, value)`
+    /// pairs.
+    pub(crate) async fn new(settings: &[(&str, Value)]) -> Self {
+        let (mut service, socket, client) = service();
+
+        // `Client` suppresses outbound requests until the service has answered
+        // an `initialize` request, so run one through it first. This is the
+        // service's own state machine, unrelated to the `initialize` event the
+        // tests send to the main loop.
+        let initialize = json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": { "capabilities": {} },
+        });
+        service
+            .call(serde_json::from_value(initialize).unwrap())
+            .await
+            .unwrap();
+
+        let settings = Arc::new(Mutex::new(
+            settings
+                .iter()
+                .map(|(section, value)| ((*section).to_string(), value.clone()))
+                .collect(),
+        ));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+
+        let mut peer = JoinSet::new();
+        peer.spawn(answer_requests(
+            socket,
+            Arc::clone(&settings),
+            Arc::clone(&requests),
+        ));
+
+        Self {
+            client,
+            settings,
+            requests,
+            _peer: peer,
+        }
+    }
+
+    /// The client to hand to `GlobalState`. Every clone talks to the same peer.
+    pub(crate) fn client(&self) -> Client {
+        self.client.clone()
+    }
+
+    /// Change what the peer answers for `section`, as a user changing a setting
+    /// does. Takes effect on the next `workspace/configuration` request.
+    pub(crate) fn set_setting(&self, section: &str, value: Value) {
+        self.settings
+            .lock()
+            .unwrap()
+            .insert(section.to_string(), value);
+    }
+
+    /// Methods of the requests the peer has answered, in order. Notifications
+    /// aren't recorded.
+    pub(crate) fn answered_requests(&self) -> Vec<String> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+/// Answer every request the server sends until it drops its [`Client`].
+async fn answer_requests(
+    socket: ClientSocket,
+    settings: Arc<Mutex<HashMap<String, Value>>>,
+    requests: Arc<Mutex<Vec<String>>>,
+) {
+    let (mut incoming, mut outgoing) = socket.split();
+
+    while let Some(request) = incoming.next().await {
+        let (method, id, params) = request.into_parts();
+
+        // A notification, such as `textDocument/publishDiagnostics`, carries no
+        // id and gets no reply.
+        let Some(id) = id else {
+            continue;
+        };
+
+        requests.lock().unwrap().push(method.to_string());
+
+        let result = match method.as_ref() {
+            "workspace/configuration" => {
+                configuration_result(params.as_ref(), &settings.lock().unwrap())
+            },
+            _ => Value::Null,
+        };
+
+        if outgoing
+            .send(jsonrpc::Response::from_ok(id, result))
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
+}
+
+/// One value per requested item, in the order asked, since `update_config()`
+/// zips the response against the items it sent.
+fn configuration_result(params: Option<&Value>, settings: &HashMap<String, Value>) -> Value {
+    let Some(items) = params
+        .and_then(|params| params.get("items"))
+        .and_then(Value::as_array)
+    else {
+        return Value::Array(vec![]);
+    };
+
+    items
+        .iter()
+        .map(|item| {
+            item.get("section")
+                .and_then(Value::as_str)
+                .and_then(|section| settings.get(section).cloned())
+                .unwrap_or(Value::Null)
+        })
+        .collect()
+}
+
+/// A service, its loopback socket, and the `Client` the service handed to its
+/// init closure.
+fn service() -> (LspService<Dummy>, ClientSocket, Client) {
+    let captured = Arc::new(Mutex::new(None));
+    let sink = Arc::clone(&captured);
+    let (service, socket) = LspService::new(move |client| {
+        *sink.lock().unwrap() = Some(client);
+        Dummy
+    });
+
+    // Bind first so the `MutexGuard` temporary drops at the `;`, not at the
+    // end of the block.
+    let client = captured.lock().unwrap().take();
+    (service, socket, client.unwrap())
+}
+
+/// The `LanguageServer` the service dispatches to. Only `initialize` is ever
+/// called, to open the service's outbound gate. Requests from the tests go
+/// straight to `GlobalState::handle_event()` instead.
+struct Dummy;
+
+impl LanguageServer for Dummy {
+    async fn initialize(
+        &self,
+        _: lsp_types::InitializeParams,
+    ) -> jsonrpc::Result<lsp_types::InitializeResult> {
+        Ok(lsp_types::InitializeResult::default())
+    }
+
+    async fn shutdown(&self) -> jsonrpc::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use tokio::sync::mpsc::UnboundedReceiver;
 use tower_lsp_server::ls_types::ClientCapabilities;
+use tower_lsp_server::ls_types::DidChangeConfigurationParams;
 use tower_lsp_server::ls_types::DidChangeTextDocumentParams;
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
@@ -62,11 +63,21 @@ fn initialize_with_configuration_support(
     (event, rx)
 }
 
-/// An `initialized` notification that starts configuration resolution and releases deferred source fetching.
+/// An `initialized` notification that resolves configuration and releases deferred source fetching.
 pub(crate) fn initialized() -> Event {
     Event::Lsp(LspMessage::Notification(LspNotification::Initialized(
         InitializedParams {},
     )))
+}
+
+/// A `didChangeConfiguration` notification. The server ignores its `settings`
+/// payload and pulls the registered settings again.
+pub(crate) fn did_change_configuration() -> Event {
+    Event::Lsp(LspMessage::Notification(
+        LspNotification::DidChangeConfiguration(DidChangeConfigurationParams {
+            settings: serde_json::Value::Null,
+        }),
+    ))
 }
 
 pub(crate) fn did_change_workspace_folders(path: &Path) -> Event {

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use serde_json::Value;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tower_lsp_server::ls_types::ClientCapabilities;
 use tower_lsp_server::ls_types::DidChangeConfigurationParams;
@@ -29,20 +30,30 @@ use crate::lsp::main_loop::Event;
 /// it for the duration of the test: dropping it early makes `respond()`'s send
 /// fail, which nextest then reports as a leak.
 pub(crate) fn initialize(path: &Path) -> (Event, UnboundedReceiver<RequestResponse>) {
-    initialize_with_configuration_support(path, true)
+    initialize_with(path, true, None)
 }
 
-/// An [`initialize()`] request from a client that doesn't support
-/// `workspace/configuration`, so the server never asks for settings.
+/// A pull-capable [`initialize()`] request with `initialization_options`.
+pub(crate) fn initialize_with_options(
+    path: &Path,
+    initialization_options: Value,
+) -> (Event, UnboundedReceiver<RequestResponse>) {
+    initialize_with(path, true, Some(initialization_options))
+}
+
+/// An [`initialize()`] request from a client without `workspace/configuration`
+/// support, using `initialization_options` for its global settings.
 pub(crate) fn initialize_without_configuration(
     path: &Path,
+    initialization_options: Option<Value>,
 ) -> (Event, UnboundedReceiver<RequestResponse>) {
-    initialize_with_configuration_support(path, false)
+    initialize_with(path, false, initialization_options)
 }
 
-fn initialize_with_configuration_support(
+fn initialize_with(
     path: &Path,
     configuration: bool,
+    initialization_options: Option<Value>,
 ) -> (Event, UnboundedReceiver<RequestResponse>) {
     let params = InitializeParams {
         capabilities: ClientCapabilities {
@@ -56,6 +67,7 @@ fn initialize_with_configuration_support(
             uri: Uri::from_file_path(path).unwrap(),
             name: String::new(),
         }]),
+        initialization_options,
         ..Default::default()
     };
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -37,9 +37,7 @@ pub(crate) fn initialize(path: &Path) -> (Event, UnboundedReceiver<RequestRespon
     (event, rx)
 }
 
-/// The `initialized` notification, sent once the client has processed the
-/// `initialize` response. This is what triggers the deferred workspace scan;
-/// see `state_handlers::handle_initialized()`.
+/// An `initialized` notification that starts configuration resolution and releases deferred source fetching.
 pub(crate) fn initialized() -> Event {
     Event::Lsp(LspMessage::Notification(LspNotification::Initialized(
         InitializedParams {},

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 
+use tokio::sync::mpsc::UnboundedReceiver;
 use tower_lsp_server::ls_types::DidChangeTextDocumentParams;
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
+use tower_lsp_server::ls_types::InitializeParams;
 use tower_lsp_server::ls_types::TextDocumentContentChangeEvent;
 use tower_lsp_server::ls_types::TextDocumentItem;
 use tower_lsp_server::ls_types::Uri;
@@ -12,7 +14,32 @@ use tower_lsp_server::ls_types::WorkspaceFoldersChangeEvent;
 
 use crate::lsp::backend::LspMessage;
 use crate::lsp::backend::LspNotification;
+use crate::lsp::backend::LspRequest;
+use crate::lsp::backend::RequestResponse;
 use crate::lsp::main_loop::Event;
+
+/// An `initialize` request opening `path` as the sole workspace folder, with
+/// `initialization_options` passed through verbatim.
+///
+/// Hand back the response receiver along with the event. The caller has to hold
+/// it for the duration of the test: dropping it early makes `respond()`'s send
+/// fail, which nextest then reports as a leak.
+pub(crate) fn initialize(
+    path: &Path,
+    initialization_options: Option<serde_json::Value>,
+) -> (Event, UnboundedReceiver<RequestResponse>) {
+    let params = InitializeParams {
+        workspace_folders: Some(vec![WorkspaceFolder {
+            uri: Uri::from_file_path(path).unwrap(),
+            name: String::new(),
+        }]),
+        initialization_options,
+        ..Default::default()
+    };
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let event = Event::Lsp(LspMessage::Request(LspRequest::Initialize(params), tx));
+    (event, rx)
+}
 
 pub(crate) fn did_change_workspace_folders(path: &Path) -> Event {
     Event::Lsp(LspMessage::Notification(

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use tokio::sync::mpsc::UnboundedReceiver;
+use tower_lsp_server::ls_types::ClientCapabilities;
 use tower_lsp_server::ls_types::DidChangeTextDocumentParams;
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
@@ -10,6 +11,7 @@ use tower_lsp_server::ls_types::TextDocumentContentChangeEvent;
 use tower_lsp_server::ls_types::TextDocumentItem;
 use tower_lsp_server::ls_types::Uri;
 use tower_lsp_server::ls_types::VersionedTextDocumentIdentifier;
+use tower_lsp_server::ls_types::WorkspaceClientCapabilities;
 use tower_lsp_server::ls_types::WorkspaceFolder;
 use tower_lsp_server::ls_types::WorkspaceFoldersChangeEvent;
 
@@ -19,13 +21,36 @@ use crate::lsp::backend::LspRequest;
 use crate::lsp::backend::RequestResponse;
 use crate::lsp::main_loop::Event;
 
-/// An `initialize` request opening `path` as the sole workspace folder.
+/// An `initialize` request opening `path` as the sole workspace folder, from a
+/// client that answers `workspace/configuration` like Positron does.
 ///
 /// Hand back the response receiver along with the event. The caller has to hold
 /// it for the duration of the test: dropping it early makes `respond()`'s send
 /// fail, which nextest then reports as a leak.
 pub(crate) fn initialize(path: &Path) -> (Event, UnboundedReceiver<RequestResponse>) {
+    initialize_with_configuration_support(path, true)
+}
+
+/// An [`initialize()`] request from a client that doesn't support
+/// `workspace/configuration`, so the server never asks for settings.
+pub(crate) fn initialize_without_configuration(
+    path: &Path,
+) -> (Event, UnboundedReceiver<RequestResponse>) {
+    initialize_with_configuration_support(path, false)
+}
+
+fn initialize_with_configuration_support(
+    path: &Path,
+    configuration: bool,
+) -> (Event, UnboundedReceiver<RequestResponse>) {
     let params = InitializeParams {
+        capabilities: ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                configuration: Some(configuration),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
         workspace_folders: Some(vec![WorkspaceFolder {
             uri: Uri::from_file_path(path).unwrap(),
             name: String::new(),

--- a/crates/ark/src/lsp/tests/utils/events.rs
+++ b/crates/ark/src/lsp/tests/utils/events.rs
@@ -5,6 +5,7 @@ use tower_lsp_server::ls_types::DidChangeTextDocumentParams;
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
 use tower_lsp_server::ls_types::InitializeParams;
+use tower_lsp_server::ls_types::InitializedParams;
 use tower_lsp_server::ls_types::TextDocumentContentChangeEvent;
 use tower_lsp_server::ls_types::TextDocumentItem;
 use tower_lsp_server::ls_types::Uri;
@@ -18,27 +19,31 @@ use crate::lsp::backend::LspRequest;
 use crate::lsp::backend::RequestResponse;
 use crate::lsp::main_loop::Event;
 
-/// An `initialize` request opening `path` as the sole workspace folder, with
-/// `initialization_options` passed through verbatim.
+/// An `initialize` request opening `path` as the sole workspace folder.
 ///
 /// Hand back the response receiver along with the event. The caller has to hold
 /// it for the duration of the test: dropping it early makes `respond()`'s send
 /// fail, which nextest then reports as a leak.
-pub(crate) fn initialize(
-    path: &Path,
-    initialization_options: Option<serde_json::Value>,
-) -> (Event, UnboundedReceiver<RequestResponse>) {
+pub(crate) fn initialize(path: &Path) -> (Event, UnboundedReceiver<RequestResponse>) {
     let params = InitializeParams {
         workspace_folders: Some(vec![WorkspaceFolder {
             uri: Uri::from_file_path(path).unwrap(),
             name: String::new(),
         }]),
-        initialization_options,
         ..Default::default()
     };
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let event = Event::Lsp(LspMessage::Request(LspRequest::Initialize(params), tx));
     (event, rx)
+}
+
+/// The `initialized` notification, sent once the client has processed the
+/// `initialize` response. This is what triggers the deferred workspace scan;
+/// see `state_handlers::handle_initialized()`.
+pub(crate) fn initialized() -> Event {
+    Event::Lsp(LspMessage::Notification(LspNotification::Initialized(
+        InitializedParams {},
+    )))
 }
 
 pub(crate) fn did_change_workspace_folders(path: &Path) -> Event {

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -21,6 +21,7 @@ use tower_lsp_server::Client;
 use tower_lsp_server::LanguageServer;
 use tower_lsp_server::LspService;
 
+use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
@@ -72,11 +73,12 @@ pub(super) fn source_scheduler_for_test(handler: Arc<dyn SourceHandler>) -> Sour
     scheduler
 }
 
-/// Enable source fetching after [`WorldState::new()`] applies
-/// `OAK_SOURCE_FETCHING_ENABLED`.
-pub(super) fn world_with_source_fetching(db: OakDatabase) -> WorldState {
+/// A [`WorldState`] with source fetching set to `enabled`, whatever the ambient
+/// `OAK_SOURCE_FETCHING_ENABLED` says.
+pub(super) fn world_with_source_fetching(db: OakDatabase, enabled: bool) -> WorldState {
+    unsafe { std::env::remove_var(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR) };
     let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = true;
+    world.config.oak.source_fetching_enabled = enabled;
     world
 }
 

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -65,21 +65,15 @@ pub(super) fn write_sources(dir: &Path, files: &[(&str, &str)]) {
     }
 }
 
-/// A [`SourceScheduler`] already past the startup wait for the client's
-/// settings, so a test can drive fetches without replaying the `initialized`
-/// handshake that would normally release them.
+/// Create a [`SourceScheduler`] with its startup configuration gate open.
 pub(super) fn source_scheduler_for_test(handler: Arc<dyn SourceHandler>) -> SourceScheduler {
     let mut scheduler = SourceScheduler::new(Some(handler));
     scheduler.config_arrived();
     scheduler
 }
 
-/// A [`WorldState`] with source fetching pinned on.
-///
-/// `WorldState::new()` resolves `OAK_SOURCE_FETCHING_ENABLED`, so a test that
-/// drives a fetch pins the setting instead of inheriting the default. Otherwise
-/// exporting the variable to save bandwidth locally would decide what these
-/// tests exercise.
+/// Enable source fetching after [`WorldState::new()`] applies
+/// `OAK_SOURCE_FETCHING_ENABLED`.
 pub(super) fn world_with_source_fetching(db: OakDatabase) -> WorldState {
     let mut world = WorldState::new(db);
     world.config.oak.source_fetching_enabled = true;

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -15,6 +15,7 @@ pub(super) use events::did_change_configuration;
 pub(super) use events::did_change_workspace_folders;
 pub(super) use events::did_open;
 pub(super) use events::initialize;
+pub(super) use events::initialize_with_options;
 pub(super) use events::initialize_without_configuration;
 pub(super) use events::initialized;
 pub(super) use namespace_writer::NamespaceWriter;

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -3,6 +3,7 @@ mod events;
 mod namespace_writer;
 
 use std::path::Path;
+use std::sync::Arc;
 
 use aether_path::FilePath;
 pub(super) use description_writer::DescriptionWriter;
@@ -10,6 +11,7 @@ pub(super) use events::did_change;
 pub(super) use events::did_change_workspace_folders;
 pub(super) use events::did_open;
 pub(super) use events::initialize;
+pub(super) use events::initialized;
 pub(super) use namespace_writer::NamespaceWriter;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;
@@ -19,6 +21,8 @@ use tower_lsp_server::Client;
 use tower_lsp_server::LanguageServer;
 use tower_lsp_server::LspService;
 
+use crate::lsp::sources::SourceHandler;
+use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::url::UriExt;
 
@@ -59,6 +63,15 @@ pub(super) fn write_sources(dir: &Path, files: &[(&str, &str)]) {
     for (basename, contents) in files {
         std::fs::write(dir.join(basename), contents).unwrap();
     }
+}
+
+/// A [`SourceScheduler`] already past the startup wait for the client's
+/// settings, so a test can drive fetches without replaying the `initialized`
+/// handshake that would normally release them.
+pub(super) fn source_scheduler_for_test(handler: Arc<dyn SourceHandler>) -> SourceScheduler {
+    let mut scheduler = SourceScheduler::new(Some(handler));
+    scheduler.config_arrived();
+    scheduler
 }
 
 /// A [`WorldState`] with source fetching pinned on.

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -10,6 +10,7 @@ pub(super) use events::did_change;
 pub(super) use events::did_change_workspace_folders;
 pub(super) use events::did_open;
 pub(super) use namespace_writer::NamespaceWriter;
+use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use tower_lsp_server::ls_types as lsp_types;
 use tower_lsp_server::ls_types::Uri;
@@ -57,6 +58,18 @@ pub(super) fn write_sources(dir: &Path, files: &[(&str, &str)]) {
     for (basename, contents) in files {
         std::fs::write(dir.join(basename), contents).unwrap();
     }
+}
+
+/// A [`WorldState`] with source fetching pinned on.
+///
+/// `WorldState::new()` resolves `OAK_SOURCE_FETCHING_ENABLED`, so a test that
+/// drives a fetch pins the setting instead of inheriting the default. Otherwise
+/// exporting the variable to save bandwidth locally would decide what these
+/// tests exercise.
+pub(super) fn world_with_source_fetching(db: OakDatabase) -> WorldState {
+    let mut world = WorldState::new(db);
+    world.config.oak.source_fetching_enabled = true;
+    world
 }
 
 pub(super) fn make_state(wire: &str, contents: &str) -> (WorldState, Uri) {

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -1,3 +1,4 @@
+mod client;
 mod description_writer;
 mod events;
 mod namespace_writer;
@@ -6,8 +7,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use aether_path::FilePath;
+pub(super) use client::test_client;
+pub(super) use client::TestClient;
 pub(super) use description_writer::DescriptionWriter;
 pub(super) use events::did_change;
+pub(super) use events::did_change_configuration;
 pub(super) use events::did_change_workspace_folders;
 pub(super) use events::did_open;
 pub(super) use events::initialize;
@@ -18,47 +22,12 @@ use oak_db::OakDatabase;
 use oak_scan::DbScan;
 use tower_lsp_server::ls_types as lsp_types;
 use tower_lsp_server::ls_types::Uri;
-use tower_lsp_server::Client;
-use tower_lsp_server::LanguageServer;
-use tower_lsp_server::LspService;
 
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::sources::SourceHandler;
 use crate::lsp::sources::SourceScheduler;
 use crate::lsp::state::WorldState;
 use crate::lsp::traits::url::UriExt;
-
-/// Get a real `Client` without a live connection. `LspService::new` hands a
-/// `Client` to its init closure; we capture it and drop the service. The
-/// client's sends go nowhere, which is fine since the event paths under test
-/// never use it.
-pub(super) fn test_client() -> Client {
-    struct Dummy;
-
-    impl LanguageServer for Dummy {
-        async fn initialize(
-            &self,
-            _: lsp_types::InitializeParams,
-        ) -> tower_lsp_server::jsonrpc::Result<lsp_types::InitializeResult> {
-            Ok(lsp_types::InitializeResult::default())
-        }
-        async fn shutdown(&self) -> tower_lsp_server::jsonrpc::Result<()> {
-            Ok(())
-        }
-    }
-
-    let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
-    let sink = std::sync::Arc::clone(&captured);
-    let (_service, _socket) = LspService::new(move |client| {
-        *sink.lock().unwrap() = Some(client);
-        Dummy
-    });
-
-    // Bind first so the `MutexGuard` temporary drops at the `;`, not at the
-    // end of the block.
-    let client = captured.lock().unwrap().take();
-    client.unwrap()
-}
 
 pub(super) fn write_sources(dir: &Path, files: &[(&str, &str)]) {
     std::fs::create_dir_all(dir).unwrap();
@@ -74,13 +43,11 @@ pub(super) fn source_scheduler_for_test(handler: Arc<dyn SourceHandler>) -> Sour
     scheduler
 }
 
-/// A [`WorldState`] with source fetching set to `enabled`, whatever the ambient
-/// `OAK_SOURCE_FETCHING_ENABLED` says.
-pub(super) fn world_with_source_fetching(db: OakDatabase, enabled: bool) -> WorldState {
+/// Creates a [`WorldState`] with default source fetching by removing the ambient
+/// `OAK_SOURCE_FETCHING_ENABLED`. Tests disable it through [`TestClient`].
+pub(super) fn world_with_source_fetching(db: OakDatabase) -> WorldState {
     unsafe { std::env::remove_var(OAK_SOURCE_FETCHING_ENABLED_ENV_VAR) };
-    let mut world = WorldState::new(db);
-    world.config.oak.source_fetching_enabled = enabled;
-    world
+    WorldState::new(db)
 }
 
 pub(super) fn make_state(wire: &str, contents: &str) -> (WorldState, Uri) {

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -9,6 +9,7 @@ pub(super) use description_writer::DescriptionWriter;
 pub(super) use events::did_change;
 pub(super) use events::did_change_workspace_folders;
 pub(super) use events::did_open;
+pub(super) use events::initialize;
 pub(super) use namespace_writer::NamespaceWriter;
 use oak_db::OakDatabase;
 use oak_scan::DbScan;

--- a/crates/ark/src/lsp/tests/utils/mod.rs
+++ b/crates/ark/src/lsp/tests/utils/mod.rs
@@ -11,6 +11,7 @@ pub(super) use events::did_change;
 pub(super) use events::did_change_workspace_folders;
 pub(super) use events::did_open;
 pub(super) use events::initialize;
+pub(super) use events::initialize_without_configuration;
 pub(super) use events::initialized;
 pub(super) use namespace_writer::NamespaceWriter;
 use oak_db::OakDatabase;

--- a/crates/ark_test/src/lsp_client.rs
+++ b/crates/ark_test/src/lsp_client.rs
@@ -90,8 +90,11 @@ impl LspClient {
 
         self.send_notification("initialized", json!({}));
 
-        // The server sends `client/registerCapability` after `initialized`
+        // The server sends `client/registerCapability`, then pulls the
+        // client's settings with `workspace/configuration`, both after
+        // `initialized` and before the first workspace scan.
         self.recv_server_request("client/registerCapability");
+        self.recv_server_request("workspace/configuration");
 
         self.initialized = true;
         self.server_capabilities = Some(result.capabilities.clone());
@@ -391,14 +394,14 @@ impl LspClient {
     }
 
     /// Receive the next server-to-client request, assert its method, and
-    /// auto-reply with an empty success so the server doesn't block.
+    /// auto-reply with a response the server accepts, so it doesn't block.
     ///
     /// Skips benign server notifications. Panics on unexpected messages.
     #[track_caller]
     fn recv_server_request(&mut self, expected_method: &str) {
         loop {
             match self.recv_any() {
-                LspMessage::ServerRequest { id, method } => {
+                LspMessage::ServerRequest { id, method, params } => {
                     assert_eq!(
                         method, expected_method,
                         "Expected server request `{expected_method}`, got `{method}`"
@@ -406,7 +409,7 @@ impl LspClient {
                     let response = json!({
                         "jsonrpc": "2.0",
                         "id": id,
-                        "result": null,
+                        "result": Self::reply_to_server_request(&method, &params),
                     });
                     self.send_raw(&response);
                     return;
@@ -422,6 +425,26 @@ impl LspClient {
             }
         }
     }
+
+    /// The `result` to answer a server request with.
+    ///
+    /// `workspace/configuration` needs one value per requested item, in order,
+    /// or the server's `configs.len() != n_items` check rejects the response.
+    /// Each item settles for its own default: the server's `Setting::set`
+    /// closures already fall back to a default when a value doesn't parse as
+    /// the expected type, and `null` never parses as anything.
+    ///
+    /// Every other server request we see (currently just
+    /// `client/registerCapability`) just wants an ack.
+    fn reply_to_server_request(method: &str, params: &Value) -> Value {
+        match method {
+            "workspace/configuration" => {
+                let n_items = params["items"].as_array().map_or(0, Vec::len);
+                Value::Array(vec![Value::Null; n_items])
+            },
+            _ => Value::Null,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -434,6 +457,7 @@ enum LspMessage {
     ServerRequest {
         id: Value,
         method: String,
+        params: Value,
     },
     Notification {
         diagnostics: Option<lsp_types::PublishDiagnosticsParams>,
@@ -459,6 +483,7 @@ impl LspClient {
             (true, true, false) => LspMessage::ServerRequest {
                 id: message["id"].clone(),
                 method: message["method"].as_str().unwrap_or("unknown").to_string(),
+                params: message.get("params").cloned().unwrap_or(Value::Null),
             },
 
             (false, true, false) => {

--- a/crates/ark_test/src/lsp_client.rs
+++ b/crates/ark_test/src/lsp_client.rs
@@ -90,9 +90,8 @@ impl LspClient {
 
         self.send_notification("initialized", json!({}));
 
-        // The server sends `client/registerCapability`, then pulls the
-        // client's settings with `workspace/configuration`, both after
-        // `initialized` and before the first workspace scan.
+        // After `initialized`, the server registers capabilities and requests
+        // configuration before scheduling source fetches.
         self.recv_server_request("client/registerCapability");
         self.recv_server_request("workspace/configuration");
 
@@ -426,16 +425,9 @@ impl LspClient {
         }
     }
 
-    /// The `result` to answer a server request with.
-    ///
-    /// `workspace/configuration` needs one value per requested item, in order,
-    /// or the server's `configs.len() != n_items` check rejects the response.
-    /// Each item settles for its own default: the server's `Setting::set`
-    /// closures already fall back to a default when a value doesn't parse as
-    /// the expected type, and `null` never parses as anything.
-    ///
-    /// Every other server request we see (currently just
-    /// `client/registerCapability`) just wants an ack.
+    /// Reply to a server request without blocking the test client.
+    /// `workspace/configuration` requires one response per requested item,
+    /// while `null` selects each setting's default.
     fn reply_to_server_request(method: &str, params: &Value) -> Value {
         match method {
             "workspace/configuration" => {

--- a/crates/ark_test/src/lsp_client.rs
+++ b/crates/ark_test/src/lsp_client.rs
@@ -82,7 +82,9 @@ impl LspClient {
         let response = self.send_request(
             "initialize",
             json!({
-                "capabilities": {}
+                // `configuration` is advertised because `recv_server_request()`
+                // answers `workspace/configuration`.
+                "capabilities": { "workspace": { "configuration": true } }
             }),
         );
 

--- a/crates/oak_db/src/diagnostic.rs
+++ b/crates/oak_db/src/diagnostic.rs
@@ -121,7 +121,7 @@ fn lower_ambiguous_effect(
     let (message, annotation) = match reason {
         AmbiguityReason::LazyShadow { overwrite_range } => (
             format!(
-                "Ambiguous reading of effectful `{name}()`. An assignment to `{name}` in an enclosing \
+                "Ambiguous reading of effectful `{name}()`.\nAn assignment to `{name}` in an enclosing \
                  scope could run before this call and change its effect."
             ),
             Annotation {
@@ -131,7 +131,7 @@ fn lower_ambiguous_effect(
         ),
         AmbiguityReason::ConditionalShadow { binding_range } => (
             format!(
-                "Ambiguous reading of effectful `{name}()`. A conditional assignment could shadow `{name}` \
+                "Ambiguous reading of effectful `{name}()`.\nA conditional assignment could shadow `{name}` \
                  on some paths and change its effect."
             ),
             Annotation {
@@ -144,7 +144,7 @@ fn lower_ambiguous_effect(
             attach_range,
         } => (
             format!(
-                "Ambiguous reading of `{name}()`. The package `{package}` is conditionally attached and does not import `{name}` \
+                "Ambiguous reading of `{name}()`.\nThe package `{package}` is conditionally attached and does not import `{name}` \
                  across all paths."
             ),
             Annotation {
@@ -163,7 +163,7 @@ fn lower_ambiguous_effect(
 /// competing site to annotate.
 fn lower_ambiguous_attach_order(packages: &[String], range: TextRange) -> Diagnostic {
     let message = format!(
-        "Ambiguous attach order. The branches attach {packages} in different orders, so which \
+        "Ambiguous attach order.\nThe branches attach {packages} in different orders, so which \
          package masks the other depends on the branch taken.",
         packages = packages
             .iter()
@@ -183,7 +183,7 @@ fn lower_ambiguous_attach_order(packages: &[String], range: TextRange) -> Diagno
 fn lower_uninstalled_package(package: &str, range: TextRange) -> Diagnostic {
     Diagnostic::new(
         DiagnosticKind::UninstalledPackage,
-        format!("Package `{package}` is not installed. Language analysis will be incomplete."),
+        format!("Package `{package}` is not installed.\nLanguage analysis will be incomplete."),
         range,
         Vec::new(),
     )

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_ambiguous_attach_order.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_ambiguous_attach_order.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-attach-order]: Ambiguous attach order. The branches attach `rlang`, `cli` in different orders, so which package masks the other depends on the branch taken.
+info[ambiguous-attach-order]: Ambiguous attach order.
+                              The branches attach `rlang`, `cli` in different orders, so which package masks the other depends on the branch taken.
  --> a.R:1:1
   |
 1 | / if (cond) {

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_attach_branch_join.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_attach_branch_join.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-effect]: Ambiguous reading of `reactive()`. The package `shiny` is conditionally attached and does not import `reactive` across all paths.
+info[ambiguous-effect]: Ambiguous reading of `reactive()`.
+                        The package `shiny` is conditionally attached and does not import `reactive` across all paths.
  --> a.R:2:1
   |
 1 |   if (cond) library(shiny)

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_attach_wins_over_shadow.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_attach_wins_over_shadow.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-effect]: Ambiguous reading of `reactive()`. The package `shiny` is conditionally attached and does not import `reactive` across all paths.
+info[ambiguous-effect]: Ambiguous reading of `reactive()`.
+                        The package `shiny` is conditionally attached and does not import `reactive` across all paths.
  --> a.R:6:1
   |
 2 |     library(shiny)

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_shadow_eager.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_shadow_eager.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-effect]: Ambiguous reading of effectful `local()`. A conditional assignment could shadow `local` on some paths and change its effect.
+info[ambiguous-effect]: Ambiguous reading of effectful `local()`.
+                        A conditional assignment could shadow `local` on some paths and change its effect.
  --> a.R:3:5
   |
 2 |       if (cond) local <- identity

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_shadow_package_call.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_conditional_shadow_package_call.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-effect]: Ambiguous reading of effectful `test_that()`. A conditional assignment could shadow `test_that` on some paths and change its effect.
+info[ambiguous-effect]: Ambiguous reading of effectful `test_that()`.
+                        A conditional assignment could shadow `test_that` on some paths and change its effect.
  --> a.R:5:1
   |
 3 |     test_that <- identity

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_lazy_shadow_interleaved.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_lazy_shadow_interleaved.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-effect]: Ambiguous reading of effectful `with()`. An assignment to `with` in an enclosing scope could run before this call and change its effect.
+info[ambiguous-effect]: Ambiguous reading of effectful `with()`.
+                        An assignment to `with` in an enclosing scope could run before this call and change its effect.
  --> a.R:1:17
   |
 1 | f <- function() with(local({ x <- 1 }), { y <- 2 })
@@ -10,7 +11,8 @@ info[ambiguous-effect]: Ambiguous reading of effectful `with()`. An assignment t
 2 | local <- identity
 3 | with <- identity
   | ---- could run before the call
-info[ambiguous-effect]: Ambiguous reading of effectful `local()`. An assignment to `local` in an enclosing scope could run before this call and change its effect.
+info[ambiguous-effect]: Ambiguous reading of effectful `local()`.
+                        An assignment to `local` in an enclosing scope could run before this call and change its effect.
  --> a.R:1:22
   |
 1 | f <- function() with(local({ x <- 1 }), { y <- 2 })

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_lazy_shadow_reassignment.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_lazy_shadow_reassignment.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-info[ambiguous-effect]: Ambiguous reading of effectful `local()`. An assignment to `local` in an enclosing scope could run before this call and change its effect.
+info[ambiguous-effect]: Ambiguous reading of effectful `local()`.
+                        An assignment to `local` in an enclosing scope could run before this call and change its effect.
  --> a.R:1:17
   |
 1 | f <- function() local({ x <- 1 })

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_uninstalled_package_conditional.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_uninstalled_package_conditional.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-warning[uninstalled-package]: Package `shiny` is not installed. Language analysis will be incomplete.
+warning[uninstalled-package]: Package `shiny` is not installed.
+                              Language analysis will be incomplete.
  --> a.R:1:11
   |
 1 | if (cond) library(shiny)

--- a/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_uninstalled_package_unconditional.snap
+++ b/crates/oak_db/src/tests/snapshots/oak_db__tests__file_diagnostics__diagnostic_uninstalled_package_unconditional.snap
@@ -2,7 +2,8 @@
 source: crates/oak_db/src/tests/file_diagnostics.rs
 expression: "render(\"a.R\", source, file.diagnostics(&db))"
 ---
-warning[uninstalled-package]: Package `shiny` is not installed. Language analysis will be incomplete.
+warning[uninstalled-package]: Package `shiny` is not installed.
+                              Language analysis will be incomplete.
  --> a.R:1:1
   |
 1 | library(shiny)

--- a/crates/stdext/src/env.rs
+++ b/crates/stdext/src/env.rs
@@ -1,0 +1,40 @@
+//
+// env.rs
+//
+// Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+//
+//
+
+pub fn env_flag(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(value) => matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"),
+        Err(_) => false,
+    }
+}
+
+pub fn is_ci() -> bool {
+    env_flag("CI")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::env_flag;
+
+    #[test]
+    fn test_env_flag_only_accepts_1_and_true() {
+        let name = "STDEXT_TEST_ENV_FLAG";
+
+        for value in ["1", "true", "TRUE", "True", " true "] {
+            unsafe { std::env::set_var(name, value) };
+            assert!(env_flag(name));
+        }
+
+        for value in ["", "  ", "0", "false", "FALSE", "no", "off", "2", "yes"] {
+            unsafe { std::env::set_var(name, value) };
+            assert!(!env_flag(name));
+        }
+
+        unsafe { std::env::remove_var(name) };
+        assert!(!env_flag(name));
+    }
+}

--- a/crates/stdext/src/env.rs
+++ b/crates/stdext/src/env.rs
@@ -23,13 +23,19 @@ pub fn env_flag_opt(name: &str) -> Option<bool> {
 }
 
 pub fn is_ci() -> bool {
-    env_flag("CI")
+    match env_flag_opt("CI") {
+        Some(on) => on,
+        // providers set `CI` to their own name as well as to a truthy value.
+        // Only treat empty values as non-CI.
+        None => std::env::var("CI").is_ok_and(|value| !value.trim().is_empty()),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::env_flag;
     use super::env_flag_opt;
+    use super::is_ci;
 
     /// Preserve the distinction between an absent override and an explicit
     /// false override.
@@ -56,6 +62,24 @@ mod tests {
         }
 
         unsafe { std::env::remove_var(name) };
+    }
+
+    /// A provider naming itself in `CI`, such as Drone or Woodpecker, still
+    /// counts as CI.
+    #[test]
+    fn test_is_ci_treats_any_non_empty_value_as_ci() {
+        for value in ["1", "true", "TRUE", "yes", "drone", "woodpecker"] {
+            unsafe { std::env::set_var("CI", value) };
+            assert!(is_ci());
+        }
+
+        for value in ["0", "false", "FALSE", "", "  "] {
+            unsafe { std::env::set_var("CI", value) };
+            assert!(!is_ci());
+        }
+
+        unsafe { std::env::remove_var("CI") };
+        assert!(!is_ci());
     }
 
     #[test]

--- a/crates/stdext/src/env.rs
+++ b/crates/stdext/src/env.rs
@@ -9,8 +9,8 @@ pub fn env_flag(name: &str) -> bool {
     env_flag_opt(name).unwrap_or(false)
 }
 
-/// `None` when unset, or set to anything we don't recognise. Lets a caller fall
-/// back to another source of truth rather than to a hardcoded default.
+/// Returns `None` for unset or unrecognized values so callers preserve a
+/// lower-precedence setting.
 pub fn env_flag_opt(name: &str) -> Option<bool> {
     match std::env::var(name) {
         Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
@@ -31,9 +31,8 @@ mod tests {
     use super::env_flag;
     use super::env_flag_opt;
 
-    /// `None` has to be distinguishable from `Some(false)`, otherwise an env var
-    /// can't override a setting: unset must fall through to the setting, while
-    /// `0` must beat it.
+    /// Preserve the distinction between an absent override and an explicit
+    /// false override.
     #[test]
     fn test_env_flag_opt_separates_unset_from_false() {
         let name = "STDEXT_TEST_ENV_FLAG_OPT";
@@ -51,8 +50,6 @@ mod tests {
             assert_eq!(env_flag_opt(name), Some(false));
         }
 
-        // Unrecognised reads as unset, so a typo falls through rather than
-        // silently meaning "off".
         for value in ["", "  ", "yes", "no", "2"] {
             unsafe { std::env::set_var(name, value) };
             assert_eq!(env_flag_opt(name), None);

--- a/crates/stdext/src/env.rs
+++ b/crates/stdext/src/env.rs
@@ -6,9 +6,19 @@
 //
 
 pub fn env_flag(name: &str) -> bool {
+    env_flag_opt(name).unwrap_or(false)
+}
+
+/// `None` when unset, or set to anything we don't recognise. Lets a caller fall
+/// back to another source of truth rather than to a hardcoded default.
+pub fn env_flag_opt(name: &str) -> Option<bool> {
     match std::env::var(name) {
-        Ok(value) => matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"),
-        Err(_) => false,
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" => Some(true),
+            "0" | "false" => Some(false),
+            _ => None,
+        },
+        Err(_) => None,
     }
 }
 
@@ -19,6 +29,37 @@ pub fn is_ci() -> bool {
 #[cfg(test)]
 mod tests {
     use super::env_flag;
+    use super::env_flag_opt;
+
+    /// `None` has to be distinguishable from `Some(false)`, otherwise an env var
+    /// can't override a setting: unset must fall through to the setting, while
+    /// `0` must beat it.
+    #[test]
+    fn test_env_flag_opt_separates_unset_from_false() {
+        let name = "STDEXT_TEST_ENV_FLAG_OPT";
+
+        unsafe { std::env::remove_var(name) };
+        assert_eq!(env_flag_opt(name), None);
+
+        for value in ["1", "true", "TRUE", " true "] {
+            unsafe { std::env::set_var(name, value) };
+            assert_eq!(env_flag_opt(name), Some(true));
+        }
+
+        for value in ["0", "false", "FALSE", " false "] {
+            unsafe { std::env::set_var(name, value) };
+            assert_eq!(env_flag_opt(name), Some(false));
+        }
+
+        // Unrecognised reads as unset, so a typo falls through rather than
+        // silently meaning "off".
+        for value in ["", "  ", "yes", "no", "2"] {
+            unsafe { std::env::set_var(name, value) };
+            assert_eq!(env_flag_opt(name), None);
+        }
+
+        unsafe { std::env::remove_var(name) };
+    }
 
     #[test]
     fn test_env_flag_only_accepts_1_and_true() {

--- a/crates/stdext/src/lib.rs
+++ b/crates/stdext/src/lib.rs
@@ -9,6 +9,7 @@ pub mod all;
 pub mod any;
 pub mod case;
 pub mod cell;
+pub mod env;
 pub mod event;
 pub mod join;
 pub mod local;
@@ -22,6 +23,8 @@ pub mod testing;
 pub mod unwrap;
 
 pub use crate::cell::DebugRefCell;
+pub use crate::env::env_flag;
+pub use crate::env::is_ci;
 pub use crate::join::Joined;
 pub use crate::ok::Ok;
 pub use crate::panic::panic_message;

--- a/crates/stdext/src/lib.rs
+++ b/crates/stdext/src/lib.rs
@@ -24,6 +24,7 @@ pub mod unwrap;
 
 pub use crate::cell::DebugRefCell;
 pub use crate::env::env_flag;
+pub use crate::env::env_flag_opt;
 pub use crate::env::is_ci;
 pub use crate::join::Joined;
 pub use crate::ok::Ok;

--- a/doc/configuration-oak.md
+++ b/doc/configuration-oak.md
@@ -1,0 +1,67 @@
+# Introduction
+
+Oak is the semantic engine behind Ark's intellisense. It indexes R code per file (scopes, symbols, definitions, uses) and answers analysis questions for the LSP: diagnostics, go-to-definition, etc.
+
+For Ark's general configuration, see [configuration.md](configuration.md).
+
+# Precedence
+
+Configuration follows these rules of precedence:
+
+1. Environment variables.
+2. LSP settings from the client.
+3. Defaults.
+
+Environment variables read `1` and `true` as on, `0` and `false` as off, case-insensitively. Anything else, including the empty string, counts as unset and falls through to the setting.
+
+# LSP settings
+
+## `oak.enableSourceFetching`
+
+A boolean, default `TRUE`.
+
+Whether to recover the R sources of the packages your workspace uses, so analysis can see inside them. See [Package sources](#package-sources) for what that involves.
+
+Takes effect immediately. Turning it back on fetches sources for the packages Oak has already seen, without needing a restart.
+
+Overridden by the `OAK_ENABLE_SOURCE_FETCHING` environment variable.
+
+To avoid unnecessary traffic on CI, source fetching is disabled when the `CI` environment variable is set. Set `OAK_ENABLE_SOURCE_FETCHING=1` to opt back into fetching sources in a CI job.
+
+# Package sources
+
+When Oak detects that your code uses an external package, it tries to recover that package's R sources to index them and infer types and effects. It stops at the first thing that works:
+
+1. **Base packages** (`base`, `stats`, `utils`, and friends) come from a prebuilt archive hosted as a GitHub Release at [`posit-dev/oak-r-sources`](https://github.com/posit-dev/oak-r-sources), one release per R version. R's own source tarball is over 100MB per version, so we publish a trimmed, zstd-compressed `r-source.tar.zst` that's about 1.7MB instead.
+
+2. **Local srcrefs.** If a package was installed with srcrefs, the sources are already on your machine. Oak recovers them by running a short script in a sidecar R process. If you maintain a package, consider adding `KeepSource: true` to your DESCRIPTION file. This compels R to always install your package with sources, which is useful for both debugging and language analysis.
+
+3. **A CRAN tarball**, downloaded and unpacked.
+
+If none of those work, or if source fetching is disabled, Oak analysis degrades gracefully.
+
+## Cache
+
+Sources recovered from srcrefs or from a download are cached on disk and shared across sessions.
+
+The cache lives in `~/.cache/oak/` on macOS and Linux, and in
+`%LOCALAPPDATA%\oak\` on Windows. Laid out as:
+
+```
+oak/
+  source/v1/cran/{name}_{version}/    unpacked CRAN tarballs
+  source/v1/r/{release}_archive/      the downloaded r-source.tar.zst
+  source/v1/r/{release}_{version}/    base R sources unpacked from it
+  srcref/v1/{name}_{version}_{hash}/  sources recovered from local srcrefs
+```
+
+The `v1` is a cache format version.
+
+The srcref key includes a hash of the package's `Built:` field, so reinstalling or rebuilding a package produces a fresh entry instead of serving stale sources.
+
+Cache entries are deleted automatically when:
+
+- They've been untouched for four months.
+- Once a cache exceeds 1000 entries. The least recently used entries are deleted first.
+
+The cache is safe to delete at any time.

--- a/doc/configuration-oak.md
+++ b/doc/configuration-oak.md
@@ -22,7 +22,7 @@ A boolean, default `TRUE`.
 
 Whether to recover the R sources of the packages your workspace uses, so analysis can see inside them. See [Package sources](#package-sources) for what that involves.
 
-Takes effect immediately. Turning it back on fetches sources for the packages Oak has already seen, without needing a restart.
+Takes effect immediately. Turning it off drops the fetches that haven't started yet. Note that a fetch already under way runs to completion and its sources are kept. Turning it back on fetches sources for the packages Oak has seen meanwhile, without needing a restart.
 
 Overridden by the `OAK_SOURCE_FETCHING_ENABLED` environment variable.
 

--- a/doc/configuration-oak.md
+++ b/doc/configuration-oak.md
@@ -29,6 +29,12 @@ Overridden by the `OAK_SOURCE_FETCHING_ENABLED` environment variable.
 
 To avoid unnecessary traffic on CI, source fetching is disabled when the `CI` environment variable is set. Set `OAK_SOURCE_FETCHING_ENABLED=1` to opt back into fetching sources in a CI job.
 
+## `oak.diagnostics.experimental.enabled`
+
+A boolean, default `false`.
+
+Whether to publish diagnostics that are still experimental: ambiguous effects (like Attach or Source), and uninstalled package.
+
 # Package sources
 
 When Oak detects that your code uses an external package, it tries to recover that package's R sources to index them and infer types and effects. It stops at the first thing that works:

--- a/doc/configuration-oak.md
+++ b/doc/configuration-oak.md
@@ -16,7 +16,7 @@ Environment variables read `1` and `true` as on, `0` and `false` as off, case-in
 
 # LSP settings
 
-## `oak.enableSourceFetching`
+## `oak.sourceFetching.enabled`
 
 A boolean, default `TRUE`.
 
@@ -24,9 +24,9 @@ Whether to recover the R sources of the packages your workspace uses, so analysi
 
 Takes effect immediately. Turning it back on fetches sources for the packages Oak has already seen, without needing a restart.
 
-Overridden by the `OAK_ENABLE_SOURCE_FETCHING` environment variable.
+Overridden by the `OAK_SOURCE_FETCHING_ENABLED` environment variable.
 
-To avoid unnecessary traffic on CI, source fetching is disabled when the `CI` environment variable is set. Set `OAK_ENABLE_SOURCE_FETCHING=1` to opt back into fetching sources in a CI job.
+To avoid unnecessary traffic on CI, source fetching is disabled when the `CI` environment variable is set. Set `OAK_SOURCE_FETCHING_ENABLED=1` to opt back into fetching sources in a CI job.
 
 # Package sources
 

--- a/doc/configuration-oak.md
+++ b/doc/configuration-oak.md
@@ -10,7 +10,8 @@ Configuration follows these rules of precedence:
 
 1. Environment variables.
 2. LSP settings from the client.
-3. Defaults.
+3. `initializationOptions` from the client.
+4. Defaults.
 
 Environment variables read `1` and `true` as on, `0` and `false` as off, case-insensitively. Anything else, including the empty string, counts as unset and falls through to the setting.
 

--- a/doc/configuration-oak.md
+++ b/doc/configuration-oak.md
@@ -19,7 +19,7 @@ Environment variables read `1` and `true` as on, `0` and `false` as off, case-in
 
 ## `oak.sourceFetching.enabled`
 
-A boolean, default `TRUE`.
+A boolean, default `true`.
 
 Whether to recover the R sources of the packages your workspace uses, so analysis can see inside them. See [Package sources](#package-sources) for what that involves.
 


### PR DESCRIPTION
Follow up to #1369 for https://github.com/posit-dev/positron/issues/15211.

- Disable source fetching on CI by default. No need to impact the network and cause LSP flickering as new information comes in on CI.

- Add a user-facing LSP setting `oak.sourceFetching.enabled`, and a corresponding env var `OAK_SOURCE_FETCHING_ENABLED`. The env-var can be used on CI to opt back in the source fetching mechanism. The env-var always has precedence over the LSP setting, which follows ruff/ty.

- Start an Oak documentation page that describes the source fetching and cache and how to configure it.

### Positron Release Notes

<!--
  These notes are typically filled by the Positron team. If you are an external
  contributor, you may leave the `N/A` bullets in place.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A
