### PR TITLE
Report logical plot size in `display_data` metadata

### DIFF
--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -678,12 +678,10 @@ impl DeviceContext {
         let ctx = self.capture_execution_context();
         self.store_plot_context(id, &ctx);
 
-        let data = unwrap!(self.create_display_data_plot(id, &ctx), Err(error) => {
+        let (data, metadata) = unwrap!(self.create_display_data_plot(id, &ctx), Err(error) => {
             log::error!("Failed to create plot due to: {error}.");
             return;
         });
-
-        let metadata = json!({});
 
         // For `DisplayData`, the `transient` slot is a simple `Value`,
         // but we can use the `TransientValue` required by `UpdateDisplayData`
@@ -786,12 +784,10 @@ impl DeviceContext {
         log::trace!("Notifying Jupyter frontend of plot update");
 
         let ctx = self.capture_execution_context();
-        let data = unwrap!(self.create_display_data_plot(id, &ctx), Err(error) => {
+        let (data, metadata) = unwrap!(self.create_display_data_plot(id, &ctx), Err(error) => {
             log::error!("Failed to create plot due to: {error}.");
             return;
         });
-
-        let metadata = json!({});
 
         let transient = TransientValue {
             display_id: id.to_string(),
@@ -809,11 +805,17 @@ impl DeviceContext {
             .log_err();
     }
 
+    /// Render a plot for the Jupyter protocol, returning the display data and
+    /// its metadata.
+    ///
+    /// The metadata reports the logical size of the image so that frontends
+    /// display high-DPI renders (`pixel_ratio > 1`) at the intended size
+    /// rather than at their physical pixel size (posit-dev/positron#15261).
     fn create_display_data_plot(
         &self,
         id: &PlotId,
         ctx: &ExecutionContext,
-    ) -> Result<serde_json::Value, anyhow::Error> {
+    ) -> Result<(serde_json::Value, serde_json::Value), anyhow::Error> {
         let base = ctx.render_settings.unwrap_or(PlotRenderSettings {
             size: PlotSize {
                 width: 800,
@@ -844,7 +846,14 @@ impl DeviceContext {
         let mut map = serde_json::Map::new();
         map.insert("image/png".to_string(), serde_json::to_value(data)?);
 
-        Ok(serde_json::Value::Object(map))
+        let metadata = json!({
+            "image/png": {
+                "width": settings.size.width,
+                "height": settings.size.height,
+            }
+        });
+
+        Ok((serde_json::Value::Object(map), metadata))
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -805,12 +805,10 @@ impl DeviceContext {
             .log_err();
     }
 
-    /// Render a plot for the Jupyter protocol, returning the display data and
-    /// its metadata.
+    /// Renders a plot for Jupyter and returns its display data and metadata.
     ///
-    /// The metadata reports the logical size of the image so that frontends
-    /// display high-DPI renders (`pixel_ratio > 1`) at the intended size
-    /// rather than at their physical pixel size (posit-dev/positron#15261).
+    /// The image metadata contains logical dimensions so frontends display HiDPI
+    /// renders at their intended size rather than at their physical pixel dimensions.
     fn create_display_data_plot(
         &self,
         id: &PlotId,

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -841,17 +841,18 @@ impl DeviceContext {
             return Err(anyhow!("Failed to render plot with id {id} due to: {error}."));
         });
 
-        let mut map = serde_json::Map::new();
-        map.insert("image/png".to_string(), serde_json::to_value(data)?);
+        let mime_type = Self::get_mime_type(&settings.format);
+
+        let data = json!({ mime_type: data });
 
         let metadata = json!({
-            "image/png": {
+            mime_type: {
                 "width": settings.size.width,
                 "height": settings.size.height,
             }
         });
 
-        Ok((serde_json::Value::Object(map), metadata))
+        Ok((data, metadata))
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -688,9 +688,8 @@ fn test_plot_with_lone_fig_height_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
-/// Test that plots rendered with a high device pixel ratio report their
-/// logical size in the display_data metadata, so frontends don't display them
-/// at their physical pixel size (posit-dev/positron#15261).
+/// Verifies that a HiDPI plot reports logical dimensions in `display_data`
+/// metadata while the PNG uses physical pixel dimensions.
 #[test]
 fn test_plot_with_pixel_ratio_reports_logical_size_in_metadata() {
     let frontend = DummyArkFrontend::lock();
@@ -718,11 +717,11 @@ fn test_plot_with_pixel_ratio_reports_logical_size_in_metadata() {
     let logical_width = (4.0 * dpi).round() as u32;
     let logical_height = (3.0 * dpi).round() as u32;
 
-    // The PNG itself is rendered at 2x the logical size
+    // A 2x pixel ratio doubles the PNG's physical dimensions.
     assert_eq!(width, logical_width * 2);
     assert_eq!(height, logical_height * 2);
 
-    // The metadata reports the logical size
+    // The metadata preserves the requested logical dimensions.
     let image_metadata = &display.metadata["image/png"];
     assert_eq!(image_metadata["width"], logical_width);
     assert_eq!(image_metadata["height"], logical_height);

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -688,6 +688,49 @@ fn test_plot_with_lone_fig_height_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
+/// Test that plots rendered with a high device pixel ratio report their
+/// logical size in the display_data metadata, so frontends don't display them
+/// at their physical pixel size (posit-dev/positron#15261).
+#[test]
+fn test_plot_with_pixel_ratio_reports_logical_size_in_metadata() {
+    let frontend = DummyArkFrontend::lock();
+
+    let code = "plot(1:10)";
+    frontend.send_execute_request(code, ExecuteRequestOptions {
+        positron: Some(ExecuteRequestPositron {
+            fig_width: Some(4.0),
+            fig_height: Some(3.0),
+            output_pixel_ratio: Some(2.0),
+            ..Default::default()
+        }),
+        ..ExecuteRequestOptions::default()
+    });
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+
+    let display = frontend.recv_iopub_display_data_content();
+    let png_data = display.data["image/png"]
+        .as_str()
+        .expect("display_data should contain image/png");
+    let (width, height) = png_dimensions(png_data);
+
+    let dpi = default_dpi();
+    let logical_width = (4.0 * dpi).round() as u32;
+    let logical_height = (3.0 * dpi).round() as u32;
+
+    // The PNG itself is rendered at 2x the logical size
+    assert_eq!(width, logical_width * 2);
+    assert_eq!(height, logical_height * 2);
+
+    // The metadata reports the logical size
+    let image_metadata = &display.metadata["image/png"];
+    assert_eq!(image_metadata["width"], logical_width);
+    assert_eq!(image_metadata["height"], logical_height);
+
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}
+
 /// Test that plots rendered with output_width_px (but no fig dimensions)
 /// produce a PNG at the expected width with a 4:3 aspect ratio.
 #[test]


### PR DESCRIPTION
Addresses posit-dev/positron#15261.

## Summary

Ark renders notebook plots at `logical size × pixel ratio` physical pixels. Previously, its `display_data` and `update_display_data` messages did not report the intended logical dimensions, so frontends could display a 2× render at twice its requested width and height.

This PR adds standard Jupyter PNG metadata containing the logical `width` and `height`:

```json
{
  "image/png": {
    "width": "<logical width>",
    "height": "<logical height>"
  }
}
```

The PNG retains its higher physical resolution, while frontends—including Positron's Quarto inline-output renderer—display it at the requested logical size.

## Screenshots

**Before**

<img width="897" height="811" alt="Plot displayed at twice its intended size" src="https://github.com/user-attachments/assets/d90034b7-3aae-4d6d-92b4-7cde06af8df3" />

**After**

<img width="538" height="519" alt="Plot displayed at its intended logical size" src="https://github.com/user-attachments/assets/17c9380a-ee6e-4880-958b-13358e56a878" />

## QA

On a HiDPI display, enable inline output in a Quarto document and run:

```r
#| fig-width: 4
#| fig-height: 3
plot(1:10)
```

The plot should:

- display at 4 × 3 inches rather than 8 × 6 inches;
- remain sharp at the display's native pixel ratio.
