### PR TITLE
Pass through console document `id` from rstudioapi editor context

### DIFF
--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -435,6 +435,7 @@ pub enum UiBackendRequest {
  */
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "result")]
+#[allow(clippy::large_enum_variant)]
 pub enum UiBackendReply {
 	/// The method result
 	CallMethodReply(CallMethodResult),
@@ -533,6 +534,7 @@ pub enum UiFrontendRequest {
  */
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", content = "result")]
+#[allow(clippy::large_enum_variant)]
 pub enum UiFrontendReply {
 	/// Reply for the new_document method (no result)
 	NewDocumentReply(),

--- a/crates/amalthea/src/comm/ui_comm.rs
+++ b/crates/amalthea/src/comm/ui_comm.rs
@@ -41,7 +41,10 @@ pub struct EditorContext {
 	pub selection: Selection,
 
 	/// The selections in this text editor.
-	pub selections: Vec<Selection>
+	pub selections: Vec<Selection>,
+
+	/// A stable identifier for the document, e.g. '#console' for the console
+	pub id: Option<String>
 }
 
 /// Document metadata

--- a/crates/ark/src/modules/rstudio/document-api.R
+++ b/crates/ark/src/modules/rstudio/document-api.R
@@ -58,6 +58,7 @@
     }
 
     list(
+        id = context$id,
         path = context$document$path,
         contents = unlist(context$contents),
         selection = convert_selection(context$selections)


### PR DESCRIPTION
- Addresses posit-dev/positron#15571
- Related to https://github.com/posit-dev/positron/pull/16063

This set of PRs makes `rstudioapi` context aware of the console. The two PRs can merge in either order, because R reads the raw JSON reply instead of the generated struct.

This change adds an optional `id` field to the editor context from `.rs.api.getSourceEditorContext()`. `rstudioapi::getActiveDocumentContext()` calls this function, so it gets the new field too. When the context is the console, the frontend sets `id` to `"#console"`. Editor contexts do not yet include this field.


### Positron Release Notes

#### New Features

- `rstudioapi::getActiveDocumentContext()` and `getSourceEditorContext()` now return a document `id`. This is `"#console"` when the context is the console (posit-dev/positron#15571).

#### Bug Fixes

- N/A
