### PR TITLE
Migrate diagnostics setting to `positron.r.diagnostics.enabled`

### DIFF
--- a/crates/ark/src/lsp/config.rs
+++ b/crates/ark/src/lsp/config.rs
@@ -61,7 +61,7 @@ global_settings! {
     OAK_DIAGNOSTICS_EXPERIMENTAL_ENABLED_SETTING
         => diagnostics_experimental: diagnostics.experimental,
     OAK_SOURCE_FETCHING_ENABLED_SETTING => source_fetching_enabled: oak.source_fetching_enabled,
-    "positron.r.diagnostics.enable" => diagnostics_enable: diagnostics.enable,
+    R_DIAGNOSTICS_ENABLED_SETTING => diagnostics_enable: diagnostics.enable,
     "positron.r.symbols.includeAssignmentsInBlocks"
         => include_assignments_in_blocks: symbols.include_assignments_in_blocks,
     "positron.r.workspaceSymbols.includeCommentSections"
@@ -79,7 +79,21 @@ pub(crate) fn initialization_options(options: &Value) -> LspSettings {
             (setting.set)(&mut layer, value.clone());
         }
     }
+    let legacy_diagnostics_enable =
+        nested_setting(options, LEGACY_R_DIAGNOSTICS_ENABLE_SETTING).and_then(Value::as_bool);
+    combine_diagnostics_enable_settings(&mut layer, legacy_diagnostics_enable);
     layer
+}
+
+pub(crate) fn combine_diagnostics_enable_settings(
+    settings: &mut LspSettings,
+    legacy_enable: Option<bool>,
+) {
+    settings.diagnostics_enable = match (settings.diagnostics_enable, legacy_enable) {
+        (Some(enabled), Some(legacy_enabled)) => Some(enabled && legacy_enabled),
+        (None, legacy_enabled) => legacy_enabled,
+        (enabled, None) => enabled,
+    };
 }
 
 fn nested_setting<'options>(options: &'options Value, key: &str) -> Option<&'options Value> {
@@ -93,6 +107,8 @@ fn nested_setting<'options>(options: &'options Value, key: &str) -> Option<&'opt
 pub(crate) const OAK_DIAGNOSTICS_EXPERIMENTAL_ENABLED_SETTING: &str =
     "oak.diagnostics.experimental.enabled";
 pub(crate) const OAK_SOURCE_FETCHING_ENABLED_SETTING: &str = "oak.sourceFetching.enabled";
+pub(crate) const R_DIAGNOSTICS_ENABLED_SETTING: &str = "positron.r.diagnostics.enabled";
+pub(crate) const LEGACY_R_DIAGNOSTICS_ENABLE_SETTING: &str = "positron.r.diagnostics.enable";
 
 /// Overrides [`OAK_SOURCE_FETCHING_ENABLED_SETTING`] when set to `1`, `true`,
 /// `0`, or `false`. Set to `1` or `true` to enable source fetching on CI.

--- a/crates/ark/src/lsp/state_handlers.rs
+++ b/crates/ark/src/lsp/state_handlers.rs
@@ -55,11 +55,13 @@ use crate::console::ConsoleNotification;
 use crate::lsp;
 use crate::lsp::backend::LspResult;
 use crate::lsp::capabilities::Capabilities;
+use crate::lsp::config::combine_diagnostics_enable_settings;
 use crate::lsp::config::indent_style_from_lsp;
 use crate::lsp::config::initialization_options;
 use crate::lsp::config::LspSettings;
 use crate::lsp::config::DOCUMENT_SETTINGS;
 use crate::lsp::config::GLOBAL_SETTINGS;
+use crate::lsp::config::LEGACY_R_DIAGNOSTICS_ENABLE_SETTING;
 use crate::lsp::config::OAK_SOURCE_FETCHING_ENABLED_ENV_VAR;
 use crate::lsp::content_changes::apply_content_changes;
 use crate::lsp::main_loop::dispatch_scan_requests;
@@ -251,6 +253,13 @@ pub(crate) async fn handle_initialized(
                 register_options: Some(serde_json::json!({ "section": setting.key })),
             });
         }
+        regs.push(Registration {
+            id: uuid::Uuid::new_v4().to_string(),
+            method: String::from("workspace/didChangeConfiguration"),
+            register_options: Some(
+                serde_json::json!({ "section": LEGACY_R_DIAGNOSTICS_ENABLE_SETTING }),
+            ),
+        });
         for setting in DOCUMENT_SETTINGS {
             regs.push(Registration {
                 id: uuid::Uuid::new_v4().to_string(),
@@ -619,6 +628,11 @@ async fn pull_config(
             section: Some(mapping.key.to_string()),
         })
         .collect();
+    global_items.push(lsp_types::ConfigurationItem {
+        scope_uri: None,
+        section: Some(LEGACY_R_DIAGNOSTICS_ENABLE_SETTING.to_string()),
+    });
+    let global_items_len = global_items.len();
 
     // For document items we create a n_uris * n_document_settings array that we'll
     // handle by batch in a double loop over URIs and document settings
@@ -651,13 +665,21 @@ async fn pull_config(
         ));
     }
 
-    let document_configs = configs.split_off(GLOBAL_SETTINGS.len());
+    let document_configs = configs.split_off(global_items_len);
     let global_configs = configs;
 
     let mut global_options = LspSettings::default();
-    for (mapping, value) in GLOBAL_SETTINGS.iter().zip(global_configs) {
-        (mapping.set)(&mut global_options, value);
+    let mut global_config_values = global_configs.into_iter();
+    for setting in GLOBAL_SETTINGS {
+        let Some(value) = global_config_values.next() else {
+            break;
+        };
+        (setting.set)(&mut global_options, value);
     }
+    let legacy_diagnostics_enabled = global_config_values
+        .next()
+        .and_then(|value| value.as_bool());
+    combine_diagnostics_enable_settings(&mut global_options, legacy_diagnostics_enabled);
 
     let mut remaining = document_configs;
 

--- a/crates/ark/src/lsp/tests.rs
+++ b/crates/ark/src/lsp/tests.rs
@@ -4,6 +4,7 @@ mod find_references;
 mod goto_definition;
 mod main_loop;
 mod rename;
+mod settings;
 mod source_handler;
 mod sources;
 mod state;

--- a/crates/ark/src/lsp/tests/settings.rs
+++ b/crates/ark/src/lsp/tests/settings.rs
@@ -1,0 +1,58 @@
+use oak_db::OakDatabase;
+use serde_json::json;
+
+use super::utils::initialize;
+use super::utils::initialized;
+use super::utils::TestClient;
+use crate::lsp::config::initialization_options;
+use crate::lsp::config::LEGACY_R_DIAGNOSTICS_ENABLE_SETTING;
+use crate::lsp::config::R_DIAGNOSTICS_ENABLED_SETTING;
+use crate::lsp::main_loop::init_aux_for_test;
+use crate::lsp::main_loop::GlobalState;
+use crate::lsp::main_loop::LspState;
+use crate::lsp::sources::SourceScheduler;
+use crate::lsp::state::WorldState;
+
+#[test]
+fn test_legacy_diagnostics_initialization_option_can_disable_new_default() {
+    let options = json!({
+        "positron": {
+            "r": {
+                "diagnostics": {
+                    "enabled": true,
+                    "enable": false
+                }
+            }
+        }
+    });
+
+    assert_eq!(
+        initialization_options(&options).diagnostics_enable,
+        Some(false)
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_diagnostics_setting_can_disable_new_default() {
+    let _aux = init_aux_for_test();
+    let client = TestClient::new(&[
+        (R_DIAGNOSTICS_ENABLED_SETTING, json!(true)),
+        (LEGACY_R_DIAGNOSTICS_ENABLE_SETTING, json!(false)),
+    ])
+    .await;
+    let mut state = GlobalState::from_parts(
+        client.client(),
+        WorldState::new(OakDatabase::new()),
+        LspState::new(
+            tokio::sync::mpsc::unbounded_channel().0,
+            SourceScheduler::new(None),
+        ),
+    );
+    let workspace = tempfile::tempdir().unwrap();
+    let (event, _response_rx) = initialize(workspace.path());
+
+    state.handle_event_to_quiescence(event).await;
+    state.handle_event_to_quiescence(initialized()).await;
+
+    assert!(!state.world().config.diagnostics.enable);
+}


### PR DESCRIPTION
- Addresses posit-dev/positron#13354
- Related to https://github.com/posit-dev/positron/pull/15814

This PR migrate the R diagnostics setting from `positron.r.diagnostics.enable` to `positron.r.diagnostics.enabled`. We'll continue reading and registering the legacy setting for a good long while so existing configurations can still disable diagnostics. This applies the compatibility behavior to both initialization options and live `workspace/configuration` updates.

## Testing

- Added coverage for the new and legacy settings in initialization options.
- Added coverage for configuration updates where the legacy setting disables the new default.


### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- Updated the R diagnostics setting to use `positron.r.diagnostics.enabled` while continuing to honor the legacy setting.
