### PR TITLE
Add interpreter-wide R help search support

### DIFF
--- a/crates/amalthea/src/comm/help_comm.rs
+++ b/crates/amalthea/src/comm/help_comm.rs
@@ -11,6 +11,19 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+/// A help topic offered as an autocomplete suggestion.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct HelpTopicSuggestion {
+	/// The topic label shown to the user.
+	pub label: String,
+
+	/// The exact topic value used to open help.
+	pub topic: String,
+
+	/// Optional context such as the package containing the topic.
+	pub detail: Option<String>
+}
+
 /// Possible values for Kind in ShowHelp
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display, strum_macros::EnumString)]
 pub enum ShowHelpKind {
@@ -32,6 +45,13 @@ pub enum ShowHelpKind {
 pub struct ShowHelpTopicParams {
 	/// The help topic to show
 	pub topic: String,
+}
+
+/// Parameters for the SearchHelp method.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SearchHelpParams {
+	/// The help query to search for
+	pub query: String,
 }
 
 /// Parameters for the ShowHelp method.
@@ -62,6 +82,20 @@ pub enum HelpBackendRequest {
 	#[serde(rename = "show_help_topic")]
 	ShowHelpTopic(ShowHelpTopicParams),
 
+	/// Search the active interpreter's help system.
+	///
+	/// Searches interpreter-wide help and displays the resulting page via a
+	/// Show Help notification.
+	#[serde(rename = "search_help")]
+	SearchHelp(SearchHelpParams),
+
+	/// List help topics for autocomplete.
+	///
+	/// Returns interpreter-wide help topics that can be offered as search
+	/// suggestions.
+	#[serde(rename = "get_help_topics")]
+	GetHelpTopics,
+
 }
 
 /**
@@ -73,6 +107,12 @@ pub enum HelpBackendReply {
 	/// Whether the topic was found and shown. Topics are shown via a Show
 	/// Help notification.
 	ShowHelpTopicReply(bool),
+
+	/// Whether the search results page was shown.
+	SearchHelpReply(bool),
+
+	/// Help topic suggestions.
+	GetHelpTopicsReply(Vec<HelpTopicSuggestion>),
 
 }
 

--- a/crates/ark/src/help/r_help.rs
+++ b/crates/ark/src/help/r_help.rs
@@ -9,6 +9,7 @@ use amalthea::comm::comm_channel::CommMsg;
 use amalthea::comm::help_comm::HelpBackendReply;
 use amalthea::comm::help_comm::HelpBackendRequest;
 use amalthea::comm::help_comm::HelpFrontendEvent;
+use amalthea::comm::help_comm::HelpTopicSuggestion;
 use amalthea::comm::help_comm::ShowHelpKind;
 use amalthea::comm::help_comm::ShowHelpParams;
 use anyhow::anyhow;
@@ -74,6 +75,34 @@ impl RHelp {
                     Ok(found) => Ok(HelpBackendReply::ShowHelpTopicReply(found)),
                     Err(err) => Err(err),
                 }
+            },
+            HelpBackendRequest::SearchHelp(search) => {
+                let shown = r_task(|| {
+                    RFunction::from(".ps.help.searchHelp")
+                        .add(search.query)
+                        .call()?
+                        .to::<bool>()
+                })?;
+                Ok(HelpBackendReply::SearchHelpReply(shown))
+            },
+            HelpBackendRequest::GetHelpTopics => {
+                let topics = r_task(|| {
+                    RFunction::from(".ps.help.getHelpTopics")
+                        .call()?
+                        .to::<Vec<String>>()
+                })?;
+                let suggestions = topics
+                    .into_iter()
+                    .filter_map(|entry| {
+                        let (package, topic) = entry.split_once('\u{1f}')?;
+                        Some(HelpTopicSuggestion {
+                            label: topic.to_string(),
+                            topic: format!("{package}::{topic}"),
+                            detail: Some(package.to_string()),
+                        })
+                    })
+                    .collect();
+                Ok(HelpBackendReply::GetHelpTopicsReply(suggestions))
             },
         }
     }

--- a/crates/ark/src/help/r_help.rs
+++ b/crates/ark/src/help/r_help.rs
@@ -77,20 +77,16 @@ impl RHelp {
                 }
             },
             HelpBackendRequest::SearchHelp(search) => {
-                let shown = r_task(|| {
-                    RFunction::from(".ps.help.searchHelp")
-                        .add(search.query)
-                        .call()?
-                        .to::<bool>()
-                })?;
+                let shown = RFunction::from(".ps.help.searchHelp")
+                    .add(search.query)
+                    .call()?
+                    .to::<bool>()?;
                 Ok(HelpBackendReply::SearchHelpReply(shown))
             },
             HelpBackendRequest::GetHelpTopics => {
-                let topics = r_task(|| {
-                    RFunction::from(".ps.help.getHelpTopics")
-                        .call()?
-                        .to::<Vec<String>>()
-                })?;
+                let topics = RFunction::from(".ps.help.getHelpTopics")
+                    .call()?
+                    .to::<Vec<String>>()?;
                 let suggestions = topics
                     .into_iter()
                     .filter_map(|entry| {

--- a/crates/ark/src/modules/positron/help.R
+++ b/crates/ark/src/modules/positron/help.R
@@ -60,6 +60,26 @@ help <- function(topic, package = NULL) {
     length(results) > 0
 }
 
+# Search all installed help documentation and show R's native HTML results page.
+#' @export
+.ps.help.searchHelp <- function(query) {
+    results <- utils::help.search(query, package = NULL)
+
+    if (!in_ark_tests()) {
+        print(results)
+    }
+
+    TRUE
+}
+
+# Return package-qualified help aliases for frontend autocomplete.
+#' @export
+.ps.help.getHelpTopics <- function() {
+    matches <- utils::help.search(".", fields = "alias", package = NULL)$matches
+    matches <- matches[matches[, "Type"] == "help", , drop = FALSE]
+    unique(paste(matches[, "Package"], matches[, "Topic"], sep = "\u001f"))
+}
+
 # Resolve the package specifier, if there is one
 split_topic <- function(topic) {
     # Try `:::` first, as `::` will match both

--- a/crates/ark/src/modules/positron/help.R
+++ b/crates/ark/src/modules/positron/help.R
@@ -77,7 +77,7 @@ help <- function(topic, package = NULL) {
 .ps.help.getHelpTopics <- function() {
     matches <- utils::help.search(".", fields = "alias", package = NULL)$matches
     matches <- matches[matches[, "Type"] == "help", , drop = FALSE]
-    unique(paste(matches[, "Package"], matches[, "Topic"], sep = "\u001f"))
+    unique(paste(matches[, "Package"], matches[, "Entry"], sep = "\u001f"))
 }
 
 # Resolve the package specifier, if there is one

--- a/crates/ark/tests/integration/help.rs
+++ b/crates/ark/tests/integration/help.rs
@@ -13,6 +13,8 @@ use amalthea::comm::comm_channel::CommMsg;
 use amalthea::comm::event::CommEvent;
 use amalthea::comm::help_comm::HelpBackendReply;
 use amalthea::comm::help_comm::HelpBackendRequest;
+use amalthea::comm::help_comm::HelpTopicSuggestion;
+use amalthea::comm::help_comm::SearchHelpParams;
 use amalthea::comm::help_comm::ShowHelpTopicParams;
 use amalthea::fixtures::dummy_frontend::ExecuteRequestOptions;
 use amalthea::socket::comm::CommOutgoingTx;
@@ -83,11 +85,64 @@ impl TestRHelp {
                         assert!(found);
                         assert_eq!(id, request_id);
                     },
+                    reply => panic!("Unexpected help reply: {reply:?}"),
                 }
             },
             _ => {
                 panic!("Unexpected response from help comm: {:?}", response);
             },
+        }
+    }
+
+    fn test_search(&self, query: &str, id: &str) {
+        let request = HelpBackendRequest::SearchHelp(SearchHelpParams {
+            query: String::from(query),
+        });
+        let data = serde_json::to_value(request).unwrap();
+        let request_id = String::from(id);
+        self.comm
+            .incoming_tx
+            .send(CommMsg::Rpc {
+                id: request_id.clone(),
+                parent_header: dummy_jupyter_header(),
+                data,
+            })
+            .unwrap();
+
+        // Search results can be emitted before the RPC response. Consume the
+        // navigation event first when that happens.
+        let mut response = self.iopub_rx.recv_comm_msg();
+        while let CommMsg::Data(_) = response {
+            response = self.iopub_rx.recv_comm_msg();
+        }
+        let CommMsg::Rpc { id, data, .. } = response else {
+            panic!("Unexpected response from help comm: {response:?}");
+        };
+        assert_eq!(id, request_id);
+        assert_eq!(
+            serde_json::from_value::<HelpBackendReply>(data).unwrap(),
+            HelpBackendReply::SearchHelpReply(true)
+        );
+    }
+
+    fn get_topics(&self, id: &str) -> Vec<HelpTopicSuggestion> {
+        let data = serde_json::to_value(HelpBackendRequest::GetHelpTopics).unwrap();
+        self.comm
+            .incoming_tx
+            .send(CommMsg::Rpc {
+                id: String::from(id),
+                parent_header: dummy_jupyter_header(),
+                data,
+            })
+            .unwrap();
+
+        let response = self.iopub_rx.recv_comm_msg();
+        let CommMsg::Rpc { data, .. } = response else {
+            panic!("Unexpected response from help comm: {response:?}");
+        };
+        match serde_json::from_value::<HelpBackendReply>(data).unwrap() {
+            HelpBackendReply::GetHelpTopicsReply(topics) => topics,
+            reply => panic!("Unexpected help reply: {reply:?}"),
         }
     }
 }
@@ -124,6 +179,17 @@ fn test_help_comm() {
         r_help_port
     );
     assert!(RHelp::is_help_url(url.as_str(), r_help_port));
+}
+
+#[test]
+fn test_help_search_comm() {
+    let r_help = TestRHelp::new(String::from("test-help-search-comm-id"));
+
+    r_help.test_search("linear model", "help-search-test-id");
+    let topics = r_help.get_topics("help-topics-test-id");
+    assert!(topics
+        .iter()
+        .any(|topic| { topic.label == "plot" && topic.topic == "graphics::plot" }));
 }
 
 #[test]

--- a/crates/ark/tests/integration/help.rs
+++ b/crates/ark/tests/integration/help.rs
@@ -52,10 +52,7 @@ impl TestRHelp {
         Self { iopub_tx, iopub_rx }
     }
 
-    fn test_topic(&self, topic: &str, id: &str) {
-        let request = HelpBackendRequest::ShowHelpTopic(ShowHelpTopicParams {
-            topic: String::from(topic),
-        });
+    fn request(&self, request: HelpBackendRequest, id: &str) -> HelpBackendReply {
         let data = serde_json::to_value(request).unwrap();
         let request_id = String::from(id);
         let msg = CommMsg::Rpc {
@@ -77,70 +74,35 @@ impl TestRHelp {
         });
 
         let response = self.iopub_rx.recv_comm_msg();
-        match response {
-            CommMsg::Rpc { id, data: val, .. } => {
-                let response = serde_json::from_value::<HelpBackendReply>(val).unwrap();
-                match response {
-                    HelpBackendReply::ShowHelpTopicReply(found) => {
-                        assert!(found);
-                        assert_eq!(id, request_id);
-                    },
-                    reply => panic!("Unexpected help reply: {reply:?}"),
-                }
-            },
-            _ => {
-                panic!("Unexpected response from help comm: {:?}", response);
-            },
-        }
+        let CommMsg::Rpc { id, data, .. } = response else {
+            panic!("Unexpected response from help comm: {response:?}");
+        };
+        assert_eq!(id, request_id);
+        serde_json::from_value(data).unwrap()
+    }
+
+    fn test_topic(&self, topic: &str, id: &str) {
+        let request = HelpBackendRequest::ShowHelpTopic(ShowHelpTopicParams {
+            topic: String::from(topic),
+        });
+        assert_eq!(
+            self.request(request, id),
+            HelpBackendReply::ShowHelpTopicReply(true)
+        );
     }
 
     fn test_search(&self, query: &str, id: &str) {
         let request = HelpBackendRequest::SearchHelp(SearchHelpParams {
             query: String::from(query),
         });
-        let data = serde_json::to_value(request).unwrap();
-        let request_id = String::from(id);
-        self.comm
-            .incoming_tx
-            .send(CommMsg::Rpc {
-                id: request_id.clone(),
-                parent_header: dummy_jupyter_header(),
-                data,
-            })
-            .unwrap();
-
-        // Search results can be emitted before the RPC response. Consume the
-        // navigation event first when that happens.
-        let mut response = self.iopub_rx.recv_comm_msg();
-        while let CommMsg::Data(_) = response {
-            response = self.iopub_rx.recv_comm_msg();
-        }
-        let CommMsg::Rpc { id, data, .. } = response else {
-            panic!("Unexpected response from help comm: {response:?}");
-        };
-        assert_eq!(id, request_id);
         assert_eq!(
-            serde_json::from_value::<HelpBackendReply>(data).unwrap(),
+            self.request(request, id),
             HelpBackendReply::SearchHelpReply(true)
         );
     }
 
     fn get_topics(&self, id: &str) -> Vec<HelpTopicSuggestion> {
-        let data = serde_json::to_value(HelpBackendRequest::GetHelpTopics).unwrap();
-        self.comm
-            .incoming_tx
-            .send(CommMsg::Rpc {
-                id: String::from(id),
-                parent_header: dummy_jupyter_header(),
-                data,
-            })
-            .unwrap();
-
-        let response = self.iopub_rx.recv_comm_msg();
-        let CommMsg::Rpc { data, .. } = response else {
-            panic!("Unexpected response from help comm: {response:?}");
-        };
-        match serde_json::from_value::<HelpBackendReply>(data).unwrap() {
+        match self.request(HelpBackendRequest::GetHelpTopics, id) {
             HelpBackendReply::GetHelpTopicsReply(topics) => topics,
             reply => panic!("Unexpected help reply: {reply:?}"),
         }
@@ -183,7 +145,7 @@ fn test_help_comm() {
 
 #[test]
 fn test_help_search_comm() {
-    let r_help = TestRHelp::new(String::from("test-help-search-comm-id"));
+    let r_help = TestRHelp::new();
 
     r_help.test_search("linear model", "help-search-test-id");
     let topics = r_help.get_topics("help-topics-test-id");


### PR DESCRIPTION
This is the R side prerequisite for https://github.com/posit-dev/positron/pull/15923, to resolve https://github.com/posit-dev/positron/issues/422.

## Summary

- add Help comm requests for interpreter-wide search and autocomplete topics
- use `utils::help.search()` to search documentation across installed R packages, including unloaded packages
- return package-qualified topic suggestions so duplicate aliases open the intended documentation
- add integration coverage for search requests and topic suggestions

## Verification

- `cargo +nightly fmt --all --check`
- `cargo check --package ark`
- manually verified R search results and package-qualified topic selection in Positron

The targeted integration test reaches the new search handler locally, but cannot complete with the current system R installation because `/usr/lib/R/doc/KEYWORDS.db` is missing.
