### PR TITLE
Add support for `on.exit()` and `defer()`

### DIFF
--- a/crates/oak_ide/tests/integration/find_references.rs
+++ b/crates/oak_ide/tests/integration/find_references.rs
@@ -192,6 +192,28 @@ fn test_references_from_assign_definition_site() {
     // search path.
 }
 
+// --- NSE lazy scopes ---
+
+#[test]
+fn test_on_exit_body_use_has_lazy_view() {
+    // `on.exit(x)` runs at function exit, so its read of `x` sees the whole
+    // function frame (lazy view): both `x <- 1` and the later `x <- 2` reach it.
+    // Find-references from the *second* def includes the on.exit use even though
+    // that use sits textually before it. An eager view would exclude it.
+    let source = "f <- function() {\n  x <- 1\n  on.exit(x)\n  x <- 2\n}\n";
+    let mut db = OakDatabase::new();
+    let file = upsert(&mut db, "test.R", source);
+
+    let on_exit_use = (source.find("on.exit(x)").unwrap() + "on.exit(".len()) as u32;
+    let second_def = source.rfind("x <- 2").unwrap() as u32;
+
+    let refs = find_references(&db, file, offset(second_def), true);
+    assert_eq!(ranges(&refs), vec![
+        range(on_exit_use, on_exit_use + 1),
+        range(second_def, second_def + 1),
+    ]);
+}
+
 // --- Boundary cursor ---
 
 #[test]

--- a/crates/oak_semantic/src/effects/contrib.rs
+++ b/crates/oak_semantic/src/effects/contrib.rs
@@ -6,6 +6,7 @@ mod rlang;
 mod s7;
 mod shiny;
 mod testthat;
+mod withr;
 
 // Fields are read by the query API (`lookup`, `annotates`) in the parent
 // `effects` module, hence `pub(super)`.
@@ -131,4 +132,5 @@ pub(super) static REGISTRY: &[&[Entry]] = &[
     s7::ENTRIES,
     shiny::ENTRIES,
     testthat::ENTRIES,
+    withr::ENTRIES,
 ];

--- a/crates/oak_semantic/src/effects/contrib/base.rs
+++ b/crates/oak_semantic/src/effects/contrib/base.rs
@@ -15,10 +15,15 @@ use crate::effects::EffectsHandlers;
 use crate::semantic_index::EvalEnv::Current;
 use crate::semantic_index::EvalEnv::Nested;
 use crate::semantic_index::EvalTiming::Eager;
+use crate::semantic_index::EvalTiming::Lazy;
 
 pub(crate) static ENTRIES: &[Entry] = &[
     // base NSE
     nse!("base", "evalq", ("expr", 0, Current, Eager)),
+    // `on.exit(expr)` captures `expr` and runs it in the current function's
+    // frame when the function exits. Bindings land in that frame (`Current`) at
+    // an unknown later time (`Lazy`), the same shape as `rlang::on_load()`.
+    nse!("base", "on.exit", ("expr", 0, Current, Lazy)),
     nse!("base", "local", ("expr", 0, Nested, Eager)),
     nse!("base", "with", ("expr", 1, Nested, Eager)),
     nse!("base", "with.default", ("expr", 1, Nested, Eager)),

--- a/crates/oak_semantic/src/effects/contrib/rlang.rs
+++ b/crates/oak_semantic/src/effects/contrib/rlang.rs
@@ -8,4 +8,8 @@ use crate::semantic_index::EvalTiming::Lazy;
 pub(crate) static ENTRIES: &[Entry] = &[
     assign_op!("rlang", "%<~%", Write),
     nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
+    // `defer(expr, env = caller_env())` runs `expr` in the caller frame when it
+    // exits. Written in a function, that frame is the function itself, so it's
+    // `Current + Lazy` like `on.exit`. A non-default `env` isn't modeled.
+    nse!("rlang", "defer", ("expr", 0, Current, Lazy)),
 ];

--- a/crates/oak_semantic/src/effects/contrib/withr.rs
+++ b/crates/oak_semantic/src/effects/contrib/withr.rs
@@ -1,0 +1,11 @@
+use crate::effects::contrib::nse;
+use crate::effects::contrib::Entry;
+use crate::semantic_index::EvalEnv::Current;
+use crate::semantic_index::EvalTiming::Lazy;
+
+pub(crate) static ENTRIES: &[Entry] = &[
+    // `defer(expr, envir = parent.frame())` runs `expr` in the caller frame when
+    // it exits, the same `Current + Lazy` shape as `on.exit`. A non-default
+    // `envir` isn't modeled.
+    nse!("withr", "defer", ("expr", 0, Current, Lazy)),
+];

--- a/crates/oak_semantic/tests/integration/contrib/base.rs
+++ b/crates/oak_semantic/tests/integration/contrib/base.rs
@@ -2539,3 +2539,63 @@ f <- function() {
     assert_eq!(index.scope_ids().count(), 2);
     assert_eq!(index.scope(f_scope).kind(), ScopeKind::Function);
 }
+
+// --- `on.exit` (Current + Lazy) ---
+
+#[test]
+fn test_nse_on_exit_routes_defs_to_function() {
+    // `on.exit` is Current + Lazy, like `on_load`, but its owner is the
+    // enclosing function rather than the file: a binding inside the body runs in
+    // the function's frame at exit, so it routes there.
+    let index = index_with_base(
+        "\
+f <- function() {
+    on.exit({
+        x <- 1
+    })
+}
+",
+    );
+    let f_scope = ScopeId::from(1);
+    let on_exit_scope = ScopeId::from(2);
+
+    // `x` routes to the function scope, not the `on.exit` body.
+    assert_eq!(
+        index.symbols(f_scope).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+    assert!(index.symbols(on_exit_scope).get("x").is_none());
+
+    assert_eq!(
+        index.scope(on_exit_scope).kind(),
+        ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
+    );
+    assert_eq!(index.scope(on_exit_scope).parent(), Some(f_scope));
+}
+
+#[test]
+fn test_nse_on_exit_body_reads_function_frame_lazily() {
+    // `on.exit(x)` runs at function exit, so its read of `x` sees the whole
+    // function frame (lazy view): both `x <- 1` and the later `x <- 2` reach it.
+    // An eager read would capture only `x <- 1`.
+    let index = index_with_base(
+        "\
+f <- function() {
+    x <- 1
+    on.exit(x)
+    x <- 2
+}
+",
+    );
+    let f_scope = ScopeId::from(1);
+    let on_exit_scope = ScopeId::from(2);
+
+    let (enclosing_scope, bindings) = index
+        .enclosing_bindings(on_exit_scope, UseId::from(0))
+        .unwrap();
+    assert_eq!(enclosing_scope, f_scope);
+    assert_eq!(bindings.definitions(), &[
+        DefinitionId::from(0),
+        DefinitionId::from(1)
+    ]);
+}

--- a/crates/oak_semantic/tests/integration/contrib/rlang.rs
+++ b/crates/oak_semantic/tests/integration/contrib/rlang.rs
@@ -342,3 +342,62 @@ local({
     let (enclosing_scope, _bindings) = index.enclosing_bindings(f_scope, UseId::from(0)).unwrap();
     assert_eq!(enclosing_scope, local_scope);
 }
+
+// --- `defer` (Current + Lazy) ---
+
+#[test]
+fn test_nse_rlang_defer_routes_defs_to_function() {
+    // `rlang::defer` is Current + Lazy: like `on.exit`, a binding in the body
+    // runs in the enclosing function's frame at exit, so it routes there.
+    let index = index_with_attached(
+        "\
+f <- function() {
+    defer({
+        x <- 1
+    })
+}
+",
+        &["rlang"],
+    );
+    let f_scope = ScopeId::from(1);
+    let defer_scope = ScopeId::from(2);
+
+    assert_eq!(
+        index.symbols(f_scope).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+    assert!(index.symbols(defer_scope).get("x").is_none());
+    assert_eq!(
+        index.scope(defer_scope).kind(),
+        ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
+    );
+    assert_eq!(index.scope(defer_scope).parent(), Some(f_scope));
+}
+
+#[test]
+fn test_nse_withr_defer_routes_defs_to_function() {
+    // `withr::defer` shares the `Current + Lazy` shape of `rlang::defer`.
+    let index = index_with_attached(
+        "\
+f <- function() {
+    defer({
+        x <- 1
+    })
+}
+",
+        &["withr"],
+    );
+    let f_scope = ScopeId::from(1);
+    let defer_scope = ScopeId::from(2);
+
+    assert_eq!(
+        index.symbols(f_scope).get("x").unwrap().flags(),
+        SymbolFlags::IS_BOUND
+    );
+    assert!(index.symbols(defer_scope).get("x").is_none());
+    assert_eq!(
+        index.scope(defer_scope).kind(),
+        ScopeKind::Nse(EvalEnv::Current, EvalTiming::Lazy)
+    );
+    assert_eq!(index.scope(defer_scope).parent(), Some(f_scope));
+}


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338

Add handlers for `on.exit()` and `defer()`. For Oak's analysis purposes, these have the same semantics as `rlang::on_load()` which we used as model for `Current + Lazy` scope until now.

(It took me way too long to figure out these have the same scoping behaviour.)

### Positron Release Notes

<!--
  These notes are typically filled by the Positron team. If you are an external
  contributor, you may leave the `N/A` bullets in place.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A
