### PR TITLE
Rename `Nse` effect to `EvalQ`

### DIFF
--- a/crates/oak_db/src/tests/file.rs
+++ b/crates/oak_db/src/tests/file.rs
@@ -145,8 +145,8 @@ fn test_semantic_index_recognizes_bare_base_nse() {
     // Base NSE resolves through the real `SalsaImportsResolver` (base-only
     // `resolve_effects`): a bare `local()` still pushes a nested NSE scope, so
     // `x` lands there rather than at file scope.
-    use oak_semantic::semantic_index::NseScope;
-    use oak_semantic::semantic_index::NseTiming;
+    use oak_semantic::semantic_index::EvalEnv;
+    use oak_semantic::semantic_index::EvalTiming;
     use oak_semantic::semantic_index::ScopeId;
     use oak_semantic::semantic_index::ScopeKind;
 
@@ -159,7 +159,7 @@ fn test_semantic_index_recognizes_bare_base_nse() {
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert!(index.symbols(file_scope).get("x").is_none());
     assert!(index.symbols(local_scope).get("x").is_some());

--- a/crates/oak_db/src/tests/resolver.rs
+++ b/crates/oak_db/src/tests/resolver.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use oak_package_metadata::namespace::Import;
 use oak_package_metadata::namespace::Namespace;
 use oak_semantic::semantic_index::DefinitionKind;
-use oak_semantic::semantic_index::NseScope;
-use oak_semantic::semantic_index::NseTiming;
+use oak_semantic::semantic_index::EvalEnv;
+use oak_semantic::semantic_index::EvalTiming;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::ScopeKind;
 use oak_semantic::semantic_index::SemanticCallKind;
@@ -154,7 +154,7 @@ fn test_testthat_test_that_is_nse_without_library() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(test_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
 }
 
@@ -178,7 +178,7 @@ fn test_testthat_helper_attach_enables_nse() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -223,7 +223,7 @@ fn test_namespace_import_from_enables_nse() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -257,7 +257,7 @@ fn test_namespace_bulk_import_enables_nse() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -299,7 +299,7 @@ fn test_namespace_reexport_chases_to_source_package() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -384,7 +384,7 @@ fn test_testthat_namespace_import_enables_nse() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -488,7 +488,7 @@ fn test_later_sibling_does_not_shadow() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -510,7 +510,7 @@ fn test_predecessor_sibling_attach_enables_nse() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -724,7 +724,7 @@ fn test_attached_package_enables_nse_scope() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -742,7 +742,7 @@ fn test_base_nse_resolves_with_no_attaches() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
 }
 

--- a/crates/oak_semantic/src/builder.rs
+++ b/crates/oak_semantic/src/builder.rs
@@ -66,10 +66,10 @@ use crate::semantic_index::DefinitionId;
 use crate::semantic_index::DefinitionKind;
 use crate::semantic_index::EnclosingSnapshotId;
 use crate::semantic_index::EnclosingSnapshotKey;
+use crate::semantic_index::EvalEnv;
+use crate::semantic_index::EvalTiming;
 use crate::semantic_index::NamespaceAccess;
 use crate::semantic_index::NamespaceAccessKind;
-use crate::semantic_index::NseScope;
-use crate::semantic_index::NseTiming;
 use crate::semantic_index::Scope;
 use crate::semantic_index::ScopeId;
 use crate::semantic_index::ScopeKind;
@@ -247,7 +247,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         // Eager` never reaches here because it doesn't push a scope.
         if matches!(
             self.scopes[self.current_scope].kind,
-            ScopeKind::Nse(NseScope::Current, NseTiming::Lazy)
+            ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
         ) {
             self.add_definition_to_owner(name, flags, kind, range);
             return;
@@ -309,7 +309,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         let mut scope = self.scopes[self.current_scope].parent?;
         while matches!(
             self.scopes[scope].kind,
-            ScopeKind::Nse(NseScope::Current, NseTiming::Lazy)
+            ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
         ) {
             scope = self.scopes[scope].parent?;
         }
@@ -819,7 +819,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
 
         if let Some(target) = match self.scopes[self.current_scope].kind {
-            ScopeKind::Nse(NseScope::Current, NseTiming::Lazy) => self.definition_owner(),
+            ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy) => self.definition_owner(),
             _ => Some(self.current_scope),
         } {
             self.bound_names[target].add(name, range);

--- a/crates/oak_semantic/src/builder/builder_nse.rs
+++ b/crates/oak_semantic/src/builder/builder_nse.rs
@@ -25,8 +25,8 @@ use crate::effects::EffectsHandlers;
 use crate::effects::ResolvedArgumentEffect;
 use crate::effects::ResolvedArgumentEffects;
 use crate::resolver::ImportsResolver;
-use crate::semantic_index::NseScope;
-use crate::semantic_index::NseTiming;
+use crate::semantic_index::EvalEnv;
+use crate::semantic_index::EvalTiming;
 use crate::semantic_index::ScopeKind;
 use crate::semantic_index::SemanticDiagnostic;
 
@@ -123,16 +123,16 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                         self.scan_expression(hole);
                     }
                 },
-                Some(ResolvedArgumentEffect::Nse { scope, timing }) => match (scope, timing) {
+                Some(ResolvedArgumentEffect::EvalQ { env, timing }) => match (env, timing) {
                     // Calls like `evalq()`
-                    (NseScope::Current, NseTiming::Eager) => self.scan_expression(&value),
+                    (EvalEnv::Current, EvalTiming::Eager) => self.scan_expression(&value),
 
                     // Calls like `on_load()`. Its body runs later, so its defs
                     // land in the enclosing scope. We don't resolve the body's
                     // calls here. The walk does that once it enters the child
                     // scope. But we do grab the names it defines now, so the
                     // owner's bound names are complete before the walk reaches a sibling.
-                    (NseScope::Current, NseTiming::Lazy) => {
+                    (EvalEnv::Current, EvalTiming::Lazy) => {
                         self.record_enclosing_flow(value.syntax().text_trimmed_range());
                         self.scan_lazy_owner_bindings(&value);
                     },
@@ -145,7 +145,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     // have seeded.
                     // No `record_enclosing_flow()`: eager `Nested` bodies are
                     // never scanned at walk time, so nothing would read it.
-                    (NseScope::Nested, NseTiming::Eager) => {
+                    (EvalEnv::Nested, EvalTiming::Eager) => {
                         let old = self.flow_state.snapshot();
 
                         let range = value.syntax().text_trimmed_range();
@@ -162,7 +162,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                     // later time, so it's a child scope scanned when the walk
                     // enters it. Record the names it inherits for its callee
                     // resolution, same as a function body.
-                    (NseScope::Nested, NseTiming::Lazy) => {
+                    (EvalEnv::Nested, EvalTiming::Lazy) => {
                         self.record_enclosing_flow(value.syntax().text_trimmed_range());
                     },
                 },
@@ -505,8 +505,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 continue;
             };
             match argument {
-                ResolvedArgumentEffect::Nse { scope, timing } => {
-                    self.collect_nse_argument(*scope, *timing, &value)
+                ResolvedArgumentEffect::EvalQ { env, timing } => {
+                    self.collect_nse_argument(*env, *timing, &value)
                 },
                 // Quoted argument: only the unquote holes are live.
                 ResolvedArgumentEffect::Quote { holes } => {
@@ -524,17 +524,17 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// already scanned by the descent, so we install its pending names and only
     /// walk. The remaining lazy bodies are their own scan units that we scan
     /// here on entry.
-    fn collect_nse_argument(&mut self, scope: NseScope, timing: NseTiming, value: &AnyRExpression) {
-        match (scope, timing) {
+    fn collect_nse_argument(&mut self, env: EvalEnv, timing: EvalTiming, value: &AnyRExpression) {
+        match (env, timing) {
             // Calls like `evalq()`
-            (NseScope::Current, NseTiming::Eager) => {
+            (EvalEnv::Current, EvalTiming::Eager) => {
                 self.collect_expression(value);
             },
 
             // Calls like `local()`
-            (NseScope::Nested, NseTiming::Eager) => {
+            (EvalEnv::Nested, EvalTiming::Eager) => {
                 let range = value.syntax().text_trimmed_range();
-                let kind = ScopeKind::Nse(NseScope::Nested, NseTiming::Eager);
+                let kind = ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager);
                 let scope = self.push_scope(kind, range);
 
                 // Install the pending names the descent recorded for this body,
@@ -562,8 +562,8 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
                 self.pop_scope(scope);
             },
 
-            (nse_scope, nse_timing) => {
-                let kind = ScopeKind::Nse(nse_scope, nse_timing);
+            (env, timing) => {
+                let kind = ScopeKind::Nse(env, timing);
                 let scope = self.push_scope(kind, value.syntax().text_trimmed_range());
 
                 // Scan the child body before walking it. A `Current + Lazy`

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -12,8 +12,8 @@ pub use oak_core::range::RangedAstPtr;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
 
-use crate::semantic_index::NseScope;
-use crate::semantic_index::NseTiming;
+use crate::semantic_index::EvalEnv;
+use crate::semantic_index::EvalTiming;
 
 /// Per-package tables of which functions carry effects. Private data behind the
 /// `lookup`/`annotates` query API below.
@@ -235,8 +235,10 @@ pub type ResolvedArgumentEffects = Vec<Option<ResolvedArgumentEffect>>;
 /// The resolved, per-call effect of one argument. The builder consumes these.
 #[derive(Debug, Clone)]
 pub enum ResolvedArgumentEffect {
-    /// Quote plus Eval in a controlled scope, fused.
-    Nse { scope: NseScope, timing: NseTiming },
+    /// Quote the argument, then evaluate it in `env`. `timing` says whether
+    /// that happens eagerly at the call site (`evalq()`, `local()`) or later
+    /// at an unknown time (`on_load()`, `reactive()`).
+    EvalQ { env: EvalEnv, timing: EvalTiming },
     /// Captured unevaluated. `holes` are the sub-expressions that escape back to
     /// evaluation (e.g. bquote's `.()` contents), walked normally; everything
     /// else in the argument is inert. Empty for a plain `quote()`.
@@ -262,8 +264,10 @@ pub struct Argument {
 /// evaluation model.
 #[derive(Debug, Clone, Copy)]
 pub enum ArgumentEffect {
-    /// Quote plus Eval in a controlled scope, fused
-    Nse { scope: NseScope, timing: NseTiming },
+    /// Quote the argument, then evaluate it in `env`. `timing` says whether
+    /// that happens eagerly at the call site (`evalq()`, `local()`) or later
+    /// at an unknown time (`on_load()`, `reactive()`).
+    EvalQ { env: EvalEnv, timing: EvalTiming },
     /// Captured unevaluated, so its symbols are not uses and nothing in it runs.
     /// `quote`. A function that unquotes (`bquote()`, whose `.()` holes escape)
     /// can't be expressed statically, and must use a custom handler instead of
@@ -274,7 +278,7 @@ pub enum ArgumentEffect {
 impl ArgumentEffect {
     fn resolve(self) -> ResolvedArgumentEffect {
         match self {
-            ArgumentEffect::Nse { scope, timing } => ResolvedArgumentEffect::Nse { scope, timing },
+            ArgumentEffect::EvalQ { env, timing } => ResolvedArgumentEffect::EvalQ { env, timing },
             ArgumentEffect::Quote => ResolvedArgumentEffect::Quote { holes: Vec::new() },
         }
     }

--- a/crates/oak_semantic/src/effects/contrib.rs
+++ b/crates/oak_semantic/src/effects/contrib.rs
@@ -27,8 +27,8 @@ macro_rules! nse {
                     arguments: &[$($crate::effects::Argument {
                         name: $name,
                         position: $pos,
-                        effect: $crate::effects::ArgumentEffect::Nse {
-                            scope: $scope,
+                        effect: $crate::effects::ArgumentEffect::EvalQ {
+                            env: $scope,
                             timing: $timing,
                         },
                     }),+],

--- a/crates/oak_semantic/src/effects/contrib/base.rs
+++ b/crates/oak_semantic/src/effects/contrib/base.rs
@@ -16,9 +16,9 @@ use crate::effects::EffectsHandlers;
 use crate::effects::Formal;
 use crate::effects::ResolvedArgumentEffect;
 use crate::effects::ResolvedArgumentEffects;
-use crate::semantic_index::NseScope::Current;
-use crate::semantic_index::NseScope::Nested;
-use crate::semantic_index::NseTiming::Eager;
+use crate::semantic_index::EvalEnv::Current;
+use crate::semantic_index::EvalEnv::Nested;
+use crate::semantic_index::EvalTiming::Eager;
 
 pub(crate) static ENTRIES: &[Entry] = &[
     // base NSE

--- a/crates/oak_semantic/src/effects/contrib/rlang.rs
+++ b/crates/oak_semantic/src/effects/contrib/rlang.rs
@@ -2,8 +2,8 @@ use crate::effects::contrib::assign_op;
 use crate::effects::contrib::nse;
 use crate::effects::contrib::Entry;
 use crate::effects::TargetAccess::Write;
-use crate::semantic_index::NseScope::Current;
-use crate::semantic_index::NseTiming::Lazy;
+use crate::semantic_index::EvalEnv::Current;
+use crate::semantic_index::EvalTiming::Lazy;
 
 pub(crate) static ENTRIES: &[Entry] = &[
     assign_op!("rlang", "%<~%", Write),

--- a/crates/oak_semantic/src/effects/contrib/shiny.rs
+++ b/crates/oak_semantic/src/effects/contrib/shiny.rs
@@ -1,7 +1,7 @@
 use crate::effects::contrib::nse;
 use crate::effects::contrib::Entry;
-use crate::semantic_index::NseScope::Nested;
-use crate::semantic_index::NseTiming::Lazy;
+use crate::semantic_index::EvalEnv::Nested;
+use crate::semantic_index::EvalTiming::Lazy;
 
 pub(crate) static ENTRIES: &[Entry] = &[
     nse!("shiny", "observe", ("x", 0, Nested, Lazy)),

--- a/crates/oak_semantic/src/effects/contrib/testthat.rs
+++ b/crates/oak_semantic/src/effects/contrib/testthat.rs
@@ -1,6 +1,6 @@
 use crate::effects::contrib::nse;
 use crate::effects::contrib::Entry;
-use crate::semantic_index::NseScope::Nested;
-use crate::semantic_index::NseTiming::Eager;
+use crate::semantic_index::EvalEnv::Nested;
+use crate::semantic_index::EvalTiming::Eager;
 
 pub(crate) static ENTRIES: &[Entry] = &[nse!("testthat", "test_that", ("code", 1, Nested, Eager))];

--- a/crates/oak_semantic/src/semantic_index.rs
+++ b/crates/oak_semantic/src/semantic_index.rs
@@ -459,12 +459,12 @@ pub enum ScopeKind {
     // cross-file resolution (package namespace, session, etc.) takes over.
     File,
     Function,
-    Nse(NseScope, NseTiming),
+    Nse(EvalEnv, EvalTiming),
 }
 
 /// Where definitions in an NSE scope land.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NseScope {
+pub enum EvalEnv {
     /// Definitions go to the current (parent) environment.
     /// e.g. `rlang::on_load()`
     Current,
@@ -476,7 +476,7 @@ pub enum NseScope {
 /// Whether an NSE scope evaluates eagerly (at the call site) or lazily
 /// (at an unknown later time).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NseTiming {
+pub enum EvalTiming {
     /// Expression that runs at the call site. Free variables resolve against
     /// the linear state right there. E.g. `local()`, `evalq()`, `test_that()`.
     Eager,
@@ -495,7 +495,7 @@ impl ScopeKind {
         match self {
             ScopeKind::File => false,
             ScopeKind::Function => true,
-            ScopeKind::Nse(_, timing) => timing == NseTiming::Lazy,
+            ScopeKind::Nse(_, timing) => timing == EvalTiming::Lazy,
         }
     }
 }

--- a/crates/oak_semantic/tests/integration/builder_nse.rs
+++ b/crates/oak_semantic/tests/integration/builder_nse.rs
@@ -2,8 +2,8 @@ use aether_parser::parse;
 use aether_parser::RParserOptions;
 use oak_semantic::build_index;
 use oak_semantic::semantic_index::DefinitionId;
-use oak_semantic::semantic_index::NseScope;
-use oak_semantic::semantic_index::NseTiming;
+use oak_semantic::semantic_index::EvalEnv;
+use oak_semantic::semantic_index::EvalTiming;
 use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::ScopeKind;
 use oak_semantic::semantic_index::SemanticDiagnostic;
@@ -52,7 +52,7 @@ local({
     // `x` is defined inside the NSE scope, not at file level
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(file));
     assert_eq!(index.symbols(local_scope).len(), 1);
@@ -121,7 +121,7 @@ testthat::test_that("description", {
     // Test scope contains `x`
     assert_eq!(
         index.scope(test_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(
         index.symbols(test_scope).get("x").unwrap().flags(),
@@ -212,7 +212,7 @@ local({
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
 
@@ -292,7 +292,7 @@ testthat::test_that(code = {
 
     assert_eq!(
         index.scope(test_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(
         index.symbols(test_scope).get("x").unwrap().flags(),
@@ -315,7 +315,7 @@ local({
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(fun_scope).kind(), ScopeKind::Function);
     assert_eq!(index.scope(fun_scope).parent(), Some(local_scope));
@@ -417,7 +417,7 @@ rlang::on_load({
     // The NSE scope exists with `Current + Lazy` kind
     assert_eq!(
         index.scope(nse_scope).kind(),
-        ScopeKind::Nse(NseScope::Current, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
     );
     assert_eq!(index.scope(nse_scope).parent(), Some(file));
 
@@ -474,11 +474,11 @@ local({
     // Both calls create Nested + Eager scopes
     assert_eq!(
         index.scope(first_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(
         index.scope(second_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
 
     // `local <- identity` is in the first scope, not at file level
@@ -534,7 +534,7 @@ f <- function() {
     assert_eq!(index.scope_ids().count(), 5);
     assert_eq!(
         index.scope(outer_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(outer_local).parent(), Some(file));
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
@@ -542,7 +542,7 @@ f <- function() {
     assert_eq!(index.scope(g_scope).parent(), Some(f_scope));
     assert_eq!(
         index.scope(inner_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(inner_local).parent(), Some(f_scope));
 
@@ -580,7 +580,7 @@ if (c) local <- identity else local({
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(nse_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(nse_scope).parent(), Some(file));
 
@@ -637,7 +637,7 @@ local <- identity
     // moves into its own scope.
     assert_eq!(
         index.scope(f_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(f_local).parent(), Some(f_scope));
     assert!(index.symbols(f_scope).get("x").is_none());
@@ -650,7 +650,7 @@ local <- identity
     // lands in its own scope.
     assert_eq!(
         index.scope(eager_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(eager_local).parent(), Some(file));
     assert!(index.symbols(f_scope).get("y").is_none());
@@ -683,7 +683,7 @@ x <- 2
     assert_eq!(index.scope(fun_scope).kind(), ScopeKind::Function);
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(fun_scope));
 
@@ -719,12 +719,12 @@ local({
 
     assert_eq!(
         index.scope(outer_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(outer_local).parent(), Some(file));
     assert_eq!(
         index.scope(inner_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(inner_local).parent(), Some(outer_local));
 
@@ -907,7 +907,7 @@ base::local({
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(
         index.symbols(local_scope).get("x").unwrap().flags(),
@@ -984,7 +984,7 @@ local({
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(file));
     assert!(index.symbols(file).get("x").is_none());
@@ -1066,7 +1066,7 @@ rlang::on_load({ local <- identity })
     assert_eq!(first.scope(f_first).kind(), ScopeKind::Function);
     assert_eq!(
         first.scope(f_local_first).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(first.scope(f_local_first).parent(), Some(f_first));
     assert!(first.symbols(f_first).get("x").is_none());
@@ -1088,7 +1088,7 @@ f <- function() local({ x <- 1 })
     assert_eq!(second.scope(f_second).kind(), ScopeKind::Function);
     assert_eq!(
         second.scope(f_local_second).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(second.scope(f_local_second).parent(), Some(f_second));
     assert!(second.symbols(f_second).get("x").is_none());
@@ -1122,7 +1122,7 @@ rlang::on_load({ evalq(local <- identity) })
     assert_eq!(first.scope(f).kind(), ScopeKind::Function);
     assert_eq!(
         first.scope(nested).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(first.scope(nested).parent(), Some(f));
     assert!(first.symbols(f).get("x").is_none());
@@ -1144,7 +1144,7 @@ f <- function() local({ x <- 1 })
     assert_eq!(second.scope(f_second).kind(), ScopeKind::Function);
     assert_eq!(
         second.scope(nested_second).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(second.scope(nested_second).parent(), Some(f_second));
     assert!(second.symbols(f_second).get("x").is_none());
@@ -1173,11 +1173,11 @@ local({ x <- 1 })
     assert_eq!(index.scope_ids().count(), 3);
     assert_eq!(
         index.scope(on_load_scope).kind(),
-        ScopeKind::Nse(NseScope::Current, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
     );
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(file));
     assert!(index.symbols(file).get("x").is_none());
@@ -1199,7 +1199,7 @@ fn test_nse_parameter_default_pushes_scope() {
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(f_scope));
 
@@ -1356,7 +1356,7 @@ local({
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
 
@@ -1383,7 +1383,7 @@ local({
 
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(file));
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
@@ -1422,7 +1422,7 @@ f <- function() {
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(local_scope).parent(), Some(f_scope));
 
@@ -1453,12 +1453,12 @@ local({
     assert_eq!(index.scope_ids().count(), 3);
     assert_eq!(
         index.scope(outer_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(outer_local).parent(), Some(file));
     assert_eq!(
         index.scope(inner_local).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(index.scope(inner_local).parent(), Some(outer_local));
 
@@ -1547,7 +1547,7 @@ reactive({
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
     assert_eq!(index.scope(reactive_scope).parent(), Some(file));
     assert!(index.symbols(file).get("x").is_none());
@@ -1622,7 +1622,7 @@ library(shiny)
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
     assert_eq!(index.scope(reactive_scope).parent(), Some(f_scope));
 }
@@ -1648,11 +1648,11 @@ reactive({
     assert_eq!(index.attached_packages(), vec!["shiny"]);
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 
@@ -1681,7 +1681,7 @@ f <- function() {
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
     assert_eq!(
         index.scope(local_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Eager)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Eager)
     );
 }
 
@@ -1755,7 +1755,7 @@ reactive({
     assert_eq!(index.attached_packages(), vec!["shiny"]);
     assert_eq!(
         index.scope(reactive_scope).kind(),
-        ScopeKind::Nse(NseScope::Nested, NseTiming::Lazy)
+        ScopeKind::Nse(EvalEnv::Nested, EvalTiming::Lazy)
     );
 }
 


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338

Mechanical refactor: the `Nse` effect is renamed to `EvalQ`.

It occurred to me that `evalq()` is the quintessential data-masking function:

- It quotes and eval in one movement
- It optionally takes a data frame and parent env

```r
evalq(cyl * am, mtcars)
#> [1] 6 6 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4 4 4 0 0 0 0 0 4 4 4 8 6 8 4
```

This is thus the best analogy for data masking effects, even though by default it just evaluates in the current env (the evaluation effect is neutral).

### Positron Release Notes

<!--
  These notes are typically filled by the Positron team. If you are an external
  contributor, you may leave the `N/A` bullets in place.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A
