### PR TITLE
Keep the plot origin when a render is held past source()

### DIFF
--- a/crates/ark/src/console/console_graphics.rs
+++ b/crates/ark/src/console/console_graphics.rs
@@ -39,6 +39,5 @@ impl Console {
         let dc = Rc::clone(self.device_context());
         dc.process_changes(self);
         dc.clear_execution_context();
-        dc.clear_pending_origin();
     }
 }

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -277,7 +277,7 @@ impl DeviceContext {
     }
 
     /// Clear any unconsumed pending origin.
-    pub(crate) fn clear_pending_origin(&self) {
+    fn clear_pending_origin(&self) {
         self.pending_origin.replace(None);
     }
 
@@ -338,10 +338,13 @@ impl DeviceContext {
         let old_has_changes = self.has_changes.get();
         self.has_changes.replace(old_has_changes || is_drawing);
 
-        // Eagerly capture the plot origin when drawing first starts for this
-        // change set. The source context stack may be popped before
-        // `process_changes()` runs, so we snapshot it now while it's available.
-        if !old_has_changes && is_drawing {
+        // Eagerly capture the plot origin while the source context stack is still
+        // available, since `process_changes()` may not run until after `source()`
+        // popped it. Capture whenever we have no snapshot rather than only on the
+        // `has_changes` false->true edge, which never comes back around for a new
+        // page started while earlier changes are still pending (e.g. `dev.hold()`).
+        let needs_origin = self.pending_origin.borrow().is_none();
+        if is_drawing && needs_origin {
             let ctx = self.capture_execution_context();
             let origin = self.capture_plot_origin(&ctx);
             self.set_pending_origin(origin);

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -187,10 +187,10 @@ pub(crate) struct DeviceContext {
     /// provides the file attribution even though the execute_request came from the console.
     source_context_stack: RefCell<Vec<String>>,
 
-    /// The plot origin captured eagerly when drawing starts (i.e. when `has_changes`
-    /// transitions from false to true). This is necessary because the source context
-    /// stack may be popped before `process_changes()` runs (e.g. `source()` completes
-    /// before the execute request finishes), so we snapshot the origin at drawing time.
+    /// The plot origin for the current page, captured eagerly whenever drawing
+    /// starts and no snapshot is pending. This is necessary because the source
+    /// context stack may be popped before `process_changes()` runs (e.g. `source()`
+    /// completes before the execute request finishes).
     pending_origin: RefCell<Option<Option<PlotOrigin>>>,
 }
 
@@ -269,9 +269,8 @@ impl DeviceContext {
         self.source_context_stack.borrow().last().cloned()
     }
 
-    /// Eagerly capture the plot origin so it's available when `process_changes()` runs later.
-    /// Called when drawing first starts for a change set, since the source context stack
-    /// may be popped before we get a chance to consume it.
+    /// Eagerly capture the plot origin so it's available when `process_changes()`
+    /// runs later, since the source context stack may be popped before then.
     fn set_pending_origin(&self, origin: Option<PlotOrigin>) {
         self.pending_origin.replace(Some(origin));
     }

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -187,11 +187,10 @@ pub(crate) struct DeviceContext {
     /// provides the file attribution even though the execute_request came from the console.
     source_context_stack: RefCell<Vec<String>>,
 
-    /// The plot origin for the current page, captured eagerly whenever drawing
-    /// starts and no snapshot is pending. This is necessary because the source
-    /// context stack may be popped before `process_changes()` runs (e.g. `source()`
-    /// completes before the execute request finishes).
-    pending_origin: RefCell<Option<Option<PlotOrigin>>>,
+    /// Snapshot the origin at draw time because `source()` can pop its context
+    /// before `process_changes()` runs. The snapshot is tagged with `PlotId` so a
+    /// stale origin can't be attributed to a later page.
+    pending_origin: RefCell<Option<(PlotId, Option<PlotOrigin>)>>,
 }
 
 impl std::fmt::Debug for DeviceContext {
@@ -269,15 +268,15 @@ impl DeviceContext {
         self.source_context_stack.borrow().last().cloned()
     }
 
-    /// Eagerly capture the plot origin so it's available when `process_changes()`
-    /// runs later, since the source context stack may be popped before then.
     fn set_pending_origin(&self, origin: Option<PlotOrigin>) {
-        self.pending_origin.replace(Some(origin));
+        self.pending_origin.replace(Some((self.id(), origin)));
     }
 
-    /// Clear any unconsumed pending origin.
-    fn clear_pending_origin(&self) {
-        self.pending_origin.replace(None);
+    fn has_pending_origin(&self) -> bool {
+        match self.pending_origin.borrow().as_ref() {
+            Some((page, _)) => *page == self.id(),
+            None => false,
+        }
     }
 
     /// Create a new id for this new plot page (from Positron's perspective)
@@ -285,7 +284,6 @@ impl DeviceContext {
     fn new_positron_page(&self) {
         self.is_new_page.replace(true);
         self.id.replace(Self::new_id());
-        self.clear_pending_origin();
     }
 
     /// Deactivation hook
@@ -337,13 +335,8 @@ impl DeviceContext {
         let old_has_changes = self.has_changes.get();
         self.has_changes.replace(old_has_changes || is_drawing);
 
-        // Eagerly capture the plot origin while the source context stack is still
-        // available, since `process_changes()` may not run until after `source()`
-        // popped it. Capture whenever we have no snapshot rather than only on the
-        // `has_changes` false->true edge, which never comes back around for a new
-        // page started while earlier changes are still pending (e.g. `dev.hold()`).
-        let needs_origin = self.pending_origin.borrow().is_none();
-        if is_drawing && needs_origin {
+        // Capture each page's origin before `source()` pops its context
+        if is_drawing && !self.has_pending_origin() {
             let ctx = self.capture_execution_context();
             let origin = self.capture_plot_origin(&ctx);
             self.set_pending_origin(origin);
@@ -405,13 +398,16 @@ impl DeviceContext {
             .map(Self::code_location_to_origin)
     }
 
-    /// Take the pending origin that was captured eagerly at drawing time.
-    /// Falls back to capturing the origin now if none was pending.
-    fn take_pending_origin(&self, ctx: &ExecutionContext) -> Option<PlotOrigin> {
-        self.pending_origin
-            .borrow_mut()
-            .take()
-            .unwrap_or_else(|| self.capture_plot_origin(ctx))
+    /// Take the origin captured at drawing time for this page. Falls back to
+    /// capturing the origin now if the snapshot is missing or belongs to an
+    /// earlier page.
+    fn take_pending_origin(&self, id: &PlotId, ctx: &ExecutionContext) -> Option<PlotOrigin> {
+        let pending = self.pending_origin.borrow_mut().take();
+
+        match pending {
+            Some((page, origin)) if page == *id => origin,
+            _ => self.capture_plot_origin(ctx),
+        }
     }
 
     /// Detect the kind of plot from the recording.
@@ -714,7 +710,7 @@ impl DeviceContext {
     fn store_plot_context(&self, id: &PlotId, ctx: &ExecutionContext) {
         let kind = self.detect_plot_kind(id);
         let name = self.generate_plot_name(&kind);
-        let origin = self.take_pending_origin(ctx);
+        let origin = self.take_pending_origin(id, ctx);
 
         self.plot_contexts
             .borrow_mut()

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -585,6 +585,52 @@ fn test_plot_source_context_stacking() {
     assert!(result_a.contains(&format!("$origin_uri\n[1] \"{}\"", file_a.uri_id)));
 }
 
+/// Test that a plot created inside `source()` keeps its origin when rendering
+/// is held past the end of the `source()` call.
+///
+/// https://github.com/posit-dev/ark/issues/1334
+///
+/// While a hold is active, `process_changes()` deliberately leaves
+/// `has_changes` set so it can notify once the hold is released. That leaves
+/// `has_changes` already true when the next plot starts drawing, which skips
+/// the eager origin capture in `hook_mode()`. By the time the hold is released,
+/// `source()` has returned and its `defer()` has popped the source context, so
+/// the origin has nothing left to fall back to.
+#[test]
+fn test_plot_origin_survives_hold_across_source() {
+    let frontend = DummyArkFrontend::lock();
+
+    // Two plots under a hold, with no `dev.flush()`, so the notification is
+    // deferred past the end of `source()`.
+    let file = SourceFile::new("invisible(dev.hold())\nplot(1:5)\nplot(1:3)\n");
+
+    let code = format!("source('{}')", file.path);
+    frontend.send_execute_request(&code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    // Release the hold in a separate request, after source() has returned.
+    frontend.send_execute_request("invisible(dev.flush())", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    let display_id = frontend.recv_iopub_display_data_id();
+    assert!(!display_id.is_empty());
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    let query = format!(".ps.graphics.get_metadata('{display_id}')");
+    frontend.send_execute_request(&query, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    let result = frontend.recv_iopub_execute_result();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    assert!(result.contains(&format!("$origin_uri\n[1] \"{}\"", file.uri_id)));
+}
+
 /// Test that plots rendered with fig-width/fig-height metadata produce
 /// a PNG at the expected pixel dimensions (inches * 96 DPI).
 #[test]

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -585,23 +585,17 @@ fn test_plot_source_context_stacking() {
     assert!(result_a.contains(&format!("$origin_uri\n[1] \"{}\"", file_a.uri_id)));
 }
 
-/// Test that a plot created inside `source()` keeps its origin when rendering
-/// is held past the end of the `source()` call.
+/// Plots created by `source()` retain the file origin while `dev.hold()`
+/// defers processing until after `source()` returns.
 ///
-/// https://github.com/posit-dev/ark/issues/1334
-///
-/// While a hold is active, `process_changes()` deliberately leaves
-/// `has_changes` set so it can notify once the hold is released. That leaves
-/// `has_changes` already true when the next plot starts drawing, which skips
-/// the eager origin capture in `hook_mode()`. By the time the hold is released,
-/// `source()` has returned and its `defer()` has popped the source context, so
-/// the origin has nothing left to fall back to.
+/// `has_changes` remains true while the hold is active, so each new page must
+/// capture its origin without relying on a false-to-true transition.
 #[test]
 fn test_plot_origin_survives_hold_across_source() {
     let frontend = DummyArkFrontend::lock();
 
-    // Two plots under a hold, with no `dev.flush()`, so the notification is
-    // deferred past the end of `source()`.
+    // Deferring the notification until after `source()` returns removes the
+    // source context that fallback capture would otherwise use.
     let file = SourceFile::new("invisible(dev.hold())\nplot(1:5)\nplot(1:3)\n");
 
     let code = format!("source('{}')", file.path);
@@ -611,7 +605,7 @@ fn test_plot_origin_survives_hold_across_source() {
     frontend.recv_iopub_idle();
     frontend.recv_shell_execute_reply();
 
-    // Release the hold in a separate request, after source() has returned.
+    // Release the hold after `source()` has returned.
     frontend.send_execute_request("invisible(dev.flush())", ExecuteRequestOptions::default());
     frontend.recv_iopub_busy();
     frontend.recv_iopub_execute_input();
@@ -629,6 +623,49 @@ fn test_plot_origin_survives_hold_across_source() {
     frontend.recv_shell_execute_reply();
 
     assert!(result.contains(&format!("$origin_uri\n[1] \"{}\"", file.uri_id)));
+}
+
+/// Origins are page-scoped, so an unconsumed `source()` origin from an update
+/// cannot be attributed to a later page.
+#[test]
+fn test_plot_origin_is_not_reused_across_pages() {
+    let frontend = DummyArkFrontend::lock();
+
+    frontend.send_execute_request("plot(1:10)", ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_display_data();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    // Updates do not store metadata, leaving this page's source origin unconsumed.
+    let file = SourceFile::new("points(2, 2)\n");
+    let code = format!("source('{}')", file.path);
+    frontend.send_execute_request(&code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    frontend.recv_iopub_update_display_data();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    let code = "plot(1:5)";
+    frontend.send_execute_request(code, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    let display_id = frontend.recv_iopub_display_data_id();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    let query = format!(".ps.graphics.get_metadata('{display_id}')");
+    frontend.send_execute_request(&query, ExecuteRequestOptions::default());
+    frontend.recv_iopub_busy();
+    frontend.recv_iopub_execute_input();
+    let result = frontend.recv_iopub_execute_result();
+    frontend.recv_iopub_idle();
+    frontend.recv_shell_execute_reply();
+
+    assert!(result.contains(&format!("$code\n[1] \"{code}\"")));
+    assert!(!result.contains(&file.uri_id));
 }
 
 /// Test that plots rendered with fig-width/fig-height metadata produce


### PR DESCRIPTION
Fixes #1334.

### Summary

A plot created inside `source()` could lose its origin, leaving the Plots pane with no source file and no way to recover it. 

- `hook_mode()` only captured the origin on the `has_changes` false->true edge, so a new page starting while earlier changes were pending never re-captured after `new_positron_page()` cleared the snapshot
- `graphics_on_did_execute_request()` cleared the snapshot at the end of every request, so a render held into a later request lost it
- Now captures whenever no snapshot is pending, and drops the end-of-request clear as redundant with the new-page clear
- Adds `test_plot_origin_survives_hold_across_source`, which fails on `main` inside the assertion and passes with the fix

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Plot origin is lost on the source() path when the origin snapshot is dropped before process_changes consumes it, leaving the fallback to run after source() popped the context stack</summary>

- **Test:** [Plot File Attribution > R - Plot origin shows source file after run file command](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Plot%20File%20Attribution%20%3E%20R%20-%20Plot%20origin%20shows%20source%20file%20after%20run%20file%20command%7C%7C%7Ctest%2Fe2e%2Ftests%2Fplots%2Fplot-file-attribution.test.ts)
- **Targeted failure:** Error: expect(locator).toBeVisible() failed
- **Signal:** Observed via file probes in a RED ark integration test: push_source_context -> EAGER CAPTURE succeeds -> new_positron_page clear wipes it -> hook_mode skips re-capture (old_has_changes=true) -> end-of-request clear in graphics_on_did_execute_request drops it again -> pop_source_context -> take_pending_origin FALLBACK -> None. The end-of-request clear is the decisive path for a render held across requests. Plot renders and the metadata RPC succeeds, but .plot-origin-file never enters the DOM. Local e2e did NOT reproduce (10/10 green on macOS, origin consumed inside the same request), so the CI route is predicted, not observed.
- **Frequency:** 32/137 runs (23.4%) on main, ubuntu/electron
- **Hypothesis:** race

</details>
