### PR TITLE
Respect a lone `fig-width` or `fig-height` in plot sizing metadata

### DIFF
--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -984,6 +984,11 @@ const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
 /// Default aspect ratio (width:height) used when only output_width_px is provided.
 const DEFAULT_ASPECT_RATIO: f64 = 4.0 / 3.0;
 
+/// Default figure size in inches, matching Quarto's defaults
+/// (`fig-width: 7`, `fig-height: 5`).
+const DEFAULT_FIG_WIDTH: f64 = 7.0;
+const DEFAULT_FIG_HEIGHT: f64 = 5.0;
+
 trait IntrinsicSizeExt {
     /// Convert an intrinsic size to a logical-pixel-based `PlotSize`.
     ///
@@ -1014,8 +1019,9 @@ trait FromExecuteRequest: Sized {
 impl FromExecuteRequest for PlotRenderSettings {
     /// Create render settings from an execute request's Positron metadata.
     ///
-    /// If `fig_width`/`fig_height` are both set (Quarto), returns settings with
-    /// size in logical pixels (inches * 96 DPI).
+    /// If `fig_width` and/or `fig_height` is set (Quarto), returns settings
+    /// with size in logical pixels (inches * DPI). Either dimension may be set
+    /// alone; the missing one falls back to the Quarto default.
     ///
     /// Otherwise if `output_width_px` is set, returns settings at that width
     /// with a 4:3 aspect ratio.
@@ -1025,17 +1031,15 @@ impl FromExecuteRequest for PlotRenderSettings {
     fn from_execute_request(req: &ExecuteRequestPositron) -> Option<Self> {
         let pixel_ratio = req.output_pixel_ratio.unwrap_or(1.0);
 
-        if let (Some(w), Some(h)) = (req.fig_width, req.fig_height) {
-            if w > 0.0 && h > 0.0 {
-                return Some(Self {
-                    size: PlotSize {
-                        width: (w * DEFAULT_DPI).round() as i64,
-                        height: (h * DEFAULT_DPI).round() as i64,
-                    },
-                    pixel_ratio,
-                    format: PlotRenderFormat::Png,
-                });
-            }
+        if let Some((width, height)) = requested_fig_size(req) {
+            return Some(Self {
+                size: PlotSize {
+                    width: (width * DEFAULT_DPI).round() as i64,
+                    height: (height * DEFAULT_DPI).round() as i64,
+                },
+                pixel_ratio,
+                format: PlotRenderFormat::Png,
+            });
         }
 
         if let Some(width_px) = req.output_width_px {
@@ -1058,22 +1062,37 @@ impl FromExecuteRequest for PlotRenderSettings {
 impl FromExecuteRequest for IntrinsicSize {
     /// Create an intrinsic size from an execute request's Positron metadata.
     ///
-    /// Only returns `Some` when both `fig_width` and `fig_height` are set
+    /// Only returns `Some` when `fig_width` and/or `fig_height` is set
     /// (i.e. Quarto sizing), providing the intrinsic size in inches.
     fn from_execute_request(req: &ExecuteRequestPositron) -> Option<Self> {
-        if let (Some(w), Some(h)) = (req.fig_width, req.fig_height) {
-            if w > 0.0 && h > 0.0 {
-                return Some(Self {
-                    width: w,
-                    height: h,
-                    unit: PlotUnit::Inches,
-                    source: String::from("Quarto"),
-                });
-            }
-        }
+        let (width, height) = requested_fig_size(req)?;
 
-        None
+        Some(Self {
+            width,
+            height,
+            unit: PlotUnit::Inches,
+            source: String::from("Quarto"),
+        })
     }
+}
+
+/// The figure size requested via `fig-width`/`fig-height`, in inches.
+///
+/// Either option may be set alone, matching `quarto render`; the missing (or
+/// non-positive) dimension falls back to the Quarto default. Returns `None`
+/// when neither dimension is set.
+fn requested_fig_size(req: &ExecuteRequestPositron) -> Option<(f64, f64)> {
+    let width = req.fig_width.filter(|width| *width > 0.0);
+    let height = req.fig_height.filter(|height| *height > 0.0);
+
+    if width.is_none() && height.is_none() {
+        return None;
+    }
+
+    Some((
+        width.unwrap_or(DEFAULT_FIG_WIDTH),
+        height.unwrap_or(DEFAULT_FIG_HEIGHT),
+    ))
 }
 
 /// Compute render settings and intrinsic size from execute request metadata.

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -984,8 +984,9 @@ const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
 /// Default aspect ratio (width:height) used when only output_width_px is provided.
 const DEFAULT_ASPECT_RATIO: f64 = 4.0 / 3.0;
 
-/// Default figure size in inches, matching Quarto's defaults
-/// (`fig-width: 7`, `fig-height: 5`).
+/// Default figure size in inches, matching Quarto's base/HTML format
+/// defaults (`fig-width: 7`, `fig-height: 5`). Other formats differ (e.g.
+/// pdf is 5.5 x 3.5), but Positron doesn't know the target format.
 const DEFAULT_FIG_WIDTH: f64 = 7.0;
 const DEFAULT_FIG_HEIGHT: f64 = 5.0;
 

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -618,6 +618,76 @@ fn test_plot_with_fig_size_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
+/// Test that a lone fig-width is respected, with the height falling back to
+/// the Quarto default of 5 inches (posit-dev/positron#15259).
+#[test]
+fn test_plot_with_lone_fig_width_metadata() {
+    let frontend = DummyArkFrontend::lock();
+
+    let code = "plot(1:10)";
+    frontend.send_execute_request(code, ExecuteRequestOptions {
+        positron: Some(ExecuteRequestPositron {
+            fig_width: Some(2.0),
+            // Positron sends the output width alongside the cell options;
+            // the requested fig size should win over it
+            output_width_px: Some(600.0),
+            ..Default::default()
+        }),
+        ..ExecuteRequestOptions::default()
+    });
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+
+    let display = frontend.recv_iopub_display_data_content();
+    let png_data = display.data["image/png"]
+        .as_str()
+        .expect("display_data should contain image/png");
+    let (width, height) = png_dimensions(png_data);
+
+    let dpi = default_dpi();
+    // 2 inches * DPI, 5 inches (default) * DPI
+    assert_eq!(width, (2.0 * dpi).round() as u32);
+    assert_eq!(height, (5.0 * dpi).round() as u32);
+
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}
+
+/// Test that a lone fig-height is respected, with the width falling back to
+/// the Quarto default of 7 inches (posit-dev/positron#15259).
+#[test]
+fn test_plot_with_lone_fig_height_metadata() {
+    let frontend = DummyArkFrontend::lock();
+
+    let code = "plot(1:10)";
+    frontend.send_execute_request(code, ExecuteRequestOptions {
+        positron: Some(ExecuteRequestPositron {
+            fig_height: Some(2.0),
+            // Positron sends the output width alongside the cell options;
+            // the requested fig size should win over it
+            output_width_px: Some(600.0),
+            ..Default::default()
+        }),
+        ..ExecuteRequestOptions::default()
+    });
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+
+    let display = frontend.recv_iopub_display_data_content();
+    let png_data = display.data["image/png"]
+        .as_str()
+        .expect("display_data should contain image/png");
+    let (width, height) = png_dimensions(png_data);
+
+    let dpi = default_dpi();
+    // 7 inches (default) * DPI, 2 inches * DPI
+    assert_eq!(width, (7.0 * dpi).round() as u32);
+    assert_eq!(height, (2.0 * dpi).round() as u32);
+
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}
+
 /// Test that plots rendered with output_width_px (but no fig dimensions)
 /// produce a PNG at the expected width with a 4:3 aspect ratio.
 #[test]


### PR DESCRIPTION
Addresses posit-dev/positron#15259, identified in https://github.com/posit-dev/positron/pull/15234#issuecomment-5143761675.

Plot sizing from cell options previously required both `fig-width` and `fig-height`: a lone dimension was ignored and the plot fell back to `output_width_px` sizing. Either option may now be set alone, matching `quarto render` and the Python kernel; the missing dimension falls back to Quarto's default figure size (7 x 5 inches).

### Screenshots

<img width="466" height="961" alt="image" src="https://github.com/user-attachments/assets/e696f28d-f3dd-4ba8-8590-e1e6b495103d" />

<img width="1406" height="530" alt="image" src="https://github.com/user-attachments/assets/0824cc64-4409-408f-bdab-8c1fc72a9dac" />

### QA notes

In a Quarto document with inline output enabled, run a cell containing only `#| fig-width: 2` and `plot(1:10)`. The plot renders 2 inches wide and 5 inches tall. `#| fig-height: 2` alone gives 7 x 2 inches.

### Known issues

* The images are 2x larger than expected because of https://github.com/posit-dev/positron/issues/15261