### PR TITLE
Improve caching for effects resolution

### DIFF
--- a/crates/oak_db/src/file.rs
+++ b/crates/oak_db/src/file.rs
@@ -1,15 +1,11 @@
 use std::fs;
-use std::sync::Arc;
 
 use aether_path::FilePath;
 use biome_line_index::LineIndex;
 use biome_rowan::TextRange;
 use oak_semantic::semantic_index::AmbiguityReason;
-use oak_semantic::semantic_index::ScopeId;
 use oak_semantic::semantic_index::SemanticDiagnostic;
 use oak_semantic::semantic_index::SemanticIndex;
-use oak_semantic::semantic_index::SymbolTable;
-use oak_semantic::use_def_map::UseDefMap;
 
 use crate::db::root_by_file;
 use crate::file_revision::report_untracked_if_zero;
@@ -150,8 +146,7 @@ impl File {
     /// This is a coarse query that invalidates downstream on every edit
     /// (`AstPtr` ranges inside `Definition`s shift). External consumers should
     /// go through the narrow queries: `exports()`, `imports()`, `resolve()`,
-    /// `attached_packages()`, `symbol_table()`, `use_def_map()` to shield
-    /// themselves from edit changes.
+    /// `attached_packages()` to shield themselves from edit changes.
     ///
     /// Cross-file symbol resolution (`source()` injection, NSE resolution)
     /// is driven by [`SalsaImportsResolver`].
@@ -185,18 +180,6 @@ impl File {
     #[salsa::tracked(returns(ref), no_eq, cycle_result = semantic_index_cycle_result)]
     pub(crate) fn semantic_index(self, db: &dyn Db) -> SemanticIndex {
         build_semantic_index(self, db)
-    }
-
-    /// The symbol table for one scope of this file.
-    #[salsa::tracked]
-    pub fn symbol_table(self, db: &dyn Db, scope: ScopeId) -> Arc<SymbolTable> {
-        Arc::clone(self.semantic_index(db).symbols(scope))
-    }
-
-    /// The use-def map for one scope of this file.
-    #[salsa::tracked]
-    pub fn use_def_map(self, db: &dyn Db, scope: ScopeId) -> Arc<UseDefMap> {
-        Arc::clone(self.semantic_index(db).use_def_map(scope))
     }
 
     /// Package names from `library()` / `require()` calls that run at the

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 use biome_rowan::TextSize;
 use camino::Utf8Path;
@@ -23,10 +22,9 @@ pub enum ImportLayer {
     /// A predecessor file in a package's collation, or another workspace
     /// file. Names are resolved through `file.exports(db)`.
     File(File),
-    /// NAMESPACE `importFrom(pkg, name)` entries. Maps each imported
-    /// symbol to its source package by name. Translation to `Package`
-    /// happens at resolution time.
-    From(HashMap<String, String>),
+    /// The package whose NAMESPACE declares `importFrom(pkg, name)` entries.
+    /// [`Package::import_index`] says which entry, if any, binds a given name.
+    From(Package),
     /// A whole package made available, either via NAMESPACE `import(pkg)`,
     /// `library()` / `require()` calls, or the default R search path.
     /// Missing packages are filtered out by `imports`.
@@ -306,7 +304,7 @@ fn package_load_layers(
 
     let mut above: Vec<ImportLayer> = def_files.iter().copied().map(ImportLayer::File).collect();
     let namespace = package.namespace(db);
-    extend_with_namespace_imports(namespace, &mut above);
+    extend_with_namespace_imports(package, namespace, &mut above);
     extend_with_namespace_package_imports(db, namespace, &mut above);
 
     // Every def file's attaches go on the search path below the file's own.
@@ -357,7 +355,7 @@ fn testthat_load_layers(file: File, db: &dyn Db, package: Package) -> CrossFileL
         .map(ImportLayer::File)
         .collect();
     let namespace = package.namespace(db);
-    extend_with_namespace_imports(namespace, &mut above);
+    extend_with_namespace_imports(package, namespace, &mut above);
     extend_with_namespace_package_imports(db, namespace, &mut above);
 
     // Attaches from the sourced helpers and the loaded package, then testthat
@@ -441,18 +439,16 @@ fn testthat_support_key(file: File, db: &dyn Db) -> Cow<'_, str> {
     file.path(db).file_name().unwrap_or_default()
 }
 
-/// Push the `From` layer if the namespace has any `importFrom` entries.
-/// Collects them into a single map from name to source package.
-fn extend_with_namespace_imports(namespace: &Namespace, layers: &mut Vec<ImportLayer>) {
+/// Push the `From` layer if `package`'s namespace has any `importFrom` entries.
+fn extend_with_namespace_imports(
+    package: Package,
+    namespace: &Namespace,
+    layers: &mut Vec<ImportLayer>,
+) {
     if namespace.imports.is_empty() {
         return;
     }
-    let map: HashMap<String, String> = namespace
-        .imports
-        .iter()
-        .map(|imp| (imp.name.clone(), imp.package.clone()))
-        .collect();
-    layers.push(ImportLayer::From(map));
+    layers.push(ImportLayer::From(package));
 }
 
 /// Push one `Package` layer per `import(pkg)` directive in the namespace

--- a/crates/oak_db/src/file_imports.rs
+++ b/crates/oak_db/src/file_imports.rs
@@ -56,17 +56,14 @@ pub(crate) struct CrossFileLayers {
 }
 
 impl CrossFileLayers {
-    /// Flatten to a single lookup-ordered layer list, splicing the file's own
+    /// The layers as a single lookup-ordered list, splicing the file's own
     /// `library()` attaches into the band between the definition/namespace
     /// layers (which outrank them) and the rest of the search path.
-    pub(crate) fn splice_own_attaches(&self, own: Vec<ImportLayer>) -> Vec<ImportLayer> {
-        let mut out = Vec::with_capacity(self.above.len() + own.len() + self.below.len());
-
-        out.extend(self.above.iter().cloned());
-        out.extend(own);
-        out.extend(self.below.iter().cloned());
-
-        out
+    pub(crate) fn lookup_order<'a>(
+        &'a self,
+        own: &'a [ImportLayer],
+    ) -> impl Iterator<Item = &'a ImportLayer> {
+        self.above.iter().chain(own).chain(self.below.iter())
     }
 }
 
@@ -169,7 +166,7 @@ impl File {
     pub fn imports(self, db: &dyn Db) -> Vec<ImportLayer> {
         let layers = self.cross_file_layers(db, CollationView::Lazy);
         let own = self.attach_layers(db, AttachView::Anywhere);
-        layers.splice_own_attaches(own)
+        layers.lookup_order(&own).cloned().collect()
     }
 
     /// Import layers visible at an `offset` in a file:
@@ -212,7 +209,7 @@ impl File {
 
         let layers = self.cross_file_layers(db, collation);
         let own = self.attach_layers(db, attaches);
-        layers.splice_own_attaches(own)
+        layers.lookup_order(&own).cloned().collect()
     }
 
     /// This file's own `library()` / `require()` attaches as `Package` layers,

--- a/crates/oak_db/src/file_resolve.rs
+++ b/crates/oak_db/src/file_resolve.rs
@@ -268,12 +268,14 @@ fn resolve_import_layer<'db>(
     let package = match layer {
         ImportLayer::File(target) => return target.resolve_export(db, name),
         ImportLayer::Package(package) => *package,
-        ImportLayer::From(map) => match map.get(name.text(db).as_str()) {
-            Some(source) => match db.package_by_name(source) {
-                Some(package) => package,
+        ImportLayer::From(importer) => {
+            match importer.imported_from(db).get(name.text(db).as_str()) {
+                Some(source) => match db.package_by_name(source) {
+                    Some(package) => package,
+                    None => return Vec::new(),
+                },
                 None => return Vec::new(),
-            },
-            None => return Vec::new(),
+            }
         },
     };
     package.resolve(db, name, NamespaceVisibility::Exported)

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -8,6 +8,7 @@ use oak_semantic::effects;
 use oak_semantic::EffectsHandlers;
 use oak_semantic::ImportsResolver;
 use oak_semantic::SourceResolution;
+use rustc_hash::FxHashMap;
 use url::Url;
 
 use crate::file_imports::CollationView;
@@ -45,11 +46,50 @@ pub(crate) struct SalsaImportsResolver<'db> {
     db: &'db dyn Db,
     /// The file currently being indexed.
     file: File,
+    cache: EffectsCache,
 }
 
 impl<'db> SalsaImportsResolver<'db> {
     pub(crate) fn new(db: &'db dyn Db, file: File) -> Self {
-        Self { db, file }
+        Self {
+            db,
+            file,
+            cache: EffectsCache::default(),
+        }
+    }
+}
+
+/// Per-build memo for `resolve_effects`, keyed on `(name, attached, lazy)`.
+/// Sound because the answer only depends on the frozen db, and a
+/// `SalsaImportsResolver` lives exactly as long as one `File::semantic_index`
+/// build.
+#[derive(Default)]
+struct EffectsCache {
+    eager: FxHashMap<Vec<String>, FxHashMap<String, Option<EffectsHandlers>>>,
+    lazy: FxHashMap<Vec<String>, FxHashMap<String, Option<EffectsHandlers>>>,
+}
+
+impl EffectsCache {
+    fn get(&self, name: &str, attached: &[String], lazy: bool) -> Option<Option<EffectsHandlers>> {
+        let map = if lazy { &self.lazy } else { &self.eager };
+        map.get(attached)?.get(name).copied()
+    }
+
+    fn insert(
+        &mut self,
+        name: &str,
+        attached: &[String],
+        lazy: bool,
+        effects: Option<EffectsHandlers>,
+    ) {
+        let map = if lazy {
+            &mut self.lazy
+        } else {
+            &mut self.eager
+        };
+        map.entry(attached.to_vec())
+            .or_default()
+            .insert(name.to_string(), effects);
     }
 }
 
@@ -94,47 +134,14 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
         &mut self,
         name: &str,
         attached: &[String],
-        _lazy: bool,
+        lazy: bool,
     ) -> Option<EffectsHandlers> {
-        // Walk the same load-time layer chain as `File::resolve`, but map each
-        // layer to an NSE effect instead of a definition.
-        //
-        // Always the eager (predecessors-only) view, even for a lazy callee. A
-        // top-level callee only sees names loaded before it, so eager is exact
-        // there. A lazy callee (a function body) runs after the whole package
-        // has loaded, so R would resolve it against every sibling, and
-        // `File::resolve` does use the lazy view for that case. We can't here.
-        // This runs while the file's own index is being built, and the lazy
-        // view would read a collation successor's `exports`, whose own build
-        // reads back into this file and cycles (salsa recovers with empty
-        // exports, so the extra shadow detection it would buy is degraded
-        // anyway). A later sibling that shadows a lazy NSE call is missed here,
-        // and is linted later on.
-        let layers = self.file.cross_file_layers(self.db, CollationView::Eager);
-
-        // The file's own attaches slot between the definition/namespace band
-        // and the rest of the search path, exactly as in `File::imports`.
-        // `attached` is the builder's flow-ordered set (latest last), so
-        // eager/lazy flow-sensitivity is already applied; reverse it to LIFO so
-        // a later attach shadows an earlier one.
-        let own: Vec<ImportLayer> = attached
-            .iter()
-            .rev()
-            .filter_map(|package| self.db.package_by_name(package).map(ImportLayer::Package))
-            .collect();
-
-        for layer in layers.splice_own_attaches(own) {
-            if let ControlFlow::Break(effect) = self.layer_effect(&layer, name) {
-                return effect;
-            }
+        if let Some(effects) = self.cache.get(name, attached, lazy) {
+            return effects;
         }
-
-        // base is the bottom of every R search path and is present in any
-        // session, so its builtins (`library`, `source`, `quote`, `local`, ...)
-        // resolve by name here even when base isn't scanned into a root. A
-        // definition or a higher package on the path shadows it, which the walk
-        // above already handled before falling through.
-        effects::lookup("base", name).copied()
+        let effects = self.resolve_effects_uncached(name, attached, lazy);
+        self.cache.insert(name, attached, lazy, effects);
+        effects
     }
 }
 
@@ -151,6 +158,58 @@ enum PackageBinding {
 }
 
 impl<'db> SalsaImportsResolver<'db> {
+    /// Walks the same load-time layer chain as `File::resolve`, but maps each
+    /// layer to an NSE effect instead of a definition.
+    ///
+    /// Always the eager (predecessors-only) view, even for a lazy callee. A
+    /// top-level callee only sees names loaded before it, so eager is exact
+    /// there. A lazy callee (a function body) runs after the whole package
+    /// has loaded, so R would resolve it against every sibling, and
+    /// `File::resolve` does use the lazy view for that case. We can't here.
+    /// This runs while the file's own index is being built, and the lazy
+    /// view would read a collation successor's `exports`, whose own build
+    /// reads back into this file and cycles (salsa recovers with empty
+    /// exports, so the extra shadow detection it would buy is degraded
+    /// anyway).
+    ///
+    /// So a collation successor can neither shadow an effect we recognize nor
+    /// supply one we miss, and nothing flags either case. Breaking the cycle
+    /// would mean asking a sibling for its top-level names syntactically,
+    /// rather than for its `exports`.
+    /// TODO(diagnostics): Lint the miss, or narrow the query.
+    fn resolve_effects_uncached(
+        &self,
+        name: &str,
+        attached: &[String],
+        _lazy: bool,
+    ) -> Option<EffectsHandlers> {
+        let layers = self.file.cross_file_layers(self.db, CollationView::Eager);
+
+        // The file's own attaches slot between the definition/namespace band
+        // and the rest of the search path, exactly as in `File::imports`.
+        // `attached` is the builder's flow-ordered set (latest last), so
+        // eager/lazy flow-sensitivity is already applied; reverse it to LIFO so
+        // a later attach shadows an earlier one.
+        let own: Vec<ImportLayer> = attached
+            .iter()
+            .rev()
+            .filter_map(|package| self.db.package_by_name(package).map(ImportLayer::Package))
+            .collect();
+
+        for layer in layers.lookup_order(&own) {
+            if let ControlFlow::Break(effect) = self.layer_effect(layer, name) {
+                return effect;
+            }
+        }
+
+        // base is the bottom of every R search path and is present in any
+        // session, so its builtins (`library`, `source`, `quote`, `local`, ...)
+        // resolve by name here even when base isn't scanned into a root. A
+        // definition or a higher package on the path shadows it, which the walk
+        // above already handled before falling through.
+        effects::lookup("base", name).copied()
+    }
+
     /// Project one import layer to an NSE effect, the effects-side twin of
     /// `resolve_import_layer` in `file_resolve`. Both reduce the layer to the
     /// package it binds `name` to and split on the same cases. Only the

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -220,7 +220,7 @@ impl<'db> SalsaImportsResolver<'db> {
             // A NAMESPACE `importFrom` binds `name` unconditionally (that's what
             // the directive asserts), so it always shadows the search path
             // below. Its effect, if any, comes from the source package.
-            ImportLayer::From(map) => match map.get(name) {
+            ImportLayer::From(importer) => match importer.imported_from(self.db).get(name) {
                 Some(source) => {
                     let effect = self.db.package_by_name(source).and_then(|package| {
                         match self.package_binding(package, name) {
@@ -261,8 +261,8 @@ impl<'db> SalsaImportsResolver<'db> {
         }
         // Exports `name`, so it binds. Chase a re-export for the effect; a plain
         // own definition (no matching `importFrom`) only shadows.
-        match namespace.imports.iter().find(|import| import.name == name) {
-            Some(import) => match effects::lookup(&import.package, name) {
+        match package.imported_from(self.db).get(name) {
+            Some(source) => match effects::lookup(source, name) {
                 Some(effects) => PackageBinding::Effect(*effects),
                 None => PackageBinding::Shadow,
             },

--- a/crates/oak_db/src/imports.rs
+++ b/crates/oak_db/src/imports.rs
@@ -59,35 +59,23 @@ impl<'db> SalsaImportsResolver<'db> {
     }
 }
 
-/// Per-build memo for `resolve_effects`, keyed on `(name, attached, lazy)`.
+/// Per-build memo for `resolve_effects`, keyed on `(name, attached)`.
 /// Sound because the answer only depends on the frozen db, and a
 /// `SalsaImportsResolver` lives exactly as long as one `File::semantic_index`
 /// build.
 #[derive(Default)]
 struct EffectsCache {
-    eager: FxHashMap<Vec<String>, FxHashMap<String, Option<EffectsHandlers>>>,
-    lazy: FxHashMap<Vec<String>, FxHashMap<String, Option<EffectsHandlers>>>,
+    entries: FxHashMap<Vec<String>, FxHashMap<String, Option<EffectsHandlers>>>,
 }
 
 impl EffectsCache {
-    fn get(&self, name: &str, attached: &[String], lazy: bool) -> Option<Option<EffectsHandlers>> {
-        let map = if lazy { &self.lazy } else { &self.eager };
-        map.get(attached)?.get(name).copied()
+    fn get(&self, name: &str, attached: &[String]) -> Option<Option<EffectsHandlers>> {
+        self.entries.get(attached)?.get(name).copied()
     }
 
-    fn insert(
-        &mut self,
-        name: &str,
-        attached: &[String],
-        lazy: bool,
-        effects: Option<EffectsHandlers>,
-    ) {
-        let map = if lazy {
-            &mut self.lazy
-        } else {
-            &mut self.eager
-        };
-        map.entry(attached.to_vec())
+    fn insert(&mut self, name: &str, attached: &[String], effects: Option<EffectsHandlers>) {
+        self.entries
+            .entry(attached.to_vec())
             .or_default()
             .insert(name.to_string(), effects);
     }
@@ -130,17 +118,12 @@ impl<'db> ImportsResolver for SalsaImportsResolver<'db> {
         })
     }
 
-    fn resolve_effects(
-        &mut self,
-        name: &str,
-        attached: &[String],
-        lazy: bool,
-    ) -> Option<EffectsHandlers> {
-        if let Some(effects) = self.cache.get(name, attached, lazy) {
+    fn resolve_effects(&mut self, name: &str, attached: &[String]) -> Option<EffectsHandlers> {
+        if let Some(effects) = self.cache.get(name, attached) {
             return effects;
         }
-        let effects = self.resolve_effects_uncached(name, attached, lazy);
-        self.cache.insert(name, attached, lazy, effects);
+        let effects = self.resolve_effects_uncached(name, attached);
+        self.cache.insert(name, attached, effects);
         effects
     }
 }
@@ -172,17 +155,13 @@ impl<'db> SalsaImportsResolver<'db> {
     /// exports, so the extra shadow detection it would buy is degraded
     /// anyway).
     ///
-    /// So a collation successor can neither shadow an effect we recognize nor
-    /// supply one we miss, and nothing flags either case. Breaking the cycle
-    /// would mean asking a sibling for its top-level names syntactically,
-    /// rather than for its `exports`.
-    /// TODO(diagnostics): Lint the miss, or narrow the query.
-    fn resolve_effects_uncached(
-        &self,
-        name: &str,
-        attached: &[String],
-        _lazy: bool,
-    ) -> Option<EffectsHandlers> {
+    /// A later sibling that shadows a lazy NSE call is missed here, and nothing
+    /// flags it.
+    ///
+    /// TODO(diagnostics): Detect it in the post-index diagnostics query, where
+    /// reading a successor's `exports` doesn't cycle. Unlike the ambiguities the
+    /// builder records, this one can't be seen from inside the file.
+    fn resolve_effects_uncached(&self, name: &str, attached: &[String]) -> Option<EffectsHandlers> {
         let layers = self.file.cross_file_layers(self.db, CollationView::Eager);
 
         // The file's own attaches slot between the definition/namespace band

--- a/crates/oak_db/src/package.rs
+++ b/crates/oak_db/src/package.rs
@@ -6,6 +6,7 @@ use oak_package_metadata::description::Description;
 use oak_package_metadata::description::Priority;
 use oak_package_metadata::index::Index;
 use oak_package_metadata::namespace::Namespace;
+use rustc_hash::FxHashMap;
 use stdext::result::ResultExt;
 
 use crate::file_revision::report_untracked_if_zero;
@@ -127,6 +128,23 @@ impl Package {
                 Namespace::default()
             },
         }
+    }
+
+    /// NAMESPACE `importFrom` entries keyed by imported name, each mapping to
+    /// its source package name. Lets the resolution paths look up a name
+    /// directly instead of scanning [`Namespace::imports`].
+    ///
+    /// The value is the source package's name, not a resolved `Package`:
+    /// resolving through [`Db::package_by_name`] depends on which roots are
+    /// live, and baking that in here would invalidate this index on every
+    /// root change. Call sites resolve the name themselves.
+    #[salsa::tracked(returns(ref))]
+    pub(crate) fn imported_from(self, db: &dyn Db) -> FxHashMap<String, String> {
+        self.namespace(db)
+            .imports
+            .iter()
+            .map(|import| (import.name.clone(), import.package.clone()))
+            .collect()
     }
 
     /// The package's `Version:`, parsed lazily from `DESCRIPTION`. `None`

--- a/crates/oak_db/src/package_resolve.rs
+++ b/crates/oak_db/src/package_resolve.rs
@@ -68,13 +68,8 @@ impl<'db> Package {
         // resolve the name among its exports instead.
         if results.is_empty() {
             let name_str = name.text(db).as_str();
-            if let Some(import) = self
-                .namespace(db)
-                .imports
-                .iter()
-                .find(|import| import.name == name_str)
-            {
-                if let Some(source) = db.package_by_name(&import.package) {
+            if let Some(source_name) = self.imported_from(db).get(name_str) {
+                if let Some(source) = db.package_by_name(source_name) {
                     results = source.resolve(db, name, NamespaceVisibility::Exported);
                 }
             }

--- a/crates/oak_db/src/tests/file_imports.rs
+++ b/crates/oak_db/src/tests/file_imports.rs
@@ -174,9 +174,12 @@ fn test_package_file_emits_namespace_and_collation_layers() {
     let mut shape = Vec::new();
     for layer in layers {
         match layer {
-            ImportLayer::From(map) => {
-                let mut entries: Vec<(String, String)> =
-                    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            ImportLayer::From(package) => {
+                let mut entries: Vec<(String, String)> = package
+                    .imported_from(&db)
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
                 entries.sort();
                 shape.push(format!("From({entries:?})"));
             },
@@ -527,9 +530,12 @@ fn shape(db: &TestDb, layers: &[ImportLayer]) -> Vec<String> {
     layers
         .iter()
         .map(|layer| match layer {
-            ImportLayer::From(map) => {
-                let mut entries: Vec<(String, String)> =
-                    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            ImportLayer::From(package) => {
+                let mut entries: Vec<(String, String)> = package
+                    .imported_from(db)
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
                 entries.sort();
                 format!("From({entries:?})")
             },

--- a/crates/oak_semantic/src/builder/effects.rs
+++ b/crates/oak_semantic/src/builder/effects.rs
@@ -115,17 +115,16 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         }
 
         // Now check imports since the symbol is locally unbound
-        let lazy = self.scan_is_lazy();
         let attached = attach_search_path(
             &self.scan.attached_inherited,
             self.scan.attached_so_far.packages(),
         );
-        let effects = self.resolver.resolve_effects(sym, &attached, lazy);
+        let effects = self.resolver.resolve_effects(sym, &attached);
 
         let Some(effects) = effects else {
             // The search path didn't resolve. Probe whether it would have if a
             // dropped attach had survived the join, so we can flag it.
-            self.record_conditional_attach_ambiguity(sym, range, lazy);
+            self.record_conditional_attach_ambiguity(sym, range);
             return None;
         };
 
@@ -254,18 +253,6 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         None
     }
 
-    /// Whether the scan is currently inside a lazy context.
-    ///
-    /// Laziness is monotone from the outside in. Once an enclosing context runs
-    /// lazily, everything nested in it does too, even an eager `local()`.
-    fn scan_is_lazy(&self) -> bool {
-        self.scopes[self.current_scope].kind.is_lazy() ||
-            self.scan
-                .open_scopes
-                .iter()
-                .any(|frame| frame.kind.is_lazy())
-    }
-
     fn record_lazy_shadow_ambiguity(
         &mut self,
         name: String,
@@ -288,12 +275,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
     /// which needs the complete set of lazy-context attaches from a post-pass,
     /// not this call-site probe. That belongs in the future salsa diagnostics
     /// query where this lint family should move too.
-    fn record_conditional_attach_ambiguity(
-        &mut self,
-        sym: &str,
-        call_range: TextRange,
-        lazy: bool,
-    ) {
+    fn record_conditional_attach_ambiguity(&mut self, sym: &str, call_range: TextRange) {
         // A package in `attached_anywhere` but off the search path means it was
         // dropped at a branch or loop join
         let search_path = attach_search_path(
@@ -313,7 +295,7 @@ impl<R: ImportsResolver> SemanticIndexBuilder<R> {
         for (package, attach_range) in dropped.into_iter().rev() {
             if self
                 .resolver
-                .resolve_effects(sym, std::slice::from_ref(&package), lazy)
+                .resolve_effects(sym, std::slice::from_ref(&package))
                 .is_none()
             {
                 continue;

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -27,11 +27,17 @@ mod contrib;
 /// for a name carried by several packages (e.g. `defer()` in both withr and
 /// rlang) are kept in registry order, so `lookup` breaks a tie the same way a
 /// scan of `REGISTRY` would.
-static INDEX: LazyLock<FxHashMap<&'static str, Vec<&'static contrib::Entry>>> =
+static INDEX: LazyLock<FxHashMap<&'static str, Vec<(&'static str, &'static EffectsHandlers)>>> =
     LazyLock::new(|| {
-        let mut index: FxHashMap<&'static str, Vec<&'static contrib::Entry>> = FxHashMap::default();
-        for entry in contrib::REGISTRY.iter().flat_map(|entries| entries.iter()) {
-            index.entry(entry.function).or_default().push(entry);
+        let mut index: FxHashMap<&'static str, Vec<(&'static str, &'static EffectsHandlers)>> =
+            FxHashMap::default();
+        for package in contrib::REGISTRY {
+            for entry in package.functions {
+                index
+                    .entry(entry.function)
+                    .or_default()
+                    .push((package.name, &entry.effects));
+            }
         }
         index
     });
@@ -83,8 +89,8 @@ pub fn lookup(package: &str, function: &str) -> Option<&'static EffectsHandlers>
     INDEX
         .get(function)?
         .iter()
-        .find(|entry| entry.package == package)
-        .map(|entry| &entry.effects)
+        .find(|(entry_package, _)| *entry_package == package)
+        .map(|(_, effects)| *effects)
 }
 
 /// Whether any registry entry annotates `name`. This is the bare-callee front

--- a/crates/oak_semantic/src/effects.rs
+++ b/crates/oak_semantic/src/effects.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use aether_syntax::AnyRArgumentName;
 use aether_syntax::AnyRExpression;
 use aether_syntax::AnyRValue;
@@ -11,6 +13,7 @@ use biome_rowan::AstSeparatedList;
 pub use oak_core::range::RangedAstPtr;
 use oak_core::syntax_ext::RIdentifierExt;
 use oak_core::syntax_ext::RStringValueExt;
+use rustc_hash::FxHashMap;
 
 use crate::semantic_index::EvalEnv;
 use crate::semantic_index::EvalTiming;
@@ -18,6 +21,20 @@ use crate::semantic_index::EvalTiming;
 /// Per-package tables of which functions carry effects. Private data behind the
 /// `lookup`/`annotates` query API below.
 mod contrib;
+
+/// Registry entries keyed by function name so they can be queried by `lookup()`
+/// (package plus function) and `annotates()` (function only) probe on. Entries
+/// for a name carried by several packages (e.g. `defer()` in both withr and
+/// rlang) are kept in registry order, so `lookup` breaks a tie the same way a
+/// scan of `REGISTRY` would.
+static INDEX: LazyLock<FxHashMap<&'static str, Vec<&'static contrib::Entry>>> =
+    LazyLock::new(|| {
+        let mut index: FxHashMap<&'static str, Vec<&'static contrib::Entry>> = FxHashMap::default();
+        for entry in contrib::REGISTRY.iter().flat_map(|entries| entries.iter()) {
+            index.entry(entry.function).or_default().push(entry);
+        }
+        index
+    });
 
 /// Effects of a call, resolved against the call site.
 #[derive(Debug, Clone, Default)]
@@ -63,10 +80,10 @@ pub struct EffectsHandlers {
 
 /// Look up the effect handlers of a `(package, function)` pair.
 pub fn lookup(package: &str, function: &str) -> Option<&'static EffectsHandlers> {
-    contrib::REGISTRY
+    INDEX
+        .get(function)?
         .iter()
-        .flat_map(|entries| entries.iter())
-        .find(|entry| entry.package == package && entry.function == function)
+        .find(|entry| entry.package == package)
         .map(|entry| &entry.effects)
 }
 
@@ -74,10 +91,7 @@ pub fn lookup(package: &str, function: &str) -> Option<&'static EffectsHandlers>
 /// gate: an unannotated name can't resolve to an effect no matter which provider
 /// wins, so recognition skips resolution entirely.
 pub fn annotates(name: &str) -> bool {
-    contrib::REGISTRY
-        .iter()
-        .flat_map(|entries| entries.iter())
-        .any(|entry| entry.function == name)
+    INDEX.contains_key(name)
 }
 
 /// Resolver for an effect of a call.

--- a/crates/oak_semantic/src/effects/contrib.rs
+++ b/crates/oak_semantic/src/effects/contrib.rs
@@ -11,17 +11,21 @@ mod withr;
 // Fields are read by the query API (`lookup`, `annotates`) in the parent
 // `effects` module, hence `pub(super)`.
 pub(crate) struct Entry {
-    pub(super) package: &'static str,
     pub(super) function: &'static str,
     pub(super) effects: EffectsHandlers,
+}
+
+/// A package's function entries, grouped under the name they all share.
+pub(crate) struct PackageEntries {
+    pub(super) name: &'static str,
+    pub(super) functions: &'static [Entry],
 }
 
 /// An NSE entry. Each `(name, position, scope, laziness)` tuple is a scoped
 /// argument; list more than one for a function that scopes several.
 macro_rules! nse {
-    ($pkg:literal, $func:literal, $(($name:literal, $pos:literal, $scope:expr, $timing:expr)),+ $(,)?) => {
+    ($func:literal, $(($name:literal, $pos:literal, $scope:expr, $timing:expr)),+ $(,)?) => {
         $crate::effects::contrib::Entry {
-            package: $pkg,
             function: $func,
             effects: $crate::effects::EffectsHandlers {
                 arguments: Some(&$crate::effects::ArgumentsAnnotation {
@@ -47,9 +51,8 @@ pub(crate) use nse;
 /// unevaluated: its symbols aren't uses and nothing in it runs. `quote`,
 /// `bquote`.
 macro_rules! quoted {
-    ($pkg:literal, $func:literal, $(($name:literal, $pos:literal)),+ $(,)?) => {
+    ($func:literal, $(($name:literal, $pos:literal)),+ $(,)?) => {
         $crate::effects::contrib::Entry {
-            package: $pkg,
             function: $func,
             effects: $crate::effects::EffectsHandlers {
                 arguments: Some(&$crate::effects::ArgumentsAnnotation {
@@ -71,9 +74,8 @@ pub(crate) use quoted;
 /// A source entry: `(path-argument position)`. The function reads and evaluates
 /// another file, injecting its top-level names into the caller.
 macro_rules! source {
-    ($pkg:literal, $func:literal, $pos:literal) => {
+    ($func:literal, $pos:literal) => {
         $crate::effects::contrib::Entry {
-            package: $pkg,
             function: $func,
             effects: $crate::effects::EffectsHandlers {
                 arguments: None,
@@ -90,9 +92,8 @@ pub(crate) use source;
 /// current scope, naming it in a positional argument it evaluates (`assign("x",
 /// v)`).
 macro_rules! assign {
-    ($pkg:literal, $func:literal, $pos:literal) => {
+    ($func:literal, $pos:literal) => {
         $crate::effects::contrib::Entry {
-            package: $pkg,
             function: $func,
             effects: $crate::effects::EffectsHandlers {
                 arguments: None,
@@ -110,9 +111,8 @@ pub(crate) use assign;
 /// unevaluated, so the name comes from the LHS text rather than a positional
 /// argument, hence no position.
 macro_rules! assign_op {
-    ($pkg:literal, $func:literal, $target:expr) => {
+    ($func:literal, $target:expr) => {
         $crate::effects::contrib::Entry {
-            package: $pkg,
             function: $func,
             effects: $crate::effects::EffectsHandlers {
                 arguments: None,
@@ -125,12 +125,33 @@ macro_rules! assign_op {
 }
 pub(crate) use assign_op;
 
-pub(super) static REGISTRY: &[&[Entry]] = &[
-    base::ENTRIES,
-    magrittr::ENTRIES,
-    rlang::ENTRIES,
-    s7::ENTRIES,
-    shiny::ENTRIES,
-    testthat::ENTRIES,
-    withr::ENTRIES,
+pub(super) static REGISTRY: &[PackageEntries] = &[
+    PackageEntries {
+        name: "base",
+        functions: base::ENTRIES,
+    },
+    PackageEntries {
+        name: "magrittr",
+        functions: magrittr::ENTRIES,
+    },
+    PackageEntries {
+        name: "rlang",
+        functions: rlang::ENTRIES,
+    },
+    PackageEntries {
+        name: "S7",
+        functions: s7::ENTRIES,
+    },
+    PackageEntries {
+        name: "shiny",
+        functions: shiny::ENTRIES,
+    },
+    PackageEntries {
+        name: "testthat",
+        functions: testthat::ENTRIES,
+    },
+    PackageEntries {
+        name: "withr",
+        functions: withr::ENTRIES,
+    },
 ];

--- a/crates/oak_semantic/src/effects/contrib/base.rs
+++ b/crates/oak_semantic/src/effects/contrib/base.rs
@@ -19,22 +19,21 @@ use crate::semantic_index::EvalTiming::Lazy;
 
 pub(crate) static ENTRIES: &[Entry] = &[
     // base NSE
-    nse!("base", "evalq", ("expr", 0, Current, Eager)),
+    nse!("evalq", ("expr", 0, Current, Eager)),
     // `on.exit(expr)` captures `expr` and runs it in the current function's
     // frame when the function exits. Bindings land in that frame (`Current`) at
     // an unknown later time (`Lazy`), the same shape as `rlang::on_load()`.
-    nse!("base", "on.exit", ("expr", 0, Current, Lazy)),
-    nse!("base", "local", ("expr", 0, Nested, Eager)),
-    nse!("base", "with", ("expr", 1, Nested, Eager)),
-    nse!("base", "with.default", ("expr", 1, Nested, Eager)),
-    nse!("base", "within", ("expr", 1, Nested, Eager)),
-    nse!("base", "within.data.frame", ("expr", 1, Nested, Eager)),
+    nse!("on.exit", ("expr", 0, Current, Lazy)),
+    nse!("local", ("expr", 0, Nested, Eager)),
+    nse!("with", ("expr", 1, Nested, Eager)),
+    nse!("with.default", ("expr", 1, Nested, Eager)),
+    nse!("within", ("expr", 1, Nested, Eager)),
+    nse!("within.data.frame", ("expr", 1, Nested, Eager)),
     // base quote
-    quoted!("base", "quote", ("expr", 0)),
+    quoted!("quote", ("expr", 0)),
     // `bquote` quotes `expr` too, but its `.()` holes escape to evaluation, so
     // it needs a handler rather than a static per-argument effect.
     Entry {
-        package: "base",
         function: "bquote",
         effects: EffectsHandlers {
             arguments: Some(&BquoteHandler),
@@ -47,7 +46,6 @@ pub(crate) static ENTRIES: &[Entry] = &[
     // binds, so it needs a handler that queries the scope rather than a static
     // per-argument effect.
     Entry {
-        package: "base",
         function: "substitute",
         effects: EffectsHandlers {
             arguments: Some(&SubstituteHandler),
@@ -60,16 +58,15 @@ pub(crate) static ENTRIES: &[Entry] = &[
     attach_entry("library"),
     attach_entry("require"),
     // base source
-    source!("base", "source", 0),
+    source!("source", 0),
     // base assign
-    assign!("base", "assign", 0),
-    assign!("base", "delayedAssign", 0),
+    assign!("assign", 0),
+    assign!("delayedAssign", 0),
 ];
 
 /// Build the attach [`Entry`] for a base function served by [`LibraryHandler`].
 const fn attach_entry(function: &'static str) -> Entry {
     Entry {
-        package: "base",
         function,
         effects: EffectsHandlers {
             arguments: None,

--- a/crates/oak_semantic/src/effects/contrib/magrittr.rs
+++ b/crates/oak_semantic/src/effects/contrib/magrittr.rs
@@ -2,4 +2,4 @@ use crate::effects::contrib::assign_op;
 use crate::effects::contrib::Entry;
 use crate::effects::TargetAccess::ReadWrite;
 
-pub(crate) static ENTRIES: &[Entry] = &[assign_op!("magrittr", "%<>%", ReadWrite)];
+pub(crate) static ENTRIES: &[Entry] = &[assign_op!("%<>%", ReadWrite)];

--- a/crates/oak_semantic/src/effects/contrib/rlang.rs
+++ b/crates/oak_semantic/src/effects/contrib/rlang.rs
@@ -6,10 +6,10 @@ use crate::semantic_index::EvalEnv::Current;
 use crate::semantic_index::EvalTiming::Lazy;
 
 pub(crate) static ENTRIES: &[Entry] = &[
-    assign_op!("rlang", "%<~%", Write),
-    nse!("rlang", "on_load", ("expr", 0, Current, Lazy)),
+    assign_op!("%<~%", Write),
+    nse!("on_load", ("expr", 0, Current, Lazy)),
     // `defer(expr, env = caller_env())` runs `expr` in the caller frame when it
     // exits. Written in a function, that frame is the function itself, so it's
     // `Current + Lazy` like `on.exit`. A non-default `env` isn't modeled.
-    nse!("rlang", "defer", ("expr", 0, Current, Lazy)),
+    nse!("defer", ("expr", 0, Current, Lazy)),
 ];

--- a/crates/oak_semantic/src/effects/contrib/s7.rs
+++ b/crates/oak_semantic/src/effects/contrib/s7.rs
@@ -2,4 +2,4 @@ use crate::effects::contrib::assign_op;
 use crate::effects::contrib::Entry;
 use crate::effects::TargetAccess::Write;
 
-pub(crate) static ENTRIES: &[Entry] = &[assign_op!("S7", ":=", Write)];
+pub(crate) static ENTRIES: &[Entry] = &[assign_op!(":=", Write)];

--- a/crates/oak_semantic/src/effects/contrib/shiny.rs
+++ b/crates/oak_semantic/src/effects/contrib/shiny.rs
@@ -4,11 +4,11 @@ use crate::semantic_index::EvalEnv::Nested;
 use crate::semantic_index::EvalTiming::Lazy;
 
 pub(crate) static ENTRIES: &[Entry] = &[
-    nse!("shiny", "observe", ("x", 0, Nested, Lazy)),
-    nse!("shiny", "reactive", ("x", 0, Nested, Lazy)),
-    nse!("shiny", "renderPlot", ("expr", 0, Nested, Lazy)),
-    nse!("shiny", "renderPrint", ("expr", 0, Nested, Lazy)),
-    nse!("shiny", "renderTable", ("expr", 0, Nested, Lazy)),
-    nse!("shiny", "renderText", ("expr", 0, Nested, Lazy)),
-    nse!("shiny", "renderUI", ("expr", 0, Nested, Lazy)),
+    nse!("observe", ("x", 0, Nested, Lazy)),
+    nse!("reactive", ("x", 0, Nested, Lazy)),
+    nse!("renderPlot", ("expr", 0, Nested, Lazy)),
+    nse!("renderPrint", ("expr", 0, Nested, Lazy)),
+    nse!("renderTable", ("expr", 0, Nested, Lazy)),
+    nse!("renderText", ("expr", 0, Nested, Lazy)),
+    nse!("renderUI", ("expr", 0, Nested, Lazy)),
 ];

--- a/crates/oak_semantic/src/effects/contrib/testthat.rs
+++ b/crates/oak_semantic/src/effects/contrib/testthat.rs
@@ -3,4 +3,4 @@ use crate::effects::contrib::Entry;
 use crate::semantic_index::EvalEnv::Nested;
 use crate::semantic_index::EvalTiming::Eager;
 
-pub(crate) static ENTRIES: &[Entry] = &[nse!("testthat", "test_that", ("code", 1, Nested, Eager))];
+pub(crate) static ENTRIES: &[Entry] = &[nse!("test_that", ("code", 1, Nested, Eager))];

--- a/crates/oak_semantic/src/effects/contrib/withr.rs
+++ b/crates/oak_semantic/src/effects/contrib/withr.rs
@@ -7,5 +7,5 @@ pub(crate) static ENTRIES: &[Entry] = &[
     // `defer(expr, envir = parent.frame())` runs `expr` in the caller frame when
     // it exits, the same `Current + Lazy` shape as `on.exit`. A non-default
     // `envir` isn't modeled.
-    nse!("withr", "defer", ("expr", 0, Current, Lazy)),
+    nse!("defer", ("expr", 0, Current, Lazy)),
 ];

--- a/crates/oak_semantic/src/resolver.rs
+++ b/crates/oak_semantic/src/resolver.rs
@@ -48,19 +48,12 @@ pub trait ImportsResolver {
     /// Returns `None` when the target can't be located.
     fn resolve_source(&mut self, path: &str) -> Option<SourceResolution>;
 
-    /// Resolve a bare callee `name` to its effects. The builder state is passed
-    /// in because the resolver can't query our own semantic index without
-    /// creating a cycle:
-    ///
-    /// - `attached`: packages attached at this point, in flow order.
-    /// - `lazy`: whether the callee sits in a lazy context like a function.
-    fn resolve_effects(
-        &mut self,
-        name: &str,
-        attached: &[String],
-        lazy: bool,
-    ) -> Option<EffectsHandlers> {
-        let _ = (name, attached, lazy);
+    /// Resolve a bare callee `name` to its effects. `attached` is the packages
+    /// attached at this point, in flow order. The builder passes it in because
+    /// the resolver can't query our own semantic index without creating a
+    /// cycle.
+    fn resolve_effects(&mut self, name: &str, attached: &[String]) -> Option<EffectsHandlers> {
+        let _ = (name, attached);
         None
     }
 

--- a/crates/oak_semantic/tests/integration/contrib/base.rs
+++ b/crates/oak_semantic/tests/integration/contrib/base.rs
@@ -67,7 +67,7 @@ impl ImportsResolver for ConstResolver {
         Some(self.0.clone())
     }
 
-    fn resolve_effects(&mut self, name: &str, _: &[String], _: bool) -> Option<EffectsHandlers> {
+    fn resolve_effects(&mut self, name: &str, _: &[String]) -> Option<EffectsHandlers> {
         // `source()` recognition runs on the resolve path, so a source-only
         // resolver still has to resolve base effects for `source` to be seen.
         effects::lookup("base", name).copied()
@@ -82,7 +82,7 @@ impl ImportsResolver for MapResolver {
         self.0.get(path).cloned()
     }
 
-    fn resolve_effects(&mut self, name: &str, _: &[String], _: bool) -> Option<EffectsHandlers> {
+    fn resolve_effects(&mut self, name: &str, _: &[String]) -> Option<EffectsHandlers> {
         effects::lookup("base", name).copied()
     }
 }
@@ -98,7 +98,7 @@ impl ImportsResolver for MultiFileResolver {
         self.sources.get(path).cloned()
     }
 
-    fn resolve_effects(&mut self, name: &str, _: &[String], _: bool) -> Option<EffectsHandlers> {
+    fn resolve_effects(&mut self, name: &str, _: &[String]) -> Option<EffectsHandlers> {
         if name == "source" {
             return Some(EffectsHandlers {
                 arguments: None,
@@ -122,7 +122,7 @@ impl ImportsResolver for PositionResolver {
         None
     }
 
-    fn resolve_effects(&mut self, name: &str, _: &[String], _: bool) -> Option<EffectsHandlers> {
+    fn resolve_effects(&mut self, name: &str, _: &[String]) -> Option<EffectsHandlers> {
         if name == "source" {
             return Some(EffectsHandlers {
                 arguments: None,
@@ -142,7 +142,7 @@ impl ImportsResolver for MultiAssignResolver {
         None
     }
 
-    fn resolve_effects(&mut self, name: &str, _: &[String], _: bool) -> Option<EffectsHandlers> {
+    fn resolve_effects(&mut self, name: &str, _: &[String]) -> Option<EffectsHandlers> {
         if name == "assign" {
             return Some(EffectsHandlers {
                 arguments: None,
@@ -2557,63 +2557,6 @@ local({
         index.symbols(inner_local).get("y").unwrap().flags(),
         SymbolFlags::IS_BOUND
     );
-}
-
-#[test]
-fn test_nse_descent_lazy_flag_eager_vs_lazy_context() {
-    // An eager callee at file scope consults with `lazy = false`; the same
-    // callee inside a function body consults with `lazy = true`.
-    let resolver = TestImportsResolver::with_base();
-    let log = resolver.consultation_log();
-
-    build_with(
-        "\
-local({ x <- 1 })
-f <- function() {
-    local({ y <- 1 })
-}
-",
-        resolver,
-    );
-
-    let records = log.borrow();
-    let local_lazy: Vec<bool> = records
-        .iter()
-        .filter(|(name, _lazy)| name == "local")
-        .map(|(_name, lazy)| *lazy)
-        .collect();
-    assert_eq!(local_lazy, vec![false, true]);
-}
-
-#[test]
-fn test_nse_descent_eager_in_eager_in_function_stays_lazy() {
-    // An eager `local` nested inside another eager `local` inside a function
-    // still consults with `lazy = true`. Laziness is a property of the enclosing
-    // scan unit (the function), which the descent preserves by keeping
-    // `current_scope` on the function while it scans both eager bodies inline. If
-    // the inner `local` were resolved against its immediate eager scope instead,
-    // `is_lazy()` would read `false` and the flag would regress.
-    let resolver = TestImportsResolver::with_base();
-    let log = resolver.consultation_log();
-
-    build_with(
-        "\
-f <- function() {
-    local({
-        local({ x <- 1 })
-    })
-}
-",
-        resolver,
-    );
-
-    let records = log.borrow();
-    let local_lazy: Vec<bool> = records
-        .iter()
-        .filter(|(name, _lazy)| name == "local")
-        .map(|(_name, lazy)| *lazy)
-        .collect();
-    assert_eq!(local_lazy, vec![true, true]);
 }
 
 // --- Attach tracking ---

--- a/crates/oak_semantic/tests/integration/resolvers.rs
+++ b/crates/oak_semantic/tests/integration/resolvers.rs
@@ -1,5 +1,4 @@
 use std::cell::Cell;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -22,9 +21,6 @@ pub struct TestImportsResolver {
     /// Count of `resolve_effects` consultations, so tests can assert the front
     /// gate keeps unannotated names off the resolver.
     consultations: Rc<Cell<usize>>,
-    /// Per-consultation `(name, lazy)` records, so tests can pin the `lazy` flag
-    /// the builder derives from the callee's context.
-    consultation_log: Rc<RefCell<Vec<(String, bool)>>>,
     /// `source()` paths this resolver knows, mapped to the names they export.
     sources: HashMap<String, SourceResolution>,
 }
@@ -45,7 +41,6 @@ impl TestImportsResolver {
         Self {
             always_attached,
             consultations: Rc::new(Cell::new(0)),
-            consultation_log: Rc::new(RefCell::new(Vec::new())),
             sources: HashMap::new(),
         }
     }
@@ -67,12 +62,6 @@ impl TestImportsResolver {
     pub fn consultations(&self) -> Rc<Cell<usize>> {
         Rc::clone(&self.consultations)
     }
-
-    /// A handle to the per-consultation `(name, lazy)` log. Clone it before
-    /// moving the resolver into `build_index`, then read it after the build.
-    pub fn consultation_log(&self) -> Rc<RefCell<Vec<(String, bool)>>> {
-        Rc::clone(&self.consultation_log)
-    }
 }
 
 impl ImportsResolver for TestImportsResolver {
@@ -80,16 +69,8 @@ impl ImportsResolver for TestImportsResolver {
         self.sources.get(path).cloned()
     }
 
-    fn resolve_effects(
-        &mut self,
-        name: &str,
-        attached: &[String],
-        lazy: bool,
-    ) -> Option<EffectsHandlers> {
+    fn resolve_effects(&mut self, name: &str, attached: &[String]) -> Option<EffectsHandlers> {
         self.consultations.set(self.consultations.get() + 1);
-        self.consultation_log
-            .borrow_mut()
-            .push((name.to_string(), lazy));
         attached
             .iter()
             .rev()


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/ark/issues/1338

-  Effect resolution now memoizes per `(name, attached)` pair to avoid rewalking the cross-file layer chain on every call.

- The static effect registry (`base`, `magrittr`, `rlang`, `S7`, `shiny`, `testthat`, `withr`) is now indexed by name in a `LazyLock<FxHashMap>` built once, to avoid a linear scan on every `lookup()`/`annotates()` call.

- `ImportLayer::From` now holds the `Package` itself instead of a freshly-rebuilt `HashMap` of its `importFrom` table. The map is now cached by its own query (`Package::imported_from()`).

### Positron Release Notes

<!--
  These notes are typically filled by the Positron team. If you are an external
  contributor, you may leave the `N/A` bullets in place.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A
