### PR TITLE
Render unsized plots at the default figure size in notebook sessions

### DIFF
--- a/crates/amalthea/src/wire/execute_request.rs
+++ b/crates/amalthea/src/wire/execute_request.rs
@@ -53,11 +53,10 @@ pub struct ExecuteRequestPositron {
     #[serde(rename = "fig-height")]
     pub fig_height: Option<f64>,
 
-    /// Output area width in pixels.
+    /// Width of the frontend output area in pixels.
     ///
-    /// Currently unused: unsized plots deliberately render at the default
-    /// figure size rather than scaling with the output area
-    /// (posit-dev/positron#15260).
+    /// Retained for protocol compatibility but not used for plot sizing. Plots
+    /// without explicit dimensions use the default figure size.
     pub output_width_px: Option<f64>,
 
     /// Device pixel ratio of the output area

--- a/crates/amalthea/src/wire/execute_request.rs
+++ b/crates/amalthea/src/wire/execute_request.rs
@@ -53,7 +53,11 @@ pub struct ExecuteRequestPositron {
     #[serde(rename = "fig-height")]
     pub fig_height: Option<f64>,
 
-    /// Output area width in pixels
+    /// Output area width in pixels.
+    ///
+    /// Currently unused: unsized plots deliberately render at the default
+    /// figure size rather than scaling with the output area
+    /// (posit-dev/positron#15260).
     pub output_width_px: Option<f64>,
 
     /// Device pixel ratio of the output area

--- a/crates/ark/src/console/console_graphics.rs
+++ b/crates/ark/src/console/console_graphics.rs
@@ -12,11 +12,10 @@ use amalthea::wire::execute_request::ExecuteRequestPositron;
 use crate::console::Console;
 
 impl Console {
-    /// Push execution context to the graphics device when an execute request starts.
+    /// Pushes execution context to the graphics device when an execute request starts.
     ///
-    /// Stores the execution_id, code, code_location, and any plot sizing
-    /// metadata from the request (fig size, pixel ratio) so they can be
-    /// captured when new plots are created during execution.
+    /// The context attributes newly created plots to the execution and captures its
+    /// requested figure dimensions and device pixel ratio.
     pub(super) fn graphics_on_execute_request(
         &self,
         execution_id: String,

--- a/crates/ark/src/console/console_graphics.rs
+++ b/crates/ark/src/console/console_graphics.rs
@@ -6,32 +6,26 @@
 
 use std::rc::Rc;
 
-use amalthea::comm::plot_comm::IntrinsicSize;
-use amalthea::comm::plot_comm::PlotRenderSettings;
 use amalthea::wire::execute_request::CodeLocation;
+use amalthea::wire::execute_request::ExecuteRequestPositron;
 
 use crate::console::Console;
 
 impl Console {
     /// Push execution context to the graphics device when an execute request starts.
     ///
-    /// Stores the execution_id, code, code_location, and optional sizing overrides
-    /// so they can be captured when new plots are created during execution.
+    /// Stores the execution_id, code, code_location, and any plot sizing
+    /// metadata from the request (fig size, pixel ratio) so they can be
+    /// captured when new plots are created during execution.
     pub(super) fn graphics_on_execute_request(
         &self,
         execution_id: String,
         code: String,
         code_location: Option<CodeLocation>,
-        render_settings: Option<PlotRenderSettings>,
-        intrinsic_size: Option<IntrinsicSize>,
+        positron: Option<&ExecuteRequestPositron>,
     ) {
-        self.device_context().set_execution_context(
-            execution_id,
-            code,
-            code_location,
-            render_settings,
-            intrinsic_size,
-        );
+        self.device_context()
+            .set_execution_context(execution_id, code, code_location, positron);
     }
 
     /// Process pending graphics changes after an execute request completes.

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -1522,8 +1522,8 @@ impl Console {
                     reply_tx,
                 });
 
-                // Push execution context to graphics device for plot attribution
-                // and plot sizing metadata (e.g. Quarto's fig size).
+                // Make plot attribution and request-specific sizing available to the
+                // graphics device.
                 let code_location = exec_req.code_location().log_err().flatten();
                 self.graphics_on_execute_request(
                     originator.header.msg_id.clone(),

--- a/crates/ark/src/console/console_repl.rs
+++ b/crates/ark/src/console/console_repl.rs
@@ -1523,19 +1523,13 @@ impl Console {
                 });
 
                 // Push execution context to graphics device for plot attribution
-                // and optional sizing overrides from Quarto.
+                // and plot sizing metadata (e.g. Quarto's fig size).
                 let code_location = exec_req.code_location().log_err().flatten();
-                let (render_settings, intrinsic_size) = exec_req
-                    .positron
-                    .as_ref()
-                    .map(graphics_device::compute_plot_overrides)
-                    .unwrap_or((None, None));
                 self.graphics_on_execute_request(
                     originator.header.msg_id.clone(),
                     exec_req.code.clone(),
                     code_location,
-                    render_settings,
-                    intrinsic_size,
+                    exec_req.positron.as_ref(),
                 );
 
                 input

--- a/crates/ark/src/plots.rs
+++ b/crates/ark/src/plots.rs
@@ -6,3 +6,4 @@
 //
 
 pub mod graphics_device;
+pub mod sizing;

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -92,11 +92,46 @@ struct ExecutionContext {
     execution_id: String,
     code: String,
     code_location: Option<CodeLocation>,
-    /// Render settings override from the execute request (e.g. Quarto sizing metadata).
-    /// When `Some`, used instead of `DeviceContext::prerender_settings` for pre-rendering.
-    render_settings: Option<PlotRenderSettings>,
-    /// Intrinsic size from the execute request (e.g. Quarto's fig-width/fig-height in inches).
-    intrinsic_size: Option<IntrinsicSize>,
+    /// Figure width in inches requested by the execute request (Quarto's
+    /// `fig-width`), validated positive.
+    fig_width: Option<f64>,
+    /// Figure height in inches requested by the execute request (Quarto's
+    /// `fig-height`), validated positive.
+    fig_height: Option<f64>,
+    /// Device pixel ratio of the frontend's display (`output_pixel_ratio`).
+    pixel_ratio: Option<f64>,
+}
+
+impl ExecutionContext {
+    /// The figure size requested via `fig-width`/`fig-height`, in inches.
+    ///
+    /// Either option may be set alone, matching `quarto render`; the missing
+    /// dimension falls back to the Quarto default. Returns `None` when
+    /// neither dimension is set.
+    fn requested_fig_size(&self) -> Option<(f64, f64)> {
+        if self.fig_width.is_none() && self.fig_height.is_none() {
+            return None;
+        }
+
+        Some((
+            self.fig_width.unwrap_or(DEFAULT_FIG_WIDTH),
+            self.fig_height.unwrap_or(DEFAULT_FIG_HEIGHT),
+        ))
+    }
+
+    /// The requested figure size as an `IntrinsicSize` for the plot comm.
+    ///
+    /// Returns `None` when no figure size was requested.
+    fn intrinsic_size(&self) -> Option<IntrinsicSize> {
+        let (width, height) = self.requested_fig_size()?;
+
+        Some(IntrinsicSize {
+            width,
+            height,
+            unit: PlotUnit::Inches,
+            source: String::from("Quarto"),
+        })
+    }
 }
 
 /// Per-plot context captured at creation time.
@@ -237,15 +272,23 @@ impl DeviceContext {
         execution_id: String,
         code: String,
         code_location: Option<CodeLocation>,
-        render_settings: Option<PlotRenderSettings>,
-        intrinsic_size: Option<IntrinsicSize>,
+        positron: Option<&ExecuteRequestPositron>,
     ) {
+        let fig_width = positron
+            .and_then(|req| req.fig_width)
+            .filter(|width| *width > 0.0);
+        let fig_height = positron
+            .and_then(|req| req.fig_height)
+            .filter(|height| *height > 0.0);
+        let pixel_ratio = positron.and_then(|req| req.output_pixel_ratio);
+
         *self.execution_context.borrow_mut() = Some(ExecutionContext {
             execution_id,
             code,
             code_location,
-            render_settings,
-            intrinsic_size,
+            fig_width,
+            fig_height,
+            pixel_ratio,
         });
     }
 
@@ -631,11 +674,15 @@ impl DeviceContext {
         let ctx = self.capture_execution_context();
         self.store_plot_context(id, &ctx);
 
-        // Use render settings from the execute request if available, otherwise fall back
-        // to the default prerender settings.
-        let settings = ctx
-            .render_settings
-            .unwrap_or_else(|| self.prerender_settings.get());
+        // Pre-render at the requested figure size if the execute request
+        // specified one, otherwise fall back to the frontend-driven prerender
+        // settings.
+        let settings = match ctx.requested_fig_size() {
+            Some((width, height)) => {
+                render_settings_from_inches(width, height, ctx.pixel_ratio.unwrap_or(1.0))
+            },
+            None => self.prerender_settings.get(),
+        };
 
         let open_data = match self.render_plot(id, &settings) {
             Ok(pre_render) => {
@@ -722,7 +769,7 @@ impl DeviceContext {
                     code: ctx.code.clone(),
                     origin,
                 },
-                intrinsic_size: ctx.intrinsic_size.clone(),
+                intrinsic_size: ctx.intrinsic_size(),
             });
     }
 
@@ -814,28 +861,22 @@ impl DeviceContext {
         id: &PlotId,
         ctx: &ExecutionContext,
     ) -> Result<(serde_json::Value, serde_json::Value), anyhow::Error> {
-        let base = ctx.render_settings.unwrap_or(PlotRenderSettings {
-            size: PlotSize {
-                width: 800,
-                height: 600,
-            },
-            pixel_ratio: 1.0,
-            format: PlotRenderFormat::Png,
-        });
-
+        // Resolve each dimension independently: the `ark.plot.*` R options
+        // override the execute request's figure size, which overrides the
+        // default figure size. Unsized plots deliberately render at the
+        // default figure size rather than scaling with the output area
+        // (posit-dev/positron#15260).
         let width = r_option_positive_f64("ark.plot.width")
-            .map(|w| (w * DEFAULT_DPI).round() as i64)
-            .unwrap_or(base.size.width);
+            .or(ctx.fig_width)
+            .unwrap_or(DEFAULT_FIG_WIDTH);
         let height = r_option_positive_f64("ark.plot.height")
-            .map(|h| (h * DEFAULT_DPI).round() as i64)
-            .unwrap_or(base.size.height);
-        let pixel_ratio = r_option_positive_f64("ark.plot.pixel_ratio").unwrap_or(base.pixel_ratio);
+            .or(ctx.fig_height)
+            .unwrap_or(DEFAULT_FIG_HEIGHT);
+        let pixel_ratio = r_option_positive_f64("ark.plot.pixel_ratio")
+            .or(ctx.pixel_ratio)
+            .unwrap_or(1.0);
 
-        let settings = PlotRenderSettings {
-            size: PlotSize { width, height },
-            pixel_ratio,
-            format: base.format,
-        };
+        let settings = render_settings_from_inches(width, height, pixel_ratio);
 
         let data = unwrap!(self.render_plot(id, &settings), Err(error) => {
             return Err(anyhow!("Failed to render plot with id {id} due to: {error}."));
@@ -1018,101 +1059,20 @@ impl IntrinsicSizeExt for IntrinsicSize {
     }
 }
 
-trait FromExecuteRequest: Sized {
-    fn from_execute_request(req: &ExecuteRequestPositron) -> Option<Self>;
-}
-
-impl FromExecuteRequest for PlotRenderSettings {
-    /// Create render settings from an execute request's Positron metadata.
-    ///
-    /// If `fig_width` and/or `fig_height` is set (Quarto), returns settings
-    /// with size in logical pixels (inches * DPI). Either dimension may be set
-    /// alone; the missing one falls back to the Quarto default.
-    ///
-    /// Otherwise, if the request describes the output area (`output_width_px`
-    /// or `output_pixel_ratio`), returns settings at the default figure size,
-    /// so that plots keep a predictable size rather than scaling with the
-    /// viewport.
-    ///
-    /// Sizes are in CSS/logical pixels. The R rendering layer handles physical
-    /// pixel scaling via the separate `pixel_ratio` parameter.
-    fn from_execute_request(req: &ExecuteRequestPositron) -> Option<Self> {
-        let pixel_ratio = req.output_pixel_ratio.unwrap_or(1.0);
-
-        if let Some((width, height)) = requested_fig_size(req) {
-            return Some(Self {
-                size: PlotSize {
-                    width: (width * DEFAULT_DPI).round() as i64,
-                    height: (height * DEFAULT_DPI).round() as i64,
-                },
-                pixel_ratio,
-                format: PlotRenderFormat::Png,
-            });
-        }
-
-        // The frontend describes a sized output area (notebook or inline
-        // output) but the cell didn't request a figure size. Render at the
-        // default figure size rather than sizing to the output area width
-        // (posit-dev/positron#15260).
-        if req.output_width_px.is_some() || req.output_pixel_ratio.is_some() {
-            return Some(Self {
-                size: PlotSize {
-                    width: (DEFAULT_FIG_WIDTH * DEFAULT_DPI).round() as i64,
-                    height: (DEFAULT_FIG_HEIGHT * DEFAULT_DPI).round() as i64,
-                },
-                pixel_ratio,
-                format: PlotRenderFormat::Png,
-            });
-        }
-
-        None
-    }
-}
-
-impl FromExecuteRequest for IntrinsicSize {
-    /// Create an intrinsic size from an execute request's Positron metadata.
-    ///
-    /// Only returns `Some` when `fig_width` and/or `fig_height` is set
-    /// (i.e. Quarto sizing), providing the intrinsic size in inches.
-    fn from_execute_request(req: &ExecuteRequestPositron) -> Option<Self> {
-        let (width, height) = requested_fig_size(req)?;
-
-        Some(Self {
-            width,
-            height,
-            unit: PlotUnit::Inches,
-            source: String::from("Quarto"),
-        })
-    }
-}
-
-/// The figure size requested via `fig-width`/`fig-height`, in inches.
+/// Build PNG render settings from a figure size in inches.
 ///
-/// Either option may be set alone, matching `quarto render`; the missing (or
-/// non-positive) dimension falls back to the Quarto default. Returns `None`
-/// when neither dimension is set.
-fn requested_fig_size(req: &ExecuteRequestPositron) -> Option<(f64, f64)> {
-    let width = req.fig_width.filter(|width| *width > 0.0);
-    let height = req.fig_height.filter(|height| *height > 0.0);
-
-    if width.is_none() && height.is_none() {
-        return None;
+/// The size is converted to CSS/logical pixels (inches * DPI). The R
+/// rendering layer handles physical pixel scaling via the separate
+/// `pixel_ratio` parameter.
+fn render_settings_from_inches(width: f64, height: f64, pixel_ratio: f64) -> PlotRenderSettings {
+    PlotRenderSettings {
+        size: PlotSize {
+            width: (width * DEFAULT_DPI).round() as i64,
+            height: (height * DEFAULT_DPI).round() as i64,
+        },
+        pixel_ratio,
+        format: PlotRenderFormat::Png,
     }
-
-    Some((
-        width.unwrap_or(DEFAULT_FIG_WIDTH),
-        height.unwrap_or(DEFAULT_FIG_HEIGHT),
-    ))
-}
-
-/// Compute render settings and intrinsic size from execute request metadata.
-pub(crate) fn compute_plot_overrides(
-    req: &ExecuteRequestPositron,
-) -> (Option<PlotRenderSettings>, Option<IntrinsicSize>) {
-    (
-        PlotRenderSettings::from_execute_request(req),
-        IntrinsicSize::from_execute_request(req),
-    )
 }
 
 /// Activation callback
@@ -1401,8 +1361,9 @@ mod tests {
         assert_eq!(ctx.execution_id, "");
         assert_eq!(ctx.code, "");
         assert!(ctx.code_location.is_none());
-        assert!(ctx.render_settings.is_none());
-        assert!(ctx.intrinsic_size.is_none());
+        assert!(ctx.fig_width.is_none());
+        assert!(ctx.fig_height.is_none());
+        assert!(ctx.pixel_ratio.is_none());
     }
 
     #[test]
@@ -1411,7 +1372,6 @@ mod tests {
         dc.set_execution_context(
             String::from("msg-123"),
             String::from("plot(1:10)"),
-            None,
             None,
             None,
         );
@@ -1427,7 +1387,6 @@ mod tests {
         dc.set_execution_context(
             String::from("msg-123"),
             String::from("plot(1:10)"),
-            None,
             None,
             None,
         );

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -27,7 +27,6 @@ use amalthea::comm::plot_comm::PlotRenderFormat;
 use amalthea::comm::plot_comm::PlotRenderSettings;
 use amalthea::comm::plot_comm::PlotResult;
 use amalthea::comm::plot_comm::PlotSize;
-use amalthea::comm::plot_comm::PlotUnit;
 use amalthea::comm::plot_comm::UpdateParams;
 use amalthea::socket::comm::CommOutgoingTx;
 use amalthea::socket::iopub::IOPubMessage;
@@ -58,7 +57,9 @@ use crate::comm_handler::CommHandlerContext;
 use crate::console::Console;
 use crate::console::SessionMode;
 use crate::modules::ARK_ENVS;
-use crate::r_task;
+use crate::plots::sizing::IntrinsicSizeExt;
+use crate::plots::sizing::PlotSizing;
+use crate::plots::sizing::DEFAULT_DPI;
 
 pub const PLOT_COMM_NAME: &str = "positron.plot";
 
@@ -92,46 +93,8 @@ struct ExecutionContext {
     execution_id: String,
     code: String,
     code_location: Option<CodeLocation>,
-    /// Figure width in inches requested by the execute request (Quarto's
-    /// `fig-width`), validated positive.
-    fig_width: Option<f64>,
-    /// Figure height in inches requested by the execute request (Quarto's
-    /// `fig-height`), validated positive.
-    fig_height: Option<f64>,
-    /// Device pixel ratio of the frontend's display (`output_pixel_ratio`).
-    pixel_ratio: Option<f64>,
-}
-
-impl ExecutionContext {
-    /// The figure size requested via `fig-width`/`fig-height`, in inches.
-    ///
-    /// Either option may be set alone, matching `quarto render`; the missing
-    /// dimension falls back to the Quarto default. Returns `None` when
-    /// neither dimension is set.
-    fn requested_fig_size(&self) -> Option<(f64, f64)> {
-        if self.fig_width.is_none() && self.fig_height.is_none() {
-            return None;
-        }
-
-        Some((
-            self.fig_width.unwrap_or(DEFAULT_FIG_WIDTH),
-            self.fig_height.unwrap_or(DEFAULT_FIG_HEIGHT),
-        ))
-    }
-
-    /// The requested figure size as an `IntrinsicSize` for the plot comm.
-    ///
-    /// Returns `None` when no figure size was requested.
-    fn intrinsic_size(&self) -> Option<IntrinsicSize> {
-        let (width, height) = self.requested_fig_size()?;
-
-        Some(IntrinsicSize {
-            width,
-            height,
-            unit: PlotUnit::Inches,
-            source: String::from("Quarto"),
-        })
-    }
+    /// Plot sizing metadata from the execute request (e.g. Quarto's fig size).
+    sizing: PlotSizing,
 }
 
 /// Per-plot context captured at creation time.
@@ -274,21 +237,11 @@ impl DeviceContext {
         code_location: Option<CodeLocation>,
         positron: Option<&ExecuteRequestPositron>,
     ) {
-        let fig_width = positron
-            .and_then(|req| req.fig_width)
-            .filter(|width| *width > 0.0);
-        let fig_height = positron
-            .and_then(|req| req.fig_height)
-            .filter(|height| *height > 0.0);
-        let pixel_ratio = positron.and_then(|req| req.output_pixel_ratio);
-
         *self.execution_context.borrow_mut() = Some(ExecutionContext {
             execution_id,
             code,
             code_location,
-            fig_width,
-            fig_height,
-            pixel_ratio,
+            sizing: PlotSizing::from_request(positron),
         });
     }
 
@@ -677,12 +630,10 @@ impl DeviceContext {
         // Pre-render at the requested figure size if the execute request
         // specified one, otherwise fall back to the frontend-driven prerender
         // settings.
-        let settings = match ctx.requested_fig_size() {
-            Some((width, height)) => {
-                render_settings_from_inches(width, height, ctx.pixel_ratio.unwrap_or(1.0))
-            },
-            None => self.prerender_settings.get(),
-        };
+        let settings = ctx
+            .sizing
+            .requested_render_settings()
+            .unwrap_or_else(|| self.prerender_settings.get());
 
         let open_data = match self.render_plot(id, &settings) {
             Ok(pre_render) => {
@@ -769,7 +720,7 @@ impl DeviceContext {
                     code: ctx.code.clone(),
                     origin,
                 },
-                intrinsic_size: ctx.intrinsic_size(),
+                intrinsic_size: ctx.sizing.intrinsic_size(),
             });
     }
 
@@ -840,7 +791,7 @@ impl DeviceContext {
         // fig options apply to plots it modifies), so refresh the stored
         // intrinsic size to match what was just rendered.
         if let Some(plot_ctx) = self.plot_contexts.borrow_mut().get_mut(id) {
-            plot_ctx.intrinsic_size = ctx.intrinsic_size();
+            plot_ctx.intrinsic_size = ctx.sizing.intrinsic_size();
         }
 
         let transient = TransientValue {
@@ -868,22 +819,7 @@ impl DeviceContext {
         id: &PlotId,
         ctx: &ExecutionContext,
     ) -> Result<(serde_json::Value, serde_json::Value), anyhow::Error> {
-        // Resolve each dimension independently: the `ark.plot.*` R options
-        // override the execute request's figure size, which overrides the
-        // default figure size. Unsized plots deliberately render at the
-        // default figure size rather than scaling with the output area
-        // (posit-dev/positron#15260).
-        let width = r_option_positive_f64("ark.plot.width")
-            .or(ctx.fig_width)
-            .unwrap_or(DEFAULT_FIG_WIDTH);
-        let height = r_option_positive_f64("ark.plot.height")
-            .or(ctx.fig_height)
-            .unwrap_or(DEFAULT_FIG_HEIGHT);
-        let pixel_ratio = r_option_positive_f64("ark.plot.pixel_ratio")
-            .or(ctx.pixel_ratio)
-            .unwrap_or(1.0);
-
-        let settings = render_settings_from_inches(width, height, pixel_ratio);
+        let settings = ctx.sizing.resolved_render_settings();
 
         let data = unwrap!(self.render_plot(id, &settings), Err(error) => {
             return Err(anyhow!("Failed to render plot with id {id} due to: {error}."));
@@ -1025,60 +961,6 @@ impl From<PlotId> for RObject {
 impl From<&PlotId> for RObject {
     fn from(value: &PlotId) -> Self {
         RObject::from(value.0.as_str())
-    }
-}
-
-/// Default DPI for converting inches to pixels.
-/// Matches R's default: 96 on macOS, 72 on Linux/Windows.
-/// See `default_resolution_in_pixels_per_inch()` in graphics.R.
-const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
-    96.0
-} else {
-    72.0
-};
-
-/// Default figure size in inches, matching Quarto's base/HTML format
-/// defaults (`fig-width: 7`, `fig-height: 5`). Other formats differ (e.g.
-/// pdf is 5.5 x 3.5), but Positron doesn't know the target format.
-const DEFAULT_FIG_WIDTH: f64 = 7.0;
-const DEFAULT_FIG_HEIGHT: f64 = 5.0;
-
-trait IntrinsicSizeExt {
-    /// Convert an intrinsic size to a logical-pixel-based `PlotSize`.
-    ///
-    /// Returns dimensions in CSS/logical pixels. The R rendering layer handles
-    /// physical pixel scaling via the separate `pixel_ratio` parameter.
-    fn to_plot_size(&self) -> PlotSize;
-}
-
-impl IntrinsicSizeExt for IntrinsicSize {
-    fn to_plot_size(&self) -> PlotSize {
-        match self.unit {
-            PlotUnit::Inches => PlotSize {
-                width: (self.width * DEFAULT_DPI).round() as i64,
-                height: (self.height * DEFAULT_DPI).round() as i64,
-            },
-            PlotUnit::Pixels => PlotSize {
-                width: self.width.round() as i64,
-                height: self.height.round() as i64,
-            },
-        }
-    }
-}
-
-/// Build PNG render settings from a figure size in inches.
-///
-/// The size is converted to CSS/logical pixels (inches * DPI). The R
-/// rendering layer handles physical pixel scaling via the separate
-/// `pixel_ratio` parameter.
-fn render_settings_from_inches(width: f64, height: f64, pixel_ratio: f64) -> PlotRenderSettings {
-    PlotRenderSettings {
-        size: PlotSize {
-            width: (width * DEFAULT_DPI).round() as i64,
-            height: (height * DEFAULT_DPI).round() as i64,
-        },
-        pixel_ratio,
-        format: PlotRenderFormat::Png,
     }
 }
 
@@ -1337,21 +1219,6 @@ unsafe extern "C-unwind" fn ps_graphics_default_dpi() -> anyhow::Result<SEXP> {
     Ok(RObject::from(DEFAULT_DPI as i32).sexp)
 }
 
-/// Read a positive `f64` from an R option. Returns `None` if the option is
-/// unset, not numeric, or not positive.
-fn r_option_positive_f64(name: &str) -> Option<f64> {
-    let value = r_task(|| {
-        RFunction::from("getOption")
-            .param("x", name)
-            .call()?
-            .to::<f64>()
-    });
-    match value {
-        Ok(v) if v > 0.0 => Some(v),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1368,9 +1235,9 @@ mod tests {
         assert_eq!(ctx.execution_id, "");
         assert_eq!(ctx.code, "");
         assert!(ctx.code_location.is_none());
-        assert!(ctx.fig_width.is_none());
-        assert!(ctx.fig_height.is_none());
-        assert!(ctx.pixel_ratio.is_none());
+        assert!(ctx.sizing.fig_width.is_none());
+        assert!(ctx.sizing.fig_height.is_none());
+        assert!(ctx.sizing.pixel_ratio.is_none());
     }
 
     #[test]

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -836,6 +836,13 @@ impl DeviceContext {
             return;
         });
 
+        // Sizing follows the current execution (as in knitr, where a chunk's
+        // fig options apply to plots it modifies), so refresh the stored
+        // intrinsic size to match what was just rendered.
+        if let Some(plot_ctx) = self.plot_contexts.borrow_mut().get_mut(id) {
+            plot_ctx.intrinsic_size = ctx.intrinsic_size();
+        }
+
         let transient = TransientValue {
             display_id: id.to_string(),
             data: None,

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -989,9 +989,6 @@ const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
     72.0
 };
 
-/// Default aspect ratio (width:height) used when only output_width_px is provided.
-const DEFAULT_ASPECT_RATIO: f64 = 4.0 / 3.0;
-
 /// Default figure size in inches, matching Quarto's base/HTML format
 /// defaults (`fig-width: 7`, `fig-height: 5`). Other formats differ (e.g.
 /// pdf is 5.5 x 3.5), but Positron doesn't know the target format.
@@ -1032,8 +1029,10 @@ impl FromExecuteRequest for PlotRenderSettings {
     /// with size in logical pixels (inches * DPI). Either dimension may be set
     /// alone; the missing one falls back to the Quarto default.
     ///
-    /// Otherwise if `output_width_px` is set, returns settings at that width
-    /// with a 4:3 aspect ratio.
+    /// Otherwise, if the request describes the output area (`output_width_px`
+    /// or `output_pixel_ratio`), returns settings at the default figure size,
+    /// so that plots keep a predictable size rather than scaling with the
+    /// viewport.
     ///
     /// Sizes are in CSS/logical pixels. The R rendering layer handles physical
     /// pixel scaling via the separate `pixel_ratio` parameter.
@@ -1051,17 +1050,19 @@ impl FromExecuteRequest for PlotRenderSettings {
             });
         }
 
-        if let Some(width_px) = req.output_width_px {
-            if width_px > 0.0 {
-                return Some(Self {
-                    size: PlotSize {
-                        width: width_px.round() as i64,
-                        height: (width_px / DEFAULT_ASPECT_RATIO).round() as i64,
-                    },
-                    pixel_ratio,
-                    format: PlotRenderFormat::Png,
-                });
-            }
+        // The frontend describes a sized output area (notebook or inline
+        // output) but the cell didn't request a figure size. Render at the
+        // default figure size rather than sizing to the output area width
+        // (posit-dev/positron#15260).
+        if req.output_width_px.is_some() || req.output_pixel_ratio.is_some() {
+            return Some(Self {
+                size: PlotSize {
+                    width: (DEFAULT_FIG_WIDTH * DEFAULT_DPI).round() as i64,
+                    height: (DEFAULT_FIG_HEIGHT * DEFAULT_DPI).round() as i64,
+                },
+                pixel_ratio,
+                format: PlotRenderFormat::Png,
+            });
         }
 
         None

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -93,7 +93,7 @@ struct ExecutionContext {
     execution_id: String,
     code: String,
     code_location: Option<CodeLocation>,
-    /// Plot sizing metadata from the execute request (e.g. Quarto's fig size).
+    /// Unresolved figure dimensions and pixel ratio from the execute request.
     sizing: PlotSizing,
 }
 
@@ -627,9 +627,7 @@ impl DeviceContext {
         let ctx = self.capture_execution_context();
         self.store_plot_context(id, &ctx);
 
-        // Pre-render at the requested figure size if the execute request
-        // specified one, otherwise fall back to the frontend-driven prerender
-        // settings.
+        // Prefer explicit figure dimensions; otherwise use the frontend's prerender settings.
         let settings = ctx
             .sizing
             .requested_render_settings()
@@ -787,9 +785,8 @@ impl DeviceContext {
             return;
         });
 
-        // Sizing follows the current execution (as in knitr, where a chunk's
-        // fig options apply to plots it modifies), so refresh the stored
-        // intrinsic size to match what was just rendered.
+        // A plot update inherits the current execution's figure dimensions, matching
+        // knitr's treatment of plots modified by a later chunk.
         if let Some(plot_ctx) = self.plot_contexts.borrow_mut().get_mut(id) {
             plot_ctx.intrinsic_size = ctx.sizing.intrinsic_size();
         }

--- a/crates/ark/src/plots/sizing.rs
+++ b/crates/ark/src/plots/sizing.rs
@@ -15,42 +15,39 @@ use harp::exec::RFunctionExt;
 
 use crate::r_task;
 
-/// Default DPI for converting inches to pixels.
-/// Matches R's default: 96 on macOS, 72 on Linux/Windows.
-/// See `default_resolution_in_pixels_per_inch()` in graphics.R.
+/// Default conversion from inches to logical pixels: 96 DPI on macOS and
+/// 72 DPI elsewhere, matching `default_resolution_in_pixels_per_inch()` in
+/// `graphics.R`.
 pub(crate) const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
     96.0
 } else {
     72.0
 };
 
-/// Default figure size in inches, matching Quarto's base/HTML format
-/// defaults (`fig-width: 7`, `fig-height: 5`). Other formats differ (e.g.
-/// pdf is 5.5 x 3.5), but Positron doesn't know the target format.
+/// Default figure dimensions for Quarto base and HTML formats, in inches.
+///
+/// Positron cannot account for format-specific defaults such as PDF's
+/// 5.5 × 3.5 inches, so Ark consistently uses 7 × 5 inches.
 const DEFAULT_FIG_WIDTH: f64 = 7.0;
 const DEFAULT_FIG_HEIGHT: f64 = 5.0;
 
-/// Plot sizing metadata from an execute request.
+/// Unresolved plot dimensions and pixel ratio from an execute request.
 ///
-/// Holds the *unresolved* sizing request: optional figure dimensions in
-/// inches, where "unset" survives until render time so the `ark.plot.*` R
-/// options can be layered per dimension. Contrast with [PlotRenderSettings],
-/// which describes a fully resolved render in concrete pixels.
+/// Keeping each dimension optional allows it to be resolved independently at
+/// render time. [`PlotRenderSettings`] instead represents fully resolved,
+/// pixel-based settings.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct PlotSizing {
-    /// Figure width in inches requested by the execute request (Quarto's
-    /// `fig-width`), validated positive.
+    /// Requested `fig-width` in inches, if positive.
     pub(crate) fig_width: Option<f64>,
-    /// Figure height in inches requested by the execute request (Quarto's
-    /// `fig-height`), validated positive.
+    /// Requested `fig-height` in inches, if positive.
     pub(crate) fig_height: Option<f64>,
-    /// Device pixel ratio of the frontend's display (`output_pixel_ratio`).
+    /// Requested frontend device pixel ratio.
     pub(crate) pixel_ratio: Option<f64>,
 }
 
 impl PlotSizing {
-    /// Extract sizing metadata from an execute request, discarding
-    /// non-positive dimensions.
+    /// Extracts plot sizing metadata, ignoring non-positive figure dimensions.
     pub(crate) fn from_request(positron: Option<&ExecuteRequestPositron>) -> Self {
         let fig_width = positron
             .and_then(|req| req.fig_width)
@@ -67,11 +64,10 @@ impl PlotSizing {
         }
     }
 
-    /// Render settings at the requested figure size.
+    /// Resolves explicitly requested figure dimensions for prerendering.
     ///
-    /// Returns `None` when no figure size was requested, so the caller can
-    /// fall back to its own default (e.g. the frontend-driven prerender
-    /// settings).
+    /// Returns `None` if neither dimension was requested, allowing the caller to
+    /// use its frontend-driven prerender settings.
     pub(crate) fn requested_render_settings(&self) -> Option<PlotRenderSettings> {
         let (width, height) = self.fig_size()?;
 
@@ -82,13 +78,12 @@ impl PlotSizing {
         ))
     }
 
-    /// Resolve final render settings for the Jupyter protocol.
+    /// Resolves the final PNG render settings.
     ///
-    /// Each dimension resolves independently: the `ark.plot.*` R options
-    /// override the execute request's figure size, which overrides the
-    /// default figure size. Unsized plots deliberately render at the default
-    /// figure size rather than scaling with the output area
-    /// (posit-dev/positron#15260).
+    /// Each figure dimension independently uses the first positive value from its
+    /// `ark.plot.*` R option, the execute request, or the default figure size. The
+    /// pixel ratio follows the analogous option-request-default precedence.
+    /// `output_width_px` does not affect the rendered dimensions.
     pub(crate) fn resolved_render_settings(&self) -> PlotRenderSettings {
         let width = r_option_positive_f64("ark.plot.width")
             .or(self.fig_width)
@@ -103,9 +98,9 @@ impl PlotSizing {
         render_settings_from_inches(width, height, pixel_ratio)
     }
 
-    /// The requested figure size as an `IntrinsicSize` for the plot comm.
+    /// Returns the requested dimensions as plot-comm intrinsic-size metadata.
     ///
-    /// Returns `None` when no figure size was requested.
+    /// Returns `None` if neither dimension was requested.
     pub(crate) fn intrinsic_size(&self) -> Option<IntrinsicSize> {
         let (width, height) = self.fig_size()?;
 
@@ -117,11 +112,10 @@ impl PlotSizing {
         })
     }
 
-    /// The figure size requested via `fig-width`/`fig-height`, in inches.
+    /// Returns the requested figure dimensions in inches.
     ///
-    /// Either option may be set alone, matching `quarto render`; the missing
-    /// dimension falls back to the Quarto default. Returns `None` when
-    /// neither dimension is set.
+    /// A missing dimension uses its corresponding default. Returns `None` if
+    /// neither dimension was requested.
     fn fig_size(&self) -> Option<(f64, f64)> {
         if self.fig_width.is_none() && self.fig_height.is_none() {
             return None;
@@ -135,10 +129,9 @@ impl PlotSizing {
 }
 
 pub(crate) trait IntrinsicSizeExt {
-    /// Convert an intrinsic size to a logical-pixel-based `PlotSize`.
+    /// Converts intrinsic dimensions to logical pixels.
     ///
-    /// Returns dimensions in CSS/logical pixels. The R rendering layer handles
-    /// physical pixel scaling via the separate `pixel_ratio` parameter.
+    /// Physical pixel scaling is applied separately through `pixel_ratio`.
     fn to_plot_size(&self) -> PlotSize;
 }
 
@@ -157,11 +150,9 @@ impl IntrinsicSizeExt for IntrinsicSize {
     }
 }
 
-/// Build PNG render settings from a figure size in inches.
+/// Converts figure dimensions in inches into PNG settings in logical pixels.
 ///
-/// The size is converted to CSS/logical pixels (inches * DPI). The R
-/// rendering layer handles physical pixel scaling via the separate
-/// `pixel_ratio` parameter.
+/// Physical pixel scaling is applied separately through `pixel_ratio`.
 fn render_settings_from_inches(width: f64, height: f64, pixel_ratio: f64) -> PlotRenderSettings {
     PlotRenderSettings {
         size: PlotSize {
@@ -173,8 +164,9 @@ fn render_settings_from_inches(width: f64, height: f64, pixel_ratio: f64) -> Plo
     }
 }
 
-/// Read a positive `f64` from an R option. Returns `None` if the option is
-/// unset, not numeric, or not positive.
+/// Reads a positive numeric R option.
+///
+/// Returns `None` when the option is absent, non-numeric, or non-positive.
 fn r_option_positive_f64(name: &str) -> Option<f64> {
     let value = r_task(|| {
         RFunction::from("getOption")

--- a/crates/ark/src/plots/sizing.rs
+++ b/crates/ark/src/plots/sizing.rs
@@ -1,0 +1,225 @@
+//
+// sizing.rs
+//
+// Copyright (C) 2026 by Posit Software, PBC
+//
+
+use amalthea::comm::plot_comm::IntrinsicSize;
+use amalthea::comm::plot_comm::PlotRenderFormat;
+use amalthea::comm::plot_comm::PlotRenderSettings;
+use amalthea::comm::plot_comm::PlotSize;
+use amalthea::comm::plot_comm::PlotUnit;
+use amalthea::wire::execute_request::ExecuteRequestPositron;
+use harp::exec::RFunction;
+use harp::exec::RFunctionExt;
+
+use crate::r_task;
+
+/// Default DPI for converting inches to pixels.
+/// Matches R's default: 96 on macOS, 72 on Linux/Windows.
+/// See `default_resolution_in_pixels_per_inch()` in graphics.R.
+pub(crate) const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
+    96.0
+} else {
+    72.0
+};
+
+/// Default figure size in inches, matching Quarto's base/HTML format
+/// defaults (`fig-width: 7`, `fig-height: 5`). Other formats differ (e.g.
+/// pdf is 5.5 x 3.5), but Positron doesn't know the target format.
+const DEFAULT_FIG_WIDTH: f64 = 7.0;
+const DEFAULT_FIG_HEIGHT: f64 = 5.0;
+
+/// Plot sizing metadata from an execute request.
+///
+/// Holds the *unresolved* sizing request: optional figure dimensions in
+/// inches, where "unset" survives until render time so the `ark.plot.*` R
+/// options can be layered per dimension. Contrast with [PlotRenderSettings],
+/// which describes a fully resolved render in concrete pixels.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct PlotSizing {
+    /// Figure width in inches requested by the execute request (Quarto's
+    /// `fig-width`), validated positive.
+    pub(crate) fig_width: Option<f64>,
+    /// Figure height in inches requested by the execute request (Quarto's
+    /// `fig-height`), validated positive.
+    pub(crate) fig_height: Option<f64>,
+    /// Device pixel ratio of the frontend's display (`output_pixel_ratio`).
+    pub(crate) pixel_ratio: Option<f64>,
+}
+
+impl PlotSizing {
+    /// Extract sizing metadata from an execute request, discarding
+    /// non-positive dimensions.
+    pub(crate) fn from_request(positron: Option<&ExecuteRequestPositron>) -> Self {
+        let fig_width = positron
+            .and_then(|req| req.fig_width)
+            .filter(|width| *width > 0.0);
+        let fig_height = positron
+            .and_then(|req| req.fig_height)
+            .filter(|height| *height > 0.0);
+        let pixel_ratio = positron.and_then(|req| req.output_pixel_ratio);
+
+        Self {
+            fig_width,
+            fig_height,
+            pixel_ratio,
+        }
+    }
+
+    /// Render settings at the requested figure size.
+    ///
+    /// Returns `None` when no figure size was requested, so the caller can
+    /// fall back to its own default (e.g. the frontend-driven prerender
+    /// settings).
+    pub(crate) fn requested_render_settings(&self) -> Option<PlotRenderSettings> {
+        let (width, height) = self.fig_size()?;
+
+        Some(render_settings_from_inches(
+            width,
+            height,
+            self.pixel_ratio.unwrap_or(1.0),
+        ))
+    }
+
+    /// Resolve final render settings for the Jupyter protocol.
+    ///
+    /// Each dimension resolves independently: the `ark.plot.*` R options
+    /// override the execute request's figure size, which overrides the
+    /// default figure size. Unsized plots deliberately render at the default
+    /// figure size rather than scaling with the output area
+    /// (posit-dev/positron#15260).
+    pub(crate) fn resolved_render_settings(&self) -> PlotRenderSettings {
+        let width = r_option_positive_f64("ark.plot.width")
+            .or(self.fig_width)
+            .unwrap_or(DEFAULT_FIG_WIDTH);
+        let height = r_option_positive_f64("ark.plot.height")
+            .or(self.fig_height)
+            .unwrap_or(DEFAULT_FIG_HEIGHT);
+        let pixel_ratio = r_option_positive_f64("ark.plot.pixel_ratio")
+            .or(self.pixel_ratio)
+            .unwrap_or(1.0);
+
+        render_settings_from_inches(width, height, pixel_ratio)
+    }
+
+    /// The requested figure size as an `IntrinsicSize` for the plot comm.
+    ///
+    /// Returns `None` when no figure size was requested.
+    pub(crate) fn intrinsic_size(&self) -> Option<IntrinsicSize> {
+        let (width, height) = self.fig_size()?;
+
+        Some(IntrinsicSize {
+            width,
+            height,
+            unit: PlotUnit::Inches,
+            source: String::from("Quarto"),
+        })
+    }
+
+    /// The figure size requested via `fig-width`/`fig-height`, in inches.
+    ///
+    /// Either option may be set alone, matching `quarto render`; the missing
+    /// dimension falls back to the Quarto default. Returns `None` when
+    /// neither dimension is set.
+    fn fig_size(&self) -> Option<(f64, f64)> {
+        if self.fig_width.is_none() && self.fig_height.is_none() {
+            return None;
+        }
+
+        Some((
+            self.fig_width.unwrap_or(DEFAULT_FIG_WIDTH),
+            self.fig_height.unwrap_or(DEFAULT_FIG_HEIGHT),
+        ))
+    }
+}
+
+pub(crate) trait IntrinsicSizeExt {
+    /// Convert an intrinsic size to a logical-pixel-based `PlotSize`.
+    ///
+    /// Returns dimensions in CSS/logical pixels. The R rendering layer handles
+    /// physical pixel scaling via the separate `pixel_ratio` parameter.
+    fn to_plot_size(&self) -> PlotSize;
+}
+
+impl IntrinsicSizeExt for IntrinsicSize {
+    fn to_plot_size(&self) -> PlotSize {
+        match self.unit {
+            PlotUnit::Inches => PlotSize {
+                width: (self.width * DEFAULT_DPI).round() as i64,
+                height: (self.height * DEFAULT_DPI).round() as i64,
+            },
+            PlotUnit::Pixels => PlotSize {
+                width: self.width.round() as i64,
+                height: self.height.round() as i64,
+            },
+        }
+    }
+}
+
+/// Build PNG render settings from a figure size in inches.
+///
+/// The size is converted to CSS/logical pixels (inches * DPI). The R
+/// rendering layer handles physical pixel scaling via the separate
+/// `pixel_ratio` parameter.
+fn render_settings_from_inches(width: f64, height: f64, pixel_ratio: f64) -> PlotRenderSettings {
+    PlotRenderSettings {
+        size: PlotSize {
+            width: (width * DEFAULT_DPI).round() as i64,
+            height: (height * DEFAULT_DPI).round() as i64,
+        },
+        pixel_ratio,
+        format: PlotRenderFormat::Png,
+    }
+}
+
+/// Read a positive `f64` from an R option. Returns `None` if the option is
+/// unset, not numeric, or not positive.
+fn r_option_positive_f64(name: &str) -> Option<f64> {
+    let value = r_task(|| {
+        RFunction::from("getOption")
+            .param("x", name)
+            .call()?
+            .to::<f64>()
+    });
+    match value {
+        Ok(v) if v > 0.0 => Some(v),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_request_filters_non_positive_dimensions() {
+        let req = ExecuteRequestPositron {
+            fig_width: Some(-1.0),
+            fig_height: Some(0.0),
+            output_pixel_ratio: Some(2.0),
+            ..Default::default()
+        };
+
+        let sizing = PlotSizing::from_request(Some(&req));
+        assert!(sizing.fig_width.is_none());
+        assert!(sizing.fig_height.is_none());
+        assert_eq!(sizing.pixel_ratio, Some(2.0));
+    }
+
+    #[test]
+    fn test_fig_size_lone_dimension_uses_default() {
+        let sizing = PlotSizing {
+            fig_width: Some(4.0),
+            ..Default::default()
+        };
+
+        assert_eq!(sizing.fig_size(), Some((4.0, DEFAULT_FIG_HEIGHT)));
+    }
+
+    #[test]
+    fn test_intrinsic_size_none_without_fig_size() {
+        let sizing = PlotSizing::default();
+        assert!(sizing.intrinsic_size().is_none());
+    }
+}

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -731,7 +731,8 @@ fn test_plot_with_pixel_ratio_reports_logical_size_in_metadata() {
 }
 
 /// Test that plots rendered with output_width_px (but no fig dimensions)
-/// produce a PNG at the expected width with a 4:3 aspect ratio.
+/// produce a PNG at the default figure size, not sized to the output area
+/// (posit-dev/positron#15260).
 #[test]
 fn test_plot_with_output_width_metadata() {
     let frontend = DummyArkFrontend::lock();
@@ -753,9 +754,10 @@ fn test_plot_with_output_width_metadata() {
         .expect("display_data should contain image/png");
     let (width, height) = png_dimensions(png_data);
 
-    // 600px wide, 600 / (4/3) = 450px tall
-    assert_eq!(width, 600);
-    assert_eq!(height, 450);
+    let dpi = default_dpi();
+    // 7 inches (default) * DPI, 5 inches (default) * DPI
+    assert_eq!(width, (7.0 * dpi).round() as u32);
+    assert_eq!(height, (5.0 * dpi).round() as u32);
 
     frontend.recv_iopub_idle();
     frontend.recv_shell_execute_reply();

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -763,7 +763,8 @@ fn test_plot_with_output_width_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
-/// Test that plots without sizing metadata render at the default 800x600.
+/// Test that plots without sizing metadata render at the default figure size
+/// (posit-dev/positron#15260).
 #[test]
 fn test_plot_default_size_without_metadata() {
     let frontend = DummyArkFrontend::lock();
@@ -779,8 +780,44 @@ fn test_plot_default_size_without_metadata() {
         .expect("display_data should contain image/png");
     let (width, height) = png_dimensions(png_data);
 
-    assert_eq!(width, 800);
-    assert_eq!(height, 600);
+    let dpi = default_dpi();
+    // 7 inches (default) * DPI, 5 inches (default) * DPI
+    assert_eq!(width, (7.0 * dpi).round() as u32);
+    assert_eq!(height, (5.0 * dpi).round() as u32);
+
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+}
+
+/// Test that output_pixel_ratio applies to unsized plots: the PNG is rendered
+/// at the default figure size scaled by the pixel ratio.
+#[test]
+fn test_plot_with_pixel_ratio_metadata() {
+    let frontend = DummyArkFrontend::lock();
+
+    let code = "plot(1:10)";
+    frontend.send_execute_request(code, ExecuteRequestOptions {
+        positron: Some(ExecuteRequestPositron {
+            output_width_px: Some(600.0),
+            output_pixel_ratio: Some(2.0),
+            ..Default::default()
+        }),
+        ..ExecuteRequestOptions::default()
+    });
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+
+    let display = frontend.recv_iopub_display_data_content();
+    let png_data = display.data["image/png"]
+        .as_str()
+        .expect("display_data should contain image/png");
+    let (width, height) = png_dimensions(png_data);
+
+    let dpi = default_dpi();
+    // The PNG's physical size is the logical size (default figure size * DPI)
+    // scaled by the pixel ratio
+    assert_eq!(width, ((7.0 * dpi).round() as u32) * 2);
+    assert_eq!(height, ((5.0 * dpi).round() as u32) * 2);
 
     frontend.recv_iopub_idle();
     frontend.recv_shell_execute_reply();

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -730,9 +730,7 @@ fn test_plot_with_pixel_ratio_reports_logical_size_in_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
-/// Test that plots rendered with output_width_px (but no fig dimensions)
-/// produce a PNG at the default figure size, not sized to the output area
-/// (posit-dev/positron#15260).
+/// Verifies that `output_width_px` does not override the default figure dimensions.
 #[test]
 fn test_plot_with_output_width_metadata() {
     let frontend = DummyArkFrontend::lock();
@@ -755,7 +753,7 @@ fn test_plot_with_output_width_metadata() {
     let (width, height) = png_dimensions(png_data);
 
     let dpi = default_dpi();
-    // 7 inches (default) * DPI, 5 inches (default) * DPI
+    // The default 7 × 5 inch dimensions are converted at the platform DPI.
     assert_eq!(width, (7.0 * dpi).round() as u32);
     assert_eq!(height, (5.0 * dpi).round() as u32);
 
@@ -763,8 +761,7 @@ fn test_plot_with_output_width_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
-/// Test that plots without sizing metadata render at the default figure size
-/// (posit-dev/positron#15260).
+/// Verifies that plots without sizing metadata use the default figure dimensions.
 #[test]
 fn test_plot_default_size_without_metadata() {
     let frontend = DummyArkFrontend::lock();
@@ -781,7 +778,7 @@ fn test_plot_default_size_without_metadata() {
     let (width, height) = png_dimensions(png_data);
 
     let dpi = default_dpi();
-    // 7 inches (default) * DPI, 5 inches (default) * DPI
+    // The default 7 × 5 inch dimensions are converted at the platform DPI.
     assert_eq!(width, (7.0 * dpi).round() as u32);
     assert_eq!(height, (5.0 * dpi).round() as u32);
 
@@ -789,8 +786,8 @@ fn test_plot_default_size_without_metadata() {
     frontend.recv_shell_execute_reply();
 }
 
-/// Test that output_pixel_ratio applies to unsized plots: the PNG is rendered
-/// at the default figure size scaled by the pixel ratio.
+/// Verifies that the device pixel ratio scales the physical PNG dimensions of
+/// an otherwise unsized plot.
 #[test]
 fn test_plot_with_pixel_ratio_metadata() {
     let frontend = DummyArkFrontend::lock();
@@ -814,8 +811,7 @@ fn test_plot_with_pixel_ratio_metadata() {
     let (width, height) = png_dimensions(png_data);
 
     let dpi = default_dpi();
-    // The PNG's physical size is the logical size (default figure size * DPI)
-    // scaled by the pixel ratio
+    // A 2x pixel ratio doubles the PNG's physical dimensions.
     assert_eq!(width, ((7.0 * dpi).round() as u32) * 2);
     assert_eq!(height, ((5.0 * dpi).round() as u32) * 2);
 


### PR DESCRIPTION
Addresses posit-dev/positron#15260.

This PR is stacked on posit-dev/ark#1387.

## Summary

When a notebook cell does not specify `fig-width` or `fig-height`, Ark currently sizes its plots to `output_width_px` with a 4:3 aspect ratio. This makes plots expand with the viewport and become especially large when the editor is wide or other panes are minimized.

This PR instead renders unsized plots at Quarto's default figure dimensions: 7 × 5 inches. This matches `quarto render` and is analogous to the Python kernel falling back to Matplotlib's default figure size.

The same default applies when an execute request contains no Positron metadata, including requests from standard Jupyter frontends. At Ark's platform-default DPI, the resulting logical dimensions are:

- macOS at 96 DPI: 672 × 480 pixels;
- Linux and Windows at 72 DPI: 504 × 360 pixels.

`output_width_px` remains part of the protocol but no longer affects plot sizing.

## Additional changes

- `output_pixel_ratio` is applied independently of figure dimensions, so unsized plots remain sharp on HiDPI displays.
- When a later execution updates an existing plot, its stored intrinsic size is refreshed using that execution's figure dimensions. This matches knitr, where a chunk's figure options apply to plots it modifies.
- Sizing resolution is consolidated in a new `PlotSizing` type in `plots/sizing.rs`.
- Width and height resolve independently using this precedence:
  1. `ark.plot.width` or `ark.plot.height`;
  2. the requested `fig-width` or `fig-height`;
  3. the default figure dimension.

## Screenshots

**Before and after: unsized plot in a wide Quarto editor**

<!-- Add before/after screenshots of `plot(1:10)` with no cell options and the editor widened by minimizing other panes. The before image should show the plot filling the output width; the after image should show the 7 × 5 inch default. -->

**Explicit figure dimensions remain supported**

<!-- Add a screenshot of a cell using `fig-width: 4` and `fig-height: 3`, showing the unchanged 4 × 3 inch result. -->

**Unsized plots remain sharp on HiDPI displays**

<!-- Optional: add a zoomed crop comparing an unsized plot before and after this change on a HiDPI display. -->

## QA

With inline output enabled in a Quarto document:

1. Run `plot(1:10)` without cell options. It should render at 7 × 5 inches regardless of the editor width.
2. Add `fig-width` and `fig-height`. The plot should use those dimensions.
3. Set `ark.plot.width` or `ark.plot.height`. Each R option should override the corresponding cell option.
4. On a HiDPI display, verify that an unsized plot remains sharp without being displayed at an enlarged size.
