### PR TITLE
Strip carriage returns when splitting lines

### DIFF
--- a/crates/ark/src/strings.rs
+++ b/crates/ark/src/strings.rs
@@ -12,15 +12,8 @@
 /// Returns a `DoubleEndedIterator`, which is the same as the
 /// one returned by `split()` in this particular case.
 pub fn lines(text: &str) -> impl DoubleEndedIterator<Item = &str> {
-    text.split('\n').map(|line| {
-        let Some(line) = line.strip_suffix('\n') else {
-            return line;
-        };
-        let Some(line) = line.strip_suffix('\r') else {
-            return line;
-        };
-        line
-    })
+    text.split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
 }
 
 #[cfg(test)]
@@ -31,5 +24,11 @@ mod tests {
     fn test_lines() {
         let lines: Vec<&str> = lines("foo\n\n\nbar\n\n").collect();
         assert_eq!(lines, vec!["foo", "", "", "bar", "", ""])
+    }
+
+    #[test]
+    fn test_lines_crlf() {
+        let lines: Vec<&str> = lines("foo\r\n\r\nbar\r\n").collect();
+        assert_eq!(lines, vec!["foo", "", "bar", ""])
     }
 }


### PR DESCRIPTION
`strings::lines` is supposed to split text into lines and drop a trailing carriage return so CRLF input is handled, but the carriage return was never stripped. The code first checked for a trailing newline and returned early when it wasn't found. Since the function splits on newlines, no piece ever ends in a newline, so that check always returned early and the carriage return stripping below it was never reached.

The effect shows up in input boundary detection. Those lines are handed to R's parser as a character vector, and a carriage return outside a string literal is an invalid token. Complete R code then gets misclassified, and in some cases a multi-line quoted string followed by another line is reported as incomplete. On Windows with CRLF files this meant pasted code landed in the Console but never ran.

The fix drops the dead newline check and strips the carriage return directly. A new test covers CRLF input so this does not regress.

Positron already normalizes line endings before making this request, so the user-facing bug is handled there, but any other caller or a direct request with CRLF text would still hit the same mis-parse.

Fixes #1399.
