### PR TITLE
Render intrinsic size plots at correct dpi

### DIFF
--- a/crates/ark/src/modules/positron/graphics.R
+++ b/crates/ark/src/modules/positron/graphics.R
@@ -376,10 +376,11 @@ finalize_device_arguments <- function(format, width, height, pixel_ratio) {
         # values are upscaled by `pixel_ratio`.
         #
         # `res` is nominal resolution specified in pixels-per-inch (ppi).
+        # Round to whole pixels, since `pixel_ratio` can be fractional.
         return(list(
             res = default_resolution_in_pixels_per_inch() * pixel_ratio,
-            width = width * pixel_ratio,
-            height = height * pixel_ratio
+            width = round(width * pixel_ratio),
+            height = round(height * pixel_ratio)
         ))
     }
 

--- a/crates/ark/src/plots/graphics_device.rs
+++ b/crates/ark/src/plots/graphics_device.rs
@@ -481,6 +481,7 @@ impl DeviceContext {
             PlotBackendRequest::Render(plot_meta) => {
                 log::trace!("PlotBackendRequest::Render");
 
+                let mut pixel_ratio = plot_meta.pixel_ratio;
                 let size = match plot_meta.size {
                     Some(size) => size,
                     None => {
@@ -491,7 +492,12 @@ impl DeviceContext {
                             .get(id)
                             .and_then(|ctx| ctx.intrinsic_size.clone());
                         match intrinsic {
-                            Some(intrinsic) => intrinsic.to_plot_size(),
+                            Some(intrinsic) => {
+                                // Lift the resolution of physical (inch-based)
+                                // sizes so they stay crisp when scaled to fit.
+                                pixel_ratio = pixel_ratio.max(intrinsic.min_pixel_ratio());
+                                intrinsic.to_plot_size()
+                            },
                             None => {
                                 return Err(anyhow!(
                                     "No size provided for plot {id} and no intrinsic size available"
@@ -506,7 +512,7 @@ impl DeviceContext {
                         width: size.width,
                         height: size.height,
                     },
-                    pixel_ratio: plot_meta.pixel_ratio,
+                    pixel_ratio,
                     format: plot_meta.format,
                 };
 
@@ -992,6 +998,12 @@ const DEFAULT_DPI: f64 = if cfg!(target_os = "macos") {
 /// Default aspect ratio (width:height) used when only output_width_px is provided.
 const DEFAULT_ASPECT_RATIO: f64 = 4.0 / 3.0;
 
+/// Target DPI for rendering inch-based intrinsic sizes (e.g. Quarto figures).
+/// Quarto's HTML default renders figures at `fig-dpi` (96) scaled by
+/// `fig.retina` (2), i.e. 192 DPI. Matching it keeps intrinsic plots crisp when
+/// the plot pane scales them to fit, independent of the OS base screen DPI.
+const INTRINSIC_RENDER_DPI: f64 = 192.0;
+
 /// Default figure size in inches, matching Quarto's base/HTML format
 /// defaults (`fig-width: 7`, `fig-height: 5`). Other formats differ (e.g.
 /// pdf is 5.5 x 3.5), but Positron doesn't know the target format.
@@ -1004,6 +1016,14 @@ trait IntrinsicSizeExt {
     /// Returns dimensions in CSS/logical pixels. The R rendering layer handles
     /// physical pixel scaling via the separate `pixel_ratio` parameter.
     fn to_plot_size(&self) -> PlotSize;
+
+    /// Minimum pixel ratio for rendering this intrinsic size crisply.
+    ///
+    /// An inch-based size (Quarto) is a physical size that the plot pane may
+    /// scale up to fit, so it needs enough resolution to lift the effective DPI
+    /// (`DEFAULT_DPI * pixel_ratio`) up to `INTRINSIC_RENDER_DPI`. A pixel-based
+    /// size already carries its own resolution, so no floor is applied.
+    fn min_pixel_ratio(&self) -> f64;
 }
 
 impl IntrinsicSizeExt for IntrinsicSize {
@@ -1017,6 +1037,13 @@ impl IntrinsicSizeExt for IntrinsicSize {
                 width: self.width.round() as i64,
                 height: self.height.round() as i64,
             },
+        }
+    }
+
+    fn min_pixel_ratio(&self) -> f64 {
+        match self.unit {
+            PlotUnit::Inches => INTRINSIC_RENDER_DPI / DEFAULT_DPI,
+            PlotUnit::Pixels => 1.0,
         }
     }
 }

--- a/crates/ark/tests/integration/plots.rs
+++ b/crates/ark/tests/integration/plots.rs
@@ -1,3 +1,4 @@
+use amalthea::comm::plot_comm::PlotBackendReply;
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
 use amalthea::wire::execute_request::ExecuteRequestPositron;
 use amalthea::wire::execute_request::JupyterPositronLocation;
@@ -728,6 +729,90 @@ fn test_plot_with_pixel_ratio_reports_logical_size_in_metadata() {
 
     frontend.recv_iopub_idle();
     frontend.recv_shell_execute_reply();
+}
+
+/// Rendering an inch-based (Quarto) intrinsic-size plot at its intrinsic size
+/// should produce a crisp, high-DPI PNG rather than one at the low base screen
+/// DPI. Regression test for posit-dev/positron#15026.
+#[test]
+fn test_render_intrinsic_size_uses_high_dpi() {
+    let frontend = DummyArkFrontend::lock();
+    frontend.open_ui_comm();
+
+    // Create a plot carrying a Quarto intrinsic size of 4x2 inches.
+    frontend.send_execute_request("plot(1:10)", ExecuteRequestOptions {
+        positron: Some(ExecuteRequestPositron {
+            fig_width: Some(4.0),
+            fig_height: Some(2.0),
+            ..Default::default()
+        }),
+        ..ExecuteRequestOptions::default()
+    });
+
+    // In dynamic mode the plot arrives as a `positron.plot` comm open. Drain
+    // IOPub until we've seen both the plot comm and the idle status.
+    let deadline = std::time::Instant::now() + RECV_TIMEOUT;
+    let mut plot_comm_id = None;
+    let mut got_idle = false;
+    while plot_comm_id.is_none() || !got_idle {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let Some(msg) = frontend.recv_iopub_with_timeout(remaining) else {
+            panic!(
+                "Timed out waiting for plot comm (plot_comm_id={plot_comm_id:?}, got_idle={got_idle})"
+            );
+        };
+        match msg {
+            amalthea::wire::jupyter_message::Message::CommOpen(data)
+                if data.content.target_name == "positron.plot" =>
+            {
+                plot_comm_id = Some(data.content.comm_id);
+            },
+            amalthea::wire::jupyter_message::Message::Status(data)
+                if data.content.execution_state == amalthea::wire::status::ExecutionState::Idle =>
+            {
+                got_idle = true;
+            },
+            _ => {},
+        }
+    }
+    frontend.recv_shell_execute_reply();
+    let plot_comm_id = plot_comm_id.unwrap();
+
+    // Render at intrinsic size (size = null), as the plot pane does when the
+    // intrinsic sizing policy is selected. Use pixel_ratio 1 (a non-HiDPI
+    // display) to expose the low-resolution bug.
+    let data = serde_json::json!({
+        "method": "render",
+        "params": { "size": null, "pixel_ratio": 1.0, "format": "png" },
+        "id": "render-rpc",
+    });
+    frontend.send_shell_comm_msg(plot_comm_id.clone(), data);
+
+    // Drain until the plot comm's render reply arrives.
+    let deadline = std::time::Instant::now() + RECV_TIMEOUT;
+    let reply = loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let Some(msg) = frontend.recv_iopub_with_timeout(remaining) else {
+            panic!("Timed out waiting for render reply");
+        };
+        if let amalthea::wire::jupyter_message::Message::CommMsg(msg) = msg {
+            if msg.content.comm_id == plot_comm_id {
+                break msg.content.data;
+            }
+        }
+    };
+    frontend.recv_iopub_idle();
+
+    let reply: PlotBackendReply = serde_json::from_value(reply).unwrap();
+    let PlotBackendReply::RenderReply(result) = reply else {
+        panic!("Expected RenderReply, got {reply:?}");
+    };
+    let (width, height) = png_dimensions(&result.data);
+
+    // 4x2 inches at the intrinsic render DPI (192), independent of the OS base
+    // screen DPI. Before the fix this rendered at 288x144 (4x2 in at 72 DPI on
+    // Linux) or 384x192 (at 96 DPI on macOS).
+    assert_eq!((width, height), (768, 384));
 }
 
 /// Test that plots rendered with output_width_px (but no fig dimensions)


### PR DESCRIPTION
## Intent

Fixes plots rendered at intrinsic size looking pixelated and saving at low resolution when a Quarto figure size (`fig-width`/`fig-height`) is in play. 

Addresses posit-dev/positron#15026.

## Approach

A Quarto figure size is a physical size in inches. When the plot pane asks for the plot at its intrinsic size, we were converting those inches to pixels at the screen's base DPI (72 on Linux, 96 on macOS) and only scaling further by the display's pixel ratio. On an ordinary (non-HiDPI) display that left a 4x2 inch plot at just 288x144 pixels, so it looked blurry when the pane stretched it to fit, and it saved at that same low resolution. Quarto renders the same plot at 768x384.

The pixel ratio is really two things rolled into one: how dense the display is, and how sharp we render. For a physical-inch plot that the pane will scale up, tying sharpness to the display alone isn't enough.

So when rendering an inch-based intrinsic size, we now raise the effective pixel ratio to reach a target resolution of 192 DPI, matching Quarto's default (its 96 DPI figures at 2x retina). This is a floor: displays that already exceed it are left alone, and pixel-based intrinsic sizes (such as Matplotlib's) keep their own resolution. As a result a 4x2 inch plot now renders at least 768x384 on every OS.

<img width="1434" height="922" alt="image" src="https://github.com/user-attachments/assets/9b17a847-6b57-4a12-ad13-1bdcfbbf0309" />

A small companion change rounds device dimensions to whole pixels, since the new floor can produce a fractional pixel ratio.

## Testing

Adds an integration test that creates a Quarto-sized plot and sends the same intrinsic render request the plot pane sends when "intrinsic" is selected, then checks the resulting PNG is 768x384. It fails before this change and passes after.

### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixes plots rendered at intrinsic size looking pixelated and saving at low resolution when a Quarto figure size (`fig-width`/`fig-height`) is in play (#15026). 

